### PR TITLE
Add Woo order review URL tag

### DIFF
--- a/mailpoet/changelog/2026-05-21-07-44-21-added-woocommerce-order-review-url-personalization-tag-f.md
+++ b/mailpoet/changelog/2026-05-21-07-44-21-added-woocommerce-order-review-url-personalization-tag-f.md
@@ -2,4 +2,4 @@
 
 # Description
 
-WooCommerce order review URL personalization tag for automation emails
+Direct review links in WooCommerce post-purchase automation emails

--- a/mailpoet/changelog/2026-05-21-07-44-21-added-woocommerce-order-review-url-personalization-tag-f.md
+++ b/mailpoet/changelog/2026-05-21-07-44-21-added-woocommerce-order-review-url-personalization-tag-f.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+WooCommerce order review URL personalization tag for automation emails

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/AutomationSendEmailSubjectResolver.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/AutomationSendEmailSubjectResolver.php
@@ -29,7 +29,7 @@ class AutomationSendEmailSubjectResolver {
 
     $triggerSteps = $this->getTriggerStepsReachingStep($automation, $sendEmailStep);
     if ($triggerSteps === []) {
-      return $this->subjectTransformerHandler->getSubjectKeysForAutomation($automation);
+      return [];
     }
 
     return $this->intersectTriggerSubjectKeys($triggerSteps);

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/AutomationSendEmailSubjectResolver.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/AutomationSendEmailSubjectResolver.php
@@ -1,0 +1,157 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet\Actions;
+
+use MailPoet\Automation\Engine\Control\SubjectTransformerHandler;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
+
+class AutomationSendEmailSubjectResolver {
+  private Registry $registry;
+  private SubjectTransformerHandler $subjectTransformerHandler;
+
+  public function __construct(
+    Registry $registry,
+    SubjectTransformerHandler $subjectTransformerHandler
+  ) {
+    $this->registry = $registry;
+    $this->subjectTransformerHandler = $subjectTransformerHandler;
+  }
+
+  /** @return string[] */
+  public function getGuaranteedSubjectKeysForStep(Automation $automation, Step $sendEmailStep): array {
+    if ($sendEmailStep->getKey() !== SendEmailAction::KEY) {
+      return [];
+    }
+
+    $triggerSteps = $this->getTriggerStepsReachingStep($automation, $sendEmailStep);
+    if ($triggerSteps === []) {
+      return $this->subjectTransformerHandler->getSubjectKeysForAutomation($automation);
+    }
+
+    return $this->intersectTriggerSubjectKeys($triggerSteps);
+  }
+
+  /** @return string[] */
+  public function getGuaranteedSubjectKeysForEmail(Automation $automation, NewsletterEntity $newsletter): array {
+    $exactStep = $this->getExactSendEmailStep($automation, $newsletter);
+    if ($exactStep) {
+      return $this->getGuaranteedSubjectKeysForStep($automation, $exactStep);
+    }
+
+    $steps = $this->getSendEmailStepsReferencingNewsletter($automation, $newsletter);
+    if ($steps === []) {
+      return [];
+    }
+
+    $subjectKeySets = array_map(function (Step $step) use ($automation): array {
+      return $this->getGuaranteedSubjectKeysForStep($automation, $step);
+    }, $steps);
+
+    return $this->intersectSubjectKeySets($subjectKeySets);
+  }
+
+  public function hasGuaranteedSubjectForEmail(Automation $automation, NewsletterEntity $newsletter, string $subjectKey): bool {
+    return in_array($subjectKey, $this->getGuaranteedSubjectKeysForEmail($automation, $newsletter), true);
+  }
+
+  /** @return Step[] */
+  private function getTriggerStepsReachingStep(Automation $automation, Step $targetStep): array {
+    $triggerSteps = [];
+    foreach ($automation->getTriggers() as $triggerStep) {
+      if ($this->stepCanReachStep($automation, $triggerStep, $targetStep)) {
+        $triggerSteps[] = $triggerStep;
+      }
+    }
+    return $triggerSteps;
+  }
+
+  private function stepCanReachStep(Automation $automation, Step $fromStep, Step $toStep): bool {
+    $steps = $automation->getSteps();
+    $stack = [$fromStep->getId()];
+    $visited = [];
+
+    while ($stack !== []) {
+      $stepId = array_pop($stack);
+      if (!is_string($stepId) || isset($visited[$stepId])) {
+        continue;
+      }
+      $visited[$stepId] = true;
+
+      if ($stepId === $toStep->getId()) {
+        return true;
+      }
+
+      $step = $steps[$stepId] ?? null;
+      if (!$step instanceof Step) {
+        continue;
+      }
+
+      foreach ($step->getNextStepIds() as $nextStepId) {
+        $stack[] = $nextStepId;
+      }
+    }
+
+    return false;
+  }
+
+  /** @param Step[] $triggerSteps */
+  private function intersectTriggerSubjectKeys(array $triggerSteps): array {
+    $subjectKeySets = [];
+    foreach ($triggerSteps as $triggerStep) {
+      $trigger = $this->registry->getTrigger($triggerStep->getKey());
+      if (!$trigger) {
+        return [];
+      }
+      $subjectKeySets[] = $this->subjectTransformerHandler->getSubjectKeysForTrigger($trigger);
+    }
+
+    return $this->intersectSubjectKeySets($subjectKeySets);
+  }
+
+  /** @param array<int, string[]> $subjectKeySets */
+  private function intersectSubjectKeySets(array $subjectKeySets): array {
+    if ($subjectKeySets === []) {
+      return [];
+    }
+
+    $subjectKeys = array_shift($subjectKeySets);
+    foreach ($subjectKeySets as $nextSubjectKeys) {
+      $subjectKeys = array_values(array_intersect($subjectKeys, $nextSubjectKeys));
+    }
+    $subjectKeys = array_values(array_unique($subjectKeys));
+    sort($subjectKeys);
+    return $subjectKeys;
+  }
+
+  private function getExactSendEmailStep(Automation $automation, NewsletterEntity $newsletter): ?Step {
+    $stepId = $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_AUTOMATION_STEP_ID);
+    if (!is_string($stepId) || $stepId === '') {
+      return null;
+    }
+
+    $step = $automation->getStep($stepId);
+    return $step instanceof Step && $step->getKey() === SendEmailAction::KEY ? $step : null;
+  }
+
+  /** @return Step[] */
+  private function getSendEmailStepsReferencingNewsletter(Automation $automation, NewsletterEntity $newsletter): array {
+    $newsletterId = $newsletter->getId();
+    $wpPostId = $newsletter->getWpPostId();
+
+    return array_values(array_filter($automation->getSteps(), function (Step $step) use ($newsletterId, $wpPostId): bool {
+      if ($step->getKey() !== SendEmailAction::KEY) {
+        return false;
+      }
+
+      $args = $step->getArgs();
+      $emailId = $args['email_id'] ?? null;
+      $emailWpPostId = $args['email_wp_post_id'] ?? null;
+      return ($newsletterId !== null && (int)$emailId === (int)$newsletterId)
+        || ($wpPostId !== null && (int)$emailWpPostId === (int)$wpPostId);
+    }));
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -18,7 +18,9 @@ use MailPoet\Automation\Integrations\MailPoet\Payloads\SegmentPayload;
 use MailPoet\Automation\Integrations\MailPoet\Payloads\SubscriberPayload;
 use MailPoet\Automation\Integrations\WooCommerce\Payloads\AbandonedCartPayload;
 use MailPoet\Automation\Integrations\WooCommerce\Payloads\OrderPayload;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
 use MailPoet\EmailEditor\Integrations\MailPoet\BlockEmailContentDetector;
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUrl;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
@@ -66,6 +68,7 @@ class SendEmailAction implements Action {
   ];
   private const WAIT_OPTIN = 'wait_optin';
   private const OPTIN_RETRIES = 'optin_retries';
+  private const ORDER_REVIEW_URL_TOKEN = '[woocommerce/order-review-url]';
 
   public const TRANSACTIONAL_TRIGGERS = [
     'mailpoet:custom-trigger',
@@ -112,6 +115,8 @@ class SendEmailAction implements Action {
   private NewsletterSaveController $newsletterSaveController;
 
   private BlockEmailContentDetector $blockEmailContentDetector;
+  private AutomationSendEmailSubjectResolver $subjectResolver;
+  private OrderReviewUrl $orderReviewUrl;
 
   public function __construct(
     AutomationController $automationController,
@@ -125,7 +130,9 @@ class SendEmailAction implements Action {
     NewsletterOptionFieldsRepository $newsletterOptionFieldsRepository,
     WordPress $wp,
     NewsletterSaveController $newsletterSaveController,
-    BlockEmailContentDetector $blockEmailContentDetector
+    BlockEmailContentDetector $blockEmailContentDetector,
+    AutomationSendEmailSubjectResolver $subjectResolver,
+    OrderReviewUrl $orderReviewUrl
   ) {
     $this->automationController = $automationController;
     $this->settings = $settings;
@@ -139,6 +146,8 @@ class SendEmailAction implements Action {
     $this->wp = $wp;
     $this->newsletterSaveController = $newsletterSaveController;
     $this->blockEmailContentDetector = $blockEmailContentDetector;
+    $this->subjectResolver = $subjectResolver;
+    $this->orderReviewUrl = $orderReviewUrl;
   }
 
   public function getKey(): string {
@@ -214,7 +223,27 @@ class SendEmailAction implements Action {
     }
 
     $wpPost = $this->wp->getPost($wpPostId);
-    if ($wpPost instanceof \WP_Post && $this->blockEmailContentDetector->hasMeaningfulContent($wpPost)) {
+    $subjectKeys = $this->subjectResolver->getGuaranteedSubjectKeysForStep($args->getAutomation(), $args->getStep());
+    if ($this->newsletterContainsOrderReviewUrlToken($email)) {
+      if (!in_array(OrderSubject::KEY, $subjectKeys, true)) {
+        throw ValidationException::create()
+          ->withMessage(__('Cannot activate the automation because order review links require a WooCommerce order trigger.', 'mailpoet'))
+          ->withError('email_id', __('Use this email in an automation with a WooCommerce order subject or remove the order review link.', 'mailpoet'));
+      }
+
+      if (!$this->orderReviewUrl->isSupported()) {
+        throw ValidationException::create()
+          ->withMessage(__('Cannot activate the automation because WooCommerce cannot generate order review links.', 'mailpoet'))
+          ->withError('email_id', __('Update WooCommerce or remove the order review link from this email.', 'mailpoet'));
+      }
+    }
+
+    if (
+      $wpPost instanceof \WP_Post
+      && $this->blockEmailContentDetector->hasMeaningfulContent($wpPost, [
+        'automation_subject_keys' => $subjectKeys,
+      ])
+    ) {
       return;
     }
 
@@ -277,12 +306,50 @@ class SendEmailAction implements Action {
   }
 
   private function scheduleEmail(StepRunArgs $args, NewsletterEntity $newsletter, SubscriberEntity $subscriber): void {
+    $this->validateOrderReviewUrlToken($args, $newsletter);
+
     $meta = $this->getNewsletterMeta($args);
     try {
       $this->automationEmailScheduler->createSendingTask($newsletter, $subscriber, $meta);
     } catch (Throwable $e) {
       throw InvalidStateException::create()->withMessage(__('Could not create sending task.', 'mailpoet'));
     }
+  }
+
+  private function validateOrderReviewUrlToken(StepRunArgs $args, NewsletterEntity $newsletter): void {
+    if (!$this->newsletterContainsOrderReviewUrlToken($newsletter)) {
+      return;
+    }
+
+    try {
+      $orderPayload = $args->getSinglePayloadByClass(OrderPayload::class);
+    } catch (NotFoundException $e) {
+      throw InvalidStateException::create()->withMessage(__('Cannot send the email because an order is required to generate the review link.', 'mailpoet'));
+    }
+
+    if ($this->orderReviewUrl->getUrl(['order' => $orderPayload->getOrder()]) !== '') {
+      return;
+    }
+
+    throw InvalidStateException::create()->withMessage(__('Cannot send the email because WooCommerce cannot generate an order review link for this order.', 'mailpoet'));
+  }
+
+  private function newsletterContainsOrderReviewUrlToken(NewsletterEntity $newsletter): bool {
+    $wpPostId = $newsletter->getWpPostId();
+    if ($wpPostId) {
+      $wpPost = $this->wp->getPost($wpPostId);
+      if ($wpPost instanceof \WP_Post && $this->contentContainsOrderReviewUrlToken($wpPost->post_content)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        return true;
+      }
+    }
+
+    $body = json_encode($newsletter->getBody(), JSON_UNESCAPED_SLASHES);
+    return is_string($body) && $this->contentContainsOrderReviewUrlToken($body);
+  }
+
+  private function contentContainsOrderReviewUrlToken(string $content): bool {
+    $normalizedContent = rawurldecode(str_replace('\\/', '/', $content));
+    return strpos($normalizedContent, self::ORDER_REVIEW_URL_TOKEN) !== false;
   }
 
   private function getRunLogData(StepRunController $controller): array {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -240,9 +240,7 @@ class SendEmailAction implements Action {
 
     if (
       $wpPost instanceof \WP_Post
-      && $this->blockEmailContentDetector->hasMeaningfulContent($wpPost, [
-        'automation_subject_keys' => $subjectKeys,
-      ])
+      && $this->blockEmailContentDetector->hasMeaningfulContent($wpPost)
     ) {
       return;
     }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
@@ -7,7 +7,6 @@ use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\WordPress;
-use MailPoet\Automation\Integrations\MailPoet\Actions\AutomationSendEmailSubjectResolver;
 use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
 use MailPoet\Automation\Integrations\MailPoet\Templates\EmailFactory;
 use MailPoet\DI\ContainerWrapper;
@@ -29,22 +28,19 @@ class AutomationEditorLoadingHooks {
   private NewsletterDeleteController $newsletterDeleteController;
 
   private BlockEmailContentDetector $blockEmailContentDetector;
-  private AutomationSendEmailSubjectResolver $subjectResolver;
 
   public function __construct(
     WordPress $wp,
     AutomationStorage $automationStorage,
     NewslettersRepository $newslettersRepository,
     NewsletterDeleteController $newsletterDeleteController,
-    BlockEmailContentDetector $blockEmailContentDetector,
-    AutomationSendEmailSubjectResolver $subjectResolver
+    BlockEmailContentDetector $blockEmailContentDetector
   ) {
     $this->wp = $wp;
     $this->automationStorage = $automationStorage;
     $this->newslettersRepository = $newslettersRepository;
     $this->newsletterDeleteController = $newsletterDeleteController;
     $this->blockEmailContentDetector = $blockEmailContentDetector;
-    $this->subjectResolver = $subjectResolver;
   }
 
   public function init(): void {
@@ -87,10 +83,7 @@ class AutomationEditorLoadingHooks {
         $wpPostId = $newsletterEntity->getWpPostId();
         if ($wpPostId) {
           $wpPost = $this->wp->getPost($wpPostId);
-          $subjectKeys = $this->subjectResolver->getGuaranteedSubjectKeysForStep($automation, $step);
-          $disconnectEmail = !($wpPost instanceof \WP_Post) || !$this->blockEmailContentDetector->hasMeaningfulContent($wpPost, [
-            'automation_subject_keys' => $subjectKeys,
-          ]);
+          $disconnectEmail = !($wpPost instanceof \WP_Post) || !$this->blockEmailContentDetector->hasMeaningfulContent($wpPost);
           if (!$disconnectEmail && (int)($args['email_wp_post_id'] ?? 0) !== (int)$wpPostId) {
             $args['email_wp_post_id'] = $wpPostId;
           }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Automation\Integrations\MailPoet\Actions\AutomationSendEmailSubjectResolver;
 use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
 use MailPoet\Automation\Integrations\MailPoet\Templates\EmailFactory;
 use MailPoet\DI\ContainerWrapper;
@@ -28,19 +29,22 @@ class AutomationEditorLoadingHooks {
   private NewsletterDeleteController $newsletterDeleteController;
 
   private BlockEmailContentDetector $blockEmailContentDetector;
+  private AutomationSendEmailSubjectResolver $subjectResolver;
 
   public function __construct(
     WordPress $wp,
     AutomationStorage $automationStorage,
     NewslettersRepository $newslettersRepository,
     NewsletterDeleteController $newsletterDeleteController,
-    BlockEmailContentDetector $blockEmailContentDetector
+    BlockEmailContentDetector $blockEmailContentDetector,
+    AutomationSendEmailSubjectResolver $subjectResolver
   ) {
     $this->wp = $wp;
     $this->automationStorage = $automationStorage;
     $this->newslettersRepository = $newslettersRepository;
     $this->newsletterDeleteController = $newsletterDeleteController;
     $this->blockEmailContentDetector = $blockEmailContentDetector;
+    $this->subjectResolver = $subjectResolver;
   }
 
   public function init(): void {
@@ -83,7 +87,10 @@ class AutomationEditorLoadingHooks {
         $wpPostId = $newsletterEntity->getWpPostId();
         if ($wpPostId) {
           $wpPost = $this->wp->getPost($wpPostId);
-          $disconnectEmail = !$wpPost instanceof \WP_Post || !$this->blockEmailContentDetector->hasMeaningfulContent($wpPost);
+          $subjectKeys = $this->subjectResolver->getGuaranteedSubjectKeysForStep($automation, $step);
+          $disconnectEmail = !($wpPost instanceof \WP_Post) || !$this->blockEmailContentDetector->hasMeaningfulContent($wpPost, [
+            'automation_subject_keys' => $subjectKeys,
+          ]);
           if (!$disconnectEmail && (int)($args['email_wp_post_id'] ?? 0) !== (int)$wpPostId) {
             $args['email_wp_post_id'] = $wpPostId;
           }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Data\AutomationTemplate;
 use MailPoet\Automation\Engine\Templates\AutomationBuilder;
 use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
 use MailPoet\Config\Env;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WooCommerce\WooCommerceBookings\Helper as WooCommerceBookingsHelper;
 use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WooCommerceSubscriptions;
 
@@ -27,18 +28,23 @@ class TemplatesFactory {
   /** @var WooCommerceBookingsHelper */
   private $woocommerceBookingsHelper;
 
+  /** @var WooCommerceHelper */
+  private $woocommerceHelper;
+
   public function __construct(
     AutomationBuilder $builder,
     WooCommerce $woocommerce,
     WooCommerceSubscriptions $woocommerceSubscriptions,
     EmailFactory $emailFactory,
-    WooCommerceBookingsHelper $woocommerceBookingsHelper
+    WooCommerceBookingsHelper $woocommerceBookingsHelper,
+    WooCommerceHelper $woocommerceHelper
   ) {
     $this->builder = $builder;
     $this->woocommerce = $woocommerce;
     $this->woocommerceSubscriptions = $woocommerceSubscriptions;
     $this->emailFactory = $emailFactory;
     $this->woocommerceBookingsHelper = $woocommerceBookingsHelper;
+    $this->woocommerceHelper = $woocommerceHelper;
   }
 
   public function createTemplates(): array {
@@ -58,7 +64,9 @@ class TemplatesFactory {
       $templates[] = $this->createPurchasedProductTemplate();
       $templates[] = $this->createPurchasedProductWithTagTemplate();
       $templates[] = $this->createPurchasedInCategoryTemplate();
-      $templates[] = $this->createAskForReviewTemplate();
+      if ($this->woocommerceHelper->wcSupportsOrderReviewUrl()) {
+        $templates[] = $this->createAskForReviewTemplate();
+      }
       $templates[] = $this->createFollowUpPositiveReviewTemplate();
       $templates[] = $this->createFollowUpNegativeReviewTemplate();
       if ($this->woocommerceSubscriptions->isWooCommerceSubscriptionsActive()) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -10,6 +10,7 @@ use MailPoet\Cron\Workers\SendingQueue\Tasks\Posts as PostsTask;
 use MailPoet\Cron\Workers\SendingQueue\Tasks\Shortcodes as ShortcodesTask;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockDetector;
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUrl;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
@@ -86,6 +87,7 @@ class Newsletter {
   private $automationRunStorage;
 
   private CouponBlockDetector $couponBlockDetector;
+  private OrderReviewUrl $orderReviewUrl;
 
   public function __construct(
     ?WPFunctions $wp = null,
@@ -123,6 +125,7 @@ class Newsletter {
     $this->personalizer = Email_Editor_Container::container()->get(Personalizer::class);
     $this->automationRunStorage = ContainerWrapper::getInstance()->get(AutomationRunStorage::class);
     $this->couponBlockDetector = ContainerWrapper::getInstance()->get(CouponBlockDetector::class);
+    $this->orderReviewUrl = ContainerWrapper::getInstance()->get(OrderReviewUrl::class);
   }
 
   public function getNewsletterFromQueue(ScheduledTaskEntity $task): ?NewsletterEntity {
@@ -436,6 +439,8 @@ class Newsletter {
         }
       }
 
+      $this->guardOrderReviewUrlPersonalization($newsletter, $queue, $preparedNewsletter, $context);
+
       $this->personalizer->set_context($context);
       foreach ($preparedNewsletter as $key => $content) {
         $preparedNewsletter[$key] = $this->personalizer->personalize_content($content);
@@ -457,6 +462,63 @@ class Newsletter {
         'text' => $preparedNewsletter[2],
       ],
     ];
+  }
+
+  /**
+   * @param array<int|string, mixed> $contentParts
+   * @param array<string, mixed> $context
+   */
+  private function guardOrderReviewUrlPersonalization(
+    NewsletterEntity $newsletter,
+    SendingQueueEntity $queue,
+    array $contentParts,
+    array $context
+  ): void {
+    if (!$this->contentContainsOrderReviewUrlToken($contentParts)) {
+      return;
+    }
+
+    if ($this->orderReviewUrl->getUrl($context) !== '') {
+      return;
+    }
+
+    $message = __('Cannot send the email because WooCommerce cannot generate an order review link for this order.', 'mailpoet');
+    $this->failOrderReviewUrlSend($newsletter, $queue, $message);
+    throw NewsletterProcessingException::create()->withMessage($message);
+  }
+
+  /** @param mixed $content */
+  private function contentContainsOrderReviewUrlToken($content): bool {
+    if (is_array($content)) {
+      foreach ($content as $contentPart) {
+        if ($this->contentContainsOrderReviewUrlToken($contentPart)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    if (!is_string($content)) {
+      return false;
+    }
+
+    $normalizedContent = rawurldecode(str_replace('\\/', '/', $content));
+    return strpos($normalizedContent, '[woocommerce/order-review-url]') !== false;
+  }
+
+  private function failOrderReviewUrlSend(
+    NewsletterEntity $newsletter,
+    SendingQueueEntity $queue,
+    string $message
+  ): void {
+    $this->loggerFactory->getLogger(LoggerFactory::TOPIC_NEWSLETTERS)->error(
+      $message,
+      [
+        'newsletter_id' => $newsletter->getId(),
+        'queue_id' => $queue->getId(),
+      ]
+    );
+    $this->sendingQueuesRepository->pause($queue);
   }
 
   public function markNewsletterAsSent(NewsletterEntity $newsletter) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -440,6 +440,14 @@ class Newsletter {
       foreach ($preparedNewsletter as $key => $content) {
         $preparedNewsletter[$key] = $this->personalizer->personalize_content($content);
       }
+      $personalizedHtml = $this->wp->applyFilters('mailpoet_automation_email_personalize_html_after', $preparedNewsletter[1], $context);
+      if (is_string($personalizedHtml)) {
+        $preparedNewsletter[1] = $personalizedHtml;
+      }
+      $personalizedText = $this->wp->applyFilters('mailpoet_automation_email_personalize_text_after', $preparedNewsletter[2], $context);
+      if (is_string($personalizedText)) {
+        $preparedNewsletter[2] = $personalizedText;
+      }
     }
     return [
       'id' => $newsletter->getId(),

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -164,6 +164,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Validation\AutomationRules\ValidStepValidationRule::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Validation\AutomationValidator::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Actions\AutomationSendEmailSubjectResolver::class)->setPublic(true);
     // Automation - API endpoints
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationsGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationVersionsGetEndpoint::class)->setPublic(true);
@@ -377,6 +378,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\BlockEmailContentDetector::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\DependencyNotice::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypesController::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\AutomationEmailContextProvider::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\AutomationEmailPreviewOrderProvider::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes\PoweredByMailpoet::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockDetector::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockFailureTranslator::class)->setPublic(true);
@@ -387,6 +390,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Link::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\LinksToShortcodesConvertor::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUrl::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Site::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Subscriber::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTagManager::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/AutomationEmailContextProvider.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/AutomationEmailContextProvider.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet;
+
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Automation\Integrations\MailPoet\Actions\AutomationSendEmailSubjectResolver;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+use MailPoet\WP\Functions as WPFunctions;
+
+class AutomationEmailContextProvider {
+  private AutomationRunStorage $automationRunStorage;
+  private AutomationStorage $automationStorage;
+  private AutomationSendEmailSubjectResolver $subjectResolver;
+  private AutomationEmailPreviewOrderProvider $previewOrderProvider;
+  private WooCommerceHelper $wooCommerceHelper;
+  private WPFunctions $wp;
+
+  public function __construct(
+    AutomationRunStorage $automationRunStorage,
+    AutomationStorage $automationStorage,
+    AutomationSendEmailSubjectResolver $subjectResolver,
+    AutomationEmailPreviewOrderProvider $previewOrderProvider,
+    WooCommerceHelper $wooCommerceHelper,
+    WPFunctions $wp
+  ) {
+    $this->automationRunStorage = $automationRunStorage;
+    $this->automationStorage = $automationStorage;
+    $this->subjectResolver = $subjectResolver;
+    $this->previewOrderProvider = $previewOrderProvider;
+    $this->wooCommerceHelper = $wooCommerceHelper;
+    $this->wp = $wp;
+  }
+
+  /** @return array<string, mixed> */
+  public function build(NewsletterEntity $newsletter, ?SendingQueueEntity $sendingQueue, bool $preview): array {
+    if ($preview) {
+      return $this->buildPreviewContext($newsletter);
+    }
+
+    if (!$sendingQueue) {
+      return [];
+    }
+
+    return $this->buildRealSendContext($sendingQueue);
+  }
+
+  /** @return array<string, mixed> */
+  private function buildPreviewContext(NewsletterEntity $newsletter): array {
+    $automationId = $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_AUTOMATION_ID);
+    if (!is_numeric($automationId)) {
+      return [];
+    }
+
+    $automation = $this->automationStorage->getAutomation((int)$automationId);
+    if (!$automation) {
+      return [];
+    }
+
+    $subjectKeys = $this->subjectResolver->getGuaranteedSubjectKeysForEmail($automation, $newsletter);
+    $context = [
+      'automation_subject_keys' => $subjectKeys,
+    ];
+
+    if (in_array(OrderSubject::KEY, $subjectKeys, true)) {
+      $order = $this->previewOrderProvider->getOrder();
+      if ($order instanceof \WC_Order) {
+        $context['order'] = $order;
+      }
+    }
+
+    $filteredContext = $this->wp->applyFilters('mailpoet_automation_email_preview_sample_data', $context);
+    return is_array($filteredContext) ? $filteredContext : $context;
+  }
+
+  /** @return array<string, mixed> */
+  private function buildRealSendContext(SendingQueueEntity $sendingQueue): array {
+    $meta = $sendingQueue->getMeta();
+    $runId = is_array($meta) ? ($meta['automation']['run_id'] ?? null) : null;
+    if (!is_numeric($runId)) {
+      return [];
+    }
+
+    $automationRun = $this->automationRunStorage->getAutomationRun((int)$runId);
+    if (!$automationRun) {
+      return [];
+    }
+
+    $context = [];
+    $subjectKeys = [];
+    foreach ($automationRun->getSubjects() as $subject) {
+      $subjectKeys[] = $subject->getKey();
+      if ($subject->getKey() !== OrderSubject::KEY) {
+        continue;
+      }
+
+      $orderId = $subject->getArgs()['order_id'] ?? null;
+      if (!is_numeric($orderId)) {
+        continue;
+      }
+
+      $order = $this->wooCommerceHelper->wcGetOrder((int)$orderId);
+      if ($order instanceof \WC_Order) {
+        $context['order'] = $order;
+      }
+    }
+
+    $subjectKeys = array_values(array_unique($subjectKeys));
+    sort($subjectKeys);
+    $context['automation_subject_keys'] = $subjectKeys;
+
+    return $context;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/AutomationEmailPreviewOrderProvider.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/AutomationEmailPreviewOrderProvider.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet;
+
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+
+class AutomationEmailPreviewOrderProvider {
+  private WooCommerceHelper $wooCommerceHelper;
+
+  public function __construct(
+    WooCommerceHelper $wooCommerceHelper
+  ) {
+    $this->wooCommerceHelper = $wooCommerceHelper;
+  }
+
+  public function getOrder(): ?\WC_Order {
+    if (!class_exists(\WC_Order::class)) {
+      return null;
+    }
+
+    try {
+      $order = $this->getExistingReviewableOrder();
+      if ($order instanceof \WC_Order) {
+        return $order;
+      }
+    } catch (\Throwable $e) {
+      return null;
+    }
+
+    return null;
+  }
+
+  private function getExistingReviewableOrder(): ?\WC_Order {
+    $orders = $this->wooCommerceHelper->wcGetOrders([
+      'type' => 'shop_order',
+      'status' => 'completed',
+      'limit' => 10,
+      'orderby' => 'date',
+      'order' => 'DESC',
+    ]);
+
+    if (!is_array($orders)) {
+      return null;
+    }
+
+    foreach ($orders as $order) {
+      if (!$order instanceof \WC_Order) {
+        continue;
+      }
+
+      if ($order->get_order_key() === '' || count($order->get_items()) === 0) {
+        continue;
+      }
+
+      if ($this->wooCommerceHelper->wcOrderHasActionableReviewItems($order)) {
+        return $order;
+      }
+    }
+
+    return null;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/BlockEmailContentDetector.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/BlockEmailContentDetector.php
@@ -32,11 +32,8 @@ class BlockEmailContentDetector {
     $this->wp = $wp;
   }
 
-  /**
-   * @param \WP_Post|string $postOrContent
-   * @param array{automation_subject_keys?: string[]} $context
-   */
-  public function hasMeaningfulContent($postOrContent, array $context = []): bool {
+  /** @param \WP_Post|string $postOrContent */
+  public function hasMeaningfulContent($postOrContent): bool {
     if ($postOrContent instanceof \WP_Post) {
       $content = (string)$postOrContent->post_content; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     } elseif (is_string($postOrContent)) {
@@ -54,27 +51,27 @@ class BlockEmailContentDetector {
     }
 
     $blocks = $this->wp->parseBlocks($content);
-    if ($this->blocksHaveMeaningfulContent($blocks, false, $context)) {
+    if ($this->blocksHaveMeaningfulContent($blocks)) {
       return true;
     }
 
     return $this->htmlHasVisibleText($content);
   }
 
-  private function blocksHaveMeaningfulContent(array $blocks, bool $insideProductTemplate = false, array $context = []): bool {
+  private function blocksHaveMeaningfulContent(array $blocks, bool $insideProductTemplate = false): bool {
     foreach ($blocks as $block) {
       if (!is_array($block)) {
         continue;
       }
 
-      if ($this->blockHasMeaningfulContent($block, $insideProductTemplate, $context)) {
+      if ($this->blockHasMeaningfulContent($block, $insideProductTemplate)) {
         return true;
       }
     }
     return false;
   }
 
-  private function blockHasMeaningfulContent(array $block, bool $insideProductTemplate, array $context): bool {
+  private function blockHasMeaningfulContent(array $block, bool $insideProductTemplate): bool {
     $blockName = isset($block['blockName']) && is_string($block['blockName']) ? $block['blockName'] : null;
     $attrs = $this->getBlockAttrs($block);
 
@@ -92,7 +89,7 @@ class BlockEmailContentDetector {
     }
 
     $innerBlocks = isset($block['innerBlocks']) && is_array($block['innerBlocks']) ? $block['innerBlocks'] : [];
-    return $this->blocksHaveMeaningfulContent($innerBlocks, $insideProductTemplate || $blockName === 'woocommerce/product-template', $context);
+    return $this->blocksHaveMeaningfulContent($innerBlocks, $insideProductTemplate || $blockName === 'woocommerce/product-template');
   }
 
   private function isKnownRenderableDynamicBlock(?string $blockName, array $attrs, bool $insideProductTemplate): bool {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/BlockEmailContentDetector.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/BlockEmailContentDetector.php
@@ -34,8 +34,9 @@ class BlockEmailContentDetector {
 
   /**
    * @param \WP_Post|string $postOrContent
+   * @param array{automation_subject_keys?: string[]} $context
    */
-  public function hasMeaningfulContent($postOrContent): bool {
+  public function hasMeaningfulContent($postOrContent, array $context = []): bool {
     if ($postOrContent instanceof \WP_Post) {
       $content = (string)$postOrContent->post_content; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     } elseif (is_string($postOrContent)) {
@@ -53,27 +54,27 @@ class BlockEmailContentDetector {
     }
 
     $blocks = $this->wp->parseBlocks($content);
-    if ($this->blocksHaveMeaningfulContent($blocks)) {
+    if ($this->blocksHaveMeaningfulContent($blocks, false, $context)) {
       return true;
     }
 
     return $this->htmlHasVisibleText($content);
   }
 
-  private function blocksHaveMeaningfulContent(array $blocks, bool $insideProductTemplate = false): bool {
+  private function blocksHaveMeaningfulContent(array $blocks, bool $insideProductTemplate = false, array $context = []): bool {
     foreach ($blocks as $block) {
       if (!is_array($block)) {
         continue;
       }
 
-      if ($this->blockHasMeaningfulContent($block, $insideProductTemplate)) {
+      if ($this->blockHasMeaningfulContent($block, $insideProductTemplate, $context)) {
         return true;
       }
     }
     return false;
   }
 
-  private function blockHasMeaningfulContent(array $block, bool $insideProductTemplate): bool {
+  private function blockHasMeaningfulContent(array $block, bool $insideProductTemplate, array $context): bool {
     $blockName = isset($block['blockName']) && is_string($block['blockName']) ? $block['blockName'] : null;
     $attrs = $this->getBlockAttrs($block);
 
@@ -91,7 +92,7 @@ class BlockEmailContentDetector {
     }
 
     $innerBlocks = isset($block['innerBlocks']) && is_array($block['innerBlocks']) ? $block['innerBlocks'] : [];
-    return $this->blocksHaveMeaningfulContent($innerBlocks, $insideProductTemplate || $blockName === 'woocommerce/product-template');
+    return $this->blocksHaveMeaningfulContent($innerBlocks, $insideProductTemplate || $blockName === 'woocommerce/product-template', $context);
   }
 
   private function isKnownRenderableDynamicBlock(?string $blockName, array $attrs, bool $insideProductTemplate): bool {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Coupons/EmailContextBuilder.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Coupons/EmailContextBuilder.php
@@ -2,20 +2,25 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Coupons;
 
+use MailPoet\EmailEditor\Integrations\MailPoet\AutomationEmailContextProvider;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\WP\Functions as WPFunctions;
 
 class EmailContextBuilder {
   private WPFunctions $wp;
+  private ?AutomationEmailContextProvider $automationEmailContextProvider;
 
   public function __construct(
-    WPFunctions $wp
+    WPFunctions $wp,
+    ?AutomationEmailContextProvider $automationEmailContextProvider = null
   ) {
     $this->wp = $wp;
+    $this->automationEmailContextProvider = $automationEmailContextProvider;
   }
 
   public function build(NewsletterEntity $newsletter, ?SendingQueueEntity $sendingQueue, bool $preview): array {
+    $isAutomationType = $this->isAutomationType($newsletter);
     $context = [
       'integration' => 'mailpoet',
       'newsletter_id' => (int)$newsletter->getId(),
@@ -25,10 +30,17 @@ class EmailContextBuilder {
       'is_preview' => $preview,
       'is_single_recipient' => false,
       'subscriber_count' => 0,
-      'mailpoet_is_automation' => false,
+      'mailpoet_is_automation' => $isAutomationType,
     ];
 
-    if ($preview || !$sendingQueue || !$this->isAutomationType($newsletter)) {
+    if ($this->automationEmailContextProvider) {
+      $context = array_merge(
+        $context,
+        $this->automationEmailContextProvider->build($newsletter, $sendingQueue, $preview)
+      );
+    }
+
+    if ($preview || !$sendingQueue || !$isAutomationType) {
       if (!$preview && $sendingQueue && $newsletter->getType() === NewsletterEntity::TYPE_STANDARD) {
         $context['is_real_send'] = true;
         $context['subscriber_count'] = $this->getQueueSubscriberCount($sendingQueue);
@@ -40,7 +52,6 @@ class EmailContextBuilder {
     $subscribers = $task ? $task->getSubscribers() : null;
     $subscriberCount = $subscribers ? count($subscribers) : 0;
     $context['subscriber_count'] = $subscriberCount;
-    $context['mailpoet_is_automation'] = true;
 
     if ($subscriberCount !== 1) {
       return $context;

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -200,9 +200,16 @@ class EditorPageRenderer {
       'mailpoet_ai_text_generation_available' => function_exists('wp_ai_client_prompt')
         && wp_ai_client_prompt('test')->is_supported_for_text_generation(),
     ];
-    $this->wp->wpAddInlineScript('email_editor_integration', implode('', array_map(function ($key) use ($inline_script_data) {
+    $inlineScript = implode('', array_map(function ($key) use ($inline_script_data) {
       return sprintf("var %s=%s;", $key, wp_json_encode($inline_script_data[$key], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES));
-    }, array_keys($inline_script_data))), 'before');
+    }, array_keys($inline_script_data)));
+    $scriptHandles = [
+      'email_editor_integration',
+      'mailpoet-powered-by-mailpoet-block',
+    ];
+    foreach ($scriptHandles as $scriptHandle) {
+      $this->wp->wpAddInlineScript($scriptHandle, $inlineScript, 'before');
+    }
 
     // Load CSS from Post Editor
     $this->wp->wpEnqueueStyle('wp-edit-post');

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AskForReviewPostPurchasePattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AskForReviewPostPurchasePattern.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+
+class AskForReviewPostPurchasePattern extends Pattern {
+  protected $name = 'ask-for-review-post-purchase';
+  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $categories = ['purchase'];
+  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+  protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' . __('How was your experience?', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
+      __('Thanks again for your order. Your feedback helps other shoppers choose with confidence.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|20"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--20);font-size:16px">' .
+      __('If you have a minute, your review would mean a lot.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:buttons {"style":{"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|20"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
+      <div class="wp-block-buttons" style="padding-top:0;padding-bottom:var(--wp--preset--spacing--20)">
+        <!-- wp:button {"url":"[woocommerce/order-review-url]","style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+        <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[woocommerce/order-review-url]">' . __('Leave a review', 'mailpoet') . '</a></div>
+        <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"0"}}}} -->
+      <p style="padding-top:var(--wp--preset--spacing--30);padding-bottom:0;font-size:16px">' .
+      __('We appreciate your time and hope to see you again soon.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return __('Ask for a product review', 'mailpoet');
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartWithDiscountPattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AskForReviewPostPurchasePattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EducationalCampaignPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EventInvitationPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\FirstPurchaseThankYouPattern;
@@ -96,6 +97,10 @@ class PatternsController {
         new ProductPurchaseFollowUpPattern($this->cdnAssetUrl),
         new AbandonedCartPattern($this->cdnAssetUrl),
       ]);
+
+      if ($this->wooCommerceHelper->wcSupportsOrderReviewUrl()) {
+        $this->patterns[] = new AskForReviewPostPurchasePattern($this->cdnAssetUrl);
+      }
 
       // Patterns using generated coupons require WooCommerce 10.8.0+
       $wooCommerceVersion = $this->wooCommerceHelper->getWooCommerceVersion();

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -9,6 +9,7 @@ use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Link;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\LinksToShortcodesConvertor;
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUrl;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Site;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Subscriber;
 use MailPoet\Newsletter\NewslettersRepository;
@@ -18,6 +19,7 @@ class PersonalizationTagManager {
   private Subscriber $subscriber;
   private Site $site;
   private Link $link;
+  private OrderReviewUrl $orderReviewUrl;
   private WPFunctions $wp;
   private LinksToShortcodesConvertor $linksToShortcodesConvertor;
   private AutomationStorage $automationStorage;
@@ -28,6 +30,7 @@ class PersonalizationTagManager {
     Subscriber $subscriber,
     Site $site,
     Link $link,
+    OrderReviewUrl $orderReviewUrl,
     WPFunctions $wp,
     LinksToShortcodesConvertor $linksToShortcodesConvertor,
     AutomationStorage $automationStorage,
@@ -37,6 +40,7 @@ class PersonalizationTagManager {
     $this->subscriber = $subscriber;
     $this->site = $site;
     $this->link = $link;
+    $this->orderReviewUrl = $orderReviewUrl;
     $this->wp = $wp;
     $this->linksToShortcodesConvertor = $linksToShortcodesConvertor;
     $this->automationStorage = $automationStorage;
@@ -70,11 +74,17 @@ class PersonalizationTagManager {
    * @param int $automationId The automation ID
    */
   public function extendPersonalizationTagsByAutomationSubjects(int $automationId): void {
+    $this->extendPersonalizationTagsBySubjects($this->getAutomationSubjects($automationId));
+  }
+
+  /**
+   * @param string[] $availableSubjects
+   */
+  public function extendPersonalizationTagsBySubjects(array $availableSubjects): void {
     $registry = Email_Editor_Container::container()->get(
       Personalization_Tags_Registry::class
     );
 
-    $availableSubjects = $this->getAutomationSubjects($automationId);
     $this->extendWooCommerceTagsForMailPoet($registry, $availableSubjects);
 
     $this->wp->applyFilters('mailpoet_automation_email_extend_personalization_tags', $registry, $availableSubjects);
@@ -83,6 +93,7 @@ class PersonalizationTagManager {
   public function initialize() {
     // Extend tags when WooCommerce Email Editor requests personalization tags for a specific post
     $this->wp->addAction('woocommerce_email_editor_personalization_tags_for_post', [$this, 'extendPersonalizationTagsForPost']);
+    $this->wp->addAction('mailpoet_automation_email_extend_personalization_tags_for_sending', [$this, 'extendPersonalizationTagsBySubjects']);
 
     $this->wp->addFilter('woocommerce_email_editor_register_personalization_tags', function( Personalization_Tags_Registry $registry ): Personalization_Tags_Registry {
       // Subscriber Personalization Tags
@@ -190,6 +201,18 @@ class PersonalizationTagManager {
       'mailpoet_sending_newsletter_render_after_pre_process',
       [$this, 'convertLinksToShortcodes']
     );
+    $this->wp->addFilter(
+      'mailpoet_automation_email_personalize_html_after',
+      [$this, 'restorePersonalizedLinkHrefs'],
+      10,
+      2
+    );
+    $this->wp->addFilter(
+      'mailpoet_automation_email_personalize_text_after',
+      [$this, 'restorePersonalizedLinkUrls'],
+      10,
+      2
+    );
   }
 
   public function convertLinksToShortcodes(array $emailContent): array {
@@ -198,6 +221,30 @@ class PersonalizationTagManager {
     }
     $emailContent['html'] = $this->linksToShortcodesConvertor->convertLinkTagsToShortcodes($emailContent['html']);
     return $emailContent;
+  }
+
+  /**
+   * @param array<string, mixed> $context
+   */
+  public function restorePersonalizedLinkHrefs(string $html, array $context = []): string {
+    return $this->linksToShortcodesConvertor->restorePersonalizedLinkHrefs($html, $this->getPersonalizedUrlTokens($context));
+  }
+
+  /**
+   * @param array<string, mixed> $context
+   */
+  public function restorePersonalizedLinkUrls(string $content, array $context = []): string {
+    return $this->linksToShortcodesConvertor->restorePersonalizedLinkUrls($content, $this->getPersonalizedUrlTokens($context));
+  }
+
+  /**
+   * @param array<string, mixed> $context
+   * @return array<string, string>
+   */
+  private function getPersonalizedUrlTokens(array $context): array {
+    return [
+      '[woocommerce/order-review-url]' => $this->orderReviewUrl->getUrl($context),
+    ];
   }
 
   /**
@@ -236,7 +283,36 @@ class PersonalizationTagManager {
       }
     }
 
+    $this->registerOrderReviewUrlTag($registry, $availableSubjects);
+
     return $registry;
+  }
+
+  /**
+   * @param string[] $availableSubjects
+   */
+  private function registerOrderReviewUrlTag(Personalization_Tags_Registry $registry, array $availableSubjects): void {
+    if (!$this->shouldExtendTagCategory('Order', $availableSubjects)) {
+      return;
+    }
+
+    if (!$this->orderReviewUrl->isSupported()) {
+      return;
+    }
+
+    if ($registry->get_by_token('[woocommerce/order-review-url]')) {
+      return;
+    }
+
+    $registry->register(new Personalization_Tag(
+      __('Order Review URL', 'mailpoet'),
+      'woocommerce/order-review-url',
+      __('Order', 'mailpoet'),
+      [$this->orderReviewUrl, 'getUrl'],
+      [],
+      null,
+      [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+    ));
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
@@ -18,23 +18,141 @@ class LinksToShortcodesConvertor {
     '[mailpoet/newsletter-view-in-browser-url]' => '[link:newsletter_view_in_browser_url]',
   ];
 
+  private const PERSONALIZED_URL_TOKENS = [
+    '[woocommerce/order-review-url]' => true,
+  ];
+
   public function convertLinkTagsToShortcodes(string $content): string {
     $contentProcessor = new HTML_Tag_Processor($content);
     while ($contentProcessor->next_token()) {
-      if ($contentProcessor->get_token_type() === '#tag' && $contentProcessor->get_tag() === 'A' && $contentProcessor->get_attribute('data-link-href')) {
-        $href = $contentProcessor->get_attribute('data-link-href');
-        if (!isset(self::TOKEN_MAP[$href])) {
+      if ($contentProcessor->get_token_type() !== '#tag' || $contentProcessor->get_tag() !== 'A') {
+        continue;
+      }
+
+      $href = $contentProcessor->get_attribute('data-link-href');
+      if (is_string($href)) {
+        if (isset(self::TOKEN_MAP[$href])) {
+          $contentProcessor->set_attribute('href', 'http://' . self::TOKEN_MAP[$href]);
+          $contentProcessor->remove_attribute('data-link-href');
+          $contentProcessor->remove_attribute('contenteditable');
           continue;
         }
-        $contentProcessor->set_attribute('href', 'http://' . self::TOKEN_MAP[$href]);
-        $contentProcessor->remove_attribute('data-link-href');
-        $contentProcessor->remove_attribute('contenteditable');
+
+        $personalizedUrlToken = $this->normalizePersonalizedUrlToken($href);
+        if ($personalizedUrlToken !== null) {
+          $contentProcessor->set_attribute('data-link-href', $personalizedUrlToken);
+          $contentProcessor->remove_attribute('href');
+        }
+        continue;
+      }
+
+      $href = $contentProcessor->get_attribute('href');
+      if (!is_string($href)) {
+        continue;
+      }
+
+      $personalizedUrlToken = $this->normalizePersonalizedUrlToken($href);
+      if ($personalizedUrlToken !== null) {
+        $contentProcessor->set_attribute('data-link-href', $personalizedUrlToken);
+        $contentProcessor->remove_attribute('href');
       }
     }
     $contentProcessor->flush_updates();
     $updated = $contentProcessor->get_updated_html();
-    // Remove temporary prefix. It was needed so hat the HTML_Tag_Processor could add value to href.
+    // Remove temporary prefix. It was needed so that the HTML_Tag_Processor could add value to href.
     $updated = str_replace('http://[', '[', $updated);
     return $updated;
+  }
+
+  /**
+   * @param array<string, string> $personalizedUrlTokens
+   */
+  public function restorePersonalizedLinkHrefs(string $content, array $personalizedUrlTokens = []): string {
+    $contentProcessor = new HTML_Tag_Processor($content);
+    while ($contentProcessor->next_token()) {
+      if ($contentProcessor->get_token_type() !== '#tag' || $contentProcessor->get_tag() !== 'A') {
+        continue;
+      }
+
+      $href = $contentProcessor->get_attribute('data-link-href');
+      if (!is_string($href)) {
+        continue;
+      }
+
+      if ($href === '') {
+        $contentProcessor->remove_attribute('href');
+        $contentProcessor->remove_attribute('data-link-href');
+        $contentProcessor->remove_attribute('contenteditable');
+        continue;
+      }
+
+      $personalizedUrlToken = $this->normalizePersonalizedUrlToken($href);
+      if ($personalizedUrlToken !== null) {
+        $resolvedHref = $personalizedUrlTokens[$personalizedUrlToken] ?? '';
+        if ($resolvedHref === '') {
+          $contentProcessor->remove_attribute('href');
+          $contentProcessor->remove_attribute('data-link-href');
+          $contentProcessor->remove_attribute('contenteditable');
+          continue;
+        }
+        $contentProcessor->set_attribute('href', $resolvedHref);
+        $contentProcessor->remove_attribute('data-link-href');
+        $contentProcessor->remove_attribute('contenteditable');
+        continue;
+      }
+
+      $contentProcessor->set_attribute('href', $href);
+      $contentProcessor->remove_attribute('data-link-href');
+      $contentProcessor->remove_attribute('contenteditable');
+    }
+    $contentProcessor->flush_updates();
+    return $contentProcessor->get_updated_html();
+  }
+
+  /**
+   * @param array<string, string> $personalizedUrlTokens
+   */
+  public function restorePersonalizedLinkUrls(string $content, array $personalizedUrlTokens = []): string {
+    foreach ($personalizedUrlTokens as $token => $resolvedUrl) {
+      $variants = $this->getPersonalizedUrlTokenVariants($token);
+      usort($variants, function(string $a, string $b): int {
+        return strlen($b) <=> strlen($a);
+      });
+      $content = str_replace($variants, $resolvedUrl, $content);
+    }
+    return $content;
+  }
+
+  private function normalizePersonalizedUrlToken(string $url): ?string {
+    $decodedUrl = rawurldecode($url);
+    foreach (array_keys(self::PERSONALIZED_URL_TOKENS) as $token) {
+      if ($decodedUrl === $token || $decodedUrl === 'http://' . $token || $decodedUrl === 'https://' . $token) {
+        return $token;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @return string[]
+   */
+  private function getPersonalizedUrlTokenVariants(string $token): array {
+    $encodedBracketsToken = str_replace(['[', ']'], ['%5B', '%5D'], $token);
+    $closingBracketEncodedToken = str_replace(']', '%5D', $token);
+
+    $tokens = [
+      $token,
+      $encodedBracketsToken,
+      $closingBracketEncodedToken,
+    ];
+
+    $variants = [];
+    foreach ($tokens as $tokenVariant) {
+      $variants[] = $tokenVariant;
+      $variants[] = 'http://' . $tokenVariant;
+      $variants[] = 'https://' . $tokenVariant;
+    }
+
+    return array_values(array_unique($variants));
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
@@ -59,8 +59,10 @@ class LinksToShortcodesConvertor {
     }
     $contentProcessor->flush_updates();
     $updated = $contentProcessor->get_updated_html();
-    // Remove temporary prefix. It was needed so that the HTML_Tag_Processor could add value to href.
-    $updated = str_replace('http://[', '[', $updated);
+    // Remove the temporary prefix needed for HTML_Tag_Processor href updates.
+    foreach (self::TOKEN_MAP as $shortcode) {
+      $updated = str_replace('http://' . $shortcode, $shortcode, $updated);
+    }
     return $updated;
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/OrderReviewUrl.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/OrderReviewUrl.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags;
+
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+
+class OrderReviewUrl {
+  private WooCommerceHelper $wooCommerceHelper;
+
+  public function __construct(
+    WooCommerceHelper $wooCommerceHelper
+  ) {
+    $this->wooCommerceHelper = $wooCommerceHelper;
+  }
+
+  public function getUrl(array $context, array $args = []): string {
+    $order = $context['order'] ?? null;
+    if (!$order instanceof \WC_Order) {
+      return '';
+    }
+
+    if ($order->get_id() < 1 || $order->get_order_key() === '') {
+      return '';
+    }
+
+    if (!$this->isSupported()) {
+      return '';
+    }
+
+    if (!$this->wooCommerceHelper->wcOrderHasActionableReviewItems($order)) {
+      return '';
+    }
+
+    return $this->wooCommerceHelper->wcGetReviewOrderUrl($order);
+  }
+
+  public function isSupported(): bool {
+    return $this->wooCommerceHelper->wcSupportsOrderReviewUrl();
+  }
+}

--- a/mailpoet/lib/Newsletter/Preview/SendPreviewController.php
+++ b/mailpoet/lib/Newsletter/Preview/SendPreviewController.php
@@ -106,7 +106,9 @@ class SendPreviewController {
       $this->personalizer->set_context($context);
       $renderedNewsletter['subject'] = $this->personalizer->personalize_content($renderedNewsletter['subject']);
       $renderedNewsletter['body']['html'] = $this->personalizer->personalize_content($renderedNewsletter['body']['html']);
+      $renderedNewsletter['body']['html'] = $this->personalizationTagManager->restorePersonalizedLinkHrefs($renderedNewsletter['body']['html'], $context);
       $renderedNewsletter['body']['text'] = $this->personalizer->personalize_content($renderedNewsletter['body']['text']);
+      $renderedNewsletter['body']['text'] = $this->personalizationTagManager->restorePersonalizedLinkUrls($renderedNewsletter['body']['text'], $context);
     }
 
     $renderedNewsletter['id'] = $newsletter->getId();

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -80,6 +80,55 @@ class Helper {
     return wc_get_order($order);
   }
 
+  public function wcGetReviewOrderUrl(\WC_Order $order): string {
+    $callback = $this->getCallableFunction('wc_get_review_order_url');
+    if (!$callback) {
+      return '';
+    }
+
+    $url = $callback($order);
+    return is_string($url) ? $url : '';
+  }
+
+  public function wcSupportsOrderReviewUrl(): bool {
+    if ($this->getCallableFunction('wc_get_review_order_url') === null) {
+      return false;
+    }
+
+    if (!$this->isCustomerReviewRequestFeatureEnabled()) {
+      return false;
+    }
+
+    $pageId = $this->wcGetPageId('review_order');
+    if (!$pageId || $pageId < 1) {
+      return false;
+    }
+
+    $permalink = $this->wp->getPermalink($pageId);
+    return is_string($permalink) && $permalink !== '';
+  }
+
+  public function wcOrderHasActionableReviewItems(\WC_Order $order): bool {
+    $callback = ['\Automattic\WooCommerce\Internal\OrderReviews\ItemEligibility', 'has_actionable_items'];
+    if (!is_callable($callback)) {
+      return true;
+    }
+
+    return (bool)call_user_func($callback, $order);
+  }
+
+  private function getCallableFunction(string $functionName): ?callable {
+    return is_callable($functionName) ? $functionName : null;
+  }
+
+  private function isCustomerReviewRequestFeatureEnabled(): bool {
+    if (!class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
+      return false;
+    }
+
+    return \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled('customer_review_request');
+  }
+
   public function wcGetOrders(array $args) {
     return wc_get_orders($args);
   }

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -95,6 +95,10 @@ class Helper {
       return false;
     }
 
+    if ($this->getOrderReviewItemEligibilityCallback() === null) {
+      return false;
+    }
+
     if (!$this->isCustomerReviewRequestFeatureEnabled()) {
       return false;
     }
@@ -109,12 +113,17 @@ class Helper {
   }
 
   public function wcOrderHasActionableReviewItems(\WC_Order $order): bool {
-    $callback = ['\Automattic\WooCommerce\Internal\OrderReviews\ItemEligibility', 'has_actionable_items'];
-    if (!is_callable($callback)) {
-      return true;
+    $callback = $this->getOrderReviewItemEligibilityCallback();
+    if ($callback === null) {
+      return false;
     }
 
     return (bool)call_user_func($callback, $order);
+  }
+
+  private function getOrderReviewItemEligibilityCallback(): ?callable {
+    $callback = ['\Automattic\WooCommerce\Internal\OrderReviews\ItemEligibility', 'has_actionable_items'];
+    return is_callable($callback) ? $callback : null;
   }
 
   private function getCallableFunction(string $functionName): ?callable {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -26,6 +26,7 @@ use MailPoet\Automation\Integrations\WooCommerce\Subjects\AbandonedCartSubject;
 use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\AbandonedCart\AbandonedCartTrigger;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUrl;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
@@ -214,6 +215,47 @@ class SendEmailActionTest extends \MailPoetTest {
     $this->assertSame($email->getId(), $step->getArgs()['email_id']);
   }
 
+  public function testItRequiresOrderSubjectForOrderReviewUrlToken(): void {
+    $email = $this->createBlockEditorAutomationEmail('<!-- wp:button {"url":"http://%5Bwoocommerce/order-review-url%5D"} --><div class="wp-block-button"><a href="http://%5Bwoocommerce/order-review-url%5D">Leave a review</a></div><!-- /wp:button -->');
+    $step = new Step('step-id', Step::TYPE_ACTION, SendEmailAction::KEY, ['email_id' => $email->getId()], []);
+    $automation = new Automation('some-automation', [$step->getId() => $step], new \WP_User());
+    $automation->setStatus(Automation::STATUS_ACTIVE);
+
+    $orderReviewUrl = $this->createMock(OrderReviewUrl::class);
+    $orderReviewUrl->expects($this->never())->method('isSupported');
+    $action = $this->getServiceWithOverrides(SendEmailAction::class, [
+      'orderReviewUrl' => $orderReviewUrl,
+    ]);
+
+    $error = null;
+    try {
+      $action->validate(new StepValidationArgs($automation, $step, []));
+    } catch (ValidationException $error) {
+      $this->assertSame('Use this email in an automation with a WooCommerce order subject or remove the order review link.', $error->getErrors()['email_id']);
+    }
+    $this->assertNotNull($error);
+  }
+
+  public function testItRequiresWooCommerceSupportForOrderReviewUrlToken(): void {
+    $email = $this->createBlockEditorAutomationEmail('<!-- wp:button {"url":"[woocommerce/order-review-url]"} --><div class="wp-block-button"><a href="[woocommerce/order-review-url]">Leave a review</a></div><!-- /wp:button -->');
+    $step = new Step('step-id', Step::TYPE_ACTION, SendEmailAction::KEY, ['email_id' => $email->getId()], []);
+    $automation = $this->createOrderTriggeredAutomation($step);
+
+    $orderReviewUrl = $this->createMock(OrderReviewUrl::class);
+    $orderReviewUrl->expects($this->once())->method('isSupported')->willReturn(false);
+    $action = $this->getServiceWithOverrides(SendEmailAction::class, [
+      'orderReviewUrl' => $orderReviewUrl,
+    ]);
+
+    $error = null;
+    try {
+      $action->validate(new StepValidationArgs($automation, $step, []));
+    } catch (ValidationException $error) {
+      $this->assertSame('Update WooCommerce or remove the order review link from this email.', $error->getErrors()['email_id']);
+    }
+    $this->assertNotNull($error);
+  }
+
   public function testItDoesNotRunBlockEditorContentValidationForClassicEmails(): void {
     $email = (new Newsletter())->withAutomationType()->withBody(null)->create();
     $step = new Step('step-id', Step::TYPE_ACTION, SendEmailAction::KEY, ['email_id' => $email->getId()], []);
@@ -268,6 +310,68 @@ class SendEmailActionTest extends \MailPoetTest {
     $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 2);
     $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
     $this->action->run($args, $controller);
+  }
+
+  public function testItDoesNotScheduleEmailWhenOrderReviewUrlCannotBeGenerated(): void {
+    $subscriber = (new Subscriber())
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $order = $this->tester->createWooCommerceOrder();
+    $email = $this->createBlockEditorAutomationEmail('<!-- wp:button {"url":"[woocommerce/order-review-url]"} --><div class="wp-block-button"><a href="[woocommerce/order-review-url]">Leave a review</a></div><!-- /wp:button -->');
+    $step = new Step('step-id', Step::TYPE_ACTION, SendEmailAction::KEY, ['email_id' => $email->getId()], []);
+    $automation = $this->createOrderTriggeredAutomation($step);
+    $run = new AutomationRun(1, 1, 'trigger-key', [
+      new Subject('mailpoet:subscriber', ['subscriber_id' => $subscriber->getId()]),
+      new Subject(OrderSubject::KEY, ['order_id' => $order->get_id()]),
+    ], 1);
+
+    $orderReviewUrl = $this->createMock(OrderReviewUrl::class);
+    $orderReviewUrl->expects($this->once())->method('getUrl')->willReturn('');
+    $action = $this->getServiceWithOverrides(SendEmailAction::class, [
+      'orderReviewUrl' => $orderReviewUrl,
+    ]);
+
+    $args = new StepRunArgs($automation, $run, $step, $this->getSubscriberAndOrderSubjectEntries($subscriber, $order), 1);
+    $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 1);
+    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
+
+    $this->assertThrowsExceptionWithMessage(
+      'Cannot send the email because WooCommerce cannot generate an order review link for this order.',
+      function() use ($action, $args, $controller) {
+        $action->run($args, $controller);
+      }
+    );
+
+    $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
+    verify($scheduled)->arrayCount(0);
+  }
+
+  public function testItSchedulesEmailWhenOrderReviewUrlCanBeGenerated(): void {
+    $subscriber = (new Subscriber())
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $order = $this->tester->createWooCommerceOrder();
+    $email = $this->createBlockEditorAutomationEmail('<!-- wp:button {"url":"[woocommerce/order-review-url]"} --><div class="wp-block-button"><a href="[woocommerce/order-review-url]">Leave a review</a></div><!-- /wp:button -->');
+    $step = new Step('step-id', Step::TYPE_ACTION, SendEmailAction::KEY, ['email_id' => $email->getId()], []);
+    $automation = $this->createOrderTriggeredAutomation($step);
+    $run = new AutomationRun(1, 1, 'trigger-key', [
+      new Subject('mailpoet:subscriber', ['subscriber_id' => $subscriber->getId()]),
+      new Subject(OrderSubject::KEY, ['order_id' => $order->get_id()]),
+    ], 1);
+
+    $orderReviewUrl = $this->createMock(OrderReviewUrl::class);
+    $orderReviewUrl->expects($this->once())->method('getUrl')->willReturn('https://example.com/review-order/1/?key=abc');
+    $action = $this->getServiceWithOverrides(SendEmailAction::class, [
+      'orderReviewUrl' => $orderReviewUrl,
+    ]);
+
+    $args = new StepRunArgs($automation, $run, $step, $this->getSubscriberAndOrderSubjectEntries($subscriber, $order), 1);
+    $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 1);
+    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
+    $action->run($args, $controller);
+
+    $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
+    verify($scheduled)->arrayCount(1);
   }
 
   public function testItChecksThatEmailWasSent(): void {
@@ -932,6 +1036,18 @@ class SendEmailActionTest extends \MailPoetTest {
     ];
   }
 
+  private function createOrderTriggeredAutomation(Step $sendEmailStep): Automation {
+    $root = new Step('root', Step::TYPE_ROOT, 'root', [], [new NextStep('trigger')]);
+    $trigger = new Step('trigger', Step::TYPE_TRIGGER, 'woocommerce:order-completed', [], [new NextStep($sendEmailStep->getId())]);
+    $automation = new Automation('some-automation', [
+      $root->getId() => $root,
+      $trigger->getId() => $trigger,
+      $sendEmailStep->getId() => $sendEmailStep,
+    ], new \WP_User(), 1);
+    $automation->setStatus(Automation::STATUS_ACTIVE);
+    return $automation;
+  }
+
   private function getSubjectEntries(array $subjects): array {
     $segmentData = array_filter($subjects, function (Subject $subject) {
       return $subject->getKey() === 'mailpoet:segment';
@@ -942,6 +1058,13 @@ class SendEmailActionTest extends \MailPoetTest {
     return [
       new SubjectEntry($this->segmentSubject, reset($segmentData)),
       new SubjectEntry($this->subscriberSubject, reset($subscriberData)),
+    ];
+  }
+
+  private function getSubscriberAndOrderSubjectEntries(SubscriberEntity $subscriber, \WC_Order $order): array {
+    return [
+      new SubjectEntry($this->subscriberSubject, new Subject('mailpoet:subscriber', ['subscriber_id' => $subscriber->getId()])),
+      new SubjectEntry($this->diContainer->get(OrderSubject::class), new Subject(OrderSubject::KEY, ['order_id' => $order->get_id()])),
     ];
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -425,7 +425,7 @@ class NewsletterTest extends \MailPoetTest {
         $this->subscriber,
         $sendingQueue
       );
-      self::fail('Expected order review URL resolution to stop sending.');
+      $this->fail('Expected order review URL resolution to stop sending.');
     } catch (NewsletterProcessingException $exception) {
       $this->assertSame('Cannot send the email because WooCommerce cannot generate an order review link for this order.', $exception->getMessage());
     }

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -25,6 +25,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\Coupon;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\NewsletterProcessingException;
 use MailPoet\Router\Router;
 use MailPoet\RuntimeException;
 use MailPoet\Test\DataFactories\DynamicSegment;
@@ -390,6 +391,47 @@ class NewsletterTest extends \MailPoetTest {
       ->stringNotContainsString(Router::NAME . '&endpoint=track&action=click&data=');
     verify($result['body']['text'])
       ->stringNotContainsString(Router::NAME . '&endpoint=track&action=click&data=');
+  }
+
+  public function testItPausesSendingWhenOrderReviewUrlCannotBeResolved(): void {
+    $postId = WPFunctions::get()->wpInsertPost([
+      'post_type' => 'mailpoet_email',
+      'post_status' => 'private',
+      'post_title' => 'Order review email',
+      'post_content' => '<!-- wp:button {"url":"[woocommerce/order-review-url]"} --><div class="wp-block-button"><a href="[woocommerce/order-review-url]">Leave a review</a></div><!-- /wp:button -->',
+    ]);
+    $this->assertIsInt($postId);
+    $this->assertGreaterThan(0, $postId);
+
+    $newsletter = (new NewsletterFactory())
+      ->withAutomationType()
+      ->withStatus(NewsletterEntity::STATUS_ACTIVE)
+      ->withWpPostId($postId)
+      ->create();
+    $scheduledTask = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $sendingQueue = (new SendingQueueFactory())->create($scheduledTask, $newsletter);
+    $sendingQueue->setCountTotal(1);
+    $sendingQueue->setNewsletterRenderedSubject('Subject');
+    $sendingQueue->setNewsletterRenderedBody([
+      'html' => '<a data-link-href="[woocommerce/order-review-url]">Leave a review</a>',
+      'text' => '[Leave a review]([woocommerce/order-review-url])',
+    ]);
+    $this->sendingQueuesRepository->persist($sendingQueue);
+    $this->sendingQueuesRepository->flush();
+
+    try {
+      $this->newsletterTask->prepareNewsletterForSending(
+        $newsletter,
+        $this->subscriber,
+        $sendingQueue
+      );
+      self::fail('Expected order review URL resolution to stop sending.');
+    } catch (NewsletterProcessingException $exception) {
+      $this->assertSame('Cannot send the email because WooCommerce cannot generate an order review link for this order.', $exception->getMessage());
+    }
+
+    $this->entityManager->refresh($scheduledTask);
+    $this->assertSame(ScheduledTaskEntity::STATUS_PAUSED, $scheduledTask->getStatus());
   }
 
   public function testItLogsErrorWhenQueueWithCannotBeSaved() {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/AutomationEmailContextProviderTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/AutomationEmailContextProviderTest.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\EmailEditor\Integrations\MailPoet;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Automation\Integrations\MailPoet\Actions\AutomationSendEmailSubjectResolver;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
+use MailPoet\EmailEditor\Integrations\MailPoet\AutomationEmailContextProvider;
+use MailPoet\EmailEditor\Integrations\MailPoet\AutomationEmailPreviewOrderProvider;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+use MailPoet\WP\Functions as WPFunctions;
+
+/**
+ * @group woo
+ */
+class AutomationEmailContextProviderTest extends \MailPoetTest {
+  public function testItBuildsRealSendContextFromAutomationRunSubjects(): void {
+    $order = new \WC_Order();
+    $sendingQueue = new SendingQueueEntity();
+    $sendingQueue->setMeta([
+      'automation' => [
+        'run_id' => 123,
+      ],
+    ]);
+
+    $automationRun = new AutomationRun(1, 1, 'woocommerce:order-completed', [
+      new Subject(OrderSubject::KEY, ['order_id' => 456]),
+      new Subject('mailpoet:subscriber', ['subscriber_id' => 789]),
+    ], 123);
+    $automationRunStorage = $this->createMock(AutomationRunStorage::class);
+    $automationRunStorage->expects($this->once())
+      ->method('getAutomationRun')
+      ->with(123)
+      ->willReturn($automationRun);
+
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->expects($this->once())
+      ->method('wcGetOrder')
+      ->with(456)
+      ->willReturn($order);
+
+    $context = $this->createProvider([
+      'automationRunStorage' => $automationRunStorage,
+      'wooCommerceHelper' => $wooCommerceHelper,
+    ])->build($this->createMock(NewsletterEntity::class), $sendingQueue, false);
+
+    $this->assertSame(['mailpoet:subscriber', OrderSubject::KEY], $context['automation_subject_keys']);
+    $this->assertSame($order, $context['order']);
+  }
+
+  public function testItBuildsPreviewContextWithSampleOrderAndIgnoresInvalidFilterReturn(): void {
+    $order = new \WC_Order();
+    $newsletter = $this->createMock(NewsletterEntity::class);
+    $newsletter->expects($this->once())
+      ->method('getOptionValue')
+      ->with(NewsletterOptionFieldEntity::NAME_AUTOMATION_ID)
+      ->willReturn(12);
+
+    $automation = $this->createMock(Automation::class);
+    $automationStorage = $this->createMock(AutomationStorage::class);
+    $automationStorage->expects($this->once())
+      ->method('getAutomation')
+      ->with(12)
+      ->willReturn($automation);
+
+    $subjectResolver = $this->createMock(AutomationSendEmailSubjectResolver::class);
+    $subjectResolver->expects($this->once())
+      ->method('getGuaranteedSubjectKeysForEmail')
+      ->with($automation, $newsletter)
+      ->willReturn([OrderSubject::KEY]);
+
+    $previewOrderProvider = $this->createMock(AutomationEmailPreviewOrderProvider::class);
+    $previewOrderProvider->expects($this->once())
+      ->method('getOrder')
+      ->willReturn($order);
+
+    $wp = $this->createMock(WPFunctions::class);
+    $wp->expects($this->once())
+      ->method('applyFilters')
+      ->with('mailpoet_automation_email_preview_sample_data', [
+        'automation_subject_keys' => [OrderSubject::KEY],
+        'order' => $order,
+      ])
+      ->willReturn('invalid');
+
+    $context = $this->createProvider([
+      'automationStorage' => $automationStorage,
+      'subjectResolver' => $subjectResolver,
+      'previewOrderProvider' => $previewOrderProvider,
+      'wp' => $wp,
+    ])->build($newsletter, null, true);
+
+    $this->assertSame([OrderSubject::KEY], $context['automation_subject_keys']);
+    $this->assertSame($order, $context['order']);
+  }
+
+  /**
+   * @param array{
+   *   automationRunStorage?: AutomationRunStorage,
+   *   automationStorage?: AutomationStorage,
+   *   subjectResolver?: AutomationSendEmailSubjectResolver,
+   *   previewOrderProvider?: AutomationEmailPreviewOrderProvider,
+   *   wooCommerceHelper?: WooCommerceHelper,
+   *   wp?: WPFunctions
+   * } $overrides
+   */
+  private function createProvider(array $overrides): AutomationEmailContextProvider {
+    return new AutomationEmailContextProvider(
+      $overrides['automationRunStorage'] ?? $this->createMock(AutomationRunStorage::class),
+      $overrides['automationStorage'] ?? $this->createMock(AutomationStorage::class),
+      $overrides['subjectResolver'] ?? $this->createMock(AutomationSendEmailSubjectResolver::class),
+      $overrides['previewOrderProvider'] ?? $this->createMock(AutomationEmailPreviewOrderProvider::class),
+      $overrides['wooCommerceHelper'] ?? $this->createMock(WooCommerceHelper::class),
+      $overrides['wp'] ?? $this->createMock(WPFunctions::class)
+    );
+  }
+}

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/AutomationEmailPreviewOrderProviderTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/AutomationEmailPreviewOrderProviderTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\EmailEditor\Integrations\MailPoet;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\AutomationEmailPreviewOrderProvider;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+
+/**
+ * @group woo
+ */
+class AutomationEmailPreviewOrderProviderTest extends \MailPoetTest {
+  public function testItPrefersExistingReviewableCompletedOrder(): void {
+    $product = $this->tester->createWooCommerceProduct([
+      'name' => 'Reviewable product',
+      'price' => 20,
+      'status' => 'publish',
+    ]);
+    $product->set_reviews_allowed(true);
+    $product->save();
+
+    $order = $this->tester->createWooCommerceOrder();
+    $order->add_product($product, 1);
+    $order->calculate_totals();
+    $order->save();
+
+    $woocommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $woocommerceHelper->expects($this->once())
+      ->method('wcGetOrders')
+      ->with($this->callback(function(array $args): bool {
+        return ($args['status'] ?? null) === 'completed'
+          && ($args['limit'] ?? null) === 10
+          && ($args['order'] ?? null) === 'DESC';
+      }))
+      ->willReturn([$order]);
+    $woocommerceHelper->expects($this->once())
+      ->method('wcOrderHasActionableReviewItems')
+      ->with($order)
+      ->willReturn(true);
+
+    $provider = new AutomationEmailPreviewOrderProvider($woocommerceHelper);
+
+    $this->assertSame($order, $provider->getOrder());
+  }
+
+  public function testItReturnsNullWhenNoExistingReviewableOrderIsAvailable(): void {
+    $woocommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $woocommerceHelper->expects($this->once())
+      ->method('wcGetOrders')
+      ->willReturn([]);
+
+    $provider = new AutomationEmailPreviewOrderProvider($woocommerceHelper);
+
+    $this->assertNull($provider->getOrder());
+  }
+}

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/BlockEmailContentDetectorTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/BlockEmailContentDetectorTest.php
@@ -40,6 +40,7 @@ class BlockEmailContentDetectorTest extends \MailPoetTest {
       'product collection' => ['<!-- wp:woocommerce/product-collection --><div class="wp-block-woocommerce-product-collection"></div><!-- /wp:woocommerce/product-collection -->'],
       'product query post title' => ['<!-- wp:woocommerce/product-template --><!-- wp:post-title {"__woocommerceNamespace":"woocommerce/product-collection/product-title"} /--><!-- /wp:woocommerce/product-template -->'],
       'woocommerce token' => ['<!--[woocommerce/customer-first-name]-->'],
+      'woocommerce link token' => ['<a data-link-href="[woocommerce/order-review-url]">Leave a review</a>'],
       'mailpoet link token' => ['<a data-link-href="[mailpoet/subscription-unsubscribe-url]" contenteditable="false"></a>'],
     ];
   }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -17,6 +17,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
     $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
 
     $patterns = new PatternsController(
       $this->diContainer->get(CdnAssetUrl::class),
@@ -42,6 +43,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/first-purchase-thank-you', $patternNames);
     $this->assertContains('mailpoet/post-purchase-thank-you', $patternNames);
     $this->assertContains('mailpoet/product-purchase-follow-up', $patternNames);
+    $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
 
     // WooCommerce 10.8.0+ patterns (uses generated coupon block)
@@ -50,12 +52,13 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(15, $blockPatterns);
+    $this->assertCount(16, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
 
     $patterns = new PatternsController(
       $this->diContainer->get(CdnAssetUrl::class),
@@ -106,6 +109,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
     $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.7.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
 
     $patterns = new PatternsController(
       $this->diContainer->get(CdnAssetUrl::class),
@@ -125,6 +129,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/first-purchase-thank-you', $patternNames);
     $this->assertContains('mailpoet/post-purchase-thank-you', $patternNames);
     $this->assertContains('mailpoet/product-purchase-follow-up', $patternNames);
+    $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
 
     // Should NOT include generated coupon block patterns (require WooCommerce 10.8.0+)
@@ -133,7 +138,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count (all patterns except 3 coupon patterns)
-    $this->assertCount(12, $blockPatterns);
+    $this->assertCount(13, $blockPatterns);
   }
 
   /**
@@ -143,6 +148,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
     $wooCommerceHelper->method('getWooCommerceVersion')->willReturn($version);
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
 
     $patterns = new PatternsController(
       $this->diContainer->get(CdnAssetUrl::class),
@@ -176,6 +182,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
     $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
 
     $patterns = new PatternsController(
       $this->diContainer->get(CdnAssetUrl::class),
@@ -192,6 +199,49 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertStringContainsString('"expiryDay":10', $patternsByName['mailpoet/welcome-with-discount-email-content']['content']);
     $this->assertStringContainsString('"amount":15', $patternsByName['mailpoet/win-back-customer']['content']);
     $this->assertStringContainsString('"expiryDay":1', $patternsByName['mailpoet/abandoned-cart-with-discount-content']['content']);
+  }
+
+  public function testAskForReviewPatternContainsReviewButtonWithOrderReviewUrlTag(): void {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
+
+    $patterns = new PatternsController(
+      $this->diContainer->get(CdnAssetUrl::class),
+      $this->diContainer->get(WPFunctions::class),
+      $wooCommerceHelper
+    );
+
+    $content = $patterns->getPatternContent('ask-for-review-post-purchase');
+
+    $this->assertIsString($content);
+    $this->assertStringContainsString('wp:button', $content);
+    $this->assertStringContainsString('"url":"[woocommerce/order-review-url]"', $content);
+    $this->assertStringContainsString('href="[woocommerce/order-review-url]"', $content);
+    $this->assertStringNotContainsString('data-link-href="[woocommerce/order-review-url]"', $content);
+    $this->assertStringContainsString('[woocommerce/order-review-url]', $content);
+    $this->assertStringContainsString('How was your experience?', $content);
+  }
+
+  public function testItDoesNotRegisterAskForReviewPatternWhenOrderReviewUrlIsUnsupported(): void {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(false);
+
+    $patterns = new PatternsController(
+      $this->diContainer->get(CdnAssetUrl::class),
+      $this->diContainer->get(WPFunctions::class),
+      $wooCommerceHelper
+    );
+
+    $patterns->registerPatterns();
+    $blockPatterns = \WP_Block_Patterns_Registry::get_instance()->get_all_registered();
+    $patternNames = array_column($blockPatterns, 'name');
+
+    $this->assertNotContains('mailpoet/ask-for-review-post-purchase', $patternNames);
+    $this->assertNull($patterns->getPatternContent('ask-for-review-post-purchase'));
   }
 
   public function testItDoesNotRegisterWooCommercePatternsWhenWooCommerceIsInactive(): void {
@@ -218,6 +268,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/first-purchase-thank-you', $patternNames);
     $this->assertNotContains('mailpoet/post-purchase-thank-you', $patternNames);
     $this->assertNotContains('mailpoet/product-purchase-follow-up', $patternNames);
+    $this->assertNotContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertNotContains('mailpoet/win-back-customer', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
@@ -354,6 +405,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
     $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
 
     return new PatternsController(
       $this->diContainer->get(CdnAssetUrl::class),

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
@@ -125,6 +125,17 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
     $this->assertStringNotContainsString('%5Bwoocommerce/order-review-url%5D', $emailContent['html']);
   }
 
+  public function testItOnlyRemovesTemporaryHttpPrefixForKnownLinkTokens(): void {
+    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+
+    $emailContent = $personalizationManager->convertLinksToShortcodes([
+      'html' => '<a data-link-href="[mailpoet/subscription-unsubscribe-url]">Unsubscribe</a><p>http://[not-a-mailpoet-token]</p>',
+    ]);
+
+    $this->assertStringContainsString('href="[link:subscription_unsubscribe_url]"', $emailContent['html']);
+    $this->assertStringContainsString('http://[not-a-mailpoet-token]', $emailContent['html']);
+  }
+
   public function testItRestoresPersonalizedLinkHrefsAfterPersonalization(): void {
     $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
 

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
@@ -2,10 +2,15 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry;
 use Codeception\Util\Fixtures;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter as NewsletterTask;
 use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\LinksToShortcodesConvertor;
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUrl;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
@@ -69,5 +74,88 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
 
     // Tag placed out of href was not replaced
     $this->assertStringContainsString('<!--[mailpoet/subscription-unsubscribe-url]-->', $rendered['html']);
+  }
+
+  public function testItRegistersOrderReviewUrlTagForOrderAutomations(): void {
+    if (!$this->diContainer->get(OrderReviewUrl::class)->isSupported()) {
+      $this->markTestSkipped('WooCommerce order review URL helper is not available.');
+    }
+
+    $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
+    $registry->unregister('[woocommerce/order-review-url]');
+
+    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+    $personalizationManager->extendWooCommerceTagsForMailPoet($registry, [OrderSubject::KEY]);
+
+    $tag = $registry->get_by_token('[woocommerce/order-review-url]');
+    $this->assertNotNull($tag);
+    $this->assertSame('[woocommerce/order-review-url]', $tag->get_token());
+    $this->assertContains(EmailEditor::MAILPOET_EMAIL_POST_TYPE, $tag->get_post_types());
+  }
+
+  public function testItDoesNotRegisterOrderReviewUrlTagWithoutOrderSubject(): void {
+    $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
+    $registry->unregister('[woocommerce/order-review-url]');
+
+    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+    $personalizationManager->extendWooCommerceTagsForMailPoet($registry, ['mailpoet:subscriber']);
+
+    $this->assertNull($registry->get_by_token('[woocommerce/order-review-url]'));
+  }
+
+  public function testItMovesOrderReviewUrlHrefToDataAttributeBeforeLinkTracking(): void {
+    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+
+    $emailContent = $personalizationManager->convertLinksToShortcodes([
+      'html' => '<a href="[woocommerce/order-review-url]">Leave a review</a>',
+    ]);
+
+    $this->assertStringContainsString('data-link-href="[woocommerce/order-review-url]"', $emailContent['html']);
+    $this->assertStringNotContainsString(' href="[woocommerce/order-review-url]"', $emailContent['html']);
+  }
+
+  public function testItMovesEncodedOrderReviewUrlHrefToDataAttributeBeforeLinkTracking(): void {
+    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+
+    $emailContent = $personalizationManager->convertLinksToShortcodes([
+      'html' => '<a href="http://%5Bwoocommerce/order-review-url%5D">Leave a review</a>',
+    ]);
+
+    $this->assertStringContainsString('data-link-href="[woocommerce/order-review-url]"', $emailContent['html']);
+    $this->assertStringNotContainsString('%5Bwoocommerce/order-review-url%5D', $emailContent['html']);
+  }
+
+  public function testItRestoresPersonalizedLinkHrefsAfterPersonalization(): void {
+    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+
+    $html = $personalizationManager->restorePersonalizedLinkHrefs(
+      '<a data-link-href="https://example.com/review-order/abc">Leave a review</a>'
+    );
+
+    $this->assertStringContainsString('href="https://example.com/review-order/abc"', $html);
+    $this->assertStringNotContainsString('data-link-href=', $html);
+  }
+
+  public function testItResolvesOrderReviewUrlDataAttributeAfterPersonalization(): void {
+    $convertor = new LinksToShortcodesConvertor();
+
+    $html = $convertor->restorePersonalizedLinkHrefs(
+      '<a data-link-href="[woocommerce/order-review-url]">Leave a review</a>',
+      ['[woocommerce/order-review-url]' => 'https://example.com/review-order/abc']
+    );
+
+    $this->assertStringContainsString('href="https://example.com/review-order/abc"', $html);
+    $this->assertStringNotContainsString('data-link-href=', $html);
+  }
+
+  public function testItResolvesOrderReviewUrlInPlainTextAfterPersonalization(): void {
+    $convertor = new LinksToShortcodesConvertor();
+
+    $text = $convertor->restorePersonalizedLinkUrls(
+      '[Leave a review](http://[woocommerce/order-review-url%5D)',
+      ['[woocommerce/order-review-url]' => 'https://example.com/review-order/abc']
+    );
+
+    $this->assertSame('[Leave a review](https://example.com/review-order/abc)', $text);
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/OrderReviewUrlTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/OrderReviewUrlTest.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\EmailEditor\Integrations\MailPoet\PersonalizationTags;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUrl;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+
+/**
+ * @group woo
+ */
+class OrderReviewUrlTest extends \MailPoetTest {
+  public function testItReturnsEmptyStringWithoutOrderContext(): void {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->expects($this->never())->method('wcSupportsOrderReviewUrl');
+    $wooCommerceHelper->expects($this->never())->method('wcOrderHasActionableReviewItems');
+    $wooCommerceHelper->expects($this->never())->method('wcGetReviewOrderUrl');
+
+    $tag = new OrderReviewUrl($wooCommerceHelper);
+
+    $this->assertSame('', $tag->getUrl([]));
+  }
+
+  public function testItReturnsEmptyStringWhenWooCommerceDoesNotSupportOrderReviewUrls(): void {
+    $order = new \WC_Order();
+    $order->set_id(123);
+    $order->set_order_key('wc_order_abc');
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->expects($this->once())
+      ->method('wcSupportsOrderReviewUrl')
+      ->willReturn(false);
+    $wooCommerceHelper->expects($this->never())->method('wcOrderHasActionableReviewItems');
+    $wooCommerceHelper->expects($this->never())->method('wcGetReviewOrderUrl');
+
+    $tag = new OrderReviewUrl($wooCommerceHelper);
+
+    $this->assertSame('', $tag->getUrl(['order' => $order]));
+  }
+
+  public function testItReturnsEmptyStringForUnsavedOrderContext(): void {
+    $order = new \WC_Order();
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->expects($this->never())->method('wcSupportsOrderReviewUrl');
+    $wooCommerceHelper->expects($this->never())->method('wcOrderHasActionableReviewItems');
+    $wooCommerceHelper->expects($this->never())->method('wcGetReviewOrderUrl');
+
+    $tag = new OrderReviewUrl($wooCommerceHelper);
+
+    $this->assertSame('', $tag->getUrl(['order' => $order]));
+  }
+
+  public function testItReturnsEmptyStringWhenOrderHasNoActionableReviewItems(): void {
+    $order = new \WC_Order();
+    $order->set_id(123);
+    $order->set_order_key('wc_order_abc');
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->expects($this->once())
+      ->method('wcSupportsOrderReviewUrl')
+      ->willReturn(true);
+    $wooCommerceHelper->expects($this->once())
+      ->method('wcOrderHasActionableReviewItems')
+      ->with($order)
+      ->willReturn(false);
+    $wooCommerceHelper->expects($this->never())->method('wcGetReviewOrderUrl');
+
+    $tag = new OrderReviewUrl($wooCommerceHelper);
+
+    $this->assertSame('', $tag->getUrl(['order' => $order]));
+  }
+
+  public function testItReturnsWooCommerceReviewOrderUrl(): void {
+    $order = new \WC_Order();
+    $order->set_id(123);
+    $order->set_order_key('wc_order_abc');
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->expects($this->once())
+      ->method('wcSupportsOrderReviewUrl')
+      ->willReturn(true);
+    $wooCommerceHelper->expects($this->once())
+      ->method('wcOrderHasActionableReviewItems')
+      ->with($order)
+      ->willReturn(true);
+    $wooCommerceHelper->expects($this->once())
+      ->method('wcGetReviewOrderUrl')
+      ->with($order)
+      ->willReturn('https://example.com/review-order/123/?key=abc');
+
+    $tag = new OrderReviewUrl($wooCommerceHelper);
+
+    $this->assertSame('https://example.com/review-order/123/?key=abc', $tag->getUrl(['order' => $order]));
+  }
+}

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\REST\Automation\Automations;
 
 use MailPoet\REST\Automation\AutomationTest;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 
 require_once __DIR__ . '/../AutomationTest.php';
 
@@ -15,7 +16,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
 
   public function testGetAllTemplates() {
     $result = $this->get(self::ENDPOINT_PATH, []);
-    $this->assertCount(22, $result['data']);
+    $this->assertCount($this->getExpectedTemplateCount(), $result['data']);
     $this->assertEquals('subscriber-welcome-email', $result['data'][0]['slug']);
   }
 
@@ -23,7 +24,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
     wp_set_current_user($this->editorUserId);
     $data = $this->get(self::ENDPOINT_PATH, []);
 
-    $this->assertCount(22, $data['data']);
+    $this->assertCount($this->getExpectedTemplateCount(), $data['data']);
   }
 
   public function testGuestNotAllowed(): void {
@@ -65,7 +66,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
         'category' => 'review',
       ],
     ]);
-    $this->assertCount(3, $result['data']);
+    $this->assertCount($this->isOrderReviewUrlSupported() ? 3 : 2, $result['data']);
 
     $result = $this->get(self::ENDPOINT_PATH, [
       'json' => [
@@ -174,5 +175,13 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
       $this->assertEquals('svg', $template['icon_type'], "Abandoned cart template {$template['slug']} should use SVG icon");
       $this->assertStringEndsWith('/img/icons/cart.svg', $template['icon'], "Abandoned cart template {$template['slug']} should have cart icon URL");
     }
+  }
+
+  private function getExpectedTemplateCount(): int {
+    return $this->isOrderReviewUrlSupported() ? 22 : 21;
+  }
+
+  private function isOrderReviewUrlSupported(): bool {
+    return $this->diContainer->get(WooCommerceHelper::class)->wcSupportsOrderReviewUrl();
   }
 }

--- a/mailpoet/tests/unit/Automation/Integrations/MailPoet/Actions/AutomationSendEmailSubjectResolverTest.php
+++ b/mailpoet/tests/unit/Automation/Integrations/MailPoet/Actions/AutomationSendEmailSubjectResolverTest.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\MailPoet\Actions;
+
+use MailPoet\Automation\Engine\Control\SubjectTransformerHandler;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Integration\Trigger;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Integrations\MailPoet\Actions\AutomationSendEmailSubjectResolver;
+use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoetUnitTest;
+
+class AutomationSendEmailSubjectResolverTest extends MailPoetUnitTest {
+  public function testItReturnsGuaranteedOrderSubjectForOrderOnlyPath(): void {
+    $resolver = $this->createResolver([
+      'woocommerce:order-completed' => [OrderSubject::KEY, 'mailpoet:subscriber'],
+    ]);
+    $sendEmail = new Step('send', Step::TYPE_ACTION, SendEmailAction::KEY, [], []);
+    $automation = $this->createAutomation([
+      new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('trigger')]),
+      new Step('trigger', Step::TYPE_TRIGGER, 'woocommerce:order-completed', [], [new NextStep('send')]),
+      $sendEmail,
+    ]);
+
+    $this->assertSame(
+      ['mailpoet:subscriber', OrderSubject::KEY],
+      $resolver->getGuaranteedSubjectKeysForStep($automation, $sendEmail)
+    );
+  }
+
+  public function testItIntersectsSubjectsFromAllTriggersThatReachTheSendStep(): void {
+    $resolver = $this->createResolver([
+      'woocommerce:order-completed' => [OrderSubject::KEY, 'mailpoet:subscriber'],
+      'mailpoet:someone-subscribes' => ['mailpoet:subscriber'],
+    ]);
+    $sendEmail = new Step('send', Step::TYPE_ACTION, SendEmailAction::KEY, [], []);
+    $automation = $this->createAutomation([
+      new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('order-trigger'), new NextStep('subscriber-trigger')]),
+      new Step('order-trigger', Step::TYPE_TRIGGER, 'woocommerce:order-completed', [], [new NextStep('send')]),
+      new Step('subscriber-trigger', Step::TYPE_TRIGGER, 'mailpoet:someone-subscribes', [], [new NextStep('send')]),
+      $sendEmail,
+    ]);
+
+    $this->assertSame(
+      ['mailpoet:subscriber'],
+      $resolver->getGuaranteedSubjectKeysForStep($automation, $sendEmail)
+    );
+  }
+
+  public function testItReturnsNoGuaranteedSubjectsWhenReachableTriggerIsUnknown(): void {
+    $resolver = $this->createResolver([
+      'woocommerce:order-completed' => [OrderSubject::KEY, 'mailpoet:subscriber'],
+    ]);
+    $sendEmail = new Step('send', Step::TYPE_ACTION, SendEmailAction::KEY, [], []);
+    $automation = $this->createAutomation([
+      new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('known-trigger'), new NextStep('unknown-trigger')]),
+      new Step('known-trigger', Step::TYPE_TRIGGER, 'woocommerce:order-completed', [], [new NextStep('send')]),
+      new Step('unknown-trigger', Step::TYPE_TRIGGER, 'unknown:trigger', [], [new NextStep('send')]),
+      $sendEmail,
+    ]);
+
+    $this->assertSame(
+      [],
+      $resolver->getGuaranteedSubjectKeysForStep($automation, $sendEmail)
+    );
+  }
+
+  public function testSharedEmailRequiresEveryReferencingStepToHaveOrderSubject(): void {
+    $resolver = $this->createResolver([
+      'woocommerce:order-completed' => [OrderSubject::KEY, 'mailpoet:subscriber'],
+      'mailpoet:someone-subscribes' => ['mailpoet:subscriber'],
+    ]);
+    $newsletter = $this->make(NewsletterEntity::class, [
+      'getId' => 99,
+      'getWpPostId' => 123,
+      'getOptionValue' => null,
+    ]);
+    $automation = $this->createAutomation([
+      new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('order-trigger'), new NextStep('subscriber-trigger')]),
+      new Step('order-trigger', Step::TYPE_TRIGGER, 'woocommerce:order-completed', [], [new NextStep('order-send')]),
+      new Step('subscriber-trigger', Step::TYPE_TRIGGER, 'mailpoet:someone-subscribes', [], [new NextStep('subscriber-send')]),
+      new Step('order-send', Step::TYPE_ACTION, SendEmailAction::KEY, ['email_id' => 99], []),
+      new Step('subscriber-send', Step::TYPE_ACTION, SendEmailAction::KEY, ['email_id' => 99], []),
+    ]);
+
+    $this->assertSame(
+      ['mailpoet:subscriber'],
+      $resolver->getGuaranteedSubjectKeysForEmail($automation, $newsletter)
+    );
+  }
+
+  private function createResolver(array $subjectKeysByTrigger): AutomationSendEmailSubjectResolver {
+    $registry = $this->make(Registry::class, [
+      'getTrigger' => function (string $key) use ($subjectKeysByTrigger): ?Trigger {
+        if (!array_key_exists($key, $subjectKeysByTrigger)) {
+          return null;
+        }
+        return $this->makeEmpty(Trigger::class, [
+          'getKey' => $key,
+        ]);
+      },
+    ]);
+    $subjectTransformerHandler = $this->make(SubjectTransformerHandler::class, [
+      'getSubjectKeysForTrigger' => function (Trigger $trigger) use ($subjectKeysByTrigger): array {
+        return $subjectKeysByTrigger[$trigger->getKey()] ?? [];
+      },
+      'getSubjectKeysForAutomation' => [],
+    ]);
+
+    return new AutomationSendEmailSubjectResolver($registry, $subjectTransformerHandler);
+  }
+
+  /** @param Step[] $steps */
+  private function createAutomation(array $steps): Automation {
+    $stepMap = [];
+    foreach ($steps as $step) {
+      $stepMap[$step->getId()] = $step;
+    }
+    $triggerSteps = array_filter($stepMap, function (Step $step): bool {
+      return $step->getType() === Step::TYPE_TRIGGER;
+    });
+
+    return $this->make(Automation::class, [
+      'getSteps' => $stepMap,
+      'getTriggers' => $triggerSteps,
+      'getStep' => function (string $stepId) use ($stepMap): ?Step {
+        return $stepMap[$stepId] ?? null;
+      },
+    ]);
+  }
+}

--- a/mailpoet/tests/unit/Automation/Integrations/MailPoet/Actions/AutomationSendEmailSubjectResolverTest.php
+++ b/mailpoet/tests/unit/Automation/Integrations/MailPoet/Actions/AutomationSendEmailSubjectResolverTest.php
@@ -69,6 +69,23 @@ class AutomationSendEmailSubjectResolverTest extends MailPoetUnitTest {
     );
   }
 
+  public function testItReturnsNoGuaranteedSubjectsWhenNoTriggerReachesTheSendStep(): void {
+    $resolver = $this->createResolver([
+      'woocommerce:order-completed' => [OrderSubject::KEY, 'mailpoet:subscriber'],
+    ]);
+    $sendEmail = new Step('send', Step::TYPE_ACTION, SendEmailAction::KEY, [], []);
+    $automation = $this->createAutomation([
+      new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('trigger')]),
+      new Step('trigger', Step::TYPE_TRIGGER, 'woocommerce:order-completed', [], []),
+      $sendEmail,
+    ]);
+
+    $this->assertSame(
+      [],
+      $resolver->getGuaranteedSubjectKeysForStep($automation, $sendEmail)
+    );
+  }
+
   public function testSharedEmailRequiresEveryReferencingStepToHaveOrderSubject(): void {
     $resolver = $this->createResolver([
       'woocommerce:order-completed' => [OrderSubject::KEY, 'mailpoet:subscriber'],


### PR DESCRIPTION
## Description

Adds a WooCommerce order review URL personalization tag for automation emails:

- `[woocommerce/order-review-url]` resolves to WooCommerce’s order-level review request URL.
- The ask-for-review email pattern and automation template use a regular core button with that tag as the URL.
- The pattern and template are only exposed when WooCommerce can generate order review URLs.

## Code review notes

_N/A_

## QA notes

Enable WooCommerce customer review requests, create an ask-for-review automation, and edit the email action. Confirm the email contains a regular button whose URL is `[woocommerce/order-review-url]`.

Place a WooCommerce order with reviewable products, complete the order, process the automation queue, and verify the received email’s review button opens the WooCommerce review order page for that order.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1075

## Linked tickets

STOMAIL-7501

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->


<img width="1286" height="829" alt="Screenshot 2026-05-21 at 10 44 20" src="https://github.com/user-attachments/assets/60e1d9cd-c954-4a4c-b265-f5173b8631a6" />

---

<img width="654" height="583" alt="Screenshot 2026-05-21 at 11 09 25" src="https://github.com/user-attachments/assets/98cbdf2b-6e52-47e1-a054-dc8b067235c3" />



## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
2 issues found:
- Bug: 1 — fixed operator-precedence bug in AutomationEditorLoadingHooks (negation/instanceof).
- Suggestion: 1 — TypeScript conversion noted as incomplete in PR objectives; consider completing TS migration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-7501-purchased-product-review-links)

_The latest successful build from `add/STOMAIL-7501-purchased-product-review-links` will be used. If none is available, the link won't work._