### PR TITLE
Add manual starts for subscriber automations

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -381,7 +381,7 @@ class RoboFile extends \Robo\Tasks {
   }
 
   public function testJavascript($xmlOutputFile = null) {
-    $command = './node_modules/.bin/mocha --recursive --require tests/javascript/mocha-env.mjs  tests/javascript --extension spec.ts';
+    $command = './node_modules/.bin/mocha --recursive --require tests/javascript/mocha-env.mjs  tests/javascript --extension spec.ts --extension spec.tsx';
 
     if (!empty($xmlOutputFile)) {
       $command .= sprintf(

--- a/mailpoet/assets/css/src/components-automation-listing/_listing.scss
+++ b/mailpoet/assets/css/src/components-automation-listing/_listing.scss
@@ -11,3 +11,112 @@
 .mailpoet-automation-dataviews .dataviews-title-field a {
   display: inline-flex;
 }
+
+.mailpoet-automation-manual-start-modal.components-modal__frame {
+  max-width: 640px;
+  width: calc(100% - 32px);
+}
+
+.mailpoet-automation-manual-start-modal {
+  .components-modal__content {
+    overflow-wrap: anywhere;
+  }
+}
+
+.mailpoet-automation-manual-start-muted {
+  color: #646970;
+}
+
+.mailpoet-automation-manual-start-fields {
+  display: grid;
+  gap: 8px;
+  margin: 20px 0;
+
+  label {
+    font-weight: 600;
+  }
+}
+
+.mailpoet-automation-manual-start-alert {
+  margin: 16px 0;
+  padding-bottom: 8px;
+
+  &:focus {
+    box-shadow: 0 0 0 2px #2271b1;
+    outline: none;
+  }
+}
+
+.mailpoet-automation-manual-start-loading {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  min-height: 32px;
+}
+
+.mailpoet-automation-manual-start-counts {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  margin: 16px 0;
+
+  div {
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    padding: 12px;
+  }
+
+  dt {
+    color: #646970;
+    font-size: 12px;
+    margin-bottom: 4px;
+  }
+
+  dd {
+    font-size: 20px;
+    font-weight: 600;
+    margin: 0;
+  }
+}
+
+.mailpoet-automation-manual-start-skips {
+  h3 {
+    font-size: 13px;
+    margin: 16px 0 8px;
+  }
+
+  ul {
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    list-style: none;
+    margin: 0;
+    max-height: 180px;
+    overflow: auto;
+    padding: 0;
+  }
+
+  li {
+    align-items: center;
+    border-bottom: 1px solid #f0f0f1;
+    display: flex;
+    gap: 12px;
+    justify-content: space-between;
+    margin: 0;
+    padding: 8px 12px;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
+}
+
+.mailpoet-automation-manual-start-footer {
+  margin-top: 20px;
+}
+
+.mailpoet-automation-manual-start-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}

--- a/mailpoet/assets/css/src/components-automation-listing/_listing.scss
+++ b/mailpoet/assets/css/src/components-automation-listing/_listing.scss
@@ -28,13 +28,63 @@
 }
 
 .mailpoet-automation-manual-start-fields {
-  display: grid;
-  gap: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
   margin: 20px 0;
 
-  label {
+  .mailpoet-form-input {
+    width: 100%;
+  }
+
+  .filter-segment-tooltip {
+    fill: #2271b1;
+    margin-left: 8px;
+    vertical-align: middle;
+  }
+}
+
+.mailpoet-automation-manual-start-field-heading {
+  display: block;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 24px;
+  margin: 0;
+}
+
+.mailpoet-automation-manual-start-field-tip {
+  color: #3c434a;
+  font-size: 14px;
+  margin: 2px 0 0;
+}
+
+.mailpoet-automation-manual-start-filter-toggle {
+  align-items: center;
+  border-top: 1px solid #dcdcde;
+  display: flex;
+  padding-top: 16px;
+
+  .mailpoet-form-toggle-text {
+    align-items: center;
+    display: inline-flex;
     font-weight: 600;
   }
+}
+
+.mailpoet-automation-manual-start-recipient-count {
+  color: #3c434a;
+  font-size: 15px;
+  margin: 16px 0;
+
+  .estimated-recipient-count {
+    border-bottom: #949494 dashed 1px;
+    margin-left: 5px;
+  }
+}
+
+.mailpoet-automation-manual-start-recipient-count-detail {
+  color: #646970;
+  margin-left: 8px;
 }
 
 .mailpoet-automation-manual-start-alert {

--- a/mailpoet/assets/js/src/automation/listing/api-error-handler.tsx
+++ b/mailpoet/assets/js/src/automation/listing/api-error-handler.tsx
@@ -3,6 +3,7 @@ import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { ApiError } from '../api';
+import { isManualStartApiPath } from './manual-start/helpers';
 
 export const registerApiErrorHandler = (): void =>
   apiFetch.use(
@@ -23,6 +24,13 @@ export const registerApiErrorHandler = (): void =>
         const status = errorObject.data?.status;
 
         if (status && status >= 400 && status < 500) {
+          if (
+            isManualStartApiPath(options.path) ||
+            isManualStartApiPath((options as { url?: unknown }).url)
+          ) {
+            throw error;
+          }
+
           const message = errorObject.message;
           void dispatch(noticesStore).createErrorNotice(
             message ?? __('An unknown error occurred.', 'mailpoet'),

--- a/mailpoet/assets/js/src/automation/listing/api-error-handler.tsx
+++ b/mailpoet/assets/js/src/automation/listing/api-error-handler.tsx
@@ -3,7 +3,33 @@ import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { ApiError } from '../api';
-import { isManualStartApiPath } from './manual-start/helpers';
+
+function isManualStartApiPath(path: unknown): boolean {
+  if (typeof path !== 'string') {
+    return false;
+  }
+
+  const [pathname] = path.split('?', 1);
+  const segments = pathname.split('/').filter(Boolean);
+  const automationIndex = segments.indexOf('automations');
+  const automationId = segments[automationIndex + 1];
+
+  if (
+    automationIndex === -1 ||
+    segments[automationIndex + 2] !== 'manual-start'
+  ) {
+    return false;
+  }
+
+  const numericAutomationId = Number(automationId);
+  return (
+    Number.isInteger(numericAutomationId) &&
+    numericAutomationId > 0 &&
+    (segments.length === automationIndex + 3 ||
+      (segments.length === automationIndex + 4 &&
+        segments[automationIndex + 3] === 'preview'))
+  );
+}
 
 export const registerApiErrorHandler = (): void =>
   apiFetch.use(

--- a/mailpoet/assets/js/src/automation/listing/index.tsx
+++ b/mailpoet/assets/js/src/automation/listing/index.tsx
@@ -255,6 +255,7 @@ export function AutomationListing(): JSX.Element {
   const latestGroupRef = useRef(group);
   const latestViewRef = useRef(view);
   const manualStartTriggerElementRef = useRef<HTMLElement | null>(null);
+  const manualStartFocusFallbackHrefRef = useRef<string | null>(null);
 
   const automations = useSelect((select) =>
     select(storeName).getAllAutomations(),
@@ -512,8 +513,20 @@ export function AutomationListing(): JSX.Element {
   const restoreManualStartTriggerFocus = useCallback((): void => {
     const triggerElement = manualStartTriggerElementRef.current;
     manualStartTriggerElementRef.current = null;
+    const fallbackHref = manualStartFocusFallbackHrefRef.current;
+    manualStartFocusFallbackHrefRef.current = null;
     if (triggerElement && document.contains(triggerElement)) {
       triggerElement.focus();
+      return;
+    }
+
+    if (fallbackHref) {
+      const fallbackLink = Array.from(
+        document.querySelectorAll<HTMLAnchorElement>(
+          '.mailpoet-automation-dataviews .dataviews-title-field a',
+        ),
+      ).find((link) => link.getAttribute('href') === fallbackHref);
+      fallbackLink?.focus();
     }
   }, []);
 
@@ -526,6 +539,8 @@ export function AutomationListing(): JSX.Element {
     (automation: AutomationItem): void => {
       manualStartTriggerElementRef.current =
         document.activeElement as HTMLElement | null;
+      manualStartFocusFallbackHrefRef.current =
+        getAutomationEditorUrl(automation);
       setManualStartAutomation(automation);
     },
     [],

--- a/mailpoet/assets/js/src/automation/listing/index.tsx
+++ b/mailpoet/assets/js/src/automation/listing/index.tsx
@@ -21,6 +21,8 @@ import { MailPoet } from '../../mailpoet';
 import { PageHeader } from '../../common/page-header';
 import { automationFields } from './fields';
 import { getAutomationAnalyticsUrl, getAutomationEditorUrl } from './urls';
+import { isManualStartSupported } from './manual-start/helpers';
+import { ManualStartModal } from './manual-start/modal';
 
 type Group =
   | 'all'
@@ -248,8 +250,11 @@ export function AutomationListing(): JSX.Element {
   );
   const [selection, setSelection] = useState<string[]>([]);
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const [manualStartAutomation, setManualStartAutomation] =
+    useState<AutomationItem | null>(null);
   const latestGroupRef = useRef(group);
   const latestViewRef = useRef(view);
+  const manualStartTriggerElementRef = useRef<HTMLElement | null>(null);
 
   const automations = useSelect((select) =>
     select(storeName).getAllAutomations(),
@@ -504,6 +509,28 @@ export function AutomationListing(): JSX.Element {
     setPendingAction(null);
   }, [pendingAction, runAutomationAction]);
 
+  const restoreManualStartTriggerFocus = useCallback((): void => {
+    const triggerElement = manualStartTriggerElementRef.current;
+    manualStartTriggerElementRef.current = null;
+    if (triggerElement && document.contains(triggerElement)) {
+      triggerElement.focus();
+    }
+  }, []);
+
+  const closeManualStartModal = useCallback((): void => {
+    setManualStartAutomation(null);
+    window.setTimeout(restoreManualStartTriggerFocus);
+  }, [restoreManualStartTriggerFocus]);
+
+  const openManualStartModal = useCallback(
+    (automation: AutomationItem): void => {
+      manualStartTriggerElementRef.current =
+        document.activeElement as HTMLElement | null;
+      setManualStartAutomation(automation);
+    },
+    [],
+  );
+
   const actions = useMemo<Action<AutomationItem>[]>(
     () => [
       {
@@ -526,6 +553,17 @@ export function AutomationListing(): JSX.Element {
         callback: (targets) => {
           if (targets[0]) {
             window.location.href = getAutomationEditorUrl(targets[0]);
+          }
+        },
+      },
+      {
+        id: 'manual-start',
+        label: __('Start automation', 'mailpoet'),
+        supportsBulk: false,
+        isEligible: isManualStartSupported,
+        callback: (targets) => {
+          if (targets[0]) {
+            openManualStartModal(targets[0]);
           }
         },
       },
@@ -574,7 +612,7 @@ export function AutomationListing(): JSX.Element {
         },
       },
     ],
-    [runAutomationAction],
+    [openManualStartModal, runAutomationAction],
   );
 
   const emptyLabel =
@@ -637,6 +675,12 @@ export function AutomationListing(): JSX.Element {
       >
         {actionCopy.message}
       </ConfirmDialog>
+      {manualStartAutomation && (
+        <ManualStartModal
+          automation={manualStartAutomation}
+          onClose={closeManualStartModal}
+        />
+      )}
     </>
   );
 }

--- a/mailpoet/assets/js/src/automation/listing/index.tsx
+++ b/mailpoet/assets/js/src/automation/listing/index.tsx
@@ -573,7 +573,7 @@ export function AutomationListing(): JSX.Element {
       },
       {
         id: 'manual-start',
-        label: __('Start automation', 'mailpoet'),
+        label: __('Start automation for existing subscribers', 'mailpoet'),
         supportsBulk: false,
         isEligible: isManualStartSupported,
         callback: (targets) => {

--- a/mailpoet/assets/js/src/automation/listing/manual-start/api.ts
+++ b/mailpoet/assets/js/src/automation/listing/manual-start/api.ts
@@ -1,0 +1,81 @@
+import apiFetch from '@wordpress/api-fetch';
+import { normalizeManualStartError } from './helpers';
+import type {
+  ManualStartErrorResponse,
+  ManualStartPreview,
+  ManualStartPreviewRequest,
+  ManualStartRequest,
+  ManualStartResult,
+} from './types';
+
+type ManualStartPreviewEnvelope = {
+  data: ManualStartPreview;
+};
+
+type ManualStartResultEnvelope = {
+  data: ManualStartResult;
+};
+
+class ManualStartApiError extends Error implements ManualStartErrorResponse {
+  code: string;
+
+  data: ManualStartErrorResponse['data'];
+
+  constructor(error: ManualStartErrorResponse) {
+    super(error.message);
+    this.name = 'ManualStartApiError';
+    this.code = error.code;
+    this.data = error.data;
+  }
+}
+
+const manualStartPath = (automationId: number): string =>
+  `/automations/${automationId}/manual-start`;
+
+function toThrowableManualStartError(error: unknown): ManualStartApiError {
+  return new ManualStartApiError(normalizeManualStartError(error));
+}
+
+export async function previewManualStart(
+  automationId: number,
+  request: ManualStartPreviewRequest,
+  signal?: AbortSignal,
+): Promise<ManualStartPreview> {
+  try {
+    const response = await apiFetch<ManualStartPreviewEnvelope>({
+      path: `${manualStartPath(automationId)}/preview`,
+      method: 'POST',
+      data: request,
+      signal,
+    });
+
+    if (!response?.data) {
+      throw toThrowableManualStartError(null);
+    }
+
+    return response.data;
+  } catch (error) {
+    throw toThrowableManualStartError(error);
+  }
+}
+
+export async function startManualStart(
+  automationId: number,
+  request: ManualStartRequest,
+): Promise<ManualStartResult> {
+  try {
+    const response = await apiFetch<ManualStartResultEnvelope>({
+      path: manualStartPath(automationId),
+      method: 'POST',
+      data: request,
+    });
+
+    if (!response?.data) {
+      throw toThrowableManualStartError(null);
+    }
+
+    return response.data;
+  } catch (error) {
+    throw toThrowableManualStartError(error);
+  }
+}

--- a/mailpoet/assets/js/src/automation/listing/manual-start/api.ts
+++ b/mailpoet/assets/js/src/automation/listing/manual-start/api.ts
@@ -36,6 +36,16 @@ function toThrowableManualStartError(error: unknown): ManualStartApiError {
   return new ManualStartApiError(normalizeManualStartError(error));
 }
 
+function createAbortError(): Error {
+  const error = new Error('Aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
 export async function previewManualStart(
   automationId: number,
   request: ManualStartPreviewRequest,
@@ -49,12 +59,19 @@ export async function previewManualStart(
       signal,
     });
 
+    if (signal?.aborted) {
+      throw createAbortError();
+    }
+
     if (!response?.data) {
       throw toThrowableManualStartError(null);
     }
 
     return response.data;
   } catch (error) {
+    if (isAbortError(error) || signal?.aborted) {
+      throw isAbortError(error) ? error : createAbortError();
+    }
     throw toThrowableManualStartError(error);
   }
 }

--- a/mailpoet/assets/js/src/automation/listing/manual-start/helpers.ts
+++ b/mailpoet/assets/js/src/automation/listing/manual-start/helpers.ts
@@ -128,13 +128,6 @@ export function canConfirmManualStart(
   );
 }
 
-export function isManualStartApiPath(path: unknown): boolean {
-  return (
-    typeof path === 'string' &&
-    /(?:^|\/)automations\/\d+\/manual-start(?:\/preview)?(?:\?.*)?$/.test(path)
-  );
-}
-
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }

--- a/mailpoet/assets/js/src/automation/listing/manual-start/helpers.ts
+++ b/mailpoet/assets/js/src/automation/listing/manual-start/helpers.ts
@@ -132,18 +132,128 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function getNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function getStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
+}
+
+function getNumberRecord(value: unknown): Record<string, number> {
+  if (!isObject(value)) {
+    return {};
+  }
+
+  const record: Record<string, number> = {};
+  Object.entries(value).forEach(([key, count]) => {
+    const numericCount = getNumber(count);
+    if (numericCount !== null) {
+      record[key] = numericCount;
+    }
+  });
+  return record;
+}
+
+function getStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!isObject(value)) {
+    return undefined;
+  }
+
+  const record: Record<string, string> = {};
+  Object.entries(value).forEach(([key, item]) => {
+    if (typeof item === 'string') {
+      record[key] = item;
+    }
+  });
+
+  return Object.keys(record).length > 0 ? record : undefined;
+}
+
+function normalizePreview(value: unknown): ManualStartPreview | undefined {
+  if (!isObject(value)) {
+    return undefined;
+  }
+
+  const automationId = getNumber(value.automation_id);
+  const segmentId = getNumber(value.segment_id);
+  const selectedCount = getNumber(value.selected_count);
+  const eligibleCount = getNumber(value.eligible_count);
+  if (
+    typeof value.preview_signature !== 'string' ||
+    automationId === null ||
+    segmentId === null ||
+    selectedCount === null ||
+    eligibleCount === null ||
+    typeof value.duplicate_in_progress !== 'boolean'
+  ) {
+    return undefined;
+  }
+
+  const filterSegmentId =
+    value.filter_segment_id === null
+      ? null
+      : getNumber(value.filter_segment_id);
+  if (filterSegmentId === null && value.filter_segment_id !== null) {
+    return undefined;
+  }
+
+  return {
+    preview_signature: value.preview_signature,
+    automation_id: automationId,
+    segment_id: segmentId,
+    filter_segment_id: filterSegmentId,
+    selected_count: selectedCount,
+    eligible_count: eligibleCount,
+    skipped_by_reason: getNumberRecord(value.skipped_by_reason),
+    deferred_reason_keys: getStringArray(value.deferred_reason_keys),
+    duplicate_in_progress: value.duplicate_in_progress,
+  };
+}
+
+function normalizeErrorData(data: unknown): ManualStartErrorResponse['data'] {
+  if (!isObject(data)) {
+    return {};
+  }
+
+  const normalizedData: ManualStartErrorResponse['data'] = {};
+  const status = getNumber(data.status);
+  if (status !== null) {
+    normalizedData.status = status;
+  }
+
+  const preview = normalizePreview(data.preview);
+  if (preview) {
+    normalizedData.preview = preview;
+  }
+
+  if (Array.isArray(data.errors) || isObject(data.errors)) {
+    normalizedData.errors = data.errors;
+  }
+  if (data.details !== undefined) {
+    normalizedData.details = data.details;
+  }
+  const params = getStringRecord(data.params);
+  if (params) {
+    normalizedData.params = params;
+  }
+
+  return normalizedData;
+}
+
 export function normalizeManualStartError(
   error: unknown,
 ): ManualStartErrorResponse {
   if (isObject(error)) {
-    const data = isObject(error.data) ? error.data : {};
     return {
       code:
         typeof error.code === 'string'
           ? error.code
           : 'manual_start_unknown_error',
       message: typeof error.message === 'string' ? error.message : '',
-      data,
+      data: normalizeErrorData(error.data),
     };
   }
 

--- a/mailpoet/assets/js/src/automation/listing/manual-start/helpers.ts
+++ b/mailpoet/assets/js/src/automation/listing/manual-start/helpers.ts
@@ -1,0 +1,195 @@
+import { AutomationStatus } from '../automation';
+import type { AutomationItem } from '../store/types';
+import type {
+  MailPoetSegment,
+  ManualStartErrorResponse,
+  ManualStartErrorState,
+  ManualStartMetadata,
+  ManualStartPreview,
+  ManualStartSegmentOption,
+} from './types';
+
+export function normalizeSegmentId(
+  id: string | number | null | undefined,
+): string {
+  const value = String(id ?? '').trim();
+  if (!value) return '';
+
+  const numericValue = Number(value);
+  return Number.isInteger(numericValue) && numericValue > 0
+    ? String(numericValue)
+    : '';
+}
+
+export function getSegmentIdNumber(
+  id: string | number | null | undefined,
+): number | null {
+  const normalizedId = normalizeSegmentId(id);
+  return normalizedId ? Number(normalizedId) : null;
+}
+
+export function isManualStartSupported(automation: AutomationItem): boolean {
+  return (
+    !automation.isLegacy &&
+    automation.status === AutomationStatus.ACTIVE &&
+    automation.manual_start?.supported === true
+  );
+}
+
+function getAllowedSegmentIds(
+  metadata?: ManualStartMetadata,
+): Set<string> | null {
+  if (!metadata?.segment_ids || metadata.segment_ids.length === 0) {
+    return null;
+  }
+
+  const ids = metadata.segment_ids
+    .map((id) => normalizeSegmentId(id))
+    .filter(Boolean);
+  return ids.length > 0 ? new Set(ids) : null;
+}
+
+function isAvailableSegment(segment: MailPoetSegment): boolean {
+  return !segment.deleted_at && !!normalizeSegmentId(segment.id);
+}
+
+export function getManualStartDefaultListOptions(
+  segments: MailPoetSegment[],
+  metadata?: ManualStartMetadata,
+): ManualStartSegmentOption[] {
+  if (!metadata?.supported) {
+    return [];
+  }
+
+  const allowedIds = getAllowedSegmentIds(metadata);
+
+  return segments.reduce<ManualStartSegmentOption[]>((options, segment) => {
+    const id = normalizeSegmentId(segment.id);
+    if (
+      segment.type === 'default' &&
+      isAvailableSegment(segment) &&
+      (!allowedIds || allowedIds.has(id))
+    ) {
+      options.push({
+        id,
+        name: segment.name,
+        subscribers: segment.subscribers,
+      });
+    }
+    return options;
+  }, []);
+}
+
+export function getManualStartDynamicSegmentOptions(
+  segments: MailPoetSegment[],
+): ManualStartSegmentOption[] {
+  return segments.reduce<ManualStartSegmentOption[]>((options, segment) => {
+    const id = normalizeSegmentId(segment.id);
+    if (segment.type === 'dynamic' && isAvailableSegment(segment)) {
+      options.push({
+        id,
+        name: segment.name,
+        subscribers: segment.subscribers,
+      });
+    }
+    return options;
+  }, []);
+}
+
+export function previewMatchesSelections(
+  preview: ManualStartPreview | null | undefined,
+  segmentId: string | number | null | undefined,
+  filterSegmentId: string | number | null | undefined,
+): boolean {
+  if (!preview) {
+    return false;
+  }
+
+  const selectedSegmentId = getSegmentIdNumber(segmentId);
+  if (!selectedSegmentId) {
+    return false;
+  }
+
+  return (
+    preview.segment_id === selectedSegmentId &&
+    (preview.filter_segment_id ?? null) === getSegmentIdNumber(filterSegmentId)
+  );
+}
+
+export function canConfirmManualStart(
+  preview: ManualStartPreview | null | undefined,
+  segmentId: string | number | null | undefined,
+  filterSegmentId: string | number | null | undefined,
+): boolean {
+  return (
+    previewMatchesSelections(preview, segmentId, filterSegmentId) &&
+    preview.eligible_count > 0 &&
+    !preview.duplicate_in_progress
+  );
+}
+
+export function isManualStartApiPath(path: unknown): boolean {
+  return (
+    typeof path === 'string' &&
+    /(?:^|\/)automations\/\d+\/manual-start(?:\/preview)?(?:\?.*)?$/.test(path)
+  );
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function normalizeManualStartError(
+  error: unknown,
+): ManualStartErrorResponse {
+  if (isObject(error)) {
+    const data = isObject(error.data) ? error.data : {};
+    return {
+      code:
+        typeof error.code === 'string'
+          ? error.code
+          : 'manual_start_unknown_error',
+      message: typeof error.message === 'string' ? error.message : '',
+      data,
+    };
+  }
+
+  return {
+    code: 'manual_start_unknown_error',
+    message: '',
+    data: {},
+  };
+}
+
+export function getManualStartErrorState(
+  error: ManualStartErrorResponse | null | undefined,
+): ManualStartErrorState | null {
+  if (!error) {
+    return null;
+  }
+
+  if (error.code === 'manual_start_zero_eligible') {
+    return 'zero-eligible';
+  }
+  if (error.code === 'manual_start_in_progress') {
+    return 'duplicate-in-progress';
+  }
+  if (error.code === 'manual_start_stale_preview') {
+    return 'stale-preview';
+  }
+  if (
+    typeof error.data.status === 'number' &&
+    error.data.status >= 400 &&
+    error.data.status < 500
+  ) {
+    return 'validation';
+  }
+
+  return 'unknown';
+}
+
+export function isBlockingManualStartError(
+  error: ManualStartErrorResponse | null | undefined,
+): boolean {
+  return getManualStartErrorState(error) !== null;
+}

--- a/mailpoet/assets/js/src/automation/listing/manual-start/modal.tsx
+++ b/mailpoet/assets/js/src/automation/listing/manual-start/modal.tsx
@@ -1,0 +1,691 @@
+import { Button, Modal, Spinner } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+  type ReactNode,
+} from 'react';
+import { Select } from 'common/form/select/select';
+import type { AutomationItem } from '../store/types';
+import { previewManualStart, startManualStart } from './api';
+import {
+  canConfirmManualStart,
+  getManualStartDefaultListOptions,
+  getManualStartDynamicSegmentOptions,
+  getManualStartErrorState,
+  getSegmentIdNumber,
+  isBlockingManualStartError,
+  normalizeManualStartError,
+  previewMatchesSelections,
+} from './helpers';
+import type {
+  ManualStartErrorResponse,
+  ManualStartPreview,
+  ManualStartResult,
+  ManualStartSegmentOption,
+} from './types';
+
+type QueuedContext = {
+  listName: string;
+  filterName: string | null;
+};
+
+type ManualStartModalProps = {
+  automation: AutomationItem;
+  onClose: () => void;
+};
+
+const skippedReasonLabels: Record<string, string> = {
+  already_entered: __('Already entered this automation', 'mailpoet'),
+  not_subscribed: __('Not subscribed', 'mailpoet'),
+  unconfirmed: __('Unconfirmed', 'mailpoet'),
+  unsubscribed: __('Unsubscribed', 'mailpoet'),
+  bounced: __('Bounced', 'mailpoet'),
+  deleted: __('Deleted', 'mailpoet'),
+  not_in_list: __('No longer in the selected list', 'mailpoet'),
+  dynamic_filter_mismatch: __(
+    'Does not match the optional segment filter',
+    'mailpoet',
+  ),
+  trigger_filter_mismatch: __('Automation trigger filters', 'mailpoet'),
+  run_create_hook_rejected: __('Automation run hook rejected', 'mailpoet'),
+  automation_inactive: __('Automation is inactive', 'mailpoet'),
+  subscriber_missing: __('Subscriber no longer exists', 'mailpoet'),
+  step_scheduling_failed: __('Step scheduling failed', 'mailpoet'),
+};
+
+function formatCount(count: number): string {
+  return Number(count).toLocaleString();
+}
+
+function skippedReasonLabel(reason: string): string {
+  return skippedReasonLabels[reason] ?? reason.replaceAll('_', ' ');
+}
+
+function findOptionName(
+  options: ManualStartSegmentOption[],
+  id: string | number | null | undefined,
+): string | null {
+  const numericId = getSegmentIdNumber(id);
+  const option = options.find(
+    (candidate) => getSegmentIdNumber(candidate.id) === numericId,
+  );
+  return option?.name ?? null;
+}
+
+function Alert({
+  children,
+  alertRef,
+}: {
+  children: ReactNode;
+  alertRef: RefObject<HTMLDivElement>;
+}): JSX.Element {
+  return (
+    <div
+      className="notice notice-error mailpoet-automation-manual-start-alert"
+      role="alert"
+      tabIndex={-1}
+      ref={alertRef}
+    >
+      {children}
+    </div>
+  );
+}
+
+function StatusNotice({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <div
+      className="notice notice-success mailpoet-automation-manual-start-alert"
+      role="status"
+      aria-live="polite"
+      tabIndex={-1}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Counts({
+  preview,
+  result,
+}: {
+  preview?: ManualStartPreview;
+  result?: ManualStartResult;
+}): JSX.Element {
+  const selectedCount = preview?.selected_count ?? result?.selected_count ?? 0;
+  const eligibleCount = preview?.eligible_count ?? result?.eligible_count ?? 0;
+
+  return (
+    <dl className="mailpoet-automation-manual-start-counts">
+      <div>
+        <dt>{__('Selected', 'mailpoet')}</dt>
+        <dd>{formatCount(selectedCount)}</dd>
+      </div>
+      <div>
+        <dt>{__('Eligible', 'mailpoet')}</dt>
+        <dd>{formatCount(eligibleCount)}</dd>
+      </div>
+      {result && (
+        <div>
+          <dt>{__('Queued', 'mailpoet')}</dt>
+          <dd>{formatCount(result.queued_count)}</dd>
+        </div>
+      )}
+    </dl>
+  );
+}
+
+function SkippedReasons({
+  skippedByReason,
+  deferredReasonKeys = [],
+}: {
+  skippedByReason: Record<string, number>;
+  deferredReasonKeys?: string[];
+}): JSX.Element | null {
+  const skippedEntries = Object.entries(skippedByReason).filter(
+    ([, count]) => Number(count) > 0,
+  );
+
+  if (skippedEntries.length === 0 && deferredReasonKeys.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mailpoet-automation-manual-start-skips">
+      {skippedEntries.length > 0 && (
+        <>
+          <h3>{__('Skipped subscribers', 'mailpoet')}</h3>
+          <ul>
+            {skippedEntries.map(([reason, count]) => (
+              <li key={reason}>
+                <span>{skippedReasonLabel(reason)}</span>
+                <strong>{formatCount(count)}</strong>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {deferredReasonKeys.length > 0 && (
+        <p>
+          {sprintf(
+            // translators: %s is a comma-separated list of reasons.
+            __(
+              'More subscribers may be skipped while the queued task runs: %s.',
+              'mailpoet',
+            ),
+            deferredReasonKeys.map(skippedReasonLabel).join(', '),
+          )}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function getErrorMessage(error: ManualStartErrorResponse): string {
+  const state = getManualStartErrorState(error);
+  if (error.message) {
+    return error.message;
+  }
+  if (state === 'duplicate-in-progress') {
+    return __(
+      'Subscribers are already queued for this automation. Wait for the current manual start to finish before starting another one.',
+      'mailpoet',
+    );
+  }
+  if (state === 'stale-preview') {
+    return __(
+      'The audience changed since the last preview. Refresh the preview before queueing subscribers.',
+      'mailpoet',
+    );
+  }
+  if (state === 'zero-eligible') {
+    return __(
+      'No subscribers are eligible to start this automation.',
+      'mailpoet',
+    );
+  }
+
+  return __('An unknown error occurred.', 'mailpoet');
+}
+
+export function ManualStartModal({
+  automation,
+  onClose,
+}: ManualStartModalProps): JSX.Element {
+  const listSelectRef = useRef<HTMLSelectElement>(null);
+  const alertRef = useRef<HTMLDivElement>(null);
+  const successRef = useRef<HTMLDivElement>(null);
+  const [segmentId, setSegmentId] = useState('');
+  const [filterSegmentId, setFilterSegmentId] = useState('');
+  const [preview, setPreview] = useState<ManualStartPreview | null>(null);
+  const [previewError, setPreviewError] =
+    useState<ManualStartErrorResponse | null>(null);
+  const [startError, setStartError] = useState<ManualStartErrorResponse | null>(
+    null,
+  );
+  const [startResult, setStartResult] = useState<ManualStartResult | null>(
+    null,
+  );
+  const [queuedContext, setQueuedContext] = useState<QueuedContext | null>(
+    null,
+  );
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+  const [isStarting, setIsStarting] = useState(false);
+  const [refreshCount, setRefreshCount] = useState(0);
+
+  const segments = useMemo(() => window.mailpoet_segments ?? [], []);
+  const defaultLists = useMemo(
+    () => getManualStartDefaultListOptions(segments, automation.manual_start),
+    [automation.manual_start, segments],
+  );
+  const dynamicSegments = useMemo(
+    () => getManualStartDynamicSegmentOptions(segments),
+    [segments],
+  );
+  const selectedListName = useMemo(
+    () => findOptionName(defaultLists, segmentId),
+    [defaultLists, segmentId],
+  );
+  const selectedFilterName = useMemo(
+    () => findOptionName(dynamicSegments, filterSegmentId),
+    [dynamicSegments, filterSegmentId],
+  );
+  const currentPreviewMatches = previewMatchesSelections(
+    preview,
+    segmentId,
+    filterSegmentId,
+  );
+  const startErrorState = getManualStartErrorState(startError);
+  const previewErrorState = getManualStartErrorState(previewError);
+  const confirmDisabled =
+    isStarting ||
+    isPreviewLoading ||
+    startResult !== null ||
+    isBlockingManualStartError(startError) ||
+    !canConfirmManualStart(preview, segmentId, filterSegmentId);
+
+  const focusHeading = useCallback((): void => {
+    const heading = document.querySelector<HTMLElement>(
+      '.mailpoet-automation-manual-start-modal .components-modal__header-heading',
+    );
+    if (heading) {
+      heading.tabIndex = -1;
+      heading.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    window.setTimeout(() => {
+      if (defaultLists.length > 0) {
+        listSelectRef.current?.focus();
+        return;
+      }
+      focusHeading();
+    });
+  }, [defaultLists.length, focusHeading]);
+
+  useEffect(() => {
+    if (!segmentId || startResult) {
+      setPreview(null);
+      setPreviewError(null);
+      setIsPreviewLoading(false);
+      return undefined;
+    }
+
+    const numericSegmentId = getSegmentIdNumber(segmentId);
+    if (!numericSegmentId) {
+      return undefined;
+    }
+
+    const numericFilterSegmentId = getSegmentIdNumber(filterSegmentId);
+    const controller = new AbortController();
+    setIsPreviewLoading(true);
+    setPreview(null);
+    setPreviewError(null);
+    setStartError(null);
+
+    void previewManualStart(
+      automation.id,
+      {
+        segment_id: numericSegmentId,
+        filter_segment_id: numericFilterSegmentId,
+      },
+      controller.signal,
+    )
+      .then((nextPreview) => {
+        if (!controller.signal.aborted) {
+          setPreview(nextPreview);
+          setPreviewError(null);
+        }
+      })
+      .catch((error) => {
+        if (!controller.signal.aborted) {
+          setPreview(null);
+          setPreviewError(normalizeManualStartError(error));
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsPreviewLoading(false);
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [automation.id, filterSegmentId, refreshCount, segmentId, startResult]);
+
+  useEffect(() => {
+    if (
+      previewErrorState ||
+      startErrorState ||
+      (preview && currentPreviewMatches && preview.eligible_count === 0) ||
+      preview?.duplicate_in_progress
+    ) {
+      window.setTimeout(() => alertRef.current?.focus());
+    }
+  }, [currentPreviewMatches, preview, previewErrorState, startErrorState]);
+
+  useEffect(() => {
+    if (startResult) {
+      window.setTimeout(() => successRef.current?.focus());
+    }
+  }, [startResult]);
+
+  const refreshPreview = useCallback((): void => {
+    if (!segmentId || isPreviewLoading || isStarting) {
+      return;
+    }
+    setRefreshCount((count) => count + 1);
+  }, [isPreviewLoading, isStarting, segmentId]);
+
+  const handleStart = useCallback(async (): Promise<void> => {
+    if (confirmDisabled || !preview) {
+      return;
+    }
+
+    const numericSegmentId = getSegmentIdNumber(segmentId);
+    if (!numericSegmentId) {
+      return;
+    }
+
+    setIsStarting(true);
+    setStartError(null);
+    try {
+      const result = await startManualStart(automation.id, {
+        segment_id: numericSegmentId,
+        filter_segment_id: getSegmentIdNumber(filterSegmentId),
+        preview_signature: preview.preview_signature,
+      });
+      setQueuedContext({
+        listName:
+          selectedListName ??
+          sprintf(
+            // translators: %d is a list ID.
+            __('List #%d', 'mailpoet'),
+            result.segment_id,
+          ),
+        filterName: selectedFilterName,
+      });
+      setStartResult(result);
+    } catch (error) {
+      const normalizedError = normalizeManualStartError(error);
+      if (
+        normalizedError.code === 'manual_start_stale_preview' &&
+        normalizedError.data.preview
+      ) {
+        setPreview(normalizedError.data.preview);
+      }
+      setStartError(normalizedError);
+    } finally {
+      setIsStarting(false);
+    }
+  }, [
+    automation.id,
+    confirmDisabled,
+    filterSegmentId,
+    preview,
+    segmentId,
+    selectedFilterName,
+    selectedListName,
+  ]);
+
+  const handleClose = useCallback((): void => {
+    if (!isStarting) {
+      onClose();
+    }
+  }, [isStarting, onClose]);
+
+  const renderBlockingAlert = (): JSX.Element | null => {
+    if (previewError) {
+      return (
+        <Alert alertRef={alertRef}>
+          <p>{getErrorMessage(previewError)}</p>
+          <Button
+            variant="secondary"
+            onClick={refreshPreview}
+            disabled={isPreviewLoading || isStarting || !segmentId}
+          >
+            {__('Refresh preview', 'mailpoet')}
+          </Button>
+        </Alert>
+      );
+    }
+
+    if (startError) {
+      return (
+        <Alert alertRef={alertRef}>
+          <p>{getErrorMessage(startError)}</p>
+          {startErrorState === 'stale-preview' && startError.data.preview && (
+            <p>
+              {sprintf(
+                // translators: %s is the number of eligible subscribers.
+                _n(
+                  'The refreshed preview has %s eligible subscriber.',
+                  'The refreshed preview has %s eligible subscribers.',
+                  startError.data.preview.eligible_count,
+                  'mailpoet',
+                ),
+                formatCount(startError.data.preview.eligible_count),
+              )}
+            </p>
+          )}
+          <Button
+            variant="secondary"
+            onClick={refreshPreview}
+            disabled={isPreviewLoading || isStarting || !segmentId}
+          >
+            {__('Refresh preview', 'mailpoet')}
+          </Button>
+        </Alert>
+      );
+    }
+
+    if (preview?.duplicate_in_progress) {
+      return (
+        <Alert alertRef={alertRef}>
+          <p>
+            {__(
+              'Subscribers are already queued for this automation. Wait for the current manual start to finish before starting another one.',
+              'mailpoet',
+            )}
+          </p>
+          <Button
+            variant="secondary"
+            onClick={refreshPreview}
+            disabled={isPreviewLoading || isStarting || !segmentId}
+          >
+            {__('Refresh preview', 'mailpoet')}
+          </Button>
+        </Alert>
+      );
+    }
+
+    if (preview && currentPreviewMatches && preview.eligible_count === 0) {
+      return (
+        <Alert alertRef={alertRef}>
+          <p>
+            {__(
+              'No subscribers are eligible to start this automation for the selected audience.',
+              'mailpoet',
+            )}
+          </p>
+        </Alert>
+      );
+    }
+
+    return null;
+  };
+
+  const renderPreview = (): JSX.Element | null => {
+    if (!segmentId) {
+      return (
+        <p className="mailpoet-automation-manual-start-muted" role="status">
+          {__('Choose a list to preview eligible subscribers.', 'mailpoet')}
+        </p>
+      );
+    }
+
+    if (isPreviewLoading) {
+      return (
+        <div
+          className="mailpoet-automation-manual-start-loading"
+          role="status"
+          aria-live="polite"
+        >
+          <Spinner />
+          <span>{__('Loading preview...', 'mailpoet')}</span>
+        </div>
+      );
+    }
+
+    if (!preview || !currentPreviewMatches) {
+      return null;
+    }
+
+    return (
+      <div aria-live="polite">
+        <Counts preview={preview} />
+        <SkippedReasons
+          skippedByReason={preview.skipped_by_reason}
+          deferredReasonKeys={preview.deferred_reason_keys}
+        />
+      </div>
+    );
+  };
+
+  if (startResult && queuedContext) {
+    return (
+      <Modal
+        className="mailpoet-automation-manual-start-modal"
+        title={__('Start automation', 'mailpoet')}
+        onRequestClose={handleClose}
+      >
+        <div ref={successRef} tabIndex={-1}>
+          <StatusNotice>
+            <p>
+              {sprintf(
+                // translators: %1$s is the number of queued subscribers, %2$d is the task ID.
+                _n(
+                  'MailPoet queued %1$s subscriber for this automation. Task ID: %2$d.',
+                  'MailPoet queued %1$s subscribers for this automation. Task ID: %2$d.',
+                  startResult.queued_count,
+                  'mailpoet',
+                ),
+                formatCount(startResult.queued_count),
+                startResult.task_id,
+              )}
+            </p>
+          </StatusNotice>
+          <p>
+            {sprintf(
+              // translators: %s is a list name.
+              __('List: %s', 'mailpoet'),
+              queuedContext.listName,
+            )}
+          </p>
+          {queuedContext.filterName && (
+            <p>
+              {sprintf(
+                // translators: %s is a dynamic segment name.
+                __('Segment filter: %s', 'mailpoet'),
+                queuedContext.filterName,
+              )}
+            </p>
+          )}
+          <Counts result={startResult} />
+          <SkippedReasons skippedByReason={startResult.skipped_by_reason} />
+          <p className="mailpoet-automation-manual-start-muted">
+            {__(
+              'Subscribers are queued asynchronously. Delays and conditions in the automation may mean emails are not sent immediately.',
+              'mailpoet',
+            )}
+          </p>
+          <div className="mailpoet-automation-manual-start-footer">
+            <Button variant="primary" onClick={handleClose}>
+              {__('Close', 'mailpoet')}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal
+      className="mailpoet-automation-manual-start-modal"
+      title={__('Start automation', 'mailpoet')}
+      onRequestClose={handleClose}
+    >
+      <div aria-busy={isPreviewLoading || isStarting}>
+        <p>
+          {__(
+            'Choose an existing list to queue eligible subscribers into this automation. An optional segment filter can narrow the selected list.',
+            'mailpoet',
+          )}
+        </p>
+        <p className="mailpoet-automation-manual-start-muted">
+          {__(
+            'Subscribers are queued asynchronously. Delays and conditions in the automation may mean emails are not sent immediately.',
+            'mailpoet',
+          )}
+        </p>
+        {defaultLists.length === 0 && (
+          <Alert alertRef={alertRef}>
+            <p>
+              {__(
+                'No available default lists match this automation trigger.',
+                'mailpoet',
+              )}
+            </p>
+          </Alert>
+        )}
+        <div className="mailpoet-automation-manual-start-fields">
+          <label htmlFor="mailpoet-automation-manual-start-list">
+            {__('List', 'mailpoet')}
+          </label>
+          <Select
+            id="mailpoet-automation-manual-start-list"
+            ref={listSelectRef}
+            value={segmentId}
+            disabled={defaultLists.length === 0 || isStarting}
+            onChange={(event) => setSegmentId(event.currentTarget.value)}
+            isFullWidth
+            automationId="automation_manual_start_list"
+          >
+            <option value="">{__('Select a list', 'mailpoet')}</option>
+            {defaultLists.map((segment) => (
+              <option value={segment.id} key={segment.id}>
+                {segment.name}
+              </option>
+            ))}
+          </Select>
+          <label htmlFor="mailpoet-automation-manual-start-filter">
+            {__('Segment filter', 'mailpoet')}
+          </label>
+          <Select
+            id="mailpoet-automation-manual-start-filter"
+            value={filterSegmentId}
+            disabled={isStarting || !segmentId}
+            onChange={(event) => setFilterSegmentId(event.currentTarget.value)}
+            isFullWidth
+            automationId="automation_manual_start_filter"
+          >
+            <option value="">{__('No segment filter', 'mailpoet')}</option>
+            {dynamicSegments.map((segment) => (
+              <option value={segment.id} key={segment.id}>
+                {segment.name}
+              </option>
+            ))}
+          </Select>
+        </div>
+        {renderBlockingAlert()}
+        {renderPreview()}
+        <div className="mailpoet-automation-manual-start-footer">
+          <div className="mailpoet-automation-manual-start-actions">
+            <Button
+              variant="tertiary"
+              onClick={handleClose}
+              disabled={isStarting}
+            >
+              {__('Cancel', 'mailpoet')}
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => void handleStart()}
+              disabled={confirmDisabled}
+              isBusy={isStarting}
+              data-automation-id="automation_manual_start_confirm"
+            >
+              {__('Queue subscribers', 'mailpoet')}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/mailpoet/assets/js/src/automation/listing/manual-start/modal.tsx
+++ b/mailpoet/assets/js/src/automation/listing/manual-start/modal.tsx
@@ -1,5 +1,6 @@
 import { Button, Modal, Spinner } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { Icon, help } from '@wordpress/icons';
 import {
   useCallback,
   useEffect,
@@ -9,7 +10,9 @@ import {
   type RefObject,
   type ReactNode,
 } from 'react';
-import { Select } from 'common/form/select/select';
+import { ReactSelect } from 'common/form/react-select/react-select';
+import { Toggle } from 'common/form/toggle/toggle';
+import { Tooltip } from 'common/tooltip/tooltip';
 import type { AutomationItem } from '../store/types';
 import { previewManualStart, startManualStart } from './api';
 import {
@@ -32,6 +35,12 @@ import type {
 type QueuedContext = {
   listName: string;
   filterName: string | null;
+};
+
+type SegmentSelectOption = {
+  value: string;
+  label: string;
+  count?: string;
 };
 
 type ManualStartModalProps = {
@@ -77,6 +86,28 @@ function findOptionName(
   return option?.name ?? null;
 }
 
+function formatOptionCount(
+  count: string | number | undefined,
+): string | undefined {
+  if (count === undefined) {
+    return undefined;
+  }
+  const numericCount = Number(count);
+  return Number.isFinite(numericCount)
+    ? numericCount.toLocaleString()
+    : String(count);
+}
+
+function toSelectOption(
+  segment: ManualStartSegmentOption,
+): SegmentSelectOption {
+  return {
+    value: segment.id,
+    label: segment.name,
+    count: formatOptionCount(segment.subscribers),
+  };
+}
+
 function Alert({
   children,
   alertRef,
@@ -105,6 +136,37 @@ function StatusNotice({ children }: { children: ReactNode }): JSX.Element {
       tabIndex={-1}
     >
       {children}
+    </div>
+  );
+}
+
+function PreviewCounts({
+  preview,
+}: {
+  preview: ManualStartPreview;
+}): JSX.Element {
+  return (
+    <div className="mailpoet-automation-manual-start-recipient-count">
+      {__('Estimated recipients', 'mailpoet')}:
+      <Tooltip place="right" id="manual-start-estimated-count-tooltip">
+        {__('This count may change before subscribers are queued.', 'mailpoet')}
+      </Tooltip>
+      <span
+        data-tip
+        data-tooltip-id="manual-start-estimated-count-tooltip"
+        className="estimated-recipient-count"
+      >
+        {formatCount(preview.eligible_count)}
+      </span>
+      {preview.selected_count !== preview.eligible_count && (
+        <span className="mailpoet-automation-manual-start-recipient-count-detail">
+          {sprintf(
+            // translators: %s is the number of selected subscribers before eligibility checks.
+            __('%s selected before skips', 'mailpoet'),
+            formatCount(preview.selected_count),
+          )}
+        </span>
+      )}
     </div>
   );
 }
@@ -216,11 +278,11 @@ export function ManualStartModal({
   automation,
   onClose,
 }: ManualStartModalProps): JSX.Element {
-  const listSelectRef = useRef<HTMLSelectElement>(null);
   const alertRef = useRef<HTMLDivElement>(null);
   const successRef = useRef<HTMLDivElement>(null);
   const [segmentId, setSegmentId] = useState('');
   const [filterSegmentId, setFilterSegmentId] = useState('');
+  const [isFilterSegmentEnabled, setIsFilterSegmentEnabled] = useState(false);
   const [preview, setPreview] = useState<ManualStartPreview | null>(null);
   const [previewError, setPreviewError] =
     useState<ManualStartErrorResponse | null>(null);
@@ -242,22 +304,48 @@ export function ManualStartModal({
     () => getManualStartDefaultListOptions(segments, automation.manual_start),
     [automation.manual_start, segments],
   );
+  const defaultListOptions = useMemo(
+    () => defaultLists.map(toSelectOption),
+    [defaultLists],
+  );
   const dynamicSegments = useMemo(
     () => getManualStartDynamicSegmentOptions(segments),
     [segments],
+  );
+  const dynamicSegmentOptions = useMemo(
+    () => dynamicSegments.map(toSelectOption),
+    [dynamicSegments],
   );
   const selectedListName = useMemo(
     () => findOptionName(defaultLists, segmentId),
     [defaultLists, segmentId],
   );
+  const selectedListOption = useMemo(
+    () =>
+      defaultListOptions.find((option) => option.value === segmentId) ?? null,
+    [defaultListOptions, segmentId],
+  );
+  const activeFilterSegmentId = isFilterSegmentEnabled ? filterSegmentId : '';
+  const filterSelectionRequired =
+    isFilterSegmentEnabled && !activeFilterSegmentId;
   const selectedFilterName = useMemo(
-    () => findOptionName(dynamicSegments, filterSegmentId),
-    [dynamicSegments, filterSegmentId],
+    () =>
+      activeFilterSegmentId
+        ? findOptionName(dynamicSegments, activeFilterSegmentId)
+        : null,
+    [activeFilterSegmentId, dynamicSegments],
+  );
+  const selectedFilterOption = useMemo(
+    () =>
+      dynamicSegmentOptions.find(
+        (option) => option.value === activeFilterSegmentId,
+      ) ?? null,
+    [activeFilterSegmentId, dynamicSegmentOptions],
   );
   const currentPreviewMatches = previewMatchesSelections(
     preview,
     segmentId,
-    filterSegmentId,
+    activeFilterSegmentId,
   );
   const startErrorState = getManualStartErrorState(startError);
   const previewErrorState = getManualStartErrorState(previewError);
@@ -265,8 +353,9 @@ export function ManualStartModal({
     isStarting ||
     isPreviewLoading ||
     startResult !== null ||
+    filterSelectionRequired ||
     isBlockingManualStartError(startError) ||
-    !canConfirmManualStart(preview, segmentId, filterSegmentId);
+    !canConfirmManualStart(preview, segmentId, activeFilterSegmentId);
 
   const focusHeading = useCallback((): void => {
     const heading = document.querySelector<HTMLElement>(
@@ -281,7 +370,9 @@ export function ManualStartModal({
   useEffect(() => {
     window.setTimeout(() => {
       if (defaultLists.length > 0) {
-        listSelectRef.current?.focus();
+        document
+          .getElementById('mailpoet-automation-manual-start-list')
+          ?.focus();
         return;
       }
       focusHeading();
@@ -289,9 +380,10 @@ export function ManualStartModal({
   }, [defaultLists.length, focusHeading]);
 
   useEffect(() => {
-    if (!segmentId || startResult) {
+    if (!segmentId || filterSelectionRequired || startResult) {
       setPreview(null);
       setPreviewError(null);
+      setStartError(null);
       setIsPreviewLoading(false);
       return undefined;
     }
@@ -301,7 +393,7 @@ export function ManualStartModal({
       return undefined;
     }
 
-    const numericFilterSegmentId = getSegmentIdNumber(filterSegmentId);
+    const numericFilterSegmentId = getSegmentIdNumber(activeFilterSegmentId);
     const controller = new AbortController();
     setIsPreviewLoading(true);
     setPreview(null);
@@ -337,7 +429,14 @@ export function ManualStartModal({
     return () => {
       controller.abort();
     };
-  }, [automation.id, filterSegmentId, refreshCount, segmentId, startResult]);
+  }, [
+    activeFilterSegmentId,
+    automation.id,
+    filterSelectionRequired,
+    refreshCount,
+    segmentId,
+    startResult,
+  ]);
 
   useEffect(() => {
     if (
@@ -357,11 +456,38 @@ export function ManualStartModal({
   }, [startResult]);
 
   const refreshPreview = useCallback((): void => {
-    if (!segmentId || isPreviewLoading || isStarting) {
+    if (
+      !segmentId ||
+      filterSelectionRequired ||
+      isPreviewLoading ||
+      isStarting
+    ) {
       return;
     }
     setRefreshCount((count) => count + 1);
-  }, [isPreviewLoading, isStarting, segmentId]);
+  }, [filterSelectionRequired, isPreviewLoading, isStarting, segmentId]);
+
+  const handleListChange = useCallback((selectedOption: unknown): void => {
+    const option = selectedOption as SegmentSelectOption | null;
+    const nextSegmentId = option?.value ?? '';
+    setSegmentId(nextSegmentId);
+    if (!nextSegmentId) {
+      setIsFilterSegmentEnabled(false);
+      setFilterSegmentId('');
+    }
+  }, []);
+
+  const handleFilterToggle = useCallback((checked: boolean): void => {
+    setIsFilterSegmentEnabled(checked);
+    if (!checked) {
+      setFilterSegmentId('');
+    }
+  }, []);
+
+  const handleFilterChange = useCallback((selectedOption: unknown): void => {
+    const option = selectedOption as SegmentSelectOption | null;
+    setFilterSegmentId(option?.value ?? '');
+  }, []);
 
   const handleStart = useCallback(async (): Promise<void> => {
     if (confirmDisabled || !preview) {
@@ -378,7 +504,7 @@ export function ManualStartModal({
     try {
       const result = await startManualStart(automation.id, {
         segment_id: numericSegmentId,
-        filter_segment_id: getSegmentIdNumber(filterSegmentId),
+        filter_segment_id: getSegmentIdNumber(activeFilterSegmentId),
         preview_signature: preview.preview_signature,
       });
       setQueuedContext({
@@ -408,8 +534,8 @@ export function ManualStartModal({
     }
   }, [
     automation.id,
+    activeFilterSegmentId,
     confirmDisabled,
-    filterSegmentId,
     preview,
     segmentId,
     selectedFilterName,
@@ -512,6 +638,17 @@ export function ManualStartModal({
       );
     }
 
+    if (filterSelectionRequired) {
+      return (
+        <p className="mailpoet-automation-manual-start-muted" role="status">
+          {__(
+            'Choose a segment filter to preview eligible subscribers.',
+            'mailpoet',
+          )}
+        </p>
+      );
+    }
+
     if (isPreviewLoading) {
       return (
         <div
@@ -531,7 +668,7 @@ export function ManualStartModal({
 
     return (
       <div aria-live="polite">
-        <Counts preview={preview} />
+        <PreviewCounts preview={preview} />
         <SkippedReasons
           skippedByReason={preview.skipped_by_reason}
           deferredReasonKeys={preview.deferred_reason_keys}
@@ -544,7 +681,7 @@ export function ManualStartModal({
     return (
       <Modal
         className="mailpoet-automation-manual-start-modal"
-        title={__('Start automation', 'mailpoet')}
+        title={__('Start automation for existing subscribers', 'mailpoet')}
         onRequestClose={handleClose}
       >
         <div ref={successRef} tabIndex={-1}>
@@ -600,13 +737,13 @@ export function ManualStartModal({
   return (
     <Modal
       className="mailpoet-automation-manual-start-modal"
-      title={__('Start automation', 'mailpoet')}
+      title={__('Start automation for existing subscribers', 'mailpoet')}
       onRequestClose={handleClose}
     >
       <div aria-busy={isPreviewLoading || isStarting}>
         <p>
           {__(
-            'Choose an existing list to queue eligible subscribers into this automation. An optional segment filter can narrow the selected list.',
+            'Choose which existing subscribers to queue into this automation.',
             'mailpoet',
           )}
         </p>
@@ -627,43 +764,80 @@ export function ManualStartModal({
           </Alert>
         )}
         <div className="mailpoet-automation-manual-start-fields">
-          <label htmlFor="mailpoet-automation-manual-start-list">
-            {__('List', 'mailpoet')}
-          </label>
-          <Select
-            id="mailpoet-automation-manual-start-list"
-            ref={listSelectRef}
-            value={segmentId}
+          <div>
+            <label
+              className="mailpoet-automation-manual-start-field-heading"
+              htmlFor="mailpoet-automation-manual-start-list"
+            >
+              {__('Send to', 'mailpoet')}
+            </label>
+            <p
+              id="mailpoet-automation-manual-start-list-description"
+              className="mailpoet-automation-manual-start-field-tip"
+            >
+              {__(
+                'Subscribers who already entered this automation will be skipped.',
+                'mailpoet',
+              )}
+            </p>
+          </div>
+          <ReactSelect
+            inputId="mailpoet-automation-manual-start-list"
+            value={selectedListOption}
+            options={defaultListOptions}
+            placeholder={__('Choose', 'mailpoet')}
             disabled={defaultLists.length === 0 || isStarting}
-            onChange={(event) => setSegmentId(event.currentTarget.value)}
-            isFullWidth
+            isDisabled={defaultLists.length === 0 || isStarting}
+            isClearable
+            onChange={handleListChange}
             automationId="automation_manual_start_list"
-          >
-            <option value="">{__('Select a list', 'mailpoet')}</option>
-            {defaultLists.map((segment) => (
-              <option value={segment.id} key={segment.id}>
-                {segment.name}
-              </option>
-            ))}
-          </Select>
-          <label htmlFor="mailpoet-automation-manual-start-filter">
-            {__('Segment filter', 'mailpoet')}
-          </label>
-          <Select
-            id="mailpoet-automation-manual-start-filter"
-            value={filterSegmentId}
-            disabled={isStarting || !segmentId}
-            onChange={(event) => setFilterSegmentId(event.currentTarget.value)}
             isFullWidth
-            automationId="automation_manual_start_filter"
-          >
-            <option value="">{__('No segment filter', 'mailpoet')}</option>
-            {dynamicSegments.map((segment) => (
-              <option value={segment.id} key={segment.id}>
-                {segment.name}
-              </option>
-            ))}
-          </Select>
+            aria-describedby="mailpoet-automation-manual-start-list-description"
+          />
+          <div className="mailpoet-automation-manual-start-filter-toggle">
+            <Toggle
+              checked={isFilterSegmentEnabled}
+              disabled={
+                isStarting || !segmentId || dynamicSegments.length === 0
+              }
+              name="manualStartFilterSegmentEnabled"
+              onCheck={handleFilterToggle}
+              automationId="automation_manual_start_filter_toggle"
+              aria-label={__('Filter by segment', 'mailpoet')}
+            />
+            <span className="mailpoet-form-toggle-text">
+              {__('Filter by segment', 'mailpoet')}
+              <Icon
+                data-tip
+                data-tooltip-id="manual-start-filter-segment-tooltip"
+                className="filter-segment-tooltip"
+                icon={help}
+              />
+            </span>
+            <Tooltip place="right" id="manual-start-filter-segment-tooltip">
+              <div>
+                {__(
+                  'Subscribers selected in Send to will only be queued if they also belong to this segment.',
+                  'mailpoet',
+                )}
+              </div>
+            </Tooltip>
+          </div>
+          {isFilterSegmentEnabled && (
+            <ReactSelect
+              inputId="mailpoet-automation-manual-start-filter"
+              value={selectedFilterOption}
+              options={dynamicSegmentOptions}
+              placeholder={__('Choose', 'mailpoet')}
+              disabled={isStarting || !segmentId}
+              isDisabled={isStarting || !segmentId}
+              isClearable
+              onChange={handleFilterChange}
+              automationId="automation_manual_start_filter"
+              isFullWidth
+              aria-label={__('Segment filter', 'mailpoet')}
+            />
+          )}
         </div>
         {renderBlockingAlert()}
         {renderPreview()}

--- a/mailpoet/assets/js/src/automation/listing/manual-start/modal.tsx
+++ b/mailpoet/assets/js/src/automation/listing/manual-start/modal.tsx
@@ -399,6 +399,8 @@ export function ManualStartModal({
         normalizedError.data.preview
       ) {
         setPreview(normalizedError.data.preview);
+      } else {
+        setPreview(null);
       }
       setStartError(normalizedError);
     } finally {

--- a/mailpoet/assets/js/src/automation/listing/manual-start/modal.tsx
+++ b/mailpoet/assets/js/src/automation/listing/manual-start/modal.tsx
@@ -66,6 +66,8 @@ const skippedReasonLabels: Record<string, string> = {
   subscriber_missing: __('Subscriber no longer exists', 'mailpoet'),
   step_scheduling_failed: __('Step scheduling failed', 'mailpoet'),
 };
+const PREVIEW_DEBOUNCE_MS = 200;
+const LARGE_AUDIENCE_SOFT_CAP = 50000;
 
 function formatCount(count: number): string {
   return Number(count).toLocaleString();
@@ -131,6 +133,19 @@ function StatusNotice({ children }: { children: ReactNode }): JSX.Element {
   return (
     <div
       className="notice notice-success mailpoet-automation-manual-start-alert"
+      role="status"
+      aria-live="polite"
+      tabIndex={-1}
+    >
+      {children}
+    </div>
+  );
+}
+
+function WarningNotice({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <div
+      className="notice notice-warning mailpoet-automation-manual-start-alert"
       role="status"
       aria-live="polite"
       tabIndex={-1}
@@ -395,38 +410,49 @@ export function ManualStartModal({
 
     const numericFilterSegmentId = getSegmentIdNumber(activeFilterSegmentId);
     const controller = new AbortController();
+    const timeout = window.setTimeout(() => {
+      void previewManualStart(
+        automation.id,
+        {
+          segment_id: numericSegmentId,
+          filter_segment_id: numericFilterSegmentId,
+        },
+        controller.signal,
+      )
+        .then((nextPreview) => {
+          if (!controller.signal.aborted) {
+            setPreview(nextPreview);
+            setPreviewError(null);
+            if (
+              previewMatchesSelections(
+                nextPreview,
+                segmentId,
+                activeFilterSegmentId,
+              )
+            ) {
+              setStartError(null);
+            }
+          }
+        })
+        .catch((error) => {
+          if (!controller.signal.aborted) {
+            setPreview(null);
+            setPreviewError(normalizeManualStartError(error));
+          }
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) {
+            setIsPreviewLoading(false);
+          }
+        });
+    }, PREVIEW_DEBOUNCE_MS);
+
     setIsPreviewLoading(true);
-    setPreview(null);
     setPreviewError(null);
     setStartError(null);
 
-    void previewManualStart(
-      automation.id,
-      {
-        segment_id: numericSegmentId,
-        filter_segment_id: numericFilterSegmentId,
-      },
-      controller.signal,
-    )
-      .then((nextPreview) => {
-        if (!controller.signal.aborted) {
-          setPreview(nextPreview);
-          setPreviewError(null);
-        }
-      })
-      .catch((error) => {
-        if (!controller.signal.aborted) {
-          setPreview(null);
-          setPreviewError(normalizeManualStartError(error));
-        }
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) {
-          setIsPreviewLoading(false);
-        }
-      });
-
     return () => {
+      window.clearTimeout(timeout);
       controller.abort();
     };
   }, [
@@ -464,6 +490,9 @@ export function ManualStartModal({
     ) {
       return;
     }
+    setStartError(null);
+    setPreviewError(null);
+    setIsPreviewLoading(true);
     setRefreshCount((count) => count + 1);
   }, [filterSelectionRequired, isPreviewLoading, isStarting, segmentId]);
 
@@ -649,6 +678,42 @@ export function ManualStartModal({
       );
     }
 
+    if (preview && currentPreviewMatches) {
+      return (
+        <div aria-live="polite">
+          {preview.eligible_count >= LARGE_AUDIENCE_SOFT_CAP && (
+            <WarningNotice>
+              <p>
+                {sprintf(
+                  // translators: %s is the recommended maximum number of eligible subscribers before narrowing the audience.
+                  __(
+                    'Large audiences may take longer to queue. We recommend narrowing audiences above %s eligible subscribers with a segment filter.',
+                    'mailpoet',
+                  ),
+                  formatCount(LARGE_AUDIENCE_SOFT_CAP),
+                )}
+              </p>
+            </WarningNotice>
+          )}
+          <PreviewCounts preview={preview} />
+          <SkippedReasons
+            skippedByReason={preview.skipped_by_reason}
+            deferredReasonKeys={preview.deferred_reason_keys}
+          />
+          {isPreviewLoading && (
+            <div
+              className="mailpoet-automation-manual-start-loading"
+              role="status"
+              aria-live="polite"
+            >
+              <Spinner />
+              <span>{__('Refreshing preview...', 'mailpoet')}</span>
+            </div>
+          )}
+        </div>
+      );
+    }
+
     if (isPreviewLoading) {
       return (
         <div
@@ -662,19 +727,7 @@ export function ManualStartModal({
       );
     }
 
-    if (!preview || !currentPreviewMatches) {
-      return null;
-    }
-
-    return (
-      <div aria-live="polite">
-        <PreviewCounts preview={preview} />
-        <SkippedReasons
-          skippedByReason={preview.skipped_by_reason}
-          deferredReasonKeys={preview.deferred_reason_keys}
-        />
-      </div>
-    );
+    return null;
   };
 
   if (startResult && queuedContext) {

--- a/mailpoet/assets/js/src/automation/listing/manual-start/types.ts
+++ b/mailpoet/assets/js/src/automation/listing/manual-start/types.ts
@@ -1,0 +1,73 @@
+export const manualStartTriggerKey = 'mailpoet:someone-subscribes' as const;
+
+export type ManualStartMetadata = {
+  supported: boolean;
+  trigger_key: typeof manualStartTriggerKey | null;
+  segment_ids: number[] | null;
+  disabled_reason?: string;
+};
+
+export type MailPoetSegment = {
+  id: string | number;
+  name: string;
+  subscribers?: string | number;
+  type: 'default' | 'wp_users' | 'woocommerce_users' | 'dynamic';
+  deleted_at?: string | null;
+};
+
+export type ManualStartSegmentOption = {
+  id: string;
+  name: string;
+  subscribers?: string | number;
+};
+
+export type ManualStartPreview = {
+  preview_signature: string;
+  automation_id: number;
+  segment_id: number;
+  filter_segment_id: number | null;
+  selected_count: number;
+  eligible_count: number;
+  skipped_by_reason: Record<string, number>;
+  deferred_reason_keys: string[];
+  duplicate_in_progress: boolean;
+};
+
+export type ManualStartResult = {
+  task_id: number;
+  automation_id: number;
+  segment_id: number;
+  filter_segment_id: number | null;
+  selected_count: number;
+  eligible_count: number;
+  queued_count: number;
+  skipped_by_reason: Record<string, number>;
+};
+
+export type ManualStartPreviewRequest = {
+  segment_id: number;
+  filter_segment_id?: number | null;
+};
+
+export type ManualStartRequest = ManualStartPreviewRequest & {
+  preview_signature: string;
+};
+
+export type ManualStartErrorResponse = {
+  code: string;
+  message: string;
+  data: {
+    status?: number;
+    preview?: ManualStartPreview;
+    errors?: Record<string, unknown> | unknown[];
+    details?: unknown;
+    params?: Record<string, string>;
+  };
+};
+
+export type ManualStartErrorState =
+  | 'zero-eligible'
+  | 'duplicate-in-progress'
+  | 'stale-preview'
+  | 'validation'
+  | 'unknown';

--- a/mailpoet/assets/js/src/automation/listing/store/types.ts
+++ b/mailpoet/assets/js/src/automation/listing/store/types.ts
@@ -1,14 +1,9 @@
 import { ReactNode } from 'react';
 import { Automation } from '../automation';
+import type { ManualStartMetadata } from '../manual-start/types';
 
 declare global {
   interface Window {
-    mailpoet_segments: {
-      id: string;
-      name: string;
-      subscribers: string;
-      type: 'default' | 'wp_users' | 'woocommerce_users' | 'dynamic';
-    }[];
     mailpoet_roles: Record<string, string>;
     mailpoet_woocommerce_automatic_emails?: Record<
       string,
@@ -26,6 +21,7 @@ declare global {
 export type AutomationItem = Automation & {
   description?: ReactNode;
   isLegacy?: boolean;
+  manual_start?: ManualStartMetadata;
 };
 
 export type State = {

--- a/mailpoet/changelog/2026-05-21-12-53-25-added-manual-starts-for-subscriber-automations-from-exis.md
+++ b/mailpoet/changelog/2026-05-21-12-53-25-added-manual-starts-for-subscriber-automations-from-exis.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Manual starts for subscriber automations from existing lists and dynamic segment filters

--- a/mailpoet/eslint.config.js
+++ b/mailpoet/eslint.config.js
@@ -27,7 +27,7 @@ module.exports = [
   })),
   ...esTsConfig.map((config) => ({
     ...config,
-    files: ['tests/javascript/**/*.ts'],
+    files: ['tests/javascript/**/*.{ts,tsx}'],
     languageOptions: {
       ...config.languageOptions,
       globals: {

--- a/mailpoet/lib/API/REST/API.php
+++ b/mailpoet/lib/API/REST/API.php
@@ -79,9 +79,12 @@ class API {
   }
 
   private function convertToErrorResponse(Throwable $e): ErrorResponse {
-    $response = $e instanceof Exception
-      ? new ErrorResponse($e->getStatusCode(), $e->getMessage(), $e->getErrorCode(), $e->getErrors())
-      : new ErrorResponse(500, __('An unknown error occurred.', 'mailpoet'), 'mailpoet_automation_unknown_error');
+    if ($e instanceof Exception) {
+      $data = method_exists($e, 'getData') ? $e->getData() : [];
+      $response = new ErrorResponse($e->getStatusCode(), $e->getMessage(), $e->getErrorCode(), $e->getErrors(), $data);
+    } else {
+      $response = new ErrorResponse(500, __('An unknown error occurred.', 'mailpoet'), 'mailpoet_automation_unknown_error');
+    }
 
     if ($response->get_status() >= 500 && function_exists('error_log')) {
       // phpcs:disable QITStandard.PHP.DebugCode.DebugFunctionFound

--- a/mailpoet/lib/API/REST/ApiException.php
+++ b/mailpoet/lib/API/REST/ApiException.php
@@ -15,20 +15,26 @@ class ApiException extends PhpException implements Exception {
   /** @var array<string, string> */
   private $errors;
 
+  /** @var array<string, mixed> */
+  private $data;
+
   /**
    * @param array<string, string> $errors
+   * @param array<string, mixed> $data
    */
   public function __construct(
     string $message,
     int $statusCode = 400,
     string $errorCode = 'mailpoet_rest_api_error',
     array $errors = [],
-    ?Throwable $previous = null
+    ?Throwable $previous = null,
+    array $data = []
   ) {
     parent::__construct($message, 0, $previous);
     $this->statusCode = $statusCode;
     $this->errorCode = $errorCode;
     $this->errors = $errors;
+    $this->data = $data;
   }
 
   public function getStatusCode(): int {
@@ -41,5 +47,9 @@ class ApiException extends PhpException implements Exception {
 
   public function getErrors(): array {
     return $this->errors;
+  }
+
+  public function getData(): array {
+    return $this->data;
   }
 }

--- a/mailpoet/lib/API/REST/ErrorResponse.php
+++ b/mailpoet/lib/API/REST/ErrorResponse.php
@@ -7,16 +7,17 @@ class ErrorResponse extends Response {
     int $status,
     string $message,
     string $code,
-    array $errors = []
+    array $errors = [],
+    array $data = []
   ) {
     parent::__construct(null, $status);
     $this->set_data([
       'code' => $code,
       'message' => $message,
-      'data' => [
+      'data' => array_merge([
         'status' => $status,
         'errors' => $errors,
-      ],
+      ], $data),
     ]);
   }
 }

--- a/mailpoet/lib/AdminPages/AssetsController.php
+++ b/mailpoet/lib/AdminPages/AssetsController.php
@@ -114,7 +114,7 @@ class AssetsController {
       $name,
       Env::$assetsUrl . '/dist/js/' . $this->renderer->getJsAsset("$asset.js"),
       array_merge($dependencies, ['mailpoet_admin']),
-      Env::$version,
+      Env::$assetsVersion,
       true
     );
     $this->wp->wpSetScriptTranslations($name, 'mailpoet');
@@ -184,6 +184,6 @@ class AssetsController {
   }
 
   private function registerFooterScript(string $handle, string $src, array $deps = []): void {
-    $this->wp->wpRegisterScript($handle, $src, $deps, Env::$version, true);
+    $this->wp->wpRegisterScript($handle, $src, $deps, Env::$assetsVersion, true);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Control/AutomationRunCreationResult.php
+++ b/mailpoet/lib/Automation/Engine/Control/AutomationRunCreationResult.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Control;
+
+class AutomationRunCreationResult {
+  public const STATUS_CREATED = 'created';
+  public const STATUS_TRIGGER_FILTER_MISMATCH = 'trigger_filter_mismatch';
+  public const STATUS_RUN_CREATE_HOOK_REJECTED = 'run_create_hook_rejected';
+  public const STATUS_STEP_SCHEDULING_FAILED = 'step_scheduling_failed';
+
+  /** @var string */
+  private $status;
+
+  /** @var int|null */
+  private $automationRunId;
+
+  /** @var StepSchedulingResult|null */
+  private $schedulingResult;
+
+  private function __construct(
+    string $status,
+    ?int $automationRunId = null,
+    ?StepSchedulingResult $schedulingResult = null
+  ) {
+    $this->status = $status;
+    $this->automationRunId = $automationRunId;
+    $this->schedulingResult = $schedulingResult;
+  }
+
+  public static function created(int $automationRunId, StepSchedulingResult $schedulingResult): self {
+    return new self(self::STATUS_CREATED, $automationRunId, $schedulingResult);
+  }
+
+  public static function skipped(string $status): self {
+    return new self($status);
+  }
+
+  public static function schedulingFailed(int $automationRunId, StepSchedulingResult $schedulingResult): self {
+    return new self(self::STATUS_STEP_SCHEDULING_FAILED, $automationRunId, $schedulingResult);
+  }
+
+  public function getStatus(): string {
+    return $this->status;
+  }
+
+  public function getAutomationRunId(): ?int {
+    return $this->automationRunId;
+  }
+
+  public function getSchedulingResult(): ?StepSchedulingResult {
+    return $this->schedulingResult;
+  }
+
+  public function isCreated(): bool {
+    return $this->status === self::STATUS_CREATED;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Control/AutomationRunCreator.php
+++ b/mailpoet/lib/Automation/Engine/Control/AutomationRunCreator.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\AutomationRunLog;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Data\SubjectEntry;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Integration\Trigger;
@@ -57,16 +58,33 @@ class AutomationRunCreator {
 
   /**
    * @param Subject[] $subjects
+   * @return array{subjects: Subject[], subject_entries: SubjectEntry[]}
+   */
+  public function prepareSubjects(array $subjects): array {
+    $subjects = $this->subjectTransformerHandler->getAllSubjects($subjects);
+    return [
+      'subjects' => $subjects,
+      'subject_entries' => $this->subjectLoader->getSubjectsEntries($subjects),
+    ];
+  }
+
+  /**
+   * @param Subject[] $subjects
+   * @param SubjectEntry[]|null $subjectEntries
    * @param array<string, scalar|array<array-key, scalar>> $triggerLogData
    */
   public function createForAutomation(
     Automation $automation,
     Trigger $trigger,
     array $subjects,
-    array $triggerLogData = []
+    array $triggerLogData = [],
+    ?array $subjectEntries = null
   ): AutomationRunCreationResult {
-    $subjects = $this->subjectTransformerHandler->getAllSubjects($subjects);
-    $subjectEntries = $this->subjectLoader->getSubjectsEntries($subjects);
+    if ($subjectEntries === null) {
+      $preparedSubjects = $this->prepareSubjects($subjects);
+      $subjects = $preparedSubjects['subjects'];
+      $subjectEntries = $preparedSubjects['subject_entries'];
+    }
 
     $step = $automation->getTrigger($trigger->getKey());
     if (!$step) {
@@ -95,6 +113,7 @@ class AutomationRunCreator {
     if (!$createAutomationRun) {
       return AutomationRunCreationResult::skipped(
         $triggerMatches
+          || $this->wordPress->getFilterCallbacksCount(Hooks::AUTOMATION_RUN_CREATE) > 1
           ? AutomationRunCreationResult::STATUS_RUN_CREATE_HOOK_REJECTED
           : AutomationRunCreationResult::STATUS_TRIGGER_FILTER_MISMATCH
       );

--- a/mailpoet/lib/Automation/Engine/Control/AutomationRunCreator.php
+++ b/mailpoet/lib/Automation/Engine/Control/AutomationRunCreator.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Control;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Data\AutomationRunLog;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Integration\Trigger;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Engine\WordPress;
+use RuntimeException;
+use Throwable;
+
+class AutomationRunCreator {
+  /** @var AutomationRunStorage */
+  private $automationRunStorage;
+
+  /** @var SubjectLoader */
+  private $subjectLoader;
+
+  /** @var SubjectTransformerHandler */
+  private $subjectTransformerHandler;
+
+  /** @var FilterHandler */
+  private $filterHandler;
+
+  /** @var StepScheduler */
+  private $stepScheduler;
+
+  /** @var StepRunLoggerFactory */
+  private $stepRunLoggerFactory;
+
+  /** @var WordPress */
+  private $wordPress;
+
+  public function __construct(
+    AutomationRunStorage $automationRunStorage,
+    SubjectLoader $subjectLoader,
+    SubjectTransformerHandler $subjectTransformerHandler,
+    FilterHandler $filterHandler,
+    StepScheduler $stepScheduler,
+    StepRunLoggerFactory $stepRunLoggerFactory,
+    WordPress $wordPress
+  ) {
+    $this->automationRunStorage = $automationRunStorage;
+    $this->subjectLoader = $subjectLoader;
+    $this->subjectTransformerHandler = $subjectTransformerHandler;
+    $this->filterHandler = $filterHandler;
+    $this->stepScheduler = $stepScheduler;
+    $this->stepRunLoggerFactory = $stepRunLoggerFactory;
+    $this->wordPress = $wordPress;
+  }
+
+  /**
+   * @param Subject[] $subjects
+   * @param array<string, scalar|array<array-key, scalar>> $triggerLogData
+   */
+  public function createForAutomation(
+    Automation $automation,
+    Trigger $trigger,
+    array $subjects,
+    array $triggerLogData = []
+  ): AutomationRunCreationResult {
+    $subjects = $this->subjectTransformerHandler->getAllSubjects($subjects);
+    $subjectEntries = $this->subjectLoader->getSubjectsEntries($subjects);
+
+    $step = $automation->getTrigger($trigger->getKey());
+    if (!$step) {
+      throw Exceptions::automationTriggerNotFound($automation->getId(), $trigger->getKey());
+    }
+
+    $automationRun = new AutomationRun($automation->getId(), $automation->getVersionId(), $trigger->getKey(), $subjects);
+    $stepRunArgs = new StepRunArgs($automation, $automationRun, $step, $subjectEntries, 1);
+
+    $match = false;
+    try {
+      $match = $this->filterHandler->matchesFilters($stepRunArgs);
+    } catch (Exceptions\Exception $e) {
+      // Failed trigger filter evaluation does not match.
+    }
+    if (!$match) {
+      return AutomationRunCreationResult::skipped(AutomationRunCreationResult::STATUS_TRIGGER_FILTER_MISMATCH);
+    }
+
+    $triggerMatches = $trigger->isTriggeredBy($stepRunArgs);
+    $createAutomationRun = $this->wordPress->applyFilters(
+      Hooks::AUTOMATION_RUN_CREATE,
+      $triggerMatches,
+      $stepRunArgs
+    );
+    if (!$createAutomationRun) {
+      return AutomationRunCreationResult::skipped(
+        $triggerMatches
+          ? AutomationRunCreationResult::STATUS_RUN_CREATE_HOOK_REJECTED
+          : AutomationRunCreationResult::STATUS_TRIGGER_FILTER_MISMATCH
+      );
+    }
+
+    $automationRunId = $this->automationRunStorage->createAutomationRun($automationRun);
+    $automationRun->setId($automationRunId);
+
+    $logger = $this->stepRunLoggerFactory->createLogger($automationRunId, $step->getId(), AutomationRunLog::TYPE_TRIGGER, 1);
+    $logger->logStepData($step);
+    if ($triggerLogData) {
+      $logger->saveLogData($triggerLogData);
+    }
+
+    try {
+      $schedulingResult = $this->stepScheduler->scheduleNextStepWithResult($stepRunArgs);
+    } catch (Throwable $error) {
+      $this->automationRunStorage->updateStatus($automationRunId, AutomationRun::STATUS_FAILED);
+      $logger->logFailure($error);
+      return AutomationRunCreationResult::skipped(AutomationRunCreationResult::STATUS_STEP_SCHEDULING_FAILED);
+    }
+
+    if ($schedulingResult->isEnqueueFailed()) {
+      $this->automationRunStorage->updateStatus($automationRunId, AutomationRun::STATUS_FAILED);
+      $logger->logFailure(new RuntimeException(__('Could not schedule the next automation step.', 'mailpoet')));
+      return AutomationRunCreationResult::schedulingFailed($automationRunId, $schedulingResult);
+    }
+
+    $logger->logSuccess();
+    return AutomationRunCreationResult::created($automationRunId, $schedulingResult);
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Control/StepScheduler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepScheduler.php
@@ -30,23 +30,33 @@ class StepScheduler {
   }
 
   public function scheduleNextStep(StepRunArgs $args, ?int $timestamp = null): int {
+    $result = $this->scheduleNextStepWithResult($args, $timestamp);
+    return $result->getActionId() ?? 0;
+  }
+
+  public function scheduleNextStepWithResult(StepRunArgs $args, ?int $timestamp = null): StepSchedulingResult {
     $step = $args->getStep();
     $nextSteps = $step->getNextSteps();
 
     // complete the automation run if there are no more steps
     if (count($nextSteps) === 0) {
       $this->completeAutomationRun($args);
-      return 0;
+      return StepSchedulingResult::completedNoNextStep();
     }
 
     if (count($nextSteps) > 1) {
       throw Exceptions::nextStepNotScheduled($step->getId());
     }
 
-    return $this->scheduleNextStepByIndex($args, 0, $timestamp);
+    return $this->scheduleNextStepByIndexWithResult($args, 0, $timestamp);
   }
 
   public function scheduleNextStepByIndex(StepRunArgs $args, int $nextStepIndex, ?int $timestamp = null): int {
+    $result = $this->scheduleNextStepByIndexWithResult($args, $nextStepIndex, $timestamp);
+    return $result->getActionId() ?? 0;
+  }
+
+  private function scheduleNextStepByIndexWithResult(StepRunArgs $args, int $nextStepIndex, ?int $timestamp = null): StepSchedulingResult {
     $step = $args->getStep();
     $nextStep = $step->getNextSteps()[$nextStepIndex] ?? null;
     if (!$nextStep) {
@@ -57,13 +67,16 @@ class StepScheduler {
     $nextStepId = $nextStep->getId();
     if (!$nextStepId) {
       $this->completeAutomationRun($args);
-      return 0;
+      return StepSchedulingResult::completedNoNextStep();
     }
 
     $data = $this->getActionData($runId, $nextStepId);
     $id = $this->scheduleStepAction($data, $timestamp);
+    if ($id <= 0) {
+      return StepSchedulingResult::enqueueFailed($nextStepId);
+    }
     $this->automationRunStorage->updateNextStep($runId, $nextStepId);
-    return $id;
+    return StepSchedulingResult::scheduled($id, $nextStepId);
   }
 
   public function hasScheduledNextStep(StepRunArgs $args): bool {

--- a/mailpoet/lib/Automation/Engine/Control/StepSchedulingResult.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepSchedulingResult.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Control;
+
+class StepSchedulingResult {
+  public const STATUS_SCHEDULED = 'scheduled';
+  public const STATUS_COMPLETED_NO_NEXT_STEP = 'completed_no_next_step';
+  public const STATUS_ENQUEUE_FAILED = 'enqueue_failed';
+
+  /** @var string */
+  private $status;
+
+  /** @var int|null */
+  private $actionId;
+
+  /** @var string|null */
+  private $nextStepId;
+
+  private function __construct(
+    string $status,
+    ?int $actionId = null,
+    ?string $nextStepId = null
+  ) {
+    $this->status = $status;
+    $this->actionId = $actionId;
+    $this->nextStepId = $nextStepId;
+  }
+
+  public static function scheduled(int $actionId, string $nextStepId): self {
+    return new self(self::STATUS_SCHEDULED, $actionId, $nextStepId);
+  }
+
+  public static function completedNoNextStep(): self {
+    return new self(self::STATUS_COMPLETED_NO_NEXT_STEP);
+  }
+
+  public static function enqueueFailed(string $nextStepId): self {
+    return new self(self::STATUS_ENQUEUE_FAILED, null, $nextStepId);
+  }
+
+  public function getStatus(): string {
+    return $this->status;
+  }
+
+  public function getActionId(): ?int {
+    return $this->actionId;
+  }
+
+  public function getNextStepId(): ?string {
+    return $this->nextStepId;
+  }
+
+  public function isEnqueueFailed(): bool {
+    return $this->status === self::STATUS_ENQUEUE_FAILED;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -39,8 +39,15 @@ class TriggerHandler {
       return;
     }
 
+    $preparedSubjects = $this->automationRunCreator->prepareSubjects($subjects);
     foreach ($automations as $automation) {
-      $this->automationRunCreator->createForAutomation($automation, $trigger, $subjects);
+      $this->automationRunCreator->createForAutomation(
+        $automation,
+        $trigger,
+        $preparedSubjects['subjects'],
+        [],
+        $preparedSubjects['subject_entries']
+      );
     }
   }
 }

--- a/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TriggerHandler.php
@@ -2,14 +2,9 @@
 
 namespace MailPoet\Automation\Engine\Control;
 
-use MailPoet\Automation\Engine\Data\AutomationRun;
-use MailPoet\Automation\Engine\Data\AutomationRunLog;
-use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\Subject;
-use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Integration\Trigger;
-use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\WordPress;
 
@@ -17,44 +12,19 @@ class TriggerHandler {
   /** @var AutomationStorage */
   private $automationStorage;
 
-  /** @var AutomationRunStorage */
-  private $automationRunStorage;
-
-  /** @var SubjectLoader */
-  private $subjectLoader;
-
-  /** @var SubjectTransformerHandler */
-  private $subjectTransformerHandler;
-
-  /** @var FilterHandler */
-  private $filterHandler;
-
-  /** @var StepScheduler */
-  private $stepScheduler;
-
-  /** @var StepRunLoggerFactory */
-  private $stepRunLoggerFactory;
+  /** @var AutomationRunCreator */
+  private $automationRunCreator;
 
   /** @var WordPress */
   private $wordPress;
 
   public function __construct(
     AutomationStorage $automationStorage,
-    AutomationRunStorage $automationRunStorage,
-    SubjectLoader $subjectLoader,
-    SubjectTransformerHandler $subjectTransformerHandler,
-    FilterHandler $filterHandler,
-    StepScheduler $stepScheduler,
-    StepRunLoggerFactory $stepRunLoggerFactory,
+    AutomationRunCreator $automationRunCreator,
     WordPress $wordPress
   ) {
     $this->automationStorage = $automationStorage;
-    $this->automationRunStorage = $automationRunStorage;
-    $this->subjectLoader = $subjectLoader;
-    $this->subjectTransformerHandler = $subjectTransformerHandler;
-    $this->filterHandler = $filterHandler;
-    $this->stepScheduler = $stepScheduler;
-    $this->stepRunLoggerFactory = $stepRunLoggerFactory;
+    $this->automationRunCreator = $automationRunCreator;
     $this->wordPress = $wordPress;
   }
 
@@ -69,48 +39,8 @@ class TriggerHandler {
       return;
     }
 
-    // expand all subject transformations and load subject entries
-    $subjects = $this->subjectTransformerHandler->getAllSubjects($subjects);
-    $subjectEntries = $this->subjectLoader->getSubjectsEntries($subjects);
-
     foreach ($automations as $automation) {
-      $step = $automation->getTrigger($trigger->getKey());
-      if (!$step) {
-        throw Exceptions::automationTriggerNotFound($automation->getId(), $trigger->getKey());
-      }
-
-      $automationRun = new AutomationRun($automation->getId(), $automation->getVersionId(), $trigger->getKey(), $subjects);
-      $stepRunArgs = new StepRunArgs($automation, $automationRun, $step, $subjectEntries, 1);
-
-      $match = false;
-      try {
-        $match = $this->filterHandler->matchesFilters($stepRunArgs);
-      } catch (Exceptions\Exception $e) {
-        // failed filter evaluation won't match
-        ;
-      }
-      if (!$match) {
-        continue;
-      }
-
-      $createAutomationRun = $trigger->isTriggeredBy($stepRunArgs);
-      $createAutomationRun = $this->wordPress->applyFilters(
-        Hooks::AUTOMATION_RUN_CREATE,
-        $createAutomationRun,
-        $stepRunArgs
-      );
-      if (!$createAutomationRun) {
-        continue;
-      }
-
-
-      $automationRunId = $this->automationRunStorage->createAutomationRun($automationRun);
-      $automationRun->setId($automationRunId);
-      $this->stepScheduler->scheduleNextStep($stepRunArgs);
-
-      $logger = $this->stepRunLoggerFactory->createLogger($automationRunId, $step->getId(), AutomationRunLog::TYPE_TRIGGER, 1);
-      $logger->logStepData($step);
-      $logger->logSuccess();
+      $this->automationRunCreator->createForAutomation($automation, $trigger, $subjects);
     }
   }
 }

--- a/mailpoet/lib/Automation/Engine/Data/Subject.php
+++ b/mailpoet/lib/Automation/Engine/Data/Subject.php
@@ -31,6 +31,10 @@ class Subject {
     return md5($this->getKey() . serialize($this->getArgs()));
   }
 
+  public static function getHashSqlExpression(string $keyExpression, string $serializedArgsExpression): string {
+    return sprintf('MD5(CONCAT(%s, %s))', $keyExpression, $serializedArgsExpression);
+  }
+
   public function toArray(): array {
     return [
       'key' => $this->getKey(),

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationManualStartEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationManualStartEndpoint.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Endpoints\Automations;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\ManualStart\ManualStartService;
+use MailPoet\Validator\Builder;
+
+class AutomationManualStartEndpoint extends Endpoint {
+  /** @var ManualStartService */
+  private $manualStartService;
+
+  public function __construct(
+    ManualStartService $manualStartService
+  ) {
+    $this->manualStartService = $manualStartService;
+  }
+
+  public function handle(Request $request): Response {
+    return new Response($this->manualStartService->start(
+      $this->getRequiredInt($request->getParam('id')),
+      $this->getRequiredInt($request->getParam('segment_id')),
+      $this->getOptionalInt($request->getParam('filter_segment_id')),
+      $this->getRequiredString($request->getParam('preview_signature'))
+    ));
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'id' => Builder::integer()->required(),
+      'segment_id' => Builder::integer()->required(),
+      'filter_segment_id' => Builder::integer(),
+      'preview_signature' => Builder::string()->required(),
+    ];
+  }
+
+  /** @param mixed $value */
+  private function getRequiredInt($value): int {
+    if (is_numeric($value)) {
+      return (int)$value;
+    }
+    return 0;
+  }
+
+  /** @param mixed $value */
+  private function getOptionalInt($value): ?int {
+    if (!is_numeric($value)) {
+      return null;
+    }
+    return (int)$value;
+  }
+
+  /** @param mixed $value */
+  private function getRequiredString($value): string {
+    if (is_string($value)) {
+      return $value;
+    }
+    return '';
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationManualStartEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationManualStartEndpoint.php
@@ -31,7 +31,7 @@ class AutomationManualStartEndpoint extends Endpoint {
     return [
       'id' => Builder::integer()->required(),
       'segment_id' => Builder::integer()->required(),
-      'filter_segment_id' => Builder::integer(),
+      'filter_segment_id' => Builder::integer()->nullable(),
       'preview_signature' => Builder::string()->required(),
     ];
   }

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationManualStartPreviewEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationManualStartPreviewEndpoint.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Endpoints\Automations;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\ManualStart\ManualStartService;
+use MailPoet\Validator\Builder;
+
+class AutomationManualStartPreviewEndpoint extends Endpoint {
+  /** @var ManualStartService */
+  private $manualStartService;
+
+  public function __construct(
+    ManualStartService $manualStartService
+  ) {
+    $this->manualStartService = $manualStartService;
+  }
+
+  public function handle(Request $request): Response {
+    return new Response($this->manualStartService->preview(
+      $this->getRequiredInt($request->getParam('id')),
+      $this->getRequiredInt($request->getParam('segment_id')),
+      $this->getOptionalInt($request->getParam('filter_segment_id'))
+    ));
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'id' => Builder::integer()->required(),
+      'segment_id' => Builder::integer()->required(),
+      'filter_segment_id' => Builder::integer(),
+    ];
+  }
+
+  /** @param mixed $value */
+  private function getRequiredInt($value): int {
+    if (is_numeric($value)) {
+      return (int)$value;
+    }
+    return 0;
+  }
+
+  /** @param mixed $value */
+  private function getOptionalInt($value): ?int {
+    if (!is_numeric($value)) {
+      return null;
+    }
+    return (int)$value;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationManualStartPreviewEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationManualStartPreviewEndpoint.php
@@ -30,7 +30,7 @@ class AutomationManualStartPreviewEndpoint extends Endpoint {
     return [
       'id' => Builder::integer()->required(),
       'segment_id' => Builder::integer()->required(),
-      'filter_segment_id' => Builder::integer(),
+      'filter_segment_id' => Builder::integer()->nullable(),
     ];
   }
 

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -5,6 +5,8 @@ namespace MailPoet\Automation\Engine;
 use MailPoet\Automation\Engine\API\API;
 use MailPoet\Automation\Engine\Control\StepHandler;
 use MailPoet\Automation\Engine\Control\TriggerHandler;
+use MailPoet\Automation\Engine\Endpoints\Automations\AutomationManualStartEndpoint;
+use MailPoet\Automation\Engine\Endpoints\Automations\AutomationManualStartPreviewEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsCreateFromTemplateEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsDeleteEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsDuplicateEndpoint;
@@ -84,6 +86,8 @@ class Engine {
       $api->registerGetRoute('automations/(?P<id>\d+)/versions', AutomationVersionsGetEndpoint::class);
       $api->registerDeleteRoute('automations/(?P<id>\d+)', AutomationsDeleteEndpoint::class);
       $api->registerPostRoute('automations/(?P<id>\d+)/duplicate', AutomationsDuplicateEndpoint::class);
+      $api->registerPostRoute('automations/(?P<id>\d+)/manual-start/preview', AutomationManualStartPreviewEndpoint::class);
+      $api->registerPostRoute('automations/(?P<id>\d+)/manual-start', AutomationManualStartEndpoint::class);
       $api->registerPostRoute('automations/create-from-template', AutomationsCreateFromTemplateEndpoint::class);
       $api->registerGetRoute('automation-templates', AutomationTemplatesGetEndpoint::class);
       $api->registerGetRoute('automation-templates/(?P<slug>.+)', AutomationTemplateGetEndpoint::class);

--- a/mailpoet/lib/Automation/Engine/ManualStart/ManualStartAudienceRepository.php
+++ b/mailpoet/lib/Automation/Engine/ManualStart/ManualStartAudienceRepository.php
@@ -1,0 +1,326 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\ManualStart;
+
+use MailPoet\Automation\Engine\Data\Subject as SubjectData;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Segments\SegmentSubscribersRepository;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
+use MailPoetVendor\Doctrine\DBAL\ParameterType;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class ManualStartAudienceRepository {
+  public const REASON_ALREADY_ENTERED = 'already_entered';
+  public const REASON_NOT_SUBSCRIBED = 'not_subscribed';
+  public const REASON_UNCONFIRMED = 'unconfirmed';
+  public const REASON_UNSUBSCRIBED = 'unsubscribed';
+  public const REASON_BOUNCED = 'bounced';
+  public const REASON_DELETED = 'deleted';
+  public const REASON_NOT_IN_LIST = 'not_in_list';
+  public const REASON_DYNAMIC_FILTER_MISMATCH = 'dynamic_filter_mismatch';
+  public const REASON_TRIGGER_FILTER_MISMATCH = 'trigger_filter_mismatch';
+  public const REASON_RUN_CREATE_HOOK_REJECTED = 'run_create_hook_rejected';
+  public const REASON_AUTOMATION_INACTIVE = 'automation_inactive';
+  public const REASON_SUBSCRIBER_MISSING = 'subscriber_missing';
+  public const REASON_STEP_SCHEDULING_FAILED = 'step_scheduling_failed';
+
+  /** @var EntityManager */
+  private $entityManager;
+
+  /** @var SegmentSubscribersRepository */
+  private $segmentSubscribersRepository;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
+  public function __construct(
+    EntityManager $entityManager,
+    SegmentSubscribersRepository $segmentSubscribersRepository,
+    SubscribersRepository $subscribersRepository,
+    SegmentsRepository $segmentsRepository
+  ) {
+    $this->entityManager = $entityManager;
+    $this->segmentSubscribersRepository = $segmentSubscribersRepository;
+    $this->subscribersRepository = $subscribersRepository;
+    $this->segmentsRepository = $segmentsRepository;
+  }
+
+  /**
+   * @return array{selected_count: int, eligible_count: int, skipped_by_reason: array<string, int>}
+   */
+  public function getPreviewCounts(int $automationId, SegmentEntity $segment, ?SegmentEntity $filterSegment): array {
+    $statusCounts = $this->getListStatusCounts((int)$segment->getId());
+    $subscribedInList = $this->countSubscribedInList($segment, null, false, $automationId);
+    $subscribedAfterFilter = $this->countSubscribedInList($segment, $filterSegment, false, $automationId);
+    $alreadyEntered = $this->countSubscribedInList($segment, $filterSegment, true, $automationId);
+
+    $skippedByReason = [
+      self::REASON_ALREADY_ENTERED => $alreadyEntered,
+      self::REASON_NOT_SUBSCRIBED => $statusCounts[self::REASON_NOT_SUBSCRIBED],
+      self::REASON_UNCONFIRMED => $statusCounts[self::REASON_UNCONFIRMED],
+      self::REASON_UNSUBSCRIBED => $statusCounts[self::REASON_UNSUBSCRIBED],
+      self::REASON_BOUNCED => $statusCounts[self::REASON_BOUNCED],
+      self::REASON_DELETED => $statusCounts[self::REASON_DELETED],
+      self::REASON_NOT_IN_LIST => 0,
+      self::REASON_DYNAMIC_FILTER_MISMATCH => $filterSegment ? max(0, $subscribedInList - $subscribedAfterFilter) : 0,
+      self::REASON_TRIGGER_FILTER_MISMATCH => 0,
+      self::REASON_RUN_CREATE_HOOK_REJECTED => 0,
+      self::REASON_AUTOMATION_INACTIVE => 0,
+      self::REASON_SUBSCRIBER_MISSING => 0,
+      self::REASON_STEP_SCHEDULING_FAILED => 0,
+    ];
+
+    return [
+      'selected_count' => $statusCounts['selected_count'],
+      'eligible_count' => max(0, $subscribedAfterFilter - $alreadyEntered),
+      'skipped_by_reason' => $skippedByReason,
+    ];
+  }
+
+  public function queueEligibleSubscribers(ScheduledTaskEntity $task, int $automationId, SegmentEntity $segment, ?SegmentEntity $filterSegment): int {
+    $taskId = $task->getId();
+    if (!$taskId) {
+      return 0;
+    }
+
+    $scheduledTaskSubscribersTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    $eligibleQueryBuilder = $this->createSubscribedInListQueryBuilder($segment, $filterSegment);
+    $this->addAlreadyEnteredCondition($eligibleQueryBuilder, $automationId, true);
+
+    $params = array_merge($eligibleQueryBuilder->getParameters(), [
+      'taskId' => $taskId,
+      'processed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
+    ]);
+    $types = array_merge($eligibleQueryBuilder->getParameterTypes(), [
+      'taskId' => ParameterType::INTEGER,
+      'processed' => ParameterType::INTEGER,
+    ]);
+
+    return (int)$this->entityManager->getConnection()->executeStatement(
+      "INSERT IGNORE INTO $scheduledTaskSubscribersTable
+       (`task_id`, `subscriber_id`, `processed`)
+       SELECT :taskId, candidates.id, :processed
+       FROM ({$eligibleQueryBuilder->getSQL()}) candidates",
+      $params,
+      $types
+    );
+  }
+
+  public function getSubscriberIneligibleReason(int $subscriberId, int $segmentId, ?int $filterSegmentId): ?string {
+    $subscriber = $this->subscribersRepository->findOneById($subscriberId);
+    if (!$subscriber instanceof SubscriberEntity) {
+      return self::REASON_SUBSCRIBER_MISSING;
+    }
+
+    if ($subscriber->getDeletedAt() !== null) {
+      return self::REASON_DELETED;
+    }
+
+    $status = $subscriber->getStatus();
+    if ($status === SubscriberEntity::STATUS_UNCONFIRMED) {
+      return self::REASON_UNCONFIRMED;
+    }
+    if ($status === SubscriberEntity::STATUS_UNSUBSCRIBED) {
+      return self::REASON_UNSUBSCRIBED;
+    }
+    if ($status === SubscriberEntity::STATUS_BOUNCED) {
+      return self::REASON_BOUNCED;
+    }
+    if ($status !== SubscriberEntity::STATUS_SUBSCRIBED) {
+      return self::REASON_NOT_SUBSCRIBED;
+    }
+
+    if (!$this->isSubscriberSubscribedToSegment($subscriberId, $segmentId)) {
+      return self::REASON_NOT_IN_LIST;
+    }
+
+    if ($filterSegmentId !== null && !$this->isSubscriberInDynamicSegment($subscriberId, $filterSegmentId)) {
+      return self::REASON_DYNAMIC_FILTER_MISMATCH;
+    }
+
+    return null;
+  }
+
+  public function hasSubscriberEnteredAutomation(int $automationId, int $subscriberId): bool {
+    global $wpdb;
+    $runsTable = $wpdb->prefix . 'mailpoet_automation_runs';
+    $subjectsTable = $wpdb->prefix . 'mailpoet_automation_run_subjects';
+    $subject = new SubjectData(SubscriberSubject::KEY, ['subscriber_id' => $subscriberId]);
+
+    $count = $this->entityManager->getConnection()->executeQuery(
+      "SELECT COUNT(DISTINCT automation_runs.id)
+       FROM $runsTable automation_runs
+       INNER JOIN $subjectsTable automation_run_subjects ON automation_run_subjects.automation_run_id = automation_runs.id
+       WHERE automation_runs.automation_id = :automationId
+         AND automation_run_subjects.`key` = :subjectKey
+         AND automation_run_subjects.`hash` = :subjectHash",
+      [
+        'automationId' => $automationId,
+        'subjectKey' => $subject->getKey(),
+        'subjectHash' => $subject->getHash(),
+      ],
+      [
+        'automationId' => ParameterType::INTEGER,
+        'subjectKey' => ParameterType::STRING,
+        'subjectHash' => ParameterType::STRING,
+      ]
+    )->fetchOne();
+
+    return $this->toInt($count) > 0;
+  }
+
+  /**
+   * @return array<string, int>
+   */
+  private function getListStatusCounts(int $segmentId): array {
+    $subscriberSegmentTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+
+    $result = $this->entityManager->getConnection()->executeQuery(
+      "SELECT
+        COUNT(DISTINCT subscribers.id) AS selected_count,
+        IFNULL(SUM(CASE WHEN subscribers.deleted_at IS NOT NULL THEN 1 ELSE 0 END), 0) AS deleted,
+        IFNULL(SUM(CASE WHEN subscribers.deleted_at IS NULL AND subscribers.status = :unconfirmed AND subscriber_segment.status != :unsubscribed THEN 1 ELSE 0 END), 0) AS unconfirmed,
+        IFNULL(SUM(CASE WHEN subscribers.deleted_at IS NULL AND (subscribers.status = :unsubscribed OR subscriber_segment.status = :unsubscribed) THEN 1 ELSE 0 END), 0) AS unsubscribed,
+        IFNULL(SUM(CASE WHEN subscribers.deleted_at IS NULL AND subscribers.status = :bounced AND subscriber_segment.status != :unsubscribed THEN 1 ELSE 0 END), 0) AS bounced,
+        IFNULL(SUM(CASE WHEN subscribers.deleted_at IS NULL AND subscribers.status NOT IN (:knownStatuses) AND subscriber_segment.status != :unsubscribed THEN 1 ELSE 0 END), 0) AS not_subscribed
+       FROM $subscriberSegmentTable subscriber_segment
+       INNER JOIN $subscribersTable subscribers ON subscribers.id = subscriber_segment.subscriber_id
+       WHERE subscriber_segment.segment_id = :segmentId",
+      [
+        'segmentId' => $segmentId,
+        'unconfirmed' => SubscriberEntity::STATUS_UNCONFIRMED,
+        'unsubscribed' => SubscriberEntity::STATUS_UNSUBSCRIBED,
+        'bounced' => SubscriberEntity::STATUS_BOUNCED,
+        'knownStatuses' => [
+          SubscriberEntity::STATUS_SUBSCRIBED,
+          SubscriberEntity::STATUS_UNCONFIRMED,
+          SubscriberEntity::STATUS_UNSUBSCRIBED,
+          SubscriberEntity::STATUS_BOUNCED,
+        ],
+      ],
+      [
+        'segmentId' => ParameterType::INTEGER,
+        'unconfirmed' => ParameterType::STRING,
+        'unsubscribed' => ParameterType::STRING,
+        'bounced' => ParameterType::STRING,
+        'knownStatuses' => ArrayParameterType::STRING,
+      ]
+    )->fetchAssociative();
+
+    $result = is_array($result) ? $result : [];
+    return [
+      'selected_count' => $this->toInt($result['selected_count'] ?? 0),
+      self::REASON_DELETED => $this->toInt($result['deleted'] ?? 0),
+      self::REASON_UNCONFIRMED => $this->toInt($result['unconfirmed'] ?? 0),
+      self::REASON_UNSUBSCRIBED => $this->toInt($result['unsubscribed'] ?? 0),
+      self::REASON_BOUNCED => $this->toInt($result['bounced'] ?? 0),
+      self::REASON_NOT_SUBSCRIBED => $this->toInt($result['not_subscribed'] ?? 0),
+    ];
+  }
+
+  private function countSubscribedInList(SegmentEntity $segment, ?SegmentEntity $filterSegment, bool $alreadyEntered, int $automationId): int {
+    $queryBuilder = $this->createSubscribedInListQueryBuilder($segment, $filterSegment);
+    if ($alreadyEntered) {
+      $this->addAlreadyEnteredCondition($queryBuilder, $automationId, false);
+    }
+    $count = $this->entityManager->getConnection()->executeQuery(
+      "SELECT COUNT(*) FROM ({$queryBuilder->getSQL()}) manual_start_candidates",
+      $queryBuilder->getParameters(),
+      $queryBuilder->getParameterTypes()
+    )->fetchOne();
+
+    return $this->toInt($count);
+  }
+
+  private function createSubscribedInListQueryBuilder(SegmentEntity $segment, ?SegmentEntity $filterSegment): QueryBuilder {
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $subscriberSegmentTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
+
+    $queryBuilder = $this->entityManager->getConnection()->createQueryBuilder()
+      ->select('DISTINCT subscribers.id')
+      ->from($subscribersTable, 'subscribers')
+      ->innerJoin(
+        'subscribers',
+        $subscriberSegmentTable,
+        'subscriber_segment',
+        'subscriber_segment.subscriber_id = subscribers.id AND subscriber_segment.segment_id = :segmentId'
+      )
+      ->where('subscribers.deleted_at IS NULL')
+      ->andWhere('subscribers.status = :subscribed')
+      ->andWhere('subscriber_segment.status = :subscribed')
+      ->setParameter('segmentId', (int)$segment->getId(), ParameterType::INTEGER)
+      ->setParameter('subscribed', SubscriberEntity::STATUS_SUBSCRIBED, ParameterType::STRING);
+
+    if ($filterSegment instanceof SegmentEntity) {
+      $filterQueryBuilder = $this->segmentSubscribersRepository->createSubscribersInSegmentQueryBuilder($filterSegment, SubscriberEntity::STATUS_SUBSCRIBED);
+      $queryBuilder->innerJoin(
+        'subscribers',
+        '(' . $filterQueryBuilder->getSQL() . ')',
+        'filter_segment',
+        'filter_segment.id = subscribers.id'
+      );
+      $queryBuilder->setParameters(
+        array_merge($filterQueryBuilder->getParameters(), $queryBuilder->getParameters()),
+        array_merge($filterQueryBuilder->getParameterTypes(), $queryBuilder->getParameterTypes())
+      );
+    }
+
+    return $queryBuilder;
+  }
+
+  private function addAlreadyEnteredCondition(QueryBuilder $queryBuilder, int $automationId, bool $excludeAlreadyEntered): void {
+    global $wpdb;
+    $runsTable = $wpdb->prefix . 'mailpoet_automation_runs';
+    $subjectsTable = $wpdb->prefix . 'mailpoet_automation_run_subjects';
+    $existsCondition = "EXISTS (
+      SELECT 1
+      FROM $subjectsTable automation_run_subjects
+      INNER JOIN $runsTable automation_runs ON automation_runs.id = automation_run_subjects.automation_run_id
+      WHERE automation_runs.automation_id = :automationId
+        AND automation_run_subjects.`key` = :subscriberSubjectKey
+        AND automation_run_subjects.`hash` = MD5(CONCAT(:subscriberSubjectKey, CONCAT('a:1:{s:13:\"subscriber_id\";i:', subscribers.id, ';}')))
+    )";
+
+    $queryBuilder->andWhere($excludeAlreadyEntered ? "NOT $existsCondition" : $existsCondition)
+      ->setParameter('automationId', $automationId, ParameterType::INTEGER)
+      ->setParameter('subscriberSubjectKey', SubscriberSubject::KEY, ParameterType::STRING);
+  }
+
+  private function isSubscriberSubscribedToSegment(int $subscriberId, int $segmentId): bool {
+    $subscriberSegment = $this->entityManager->getRepository(SubscriberSegmentEntity::class)->findOneBy([
+      'subscriber' => $subscriberId,
+      'segment' => $segmentId,
+    ]);
+    return $subscriberSegment instanceof SubscriberSegmentEntity
+      && $subscriberSegment->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED;
+  }
+
+  private function isSubscriberInDynamicSegment(int $subscriberId, int $filterSegmentId): bool {
+    $segment = $this->segmentsRepository->findOneById($filterSegmentId);
+    if (!$segment instanceof SegmentEntity || $segment->getDeletedAt() !== null || $segment->getType() !== SegmentEntity::TYPE_DYNAMIC) {
+      return false;
+    }
+    $subscriberIds = $this->segmentSubscribersRepository->findSubscribersIdsInSegment($filterSegmentId, [$subscriberId]);
+    return in_array($subscriberId, array_map('intval', $subscriberIds), true);
+  }
+
+  /** @param mixed $value */
+  private function toInt($value): int {
+    if (is_numeric($value)) {
+      return (int)$value;
+    }
+    return 0;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/ManualStart/ManualStartAudienceRepository.php
+++ b/mailpoet/lib/Automation/Engine/ManualStart/ManualStartAudienceRepository.php
@@ -103,32 +103,31 @@ class ManualStartAudienceRepository {
     $queuedCount = 0;
     $lastSubscriberId = 0;
     do {
+      $candidateSubscriberIds = $this->getCandidateSubscriberIds($eligibleQueryBuilder, $lastSubscriberId);
+      if ($candidateSubscriberIds === []) {
+        break;
+      }
+
       $insertedCount = (int)$this->entityManager->getConnection()->executeStatement(
         "INSERT IGNORE INTO $scheduledTaskSubscribersTable
          (`task_id`, `subscriber_id`, `processed`)
-         SELECT :taskId, candidates.id, :processed
+         SELECT :manualStartTaskId, candidates.id, :manualStartProcessed
          FROM ({$eligibleQueryBuilder->getSQL()}) candidates
-         WHERE candidates.id > :lastSubscriberId
-         ORDER BY candidates.id ASC
-         LIMIT :queueLimit",
+         WHERE candidates.id IN (:manualStartSubscriberIds)",
         array_merge($eligibleQueryBuilder->getParameters(), [
-          'taskId' => $taskId,
-          'processed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
-          'lastSubscriberId' => $lastSubscriberId,
-          'queueLimit' => self::QUEUE_CHUNK_SIZE,
+          'manualStartTaskId' => $taskId,
+          'manualStartProcessed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
+          'manualStartSubscriberIds' => $candidateSubscriberIds,
         ]),
         array_merge($eligibleQueryBuilder->getParameterTypes(), [
-          'taskId' => ParameterType::INTEGER,
-          'processed' => ParameterType::INTEGER,
-          'lastSubscriberId' => ParameterType::INTEGER,
-          'queueLimit' => ParameterType::INTEGER,
+          'manualStartTaskId' => ParameterType::INTEGER,
+          'manualStartProcessed' => ParameterType::INTEGER,
+          'manualStartSubscriberIds' => ArrayParameterType::INTEGER,
         ])
       );
       $queuedCount += $insertedCount;
-      if ($insertedCount > 0) {
-        $lastSubscriberId = $this->getMaxQueuedSubscriberId((int)$taskId);
-      }
-    } while ($insertedCount === self::QUEUE_CHUNK_SIZE);
+      $lastSubscriberId = (int)max($candidateSubscriberIds);
+    } while (count($candidateSubscriberIds) === self::QUEUE_CHUNK_SIZE);
 
     return $queuedCount;
   }
@@ -289,13 +288,13 @@ class ManualStartAudienceRepository {
         'subscribers',
         $subscriberSegmentTable,
         'subscriber_segment',
-        'subscriber_segment.subscriber_id = subscribers.id AND subscriber_segment.segment_id = :segmentId'
+        'subscriber_segment.subscriber_id = subscribers.id AND subscriber_segment.segment_id = :manualStartSegmentId'
       )
       ->where('subscribers.deleted_at IS NULL')
-      ->andWhere('subscribers.status = :subscribed')
-      ->andWhere('subscriber_segment.status = :subscribed')
-      ->setParameter('segmentId', (int)$segment->getId(), ParameterType::INTEGER)
-      ->setParameter('subscribed', SubscriberEntity::STATUS_SUBSCRIBED, ParameterType::STRING);
+      ->andWhere('subscribers.status = :manualStartSubscribedStatus')
+      ->andWhere('subscriber_segment.status = :manualStartSubscribedStatus')
+      ->setParameter('manualStartSegmentId', (int)$segment->getId(), ParameterType::INTEGER)
+      ->setParameter('manualStartSubscribedStatus', SubscriberEntity::STATUS_SUBSCRIBED, ParameterType::STRING);
 
     if ($filterSegment instanceof SegmentEntity) {
       $filterQueryBuilder = $this->segmentSubscribersRepository->createSubscribersInSegmentQueryBuilder($filterSegment, SubscriberEntity::STATUS_SUBSCRIBED);
@@ -322,25 +321,44 @@ class ManualStartAudienceRepository {
       SELECT 1
       FROM $subjectsTable automation_run_subjects
       INNER JOIN $runsTable automation_runs ON automation_runs.id = automation_run_subjects.automation_run_id
-      WHERE automation_runs.automation_id = :automationId
-        AND automation_run_subjects.`key` = :subscriberSubjectKey
-        AND automation_run_subjects.`hash` = MD5(CONCAT(:subscriberSubjectKey, CONCAT('a:1:{s:13:\"subscriber_id\";i:', subscribers.id, ';}')))
+      WHERE automation_runs.automation_id = :manualStartAutomationId
+        AND automation_run_subjects.`key` = :manualStartSubscriberSubjectKey
+        AND automation_run_subjects.`hash` = MD5(CONCAT(:manualStartSubscriberSubjectKey, CONCAT('a:1:{s:13:\"subscriber_id\";i:', subscribers.id, ';}')))
     )";
 
     $queryBuilder->andWhere($excludeAlreadyEntered ? "NOT $existsCondition" : $existsCondition)
-      ->setParameter('automationId', $automationId, ParameterType::INTEGER)
-      ->setParameter('subscriberSubjectKey', SubscriberSubject::KEY, ParameterType::STRING);
+      ->setParameter('manualStartAutomationId', $automationId, ParameterType::INTEGER)
+      ->setParameter('manualStartSubscriberSubjectKey', SubscriberSubject::KEY, ParameterType::STRING);
   }
 
-  private function getMaxQueuedSubscriberId(int $taskId): int {
-    $scheduledTaskSubscribersTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
-    $maxSubscriberId = $this->entityManager->getConnection()->executeQuery(
-      "SELECT MAX(subscriber_id) FROM $scheduledTaskSubscribersTable WHERE task_id = :taskId",
-      ['taskId' => $taskId],
-      ['taskId' => ParameterType::INTEGER]
-    )->fetchOne();
+  /**
+   * @return int[]
+   */
+  private function getCandidateSubscriberIds(QueryBuilder $eligibleQueryBuilder, int $lastSubscriberId): array {
+    $subscriberIds = $this->entityManager->getConnection()->executeQuery(
+      "SELECT candidates.id
+       FROM ({$eligibleQueryBuilder->getSQL()}) candidates
+       WHERE candidates.id > :manualStartLastSubscriberId
+       ORDER BY candidates.id ASC
+       LIMIT :manualStartQueueLimit",
+      array_merge($eligibleQueryBuilder->getParameters(), [
+        'manualStartLastSubscriberId' => $lastSubscriberId,
+        'manualStartQueueLimit' => self::QUEUE_CHUNK_SIZE,
+      ]),
+      array_merge($eligibleQueryBuilder->getParameterTypes(), [
+        'manualStartLastSubscriberId' => ParameterType::INTEGER,
+        'manualStartQueueLimit' => ParameterType::INTEGER,
+      ])
+    )->fetchFirstColumn();
 
-    return $this->toInt($maxSubscriberId);
+    $ids = [];
+    foreach ($subscriberIds as $subscriberId) {
+      if (is_numeric($subscriberId)) {
+        $ids[] = (int)$subscriberId;
+      }
+    }
+
+    return $ids;
   }
 
   private function isSubscriberSubscribedToSegment(int $subscriberId, int $segmentId): bool {

--- a/mailpoet/lib/Automation/Engine/ManualStart/ManualStartAudienceRepository.php
+++ b/mailpoet/lib/Automation/Engine/ManualStart/ManualStartAudienceRepository.php
@@ -18,6 +18,8 @@ use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class ManualStartAudienceRepository {
+  public const QUEUE_CHUNK_SIZE = 100;
+
   public const REASON_ALREADY_ENTERED = 'already_entered';
   public const REASON_NOT_SUBSCRIBED = 'not_subscribed';
   public const REASON_UNCONFIRMED = 'unconfirmed';
@@ -98,23 +100,55 @@ class ManualStartAudienceRepository {
     $eligibleQueryBuilder = $this->createSubscribedInListQueryBuilder($segment, $filterSegment);
     $this->addAlreadyEnteredCondition($eligibleQueryBuilder, $automationId, true);
 
-    $params = array_merge($eligibleQueryBuilder->getParameters(), [
-      'taskId' => $taskId,
-      'processed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
-    ]);
-    $types = array_merge($eligibleQueryBuilder->getParameterTypes(), [
-      'taskId' => ParameterType::INTEGER,
-      'processed' => ParameterType::INTEGER,
-    ]);
+    $queuedCount = 0;
+    $lastSubscriberId = 0;
+    do {
+      $insertedCount = (int)$this->entityManager->getConnection()->executeStatement(
+        "INSERT IGNORE INTO $scheduledTaskSubscribersTable
+         (`task_id`, `subscriber_id`, `processed`)
+         SELECT :taskId, candidates.id, :processed
+         FROM ({$eligibleQueryBuilder->getSQL()}) candidates
+         WHERE candidates.id > :lastSubscriberId
+         ORDER BY candidates.id ASC
+         LIMIT :queueLimit",
+        array_merge($eligibleQueryBuilder->getParameters(), [
+          'taskId' => $taskId,
+          'processed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
+          'lastSubscriberId' => $lastSubscriberId,
+          'queueLimit' => self::QUEUE_CHUNK_SIZE,
+        ]),
+        array_merge($eligibleQueryBuilder->getParameterTypes(), [
+          'taskId' => ParameterType::INTEGER,
+          'processed' => ParameterType::INTEGER,
+          'lastSubscriberId' => ParameterType::INTEGER,
+          'queueLimit' => ParameterType::INTEGER,
+        ])
+      );
+      $queuedCount += $insertedCount;
+      if ($insertedCount > 0) {
+        $lastSubscriberId = $this->getMaxQueuedSubscriberId((int)$taskId);
+      }
+    } while ($insertedCount === self::QUEUE_CHUNK_SIZE);
 
-    return (int)$this->entityManager->getConnection()->executeStatement(
-      "INSERT IGNORE INTO $scheduledTaskSubscribersTable
-       (`task_id`, `subscriber_id`, `processed`)
-       SELECT :taskId, candidates.id, :processed
-       FROM ({$eligibleQueryBuilder->getSQL()}) candidates",
-      $params,
-      $types
-    );
+    return $queuedCount;
+  }
+
+  public function getSegmentIneligibleReason(int $segmentId, ?int $filterSegmentId): ?string {
+    $segment = $this->segmentsRepository->findOneById($segmentId);
+    if (!$segment instanceof SegmentEntity || $segment->getDeletedAt() !== null || $segment->getType() !== SegmentEntity::TYPE_DEFAULT) {
+      return self::REASON_NOT_IN_LIST;
+    }
+
+    if ($filterSegmentId === null) {
+      return null;
+    }
+
+    $filterSegment = $this->segmentsRepository->findOneById($filterSegmentId);
+    if (!$filterSegment instanceof SegmentEntity || $filterSegment->getDeletedAt() !== null || $filterSegment->getType() !== SegmentEntity::TYPE_DYNAMIC) {
+      return self::REASON_DYNAMIC_FILTER_MISMATCH;
+    }
+
+    return null;
   }
 
   public function getSubscriberIneligibleReason(int $subscriberId, int $segmentId, ?int $filterSegmentId): ?string {
@@ -296,6 +330,17 @@ class ManualStartAudienceRepository {
     $queryBuilder->andWhere($excludeAlreadyEntered ? "NOT $existsCondition" : $existsCondition)
       ->setParameter('automationId', $automationId, ParameterType::INTEGER)
       ->setParameter('subscriberSubjectKey', SubscriberSubject::KEY, ParameterType::STRING);
+  }
+
+  private function getMaxQueuedSubscriberId(int $taskId): int {
+    $scheduledTaskSubscribersTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    $maxSubscriberId = $this->entityManager->getConnection()->executeQuery(
+      "SELECT MAX(subscriber_id) FROM $scheduledTaskSubscribersTable WHERE task_id = :taskId",
+      ['taskId' => $taskId],
+      ['taskId' => ParameterType::INTEGER]
+    )->fetchOne();
+
+    return $this->toInt($maxSubscriberId);
   }
 
   private function isSubscriberSubscribedToSegment(int $subscriberId, int $segmentId): bool {

--- a/mailpoet/lib/Automation/Engine/ManualStart/ManualStartAudienceRepository.php
+++ b/mailpoet/lib/Automation/Engine/ManualStart/ManualStartAudienceRepository.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Automation\Engine\ManualStart;
 
+use MailPoet\Automation\Engine\Data\AutomationRun as AutomationRunData;
 use MailPoet\Automation\Engine\Data\Subject as SubjectData;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Entities\ScheduledTaskEntity;
@@ -19,6 +20,10 @@ use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class ManualStartAudienceRepository {
   public const QUEUE_CHUNK_SIZE = 100;
+  private const ENTERED_RUN_STATUSES = [
+    AutomationRunData::STATUS_RUNNING,
+    AutomationRunData::STATUS_COMPLETE,
+  ];
 
   public const REASON_ALREADY_ENTERED = 'already_entered';
   public const REASON_NOT_SUBSCRIBED = 'not_subscribed';
@@ -196,15 +201,18 @@ class ManualStartAudienceRepository {
        FROM $runsTable automation_runs
        INNER JOIN $subjectsTable automation_run_subjects ON automation_run_subjects.automation_run_id = automation_runs.id
        WHERE automation_runs.automation_id = :automationId
+         AND automation_runs.status IN (:enteredRunStatuses)
          AND automation_run_subjects.`key` = :subjectKey
          AND automation_run_subjects.`hash` = :subjectHash",
       [
         'automationId' => $automationId,
+        'enteredRunStatuses' => self::ENTERED_RUN_STATUSES,
         'subjectKey' => $subject->getKey(),
         'subjectHash' => $subject->getHash(),
       ],
       [
         'automationId' => ParameterType::INTEGER,
+        'enteredRunStatuses' => ArrayParameterType::STRING,
         'subjectKey' => ParameterType::STRING,
         'subjectHash' => ParameterType::STRING,
       ]
@@ -317,17 +325,20 @@ class ManualStartAudienceRepository {
     global $wpdb;
     $runsTable = $wpdb->prefix . 'mailpoet_automation_runs';
     $subjectsTable = $wpdb->prefix . 'mailpoet_automation_run_subjects';
+    $subjectHashExpression = SubscriberSubject::getHashSqlExpression('subscribers.id', ':manualStartSubscriberSubjectKey');
     $existsCondition = "EXISTS (
       SELECT 1
       FROM $subjectsTable automation_run_subjects
       INNER JOIN $runsTable automation_runs ON automation_runs.id = automation_run_subjects.automation_run_id
       WHERE automation_runs.automation_id = :manualStartAutomationId
+        AND automation_runs.status IN (:manualStartEnteredRunStatuses)
         AND automation_run_subjects.`key` = :manualStartSubscriberSubjectKey
-        AND automation_run_subjects.`hash` = MD5(CONCAT(:manualStartSubscriberSubjectKey, CONCAT('a:1:{s:13:\"subscriber_id\";i:', subscribers.id, ';}')))
+        AND automation_run_subjects.`hash` = $subjectHashExpression
     )";
 
     $queryBuilder->andWhere($excludeAlreadyEntered ? "NOT $existsCondition" : $existsCondition)
       ->setParameter('manualStartAutomationId', $automationId, ParameterType::INTEGER)
+      ->setParameter('manualStartEnteredRunStatuses', self::ENTERED_RUN_STATUSES, ArrayParameterType::STRING)
       ->setParameter('manualStartSubscriberSubjectKey', SubscriberSubject::KEY, ParameterType::STRING);
   }
 

--- a/mailpoet/lib/Automation/Engine/ManualStart/ManualStartContext.php
+++ b/mailpoet/lib/Automation/Engine/ManualStart/ManualStartContext.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\ManualStart;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Entities\SegmentEntity;
+
+class ManualStartContext {
+  /** @var Automation */
+  private $automation;
+
+  /** @var Step */
+  private $triggerStep;
+
+  /** @var SegmentEntity */
+  private $segment;
+
+  /** @var SegmentEntity|null */
+  private $filterSegment;
+
+  public function __construct(
+    Automation $automation,
+    Step $triggerStep,
+    SegmentEntity $segment,
+    ?SegmentEntity $filterSegment
+  ) {
+    $this->automation = $automation;
+    $this->triggerStep = $triggerStep;
+    $this->segment = $segment;
+    $this->filterSegment = $filterSegment;
+  }
+
+  public function getAutomation(): Automation {
+    return $this->automation;
+  }
+
+  public function getTriggerStep(): Step {
+    return $this->triggerStep;
+  }
+
+  public function getSegment(): SegmentEntity {
+    return $this->segment;
+  }
+
+  public function getFilterSegment(): ?SegmentEntity {
+    return $this->filterSegment;
+  }
+
+  public function getSegmentId(): int {
+    return (int)$this->segment->getId();
+  }
+
+  public function getFilterSegmentId(): ?int {
+    return $this->filterSegment ? (int)$this->filterSegment->getId() : null;
+  }
+}

--- a/mailpoet/lib/Automation/Engine/ManualStart/ManualStartService.php
+++ b/mailpoet/lib/Automation/Engine/ManualStart/ManualStartService.php
@@ -16,6 +16,7 @@ use MailPoet\Logging\LogRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\DBAL\ParameterType;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use Throwable;
@@ -23,6 +24,7 @@ use Throwable;
 class ManualStartService {
   private const LOG_LEVEL_INFO = 200;
   private const AUDIT_LOG_MESSAGE_QUEUED = 'Manual automation start queued.';
+  private const START_LOCK_TIMEOUT_SECONDS = 0;
 
   /** @var AutomationStorage */
   private $automationStorage;
@@ -68,6 +70,9 @@ class ManualStartService {
   }
 
   /**
+   * Queues subscribers synchronously for now. The UI warns when the preview
+   * crosses the documented soft cap of 50,000 eligible subscribers.
+   *
    * @return array{task_id: int, automation_id: int, segment_id: int, filter_segment_id: int|null, selected_count: int, eligible_count: int, queued_count: int, skipped_by_reason: array<string, int>}
    */
   public function start(int $automationId, int $segmentId, ?int $filterSegmentId, string $previewSignature): array {
@@ -331,18 +336,27 @@ class ManualStartService {
        FROM $tasksTable
        WHERE type = :type
          AND deleted_at IS NULL
-         AND (status = :scheduled OR status IS NULL)
+         AND (
+           status IN (:activeStatuses)
+           OR status IS NULL
+           OR in_progress = :inProgress
+         )
          AND CAST(JSON_UNQUOTE(JSON_EXTRACT(meta, '$.automation_id')) AS UNSIGNED) = :automationId
        ORDER BY id DESC
        LIMIT 1",
       [
         'type' => ManualAutomationStartWorker::TASK_TYPE,
-        'scheduled' => ScheduledTaskEntity::STATUS_SCHEDULED,
+        'activeStatuses' => [
+          ScheduledTaskEntity::STATUS_SCHEDULED,
+          ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING,
+        ],
+        'inProgress' => 1,
         'automationId' => $automationId,
       ],
       [
         'type' => ParameterType::STRING,
-        'scheduled' => ParameterType::STRING,
+        'activeStatuses' => ArrayParameterType::STRING,
+        'inProgress' => ParameterType::INTEGER,
         'automationId' => ParameterType::INTEGER,
       ]
     )->fetchOne();
@@ -405,9 +419,15 @@ class ManualStartService {
 
   private function acquireLock(string $lockName): void {
     $result = $this->entityManager->getConnection()->executeQuery(
-      'SELECT GET_LOCK(:lockName, 10)',
-      ['lockName' => $lockName],
-      ['lockName' => ParameterType::STRING]
+      'SELECT GET_LOCK(:lockName, :timeout)',
+      [
+        'lockName' => $lockName,
+        'timeout' => self::START_LOCK_TIMEOUT_SECONDS,
+      ],
+      [
+        'lockName' => ParameterType::STRING,
+        'timeout' => ParameterType::INTEGER,
+      ]
     )->fetchOne();
     if (!is_numeric($result) || (int)$result !== 1) {
       throw new ApiException(

--- a/mailpoet/lib/Automation/Engine/ManualStart/ManualStartService.php
+++ b/mailpoet/lib/Automation/Engine/ManualStart/ManualStartService.php
@@ -81,14 +81,6 @@ class ManualStartService {
       $this->assertNoActiveTask($automationId);
       $preview = $this->buildPreview($context);
 
-      if ($preview['eligible_count'] <= 0) {
-        throw new ApiException(
-          __('No subscribers are eligible to start this automation.', 'mailpoet'),
-          422,
-          'manual_start_zero_eligible'
-        );
-      }
-
       if (!hash_equals($preview['preview_signature'], $previewSignature)) {
         throw new ApiException(
           __('The audience changed since the last preview. Refresh the preview before queueing subscribers.', 'mailpoet'),
@@ -97,6 +89,14 @@ class ManualStartService {
           [],
           null,
           ['preview' => $preview]
+        );
+      }
+
+      if ($preview['eligible_count'] <= 0) {
+        throw new ApiException(
+          __('No subscribers are eligible to start this automation.', 'mailpoet'),
+          422,
+          'manual_start_zero_eligible'
         );
       }
 
@@ -293,7 +293,13 @@ class ManualStartService {
       if ($throwable instanceof ApiException) {
         throw $throwable;
       }
-      throw new ApiException(__('Could not queue subscribers for manual automation start.', 'mailpoet'), 500, 'manual_start_queue_failed');
+      throw new ApiException(
+        __('Could not queue subscribers for manual automation start.', 'mailpoet'),
+        500,
+        'manual_start_queue_failed',
+        [],
+        $throwable
+      );
     }
 
     return [

--- a/mailpoet/lib/Automation/Engine/ManualStart/ManualStartService.php
+++ b/mailpoet/lib/Automation/Engine/ManualStart/ManualStartService.php
@@ -1,0 +1,426 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\ManualStart;
+
+use MailPoet\API\REST\ApiException;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
+use MailPoet\Cron\Workers\Automations\ManualAutomationStartWorker;
+use MailPoet\Entities\LogEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Logging\LoggerFactory;
+use MailPoet\Logging\LogRepository;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\ParameterType;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+use Throwable;
+
+class ManualStartService {
+  private const LOG_LEVEL_INFO = 200;
+  private const AUDIT_LOG_MESSAGE_QUEUED = 'Manual automation start queued.';
+
+  /** @var AutomationStorage */
+  private $automationStorage;
+
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
+  /** @var ManualStartAudienceRepository */
+  private $audienceRepository;
+
+  /** @var EntityManager */
+  private $entityManager;
+
+  /** @var LogRepository */
+  private $logRepository;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    AutomationStorage $automationStorage,
+    SegmentsRepository $segmentsRepository,
+    ManualStartAudienceRepository $audienceRepository,
+    EntityManager $entityManager,
+    LogRepository $logRepository,
+    WPFunctions $wp
+  ) {
+    $this->automationStorage = $automationStorage;
+    $this->segmentsRepository = $segmentsRepository;
+    $this->audienceRepository = $audienceRepository;
+    $this->entityManager = $entityManager;
+    $this->logRepository = $logRepository;
+    $this->wp = $wp;
+  }
+
+  /**
+   * @return array{preview_signature: string, automation_id: int, segment_id: int, filter_segment_id: int|null, selected_count: int, eligible_count: int, skipped_by_reason: array<string, int>, deferred_reason_keys: string[], duplicate_in_progress: bool}
+   */
+  public function preview(int $automationId, int $segmentId, ?int $filterSegmentId): array {
+    $context = $this->validateContext($automationId, $segmentId, $filterSegmentId);
+    $this->assertNoActiveTask($automationId);
+    return $this->buildPreview($context);
+  }
+
+  /**
+   * @return array{task_id: int, automation_id: int, segment_id: int, filter_segment_id: int|null, selected_count: int, eligible_count: int, queued_count: int, skipped_by_reason: array<string, int>}
+   */
+  public function start(int $automationId, int $segmentId, ?int $filterSegmentId, string $previewSignature): array {
+    $context = $this->validateContext($automationId, $segmentId, $filterSegmentId);
+    $this->assertNoActiveTask($automationId);
+
+    $lockName = $this->getLockName($automationId);
+    $this->acquireLock($lockName);
+    try {
+      $context = $this->validateContext($automationId, $segmentId, $filterSegmentId);
+      $this->assertNoActiveTask($automationId);
+      $preview = $this->buildPreview($context);
+
+      if ($preview['eligible_count'] <= 0) {
+        throw new ApiException(
+          __('No subscribers are eligible to start this automation.', 'mailpoet'),
+          422,
+          'manual_start_zero_eligible'
+        );
+      }
+
+      if (!hash_equals($preview['preview_signature'], $previewSignature)) {
+        throw new ApiException(
+          __('The audience changed since the last preview. Refresh the preview before queueing subscribers.', 'mailpoet'),
+          409,
+          'manual_start_stale_preview',
+          [],
+          null,
+          ['preview' => $preview]
+        );
+      }
+
+      return $this->createTask($context, $preview, $previewSignature);
+    } finally {
+      $this->releaseLock($lockName);
+    }
+  }
+
+  /**
+   * @return array{supported: bool, trigger_key: string|null, segment_ids: int[]|null, disabled_reason?: string}
+   */
+  public function getMetadata(Automation $automation): array {
+    $triggerStep = $automation->getTrigger(SomeoneSubscribesTrigger::KEY);
+    if ($automation->getStatus() !== Automation::STATUS_ACTIVE) {
+      return [
+        'supported' => false,
+        'trigger_key' => $triggerStep ? SomeoneSubscribesTrigger::KEY : null,
+        'segment_ids' => null,
+        'disabled_reason' => 'automation_not_active',
+      ];
+    }
+
+    if (!$triggerStep) {
+      return [
+        'supported' => false,
+        'trigger_key' => null,
+        'segment_ids' => null,
+        'disabled_reason' => 'unsupported_trigger',
+      ];
+    }
+
+    return [
+      'supported' => true,
+      'trigger_key' => SomeoneSubscribesTrigger::KEY,
+      'segment_ids' => $this->getAllowedSegmentIds($triggerStep),
+    ];
+  }
+
+  private function validateContext(int $automationId, int $segmentId, ?int $filterSegmentId): ManualStartContext {
+    if ($automationId <= 0) {
+      throw new ApiException(__('Automation id is required.', 'mailpoet'), 400, 'manual_start_invalid_automation_id');
+    }
+
+    $automation = $this->automationStorage->getAutomation($automationId);
+    if (!$automation) {
+      throw new ApiException(__('Automation not found.', 'mailpoet'), 404, 'manual_start_automation_not_found');
+    }
+    if ($automation->getStatus() !== Automation::STATUS_ACTIVE) {
+      throw new ApiException(__('Automation must be active before it can be started manually.', 'mailpoet'), 400, 'manual_start_automation_not_active');
+    }
+
+    $triggerStep = $automation->getTrigger(SomeoneSubscribesTrigger::KEY);
+    if (!$triggerStep) {
+      throw new ApiException(__('This automation trigger does not support manual starts.', 'mailpoet'), 400, 'manual_start_unsupported_trigger');
+    }
+
+    $segment = $this->validateSegment($segmentId, SegmentEntity::TYPE_DEFAULT, 'manual_start_invalid_segment');
+    $allowedSegmentIds = $this->getAllowedSegmentIds($triggerStep);
+    if ($allowedSegmentIds !== null && !in_array($segmentId, $allowedSegmentIds, true)) {
+      throw new ApiException(__('The selected list is not allowed by this automation trigger.', 'mailpoet'), 400, 'manual_start_segment_not_allowed');
+    }
+
+    $filterSegment = null;
+    if ($filterSegmentId !== null) {
+      $filterSegment = $this->validateSegment($filterSegmentId, SegmentEntity::TYPE_DYNAMIC, 'manual_start_invalid_filter_segment');
+    }
+
+    return new ManualStartContext($automation, $triggerStep, $segment, $filterSegment);
+  }
+
+  private function validateSegment(int $segmentId, string $expectedType, string $errorCode): SegmentEntity {
+    if ($segmentId <= 0) {
+      throw new ApiException(__('Segment id must be a positive integer.', 'mailpoet'), 400, $errorCode);
+    }
+
+    $segment = $this->segmentsRepository->findOneById($segmentId);
+    if (!$segment instanceof SegmentEntity) {
+      throw new ApiException(__('Segment not found.', 'mailpoet'), 400, $errorCode);
+    }
+    if ($segment->getDeletedAt() !== null) {
+      throw new ApiException(__('Deleted segments cannot be used to start an automation.', 'mailpoet'), 400, $errorCode);
+    }
+    if ($segment->getType() !== $expectedType) {
+      throw new ApiException(__('The selected segment type is not supported for manual starts.', 'mailpoet'), 400, $errorCode);
+    }
+    return $segment;
+  }
+
+  /**
+   * @return int[]|null
+   */
+  private function getAllowedSegmentIds(Step $triggerStep): ?array {
+    $args = $triggerStep->getArgs();
+    $segmentIds = $args['segment_ids'] ?? null;
+    if (!is_array($segmentIds) || $segmentIds === []) {
+      return null;
+    }
+
+    $ids = [];
+    foreach ($segmentIds as $segmentId) {
+      if (is_numeric($segmentId) && (int)$segmentId > 0) {
+        $ids[] = (int)$segmentId;
+      }
+    }
+    $ids = array_values(array_unique($ids));
+    return $ids ?: null;
+  }
+
+  /**
+   * @return array{preview_signature: string, automation_id: int, segment_id: int, filter_segment_id: int|null, selected_count: int, eligible_count: int, skipped_by_reason: array<string, int>, deferred_reason_keys: string[], duplicate_in_progress: bool}
+   */
+  private function buildPreview(ManualStartContext $context): array {
+    $automation = $context->getAutomation();
+    $counts = $this->audienceRepository->getPreviewCounts($automation->getId(), $context->getSegment(), $context->getFilterSegment());
+    $preview = [
+      'preview_signature' => '',
+      'automation_id' => $automation->getId(),
+      'segment_id' => $context->getSegmentId(),
+      'filter_segment_id' => $context->getFilterSegmentId(),
+      'selected_count' => $counts['selected_count'],
+      'eligible_count' => $counts['eligible_count'],
+      'skipped_by_reason' => $counts['skipped_by_reason'],
+      'deferred_reason_keys' => [
+        ManualStartAudienceRepository::REASON_TRIGGER_FILTER_MISMATCH,
+        ManualStartAudienceRepository::REASON_RUN_CREATE_HOOK_REJECTED,
+        ManualStartAudienceRepository::REASON_STEP_SCHEDULING_FAILED,
+      ],
+      'duplicate_in_progress' => false,
+    ];
+    $preview['preview_signature'] = $this->createPreviewSignature($automation, $preview);
+    return $preview;
+  }
+
+  /**
+   * @param array{preview_signature: string, automation_id: int, segment_id: int, filter_segment_id: int|null, selected_count: int, eligible_count: int, skipped_by_reason: array<string, int>, deferred_reason_keys: string[], duplicate_in_progress: bool} $preview
+   * @return array{task_id: int, automation_id: int, segment_id: int, filter_segment_id: int|null, selected_count: int, eligible_count: int, queued_count: int, skipped_by_reason: array<string, int>}
+   */
+  private function createTask(ManualStartContext $context, array $preview, string $previewSignature): array {
+    $automation = $context->getAutomation();
+    $now = Carbon::now()->millisecond(0);
+    $task = new ScheduledTaskEntity();
+    $queuedCount = 0;
+
+    try {
+      $this->entityManager->wrapInTransaction(function () use ($context, $automation, $preview, $previewSignature, $now, $task, &$queuedCount): void {
+        $task->setType(ManualAutomationStartWorker::TASK_TYPE);
+        $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+        $task->setScheduledAt($now);
+        $task->setPriority(ScheduledTaskEntity::PRIORITY_HIGH);
+        $task->setMeta([
+          'automation_id' => $automation->getId(),
+          'automation_version_id' => $automation->getVersionId(),
+          'trigger_key' => SomeoneSubscribesTrigger::KEY,
+          'trigger_step_id' => $context->getTriggerStep()->getId(),
+          'segment_id' => $context->getSegmentId(),
+          'filter_segment_id' => $context->getFilterSegmentId(),
+          'requested_by' => (int)$this->wp->getCurrentUserId(),
+          'preview_signature' => $previewSignature,
+          'selected_count' => $preview['selected_count'],
+          'eligible_count' => $preview['eligible_count'],
+          'queued_count' => 0,
+          'skipped_by_reason' => $preview['skipped_by_reason'],
+          'worker_counts' => $this->getEmptyWorkerCounts(),
+          'queued_at' => $now->format('Y-m-d H:i:s'),
+        ]);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+
+        $queuedCount = $this->audienceRepository->queueEligibleSubscribers(
+          $task,
+          $automation->getId(),
+          $context->getSegment(),
+          $context->getFilterSegment()
+        );
+
+        if ($queuedCount <= 0) {
+          $this->entityManager->remove($task);
+          $this->entityManager->flush();
+          throw new ApiException(
+            __('No subscribers are eligible to start this automation.', 'mailpoet'),
+            422,
+            'manual_start_zero_eligible'
+          );
+        }
+
+        $meta = $task->getMeta() ?? [];
+        $meta['queued_count'] = $queuedCount;
+        $task->setMeta($meta);
+        $this->entityManager->flush();
+        $this->saveQueueAuditLog($task, $preview, $queuedCount);
+      });
+    } catch (Throwable $throwable) {
+      if ($throwable instanceof ApiException) {
+        throw $throwable;
+      }
+      throw new ApiException(__('Could not queue subscribers for manual automation start.', 'mailpoet'), 500, 'manual_start_queue_failed');
+    }
+
+    return [
+      'task_id' => (int)$task->getId(),
+      'automation_id' => $automation->getId(),
+      'segment_id' => $context->getSegmentId(),
+      'filter_segment_id' => $context->getFilterSegmentId(),
+      'selected_count' => $preview['selected_count'],
+      'eligible_count' => $preview['eligible_count'],
+      'queued_count' => $queuedCount,
+      'skipped_by_reason' => $preview['skipped_by_reason'],
+    ];
+  }
+
+  private function assertNoActiveTask(int $automationId): void {
+    if ($this->findActiveTaskId($automationId) !== null) {
+      throw new ApiException(
+        __('Subscribers are already queued for this automation. Wait for the current manual start to finish before starting another one.', 'mailpoet'),
+        409,
+        'manual_start_in_progress'
+      );
+    }
+  }
+
+  private function findActiveTaskId(int $automationId): ?int {
+    $tasksTable = $this->entityManager->getClassMetadata(ScheduledTaskEntity::class)->getTableName();
+    $taskId = $this->entityManager->getConnection()->executeQuery(
+      "SELECT id
+       FROM $tasksTable
+       WHERE type = :type
+         AND deleted_at IS NULL
+         AND (status = :scheduled OR status IS NULL)
+         AND CAST(JSON_UNQUOTE(JSON_EXTRACT(meta, '$.automation_id')) AS UNSIGNED) = :automationId
+       ORDER BY id DESC
+       LIMIT 1",
+      [
+        'type' => ManualAutomationStartWorker::TASK_TYPE,
+        'scheduled' => ScheduledTaskEntity::STATUS_SCHEDULED,
+        'automationId' => $automationId,
+      ],
+      [
+        'type' => ParameterType::STRING,
+        'scheduled' => ParameterType::STRING,
+        'automationId' => ParameterType::INTEGER,
+      ]
+    )->fetchOne();
+
+    return is_numeric($taskId) ? (int)$taskId : null;
+  }
+
+  /**
+   * @param array{preview_signature: string, automation_id: int, segment_id: int, filter_segment_id: int|null, selected_count: int, eligible_count: int, skipped_by_reason: array<string, int>, deferred_reason_keys: string[], duplicate_in_progress: bool} $preview
+   */
+  private function createPreviewSignature(Automation $automation, array $preview): string {
+    $payload = [
+      'automation_id' => $automation->getId(),
+      'automation_version_id' => $automation->getVersionId(),
+      'segment_id' => $preview['segment_id'],
+      'filter_segment_id' => $preview['filter_segment_id'],
+      'selected_count' => $preview['selected_count'],
+      'eligible_count' => $preview['eligible_count'],
+      'skipped_by_reason' => $preview['skipped_by_reason'],
+    ];
+    return hash('sha256', (string)$this->wp->wpJsonEncode($payload));
+  }
+
+  /**
+   * @return array{processed_count: int, created_count: int, failed_count: int, skipped_by_reason: array<string, int>, completion_log_saved: bool}
+   */
+  private function getEmptyWorkerCounts(): array {
+    return [
+      'processed_count' => 0,
+      'created_count' => 0,
+      'failed_count' => 0,
+      'skipped_by_reason' => [],
+      'completion_log_saved' => false,
+    ];
+  }
+
+  /**
+   * @param array{preview_signature: string, automation_id: int, segment_id: int, filter_segment_id: int|null, selected_count: int, eligible_count: int, skipped_by_reason: array<string, int>, deferred_reason_keys: string[], duplicate_in_progress: bool} $preview
+   */
+  private function saveQueueAuditLog(ScheduledTaskEntity $task, array $preview, int $queuedCount): void {
+    $log = new LogEntity();
+    $log->setName(LoggerFactory::TOPIC_API);
+    $log->setLevel(self::LOG_LEVEL_INFO);
+    $log->setMessage(self::AUDIT_LOG_MESSAGE_QUEUED);
+    $log->setRawMessage(self::AUDIT_LOG_MESSAGE_QUEUED);
+    $log->setContext([
+      'action' => 'manual_automation_start_queued',
+      'requested_by' => (int)$this->wp->getCurrentUserId(),
+      'task_id' => $task->getId(),
+      'automation_id' => $preview['automation_id'],
+      'segment_id' => $preview['segment_id'],
+      'filter_segment_id' => $preview['filter_segment_id'],
+      'selected_count' => $preview['selected_count'],
+      'eligible_count' => $preview['eligible_count'],
+      'queued_count' => $queuedCount,
+      'skipped_by_reason' => $preview['skipped_by_reason'],
+    ]);
+    $this->logRepository->saveLog($log);
+  }
+
+  private function acquireLock(string $lockName): void {
+    $result = $this->entityManager->getConnection()->executeQuery(
+      'SELECT GET_LOCK(:lockName, 10)',
+      ['lockName' => $lockName],
+      ['lockName' => ParameterType::STRING]
+    )->fetchOne();
+    if (!is_numeric($result) || (int)$result !== 1) {
+      throw new ApiException(
+        __('Subscribers are already being queued for this automation.', 'mailpoet'),
+        409,
+        'manual_start_in_progress'
+      );
+    }
+  }
+
+  private function releaseLock(string $lockName): void {
+    $this->entityManager->getConnection()->executeQuery(
+      'SELECT RELEASE_LOCK(:lockName)',
+      ['lockName' => $lockName],
+      ['lockName' => ParameterType::STRING]
+    );
+  }
+
+  private function getLockName(int $automationId): string {
+    return sprintf('mailpoet_manual_start_%d', $automationId);
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
+++ b/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
@@ -8,6 +8,7 @@ use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\AutomationStatistics;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\ManualStart\ManualStartService;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage;
 
@@ -18,12 +19,17 @@ class AutomationMapper {
   /** @var AutomationRunStorage */
   private $runStorage;
 
+  /** @var ManualStartService */
+  private $manualStartService;
+
   public function __construct(
     AutomationStatisticsStorage $statisticsStorage,
-    AutomationRunStorage $runStorage
+    AutomationRunStorage $runStorage,
+    ManualStartService $manualStartService
   ) {
     $this->statisticsStorage = $statisticsStorage;
     $this->runStorage = $runStorage;
+    $this->manualStartService = $manualStartService;
   }
 
   public function buildAutomation(Automation $automation, ?AutomationStatistics $statistics = null): array {
@@ -88,6 +94,7 @@ class AutomationMapper {
         'created_at' => $lastRun->getCreatedAt()->format(DateTimeImmutable::W3C),
         'updated_at' => $lastRun->getUpdatedAt()->format(DateTimeImmutable::W3C),
       ] : null,
+      'manual_start' => $this->manualStartService->getMetadata($automation),
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -35,6 +35,20 @@ class WordPress {
     return add_filter($hookName, $callback, $priority, $acceptedArgs);
   }
 
+  public function getFilterCallbacksCount(string $hookName): int {
+    global $wp_filter;
+
+    if (!isset($wp_filter[$hookName]) || !($wp_filter[$hookName] instanceof \WP_Hook)) {
+      return 0;
+    }
+
+    $count = 0;
+    foreach ($wp_filter[$hookName]->callbacks as $callbacks) {
+      $count += count($callbacks);
+    }
+    return $count;
+  }
+
   /**
    * @param non-empty-string $hookName
    * @param mixed $value

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SubscriberSubject.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SubscriberSubject.php
@@ -19,6 +19,7 @@ use MailPoet\WPCOM\DotcomHelperFunctions;
  */
 class SubscriberSubject implements Subject {
   const KEY = 'mailpoet:subscriber';
+  private const SUBJECT_ID_ARG = 'subscriber_id';
 
   /** @var SubscriberFieldsFactory */
   private $subscriberFieldsFactory;
@@ -54,12 +55,12 @@ class SubscriberSubject implements Subject {
 
   public function getArgsSchema(): ObjectSchema {
     return Builder::object([
-      'subscriber_id' => Builder::integer()->required(),
+      self::SUBJECT_ID_ARG => Builder::integer()->required(),
     ]);
   }
 
   public function getPayload(SubjectData $subjectData): Payload {
-    $id = $subjectData->getArgs()['subscriber_id'];
+    $id = $subjectData->getArgs()[self::SUBJECT_ID_ARG];
     $subscriber = $this->subscribersRepository->findOneById($id);
     if (!$subscriber) {
       // translators: %d is the ID.
@@ -71,5 +72,17 @@ class SubscriberSubject implements Subject {
   /** @return Field[] */
   public function getFields(): array {
     return $this->subscriberFieldsFactory->getFields();
+  }
+
+  public static function getHashSqlExpression(string $subscriberIdExpression, string $subjectKeyExpression): string {
+    return SubjectData::getHashSqlExpression(
+      $subjectKeyExpression,
+      sprintf(
+        "CONCAT('a:1:{s:%d:\"%s\";i:', %s, ';}')",
+        strlen(self::SUBJECT_ID_ARG),
+        self::SUBJECT_ID_ARG,
+        $subscriberIdExpression
+      )
+    );
   }
 }

--- a/mailpoet/lib/Config/Env.php
+++ b/mailpoet/lib/Config/Env.php
@@ -8,6 +8,7 @@ class Env {
   const NEWSLETTER_CONTENT_WIDTH = 1320;
 
   public static $version;
+  public static $assetsVersion;
   public static $pluginName;
   public static $pluginPath;
   public static $baseUrl;
@@ -79,8 +80,9 @@ class Env {
   public static $plugin_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   public static $temp_path; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
-  public static function init($file, $version) {
+  public static function init($file, $version, $assetsVersion = null) {
     self::$version = $version;
+    self::$assetsVersion = $assetsVersion ?? $version;
     self::$file = $file;
     self::$path = dirname(self::$file);
     self::$pluginName = 'mailpoet';

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -115,6 +115,7 @@ class Daemon {
     yield $this->workersFactory->createReEngagementEmailsSchedulerWorker();
     yield $this->workersFactory->createNewsletterTemplateThumbnailsWorker();
     yield $this->workersFactory->createAbandonedCartWorker();
+    yield $this->workersFactory->createManualAutomationStartWorker();
     yield $this->workersFactory->createBackfillEngagementDataWorker();
     yield $this->workersFactory->createMixpanelWorker();
     yield $this->workersFactory->createTracksWorker();

--- a/mailpoet/lib/Cron/Workers/Automations/ManualAutomationStartWorker.php
+++ b/mailpoet/lib/Cron/Workers/Automations/ManualAutomationStartWorker.php
@@ -1,0 +1,256 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\Workers\Automations;
+
+use MailPoet\Automation\Engine\Control\AutomationRunCreationResult;
+use MailPoet\Automation\Engine\Control\AutomationRunCreator;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\ManualStart\ManualStartAudienceRepository;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
+use MailPoet\Cron\Workers\SimpleWorker;
+use MailPoet\Entities\LogEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Logging\LoggerFactory;
+use MailPoet\Logging\LogRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use Throwable;
+
+class ManualAutomationStartWorker extends SimpleWorker {
+  const TASK_TYPE = 'automation_manual_start';
+  const AUTOMATIC_SCHEDULING = false;
+  const SUPPORT_MULTIPLE_INSTANCES = false;
+  const BATCH_SIZE = 100;
+
+  private const AUDIT_LOG_MESSAGE_COMPLETED = 'Manual automation start completed.';
+  private const LOG_LEVEL_INFO = 200;
+
+  /** @var AutomationStorage */
+  private $automationStorage;
+
+  /** @var AutomationRunCreator */
+  private $automationRunCreator;
+
+  /** @var SomeoneSubscribesTrigger */
+  private $trigger;
+
+  /** @var ManualStartAudienceRepository */
+  private $audienceRepository;
+
+  /** @var ScheduledTaskSubscribersRepository */
+  private $scheduledTaskSubscribersRepository;
+
+  /** @var LogRepository */
+  private $logRepository;
+
+  public function __construct(
+    AutomationStorage $automationStorage,
+    AutomationRunCreator $automationRunCreator,
+    SomeoneSubscribesTrigger $trigger,
+    ManualStartAudienceRepository $audienceRepository,
+    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    LogRepository $logRepository
+  ) {
+    parent::__construct();
+    $this->automationStorage = $automationStorage;
+    $this->automationRunCreator = $automationRunCreator;
+    $this->trigger = $trigger;
+    $this->audienceRepository = $audienceRepository;
+    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->logRepository = $logRepository;
+  }
+
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+    $meta = $task->getMeta() ?? [];
+    $automationId = $this->getRequiredInt($meta['automation_id'] ?? null);
+    $automationVersionId = $this->getRequiredInt($meta['automation_version_id'] ?? null);
+    $segmentId = $this->getRequiredInt($meta['segment_id'] ?? null);
+    $filterSegmentId = $this->getOptionalInt($meta['filter_segment_id'] ?? null);
+
+    if ($automationId <= 0 || $automationVersionId <= 0 || $segmentId <= 0) {
+      $task->setStatus(ScheduledTaskEntity::STATUS_INVALID);
+      $this->scheduledTasksRepository->persist($task);
+      $this->scheduledTasksRepository->flush();
+      return false;
+    }
+
+    $subscriberIds = $this->scheduledTaskSubscribersRepository->getSubscriberIdsBatchForTask((int)$task->getId(), 0, self::BATCH_SIZE);
+    if (!$subscriberIds) {
+      $this->saveCompletionIfNeeded($task);
+      return true;
+    }
+
+    $automation = $this->automationStorage->getAutomation($automationId, $automationVersionId);
+    $processedIds = [];
+    $counts = $this->getWorkerCounts($task);
+
+    foreach ($subscriberIds as $subscriberId) {
+      $this->cronHelper->enforceExecutionLimit($timer);
+      $subscriberId = (int)$subscriberId;
+      $counts['processed_count']++;
+
+      if (!$automation instanceof Automation || $automation->getStatus() !== Automation::STATUS_ACTIVE) {
+        $this->saveSkipped($task, $subscriberId, ManualStartAudienceRepository::REASON_AUTOMATION_INACTIVE, $counts);
+        continue;
+      }
+
+      $reason = $this->audienceRepository->getSubscriberIneligibleReason($subscriberId, $segmentId, $filterSegmentId);
+      if ($reason !== null) {
+        $this->saveSkipped($task, $subscriberId, $reason, $counts);
+        continue;
+      }
+      if ($this->audienceRepository->hasSubscriberEnteredAutomation($automationId, $subscriberId)) {
+        $this->saveSkipped($task, $subscriberId, ManualStartAudienceRepository::REASON_ALREADY_ENTERED, $counts);
+        continue;
+      }
+
+      $subjects = [
+        new Subject(SegmentSubject::KEY, ['segment_id' => $segmentId]),
+        new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriberId]),
+      ];
+
+      try {
+        $result = $this->automationRunCreator->createForAutomation($automation, $this->trigger, $subjects, $this->getTriggerLogData($task));
+      } catch (Throwable $throwable) {
+        $this->saveSkipped($task, $subscriberId, ManualStartAudienceRepository::REASON_STEP_SCHEDULING_FAILED, $counts);
+        continue;
+      }
+
+      if ($result->isCreated()) {
+        $processedIds[] = $subscriberId;
+        $counts['created_count']++;
+        continue;
+      }
+
+      $this->saveSkipped($task, $subscriberId, $this->mapCreationResultToReason($result), $counts);
+    }
+
+    $this->scheduledTaskSubscribersRepository->updateProcessedSubscribers($task, $processedIds);
+    $this->saveWorkerCounts($task, $counts);
+
+    if ($this->scheduledTaskSubscribersRepository->countUnprocessed($task) > 0) {
+      return false;
+    }
+
+    $this->saveCompletionIfNeeded($task);
+    return true;
+  }
+
+  /**
+   * @return array{processed_count: int, created_count: int, failed_count: int, skipped_by_reason: array<string, int>, completion_log_saved: bool}
+   */
+  private function getWorkerCounts(ScheduledTaskEntity $task): array {
+    $meta = $task->getMeta() ?? [];
+    $counts = isset($meta['worker_counts']) && is_array($meta['worker_counts']) ? $meta['worker_counts'] : [];
+    $skippedByReason = isset($counts['skipped_by_reason']) && is_array($counts['skipped_by_reason']) ? $counts['skipped_by_reason'] : [];
+    $skippedByReasonCounts = [];
+    foreach ($skippedByReason as $reason => $count) {
+      if (is_string($reason)) {
+        $skippedByReasonCounts[$reason] = $this->getRequiredInt($count);
+      }
+    }
+    return [
+      'processed_count' => $this->getRequiredInt($counts['processed_count'] ?? null),
+      'created_count' => $this->getRequiredInt($counts['created_count'] ?? null),
+      'failed_count' => $this->getRequiredInt($counts['failed_count'] ?? null),
+      'skipped_by_reason' => $skippedByReasonCounts,
+      'completion_log_saved' => (bool)($counts['completion_log_saved'] ?? false),
+    ];
+  }
+
+  /**
+   * @param array{processed_count: int, created_count: int, failed_count: int, skipped_by_reason: array<string, int>, completion_log_saved: bool} $counts
+   */
+  private function saveWorkerCounts(ScheduledTaskEntity $task, array $counts): void {
+    $meta = $task->getMeta() ?? [];
+    $meta['worker_counts'] = $counts;
+    $task->setMeta($meta);
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+  }
+
+  /**
+   * @param array{processed_count: int, created_count: int, failed_count: int, skipped_by_reason: array<string, int>, completion_log_saved: bool} $counts
+   */
+  private function saveSkipped(ScheduledTaskEntity $task, int $subscriberId, string $reason, array &$counts): void {
+    $counts['failed_count']++;
+    $counts['skipped_by_reason'][$reason] = ($counts['skipped_by_reason'][$reason] ?? 0) + 1;
+    $this->scheduledTaskSubscribersRepository->saveError($task, $subscriberId, 'skipped:' . $reason);
+  }
+
+  private function mapCreationResultToReason(AutomationRunCreationResult $result): string {
+    if ($result->getStatus() === AutomationRunCreationResult::STATUS_RUN_CREATE_HOOK_REJECTED) {
+      return ManualStartAudienceRepository::REASON_RUN_CREATE_HOOK_REJECTED;
+    }
+    if ($result->getStatus() === AutomationRunCreationResult::STATUS_STEP_SCHEDULING_FAILED) {
+      return ManualStartAudienceRepository::REASON_STEP_SCHEDULING_FAILED;
+    }
+    return ManualStartAudienceRepository::REASON_TRIGGER_FILTER_MISMATCH;
+  }
+
+  /**
+   * @return array<string, scalar>
+   */
+  private function getTriggerLogData(ScheduledTaskEntity $task): array {
+    $meta = $task->getMeta() ?? [];
+    $data = [
+      'manual_start' => true,
+      'manual_start_task_id' => $this->getRequiredInt($task->getId()),
+      'manual_start_segment_id' => $this->getRequiredInt($meta['segment_id'] ?? null),
+      'manual_start_requested_by' => $this->getRequiredInt($meta['requested_by'] ?? null),
+    ];
+    $filterSegmentId = $this->getOptionalInt($meta['filter_segment_id'] ?? null);
+    if ($filterSegmentId !== null) {
+      $data['manual_start_filter_segment_id'] = $filterSegmentId;
+    }
+    return $data;
+  }
+
+  private function saveCompletionIfNeeded(ScheduledTaskEntity $task): void {
+    $counts = $this->getWorkerCounts($task);
+    if ($counts['completion_log_saved']) {
+      return;
+    }
+    $counts['completion_log_saved'] = true;
+    $this->saveWorkerCounts($task, $counts);
+
+    $meta = $task->getMeta() ?? [];
+    $log = new LogEntity();
+    $log->setName(LoggerFactory::TOPIC_CRON);
+    $log->setLevel(self::LOG_LEVEL_INFO);
+    $log->setMessage(self::AUDIT_LOG_MESSAGE_COMPLETED);
+    $log->setRawMessage(self::AUDIT_LOG_MESSAGE_COMPLETED);
+    $log->setContext([
+      'action' => 'manual_automation_start_completed',
+      'task_id' => $task->getId(),
+      'automation_id' => $meta['automation_id'] ?? null,
+      'segment_id' => $meta['segment_id'] ?? null,
+      'filter_segment_id' => $meta['filter_segment_id'] ?? null,
+      'processed_count' => $counts['processed_count'],
+      'created_count' => $counts['created_count'],
+      'failed_count' => $counts['failed_count'],
+      'skipped_by_reason' => $counts['skipped_by_reason'],
+      'final_status' => ScheduledTaskEntity::STATUS_COMPLETED,
+    ]);
+    $this->logRepository->saveLog($log);
+  }
+
+  /** @param mixed $value */
+  private function getRequiredInt($value): int {
+    if (is_numeric($value)) {
+      return (int)$value;
+    }
+    return 0;
+  }
+
+  /** @param mixed $value */
+  private function getOptionalInt($value): ?int {
+    if (is_numeric($value)) {
+      return (int)$value;
+    }
+    return null;
+  }
+}

--- a/mailpoet/lib/Cron/Workers/Automations/ManualAutomationStartWorker.php
+++ b/mailpoet/lib/Cron/Workers/Automations/ManualAutomationStartWorker.php
@@ -84,8 +84,8 @@ class ManualAutomationStartWorker extends SimpleWorker {
     }
 
     $automation = $this->automationStorage->getAutomation($automationId, $automationVersionId);
-    $processedIds = [];
     $counts = $this->getWorkerCounts($task);
+    $segmentIneligibleReason = $this->audienceRepository->getSegmentIneligibleReason($segmentId, $filterSegmentId);
 
     foreach ($subscriberIds as $subscriberId) {
       $this->cronHelper->enforceExecutionLimit($timer);
@@ -94,6 +94,11 @@ class ManualAutomationStartWorker extends SimpleWorker {
 
       if (!$automation instanceof Automation || $automation->getStatus() !== Automation::STATUS_ACTIVE) {
         $this->saveSkipped($task, $subscriberId, ManualStartAudienceRepository::REASON_AUTOMATION_INACTIVE, $counts);
+        continue;
+      }
+
+      if ($segmentIneligibleReason !== null) {
+        $this->saveSkipped($task, $subscriberId, $segmentIneligibleReason, $counts);
         continue;
       }
 
@@ -120,16 +125,14 @@ class ManualAutomationStartWorker extends SimpleWorker {
       }
 
       if ($result->isCreated()) {
-        $processedIds[] = $subscriberId;
         $counts['created_count']++;
+        $this->scheduledTaskSubscribersRepository->updateProcessedSubscribers($task, [$subscriberId]);
+        $this->saveWorkerCounts($task, $counts);
         continue;
       }
 
       $this->saveSkipped($task, $subscriberId, $this->mapCreationResultToReason($result), $counts);
     }
-
-    $this->scheduledTaskSubscribersRepository->updateProcessedSubscribers($task, $processedIds);
-    $this->saveWorkerCounts($task, $counts);
 
     if ($this->scheduledTaskSubscribersRepository->countUnprocessed($task) > 0) {
       return false;
@@ -179,6 +182,7 @@ class ManualAutomationStartWorker extends SimpleWorker {
     $counts['failed_count']++;
     $counts['skipped_by_reason'][$reason] = ($counts['skipped_by_reason'][$reason] ?? 0) + 1;
     $this->scheduledTaskSubscribersRepository->saveError($task, $subscriberId, 'skipped:' . $reason);
+    $this->saveWorkerCounts($task, $counts);
   }
 
   private function mapCreationResultToReason(AutomationRunCreationResult $result): string {
@@ -214,8 +218,6 @@ class ManualAutomationStartWorker extends SimpleWorker {
     if ($counts['completion_log_saved']) {
       return;
     }
-    $counts['completion_log_saved'] = true;
-    $this->saveWorkerCounts($task, $counts);
 
     $meta = $task->getMeta() ?? [];
     $log = new LogEntity();
@@ -236,6 +238,8 @@ class ManualAutomationStartWorker extends SimpleWorker {
       'final_status' => ScheduledTaskEntity::STATUS_COMPLETED,
     ]);
     $this->logRepository->saveLog($log);
+    $counts['completion_log_saved'] = true;
+    $this->saveWorkerCounts($task, $counts);
   }
 
   /** @param mixed $value */

--- a/mailpoet/lib/Cron/Workers/Automations/ManualAutomationStartWorker.php
+++ b/mailpoet/lib/Cron/Workers/Automations/ManualAutomationStartWorker.php
@@ -87,52 +87,58 @@ class ManualAutomationStartWorker extends SimpleWorker {
     $counts = $this->getWorkerCounts($task);
     $segmentIneligibleReason = $this->audienceRepository->getSegmentIneligibleReason($segmentId, $filterSegmentId);
 
-    foreach ($subscriberIds as $subscriberId) {
-      $this->cronHelper->enforceExecutionLimit($timer);
-      $subscriberId = (int)$subscriberId;
-      $counts['processed_count']++;
+    try {
+      foreach ($subscriberIds as $subscriberId) {
+        $this->cronHelper->enforceExecutionLimit($timer);
+        $subscriberId = (int)$subscriberId;
+        $counts['processed_count']++;
 
-      if (!$automation instanceof Automation || $automation->getStatus() !== Automation::STATUS_ACTIVE) {
-        $this->saveSkipped($task, $subscriberId, ManualStartAudienceRepository::REASON_AUTOMATION_INACTIVE, $counts);
-        continue;
+        if (!$automation instanceof Automation || $automation->getStatus() !== Automation::STATUS_ACTIVE) {
+          $this->saveSkipped($task, $subscriberId, ManualStartAudienceRepository::REASON_AUTOMATION_INACTIVE, $counts);
+          continue;
+        }
+
+        if ($segmentIneligibleReason !== null) {
+          $this->saveSkipped($task, $subscriberId, $segmentIneligibleReason, $counts);
+          continue;
+        }
+
+        $reason = $this->audienceRepository->getSubscriberIneligibleReason($subscriberId, $segmentId, $filterSegmentId);
+        if ($reason !== null) {
+          $this->saveSkipped($task, $subscriberId, $reason, $counts);
+          continue;
+        }
+        if ($this->audienceRepository->hasSubscriberEnteredAutomation($automationId, $subscriberId)) {
+          $this->saveSkipped($task, $subscriberId, ManualStartAudienceRepository::REASON_ALREADY_ENTERED, $counts);
+          continue;
+        }
+
+        $subjects = [
+          new Subject(SegmentSubject::KEY, ['segment_id' => $segmentId]),
+          new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriberId]),
+        ];
+
+        try {
+          $result = $this->automationRunCreator->createForAutomation($automation, $this->trigger, $subjects, $this->getTriggerLogData($task));
+        } catch (Throwable $throwable) {
+          $this->saveSkipped($task, $subscriberId, ManualStartAudienceRepository::REASON_STEP_SCHEDULING_FAILED, $counts);
+          continue;
+        }
+
+        if ($result->isCreated()) {
+          $counts['created_count']++;
+          $this->scheduledTaskSubscribersRepository->updateProcessedSubscribers($task, [$subscriberId]);
+          continue;
+        }
+
+        $this->saveSkipped($task, $subscriberId, $this->mapCreationResultToReason($result), $counts);
       }
-
-      if ($segmentIneligibleReason !== null) {
-        $this->saveSkipped($task, $subscriberId, $segmentIneligibleReason, $counts);
-        continue;
-      }
-
-      $reason = $this->audienceRepository->getSubscriberIneligibleReason($subscriberId, $segmentId, $filterSegmentId);
-      if ($reason !== null) {
-        $this->saveSkipped($task, $subscriberId, $reason, $counts);
-        continue;
-      }
-      if ($this->audienceRepository->hasSubscriberEnteredAutomation($automationId, $subscriberId)) {
-        $this->saveSkipped($task, $subscriberId, ManualStartAudienceRepository::REASON_ALREADY_ENTERED, $counts);
-        continue;
-      }
-
-      $subjects = [
-        new Subject(SegmentSubject::KEY, ['segment_id' => $segmentId]),
-        new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriberId]),
-      ];
-
-      try {
-        $result = $this->automationRunCreator->createForAutomation($automation, $this->trigger, $subjects, $this->getTriggerLogData($task));
-      } catch (Throwable $throwable) {
-        $this->saveSkipped($task, $subscriberId, ManualStartAudienceRepository::REASON_STEP_SCHEDULING_FAILED, $counts);
-        continue;
-      }
-
-      if ($result->isCreated()) {
-        $counts['created_count']++;
-        $this->scheduledTaskSubscribersRepository->updateProcessedSubscribers($task, [$subscriberId]);
-        $this->saveWorkerCounts($task, $counts);
-        continue;
-      }
-
-      $this->saveSkipped($task, $subscriberId, $this->mapCreationResultToReason($result), $counts);
+    } catch (Throwable $throwable) {
+      $this->saveWorkerCounts($task, $counts);
+      throw $throwable;
     }
+
+    $this->saveWorkerCounts($task, $counts);
 
     if ($this->scheduledTaskSubscribersRepository->countUnprocessed($task) > 0) {
       return false;
@@ -182,7 +188,6 @@ class ManualAutomationStartWorker extends SimpleWorker {
     $counts['failed_count']++;
     $counts['skipped_by_reason'][$reason] = ($counts['skipped_by_reason'][$reason] ?? 0) + 1;
     $this->scheduledTaskSubscribersRepository->saveError($task, $subscriberId, 'skipped:' . $reason);
-    $this->saveWorkerCounts($task, $counts);
   }
 
   private function mapCreationResultToReason(AutomationRunCreationResult $result): string {

--- a/mailpoet/lib/Cron/Workers/SendingTaskSubscribersCleanup.php
+++ b/mailpoet/lib/Cron/Workers/SendingTaskSubscribersCleanup.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Cron\Workers;
 
+use MailPoet\Cron\Workers\Automations\ManualAutomationStartWorker;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Settings\SettingsController;
@@ -57,7 +58,8 @@ class SendingTaskSubscribersCleanup extends SimpleWorker {
       $deleted = $this->scheduledTaskSubscribersRepository->purgeOldTaskSubscribers(
         $retentionDays,
         self::TASK_BATCH_SIZE,
-        self::ROW_BATCH_SIZE
+        self::ROW_BATCH_SIZE,
+        ['sending', ManualAutomationStartWorker::TASK_TYPE]
       );
 
       if (

--- a/mailpoet/lib/Cron/Workers/WorkersFactory.php
+++ b/mailpoet/lib/Cron/Workers/WorkersFactory.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Cron\Workers;
 
 use MailPoet\Cron\Workers\Automations\AbandonedCartWorker;
+use MailPoet\Cron\Workers\Automations\ManualAutomationStartWorker;
 use MailPoet\Cron\Workers\Bounce as BounceWorker;
 use MailPoet\Cron\Workers\KeyCheck\PremiumKeyCheck as PremiumKeyCheckWorker;
 use MailPoet\Cron\Workers\KeyCheck\SendingServiceKeyCheck as SendingServiceKeyCheckWorker;
@@ -33,6 +34,7 @@ class WorkersFactory {
     BackfillEngagementData::TASK_TYPE,
     Mixpanel::TASK_TYPE,
     AbandonedCartWorker::TASK_TYPE,
+    ManualAutomationStartWorker::TASK_TYPE,
     LogCleanup::TASK_TYPE,
     SendingTaskSubscribersCleanup::TASK_TYPE,
     SendingQueueBodyCleanup::TASK_TYPE,
@@ -179,6 +181,11 @@ class WorkersFactory {
   /** @return AbandonedCartWorker */
   public function createAbandonedCartWorker() {
     return $this->container->get(AbandonedCartWorker::class);
+  }
+
+  /** @return ManualAutomationStartWorker */
+  public function createManualAutomationStartWorker() {
+    return $this->container->get(ManualAutomationStartWorker::class);
   }
 
   /** @return BackfillEngagementData */

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -138,6 +138,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Builder\UpdateAutomationController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\ActionScheduler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\AutomationController::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Control\AutomationRunCreator::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\RootStep::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\FilterHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\StepHandler::class)->setPublic(true);
@@ -149,6 +150,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Control\TriggerHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Engine::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Hooks::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\ManualStart\ManualStartAudienceRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\ManualStart\ManualStartService::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Mappers\AutomationMapper::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Registry::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Storage\AutomationRunStorage::class)->setPublic(true);
@@ -173,6 +176,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationsCreateFromTemplateEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationsDuplicateEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationsDeleteEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationManualStartPreviewEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationManualStartEndpoint::class)->setPublic(true);
     // Automation - core integration
     $container->autowire(\MailPoet\Automation\Integrations\Core\Actions\DelayAction::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\Core\Actions\IfElseAction::class)->setPublic(true);
@@ -358,6 +363,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\Workers\SubscribersStatsReport::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\NewsletterTemplateThumbnails::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\Automations\AbandonedCartWorker::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\Workers\Automations\ManualAutomationStartWorker::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SubscriberLimitNotificationWorker::class)->setPublic(true);
     // Custom field
     $container->autowire(\MailPoet\CustomFields\ApiDataSanitizer::class);

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
@@ -239,28 +239,32 @@ class ScheduledTaskSubscribersRepository extends Repository {
     return $this->countBy(['task' => $scheduledTaskEntity, 'processed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED]);
   }
 
-  public function purgeOldTaskSubscribers(int $daysToKeep, int $taskBatchSize, int $rowLimit): int {
+  public function purgeOldTaskSubscribers(int $daysToKeep, int $taskBatchSize, int $rowLimit, array $taskTypes = ['sending']): int {
     $stTable = $this->entityManager->getClassMetadata(ScheduledTaskEntity::class)->getTableName();
     $stsTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
     $cutoff = Carbon::now()->subDays($daysToKeep)->toDateTimeString();
+    $taskTypes = array_values(array_unique(array_filter($taskTypes)));
+    if (!$taskTypes) {
+      return 0;
+    }
 
     $taskIds = $this->entityManager->getConnection()->executeQuery(
       "SELECT DISTINCT st.`id`
        FROM `{$stTable}` st
        INNER JOIN `{$stsTable}` sts ON sts.`task_id` = st.`id`
-       WHERE st.`type` = :type
+       WHERE st.`type` IN (:types)
          AND st.`status` = :status
          AND st.`processed_at` < :cutoff
          AND st.`deleted_at` IS NULL
        LIMIT :taskBatchSize",
       [
-        'type' => 'sending',
+        'types' => $taskTypes,
         'status' => ScheduledTaskEntity::STATUS_COMPLETED,
         'cutoff' => $cutoff,
         'taskBatchSize' => $taskBatchSize,
       ],
       [
-        'type' => ParameterType::STRING,
+        'types' => ArrayParameterType::STRING,
         'status' => ParameterType::STRING,
         'cutoff' => ParameterType::STRING,
         'taskBatchSize' => ParameterType::INTEGER,

--- a/mailpoet/lib/Segments/SegmentSubscribersRepository.php
+++ b/mailpoet/lib/Segments/SegmentSubscribersRepository.php
@@ -117,6 +117,19 @@ class SegmentSubscribersRepository {
     }
   }
 
+  public function createSubscribersInSegmentQueryBuilder(SegmentEntity $segment, ?string $status = null): QueryBuilder {
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $queryBuilder = $this->entityManager
+      ->getConnection()
+      ->createQueryBuilder()
+      ->select("DISTINCT $subscribersTable.id")
+      ->from($subscribersTable);
+
+    return $segment->isStatic()
+      ? $this->filterSubscribersInStaticSegment($queryBuilder, $segment, $status)
+      : $this->filterSubscribersInDynamicSegment($queryBuilder, $segment, $status);
+  }
+
   /**
    * @param DynamicSegmentFilterData[] $filters
    * @return int

--- a/mailpoet/lib/Twig/Assets.php
+++ b/mailpoet/lib/Twig/Assets.php
@@ -72,7 +72,7 @@ class Assets extends AbstractExtension {
       $this->globals['assets_url'],
       strpos($script, 'lib/') === 0 ? 'js' : 'dist/js',
       $this->getAssetFileName($this->globals['assets_manifest_js'], $script),
-      Env::$version
+      Env::$assetsVersion
     );
   }
 

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 5.27.0
+ * Version: 5.27.1
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '5.27.0',
+  'version' => '5.27.1',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload_packages.php',

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 5.27.1
+ * Version: 5.27.0
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,8 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '5.27.1',
+  'version' => '5.27.0',
+  'assets_version' => '5.27.1',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload_packages.php',

--- a/mailpoet/mailpoet_initializer.php
+++ b/mailpoet/mailpoet_initializer.php
@@ -102,7 +102,8 @@ define('MAILPOET_VERSION', $mailpoetPlugin['version']);
 
 Env::init(
   $mailpoetPlugin['filename'],
-  $mailpoetPlugin['version']
+  $mailpoetPlugin['version'],
+  $mailpoetPlugin['assets_version'] ?? null
 );
 
 $requirements = new RequirementsChecker();

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -9,7 +9,7 @@
     "scss": "sass assets/css/src/:assets/dist/css/ --style compressed",
     "stylelint": "stylelint --fix",
     "stylelint-check": "stylelint",
-    "test": "env NODE_PATH=$NODE_PATH:./assets/js/src mocha --recursive --require tests/javascript/mocha-env.mjs  tests/javascript --extension spec.ts",
+    "test": "env NODE_PATH=$NODE_PATH:./assets/js/src mocha --recursive --require tests/javascript/mocha-env.mjs  tests/javascript --extension spec.ts --extension spec.tsx",
     "test:unit": "./do test:unit",
     "test:integration": "./do test:integration --skip-deps",
     "test:acceptance": "./do test:acceptance --skip-deps",

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.8
 Tested up to: 6.9
-Stable tag: 5.27.1
+Stable tag: 5.27.0
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.8
 Tested up to: 6.9
-Stable tag: 5.27.0
+Stable tag: 5.27.1
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
@@ -8,6 +8,7 @@ use MailPoet\Automation\Engine\Data\FilterGroup;
 use MailPoet\Automation\Engine\Data\Filters;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationRunLogStorage;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
@@ -159,6 +160,36 @@ class TriggerHandlerTest extends \MailPoetTest {
     $segmentSubject = new Subject(SegmentSubject::KEY, ['segment_id' => $this->segments['segment_1']->getId()]);
     $this->testee->processTrigger($trigger, [$segmentSubject]);
     $this->assertCount(0, $this->automationRunStorage->getAutomationRunsForAutomation($automation1));
+  }
+
+  public function testRunCreateFilterCanOverrideTriggerMismatch(): void {
+    $trigger = $this->diContainer->get(SomeoneSubscribesTrigger::class);
+    $automation = $this->tester->createAutomation(
+      'automation-1',
+      new Step(
+        'trigger',
+        Step::TYPE_TRIGGER,
+        $trigger->getKey(),
+        [
+          'segment_ids' => [$this->segments['segment_1']->getId()],
+        ],
+        []
+      )
+    );
+
+    $createRunFilter = function (): bool {
+      return true;
+    };
+    add_filter(Hooks::AUTOMATION_RUN_CREATE, $createRunFilter);
+
+    try {
+      $segmentSubject = new Subject(SegmentSubject::KEY, ['segment_id' => $this->segments['segment_2']->getId()]);
+      $this->testee->processTrigger($trigger, [$segmentSubject]);
+    } finally {
+      remove_filter(Hooks::AUTOMATION_RUN_CREATE, $createRunFilter);
+    }
+
+    $this->assertCount(1, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
   }
 
   public function testItAppliesFilters(): void {

--- a/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\Test\Automation\Engine\Control;
 
+use MailPoet\Automation\Engine\Control\AutomationRunCreationResult;
+use MailPoet\Automation\Engine\Control\AutomationRunCreator;
 use MailPoet\Automation\Engine\Control\TriggerHandler;
 use MailPoet\Automation\Engine\Data\Filter;
 use MailPoet\Automation\Engine\Data\FilterGroup;
@@ -190,6 +192,40 @@ class TriggerHandlerTest extends \MailPoetTest {
     }
 
     $this->assertCount(1, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
+  }
+
+  public function testRunCreateHookRejectionWinsOverTriggerMismatch(): void {
+    $trigger = $this->diContainer->get(SomeoneSubscribesTrigger::class);
+    $automationRunCreator = $this->diContainer->get(AutomationRunCreator::class);
+    $automation = $this->tester->createAutomation(
+      'automation-1',
+      new Step(
+        'trigger',
+        Step::TYPE_TRIGGER,
+        $trigger->getKey(),
+        [
+          'segment_ids' => [$this->segments['segment_1']->getId()],
+        ],
+        []
+      )
+    );
+
+    $segmentSubject = new Subject(SegmentSubject::KEY, ['segment_id' => $this->segments['segment_2']->getId()]);
+    $result = $automationRunCreator->createForAutomation($automation, $trigger, [$segmentSubject]);
+    $this->assertSame(AutomationRunCreationResult::STATUS_TRIGGER_FILTER_MISMATCH, $result->getStatus());
+
+    $rejectRunFilter = function (): bool {
+      return false;
+    };
+    add_filter(Hooks::AUTOMATION_RUN_CREATE, $rejectRunFilter);
+
+    try {
+      $result = $automationRunCreator->createForAutomation($automation, $trigger, [$segmentSubject]);
+    } finally {
+      remove_filter(Hooks::AUTOMATION_RUN_CREATE, $rejectRunFilter);
+    }
+
+    $this->assertSame(AutomationRunCreationResult::STATUS_RUN_CREATE_HOOK_REJECTED, $result->getStatus());
   }
 
   public function testItAppliesFilters(): void {

--- a/mailpoet/tests/integration/Config/EnvTest.php
+++ b/mailpoet/tests/integration/Config/EnvTest.php
@@ -6,6 +6,7 @@ use MailPoet\Config\Env;
 
 class EnvTest extends \MailPoetTest {
   public $version;
+  public $assetsVersion;
   public $file;
 
   public function _before() {
@@ -13,7 +14,15 @@ class EnvTest extends \MailPoetTest {
     // Back up original environment values
     $this->file = Env::$file;
     $this->version = Env::$version;
+    $this->assetsVersion = Env::$assetsVersion;
     Env::init('file', '1.0.0');
+  }
+
+  public function testItCanUseSeparateAssetVersion() {
+    Env::init('file', '1.0.0', '1.0.1');
+
+    verify(Env::$version)->equals('1.0.0');
+    verify(Env::$assetsVersion)->equals('1.0.1');
   }
 
   public function testItCanReturnPluginPrefix() {
@@ -47,6 +56,6 @@ class EnvTest extends \MailPoetTest {
   public function _after() {
     parent::_after();
     // Restore the original environment
-    Env::init($this->file, $this->version);
+    Env::init($this->file, $this->version, $this->assetsVersion);
   }
 }

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -321,6 +321,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'createReEngagementEmailsSchedulerWorker' => $worker,
       'createNewsletterTemplateThumbnailsWorker' => $worker,
       'createAbandonedCartWorker' => $worker,
+      'createManualAutomationStartWorker' => $worker,
       'createBackfillEngagementDataWorker' => $worker,
       'createMixpanelWorker' => $worker,
       'createTracksWorker' => $worker,

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -121,6 +121,7 @@ class DaemonTest extends \MailPoetTest {
       'createReEngagementEmailsSchedulerWorker' => $this->createSimpleWorkerMock(),
       'createNewsletterTemplateThumbnailsWorker' => $this->createSimpleWorkerMock(),
       'createAbandonedCartWorker' => $this->createSimpleWorkerMock(),
+      'createManualAutomationStartWorker' => $this->createSimpleWorkerMock(),
       'createBackfillEngagementDataWorker' => $this->createSimpleWorkerMock(),
       'createMixpanelWorker' => $this->createSimpleWorkerMock(),
       'createTracksWorker' => $this->createSimpleWorkerMock(),

--- a/mailpoet/tests/integration/Cron/Triggers/WordPressTest.php
+++ b/mailpoet/tests/integration/Cron/Triggers/WordPressTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Cron\Triggers;
 use MailPoet\Cron\CronHelper;
 use MailPoet\Cron\Workers\AuthorizedSendingEmailsCheck;
 use MailPoet\Cron\Workers\Automations\AbandonedCartWorker;
+use MailPoet\Cron\Workers\Automations\ManualAutomationStartWorker;
 use MailPoet\Cron\Workers\Bounce as BounceWorker;
 use MailPoet\Cron\Workers\InactiveSubscribers;
 use MailPoet\Cron\Workers\NewsletterTemplateThumbnails;
@@ -223,6 +224,11 @@ class WordPressTest extends \MailPoetTest {
 
   public function testItExecutesWhenAbandonedCartTaskIsDue() {
     $this->addScheduledTask(AbandonedCartWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    verify($this->wordpressTrigger->checkExecutionRequirements())->true();
+  }
+
+  public function testItExecutesWhenManualAutomationStartTaskIsDue() {
+    $this->addScheduledTask(ManualAutomationStartWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
     verify($this->wordpressTrigger->checkExecutionRequirements())->true();
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/Automations/ManualAutomationStartWorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/Automations/ManualAutomationStartWorkerTest.php
@@ -30,6 +30,7 @@ use MailPoet\Logging\LogRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Test\DataFactories\Automation as AutomationFactory;
 use MailPoet\Test\DataFactories\AutomationRun;
+use MailPoet\Test\DataFactories\DynamicSegment;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Subscriber;
 use RuntimeException;
@@ -113,6 +114,38 @@ class ManualAutomationStartWorkerTest extends \MailPoetTest {
     $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $taskSubscriber);
     $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, $taskSubscriber->getProcessed());
     $this->assertSame(ScheduledTaskSubscriberEntity::FAIL_STATUS_OK, $taskSubscriber->getFailed());
+  }
+
+  public function testItCreatesRunsWithConcreteListSubjectWhenDynamicFilterIsUsed(): void {
+    $segment = (new Segment())->create();
+    $segmentId = $this->getSegmentId($segment);
+    $filterSegment = (new DynamicSegment())->withEngagementScoreFilter(40, 'higherThan')->create();
+    $filterSegmentId = $this->getSegmentId($filterSegment);
+    $subscriber = (new Subscriber())->withSegments([$segment])->withEngagementScore(50)->create();
+    (new Subscriber())->withSegments([$segment])->withEngagementScore(10)->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->manualStartService->preview($automation->getId(), $segmentId, $filterSegmentId);
+    $this->assertSame(1, $preview['eligible_count']);
+    $start = $this->manualStartService->start($automation->getId(), $segmentId, $filterSegmentId, $preview['preview_signature']);
+
+    $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    $completed = $this->worker->processTaskStrategy($task, microtime(true));
+    $this->assertTrue($completed);
+
+    $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
+    $this->assertCount(1, $runs);
+    $run = $runs[0];
+    $this->assertSame(['subscriber_id' => $subscriber->getId()], $run->getSubjects(SubscriberSubject::KEY)[0]->getArgs());
+    $this->assertSame(['segment_id' => $segmentId], $run->getSubjects(SegmentSubject::KEY)[0]->getArgs());
+
+    $logs = $this->automationRunLogStorage->getLogsForAutomationRun($run->getId());
+    $this->assertCount(1, $logs);
+    $this->assertSame($filterSegmentId, $logs[0]->getData()['manual_start_filter_segment_id']);
   }
 
   public function testItSkipsSubscribersThatAlreadyEnteredBeforeWorkerRuns(): void {

--- a/mailpoet/tests/integration/Cron/Workers/Automations/ManualAutomationStartWorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/Automations/ManualAutomationStartWorkerTest.php
@@ -1,0 +1,175 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\Workers\Automations;
+
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\ManualStart\ManualStartService;
+use MailPoet\Automation\Engine\Storage\AutomationRunLogStorage;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
+use MailPoet\Cron\Workers\Automations\ManualAutomationStartWorker;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Test\DataFactories\Automation as AutomationFactory;
+use MailPoet\Test\DataFactories\AutomationRun;
+use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Subscriber;
+
+class ManualAutomationStartWorkerTest extends \MailPoetTest {
+  /** @var ManualStartService */
+  private $manualStartService;
+
+  /** @var ManualAutomationStartWorker */
+  private $worker;
+
+  /** @var ScheduledTasksRepository */
+  private $scheduledTasksRepository;
+
+  /** @var AutomationRunStorage */
+  private $automationRunStorage;
+
+  /** @var AutomationRunLogStorage */
+  private $automationRunLogStorage;
+
+  public function _before() {
+    parent::_before();
+    wp_set_current_user(1);
+    $this->manualStartService = $this->diContainer->get(ManualStartService::class);
+    $this->worker = $this->diContainer->get(ManualAutomationStartWorker::class);
+    $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    $this->automationRunStorage = $this->diContainer->get(AutomationRunStorage::class);
+    $this->automationRunLogStorage = $this->diContainer->get(AutomationRunLogStorage::class);
+  }
+
+  public function _after() {
+    parent::_after();
+    wp_set_current_user(0);
+  }
+
+  public function testItCreatesRunsForQueuedSubscribersWithManualStartLogData(): void {
+    $segment = (new Segment())->create();
+    $segmentId = $this->getSegmentId($segment);
+    $subscriber = (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->manualStartService->preview($automation->getId(), $segmentId, null);
+    $start = $this->manualStartService->start($automation->getId(), $segmentId, null, $preview['preview_signature']);
+
+    $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+
+    $completed = $this->worker->processTaskStrategy($task, microtime(true));
+    $this->assertTrue($completed);
+
+    $this->scheduledTasksRepository->refresh($task);
+    $this->assertSame(ScheduledTaskEntity::STATUS_COMPLETED, $task->getStatus());
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertSame(1, $workerCounts['processed_count']);
+    $this->assertSame(1, $workerCounts['created_count']);
+    $this->assertSame(0, $workerCounts['failed_count']);
+    $this->assertTrue($workerCounts['completion_log_saved']);
+
+    $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
+    $this->assertCount(1, $runs);
+    $run = $runs[0];
+    $this->assertSame(SomeoneSubscribesTrigger::KEY, $run->getTriggerKey());
+    $this->assertCount(1, $run->getSubjects(SubscriberSubject::KEY));
+    $this->assertCount(1, $run->getSubjects(SegmentSubject::KEY));
+    $this->assertSame(['subscriber_id' => $subscriber->getId()], $run->getSubjects(SubscriberSubject::KEY)[0]->getArgs());
+    $this->assertSame(['segment_id' => $segmentId], $run->getSubjects(SegmentSubject::KEY)[0]->getArgs());
+
+    $logs = $this->automationRunLogStorage->getLogsForAutomationRun($run->getId());
+    $this->assertCount(1, $logs);
+    $this->assertSame('complete', $logs[0]->getStatus());
+    $this->assertSame(SomeoneSubscribesTrigger::KEY, $logs[0]->getStepKey());
+    $this->assertTrue($logs[0]->getData()['manual_start']);
+    $this->assertSame($task->getId(), $logs[0]->getData()['manual_start_task_id']);
+    $this->assertSame($segmentId, $logs[0]->getData()['manual_start_segment_id']);
+    $this->assertSame(1, $logs[0]->getData()['manual_start_requested_by']);
+
+    $taskSubscriber = $task->getSubscribers()->first();
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $taskSubscriber);
+    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, $taskSubscriber->getProcessed());
+    $this->assertSame(ScheduledTaskSubscriberEntity::FAIL_STATUS_OK, $taskSubscriber->getFailed());
+  }
+
+  public function testItSkipsSubscribersThatAlreadyEnteredBeforeWorkerRuns(): void {
+    $segment = (new Segment())->create();
+    $segmentId = $this->getSegmentId($segment);
+    $subscriber = (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->manualStartService->preview($automation->getId(), $segmentId, null);
+    $start = $this->manualStartService->start($automation->getId(), $segmentId, null, $preview['preview_signature']);
+    (new AutomationRun())
+      ->withAutomation($automation)
+      ->withTriggerKey(SomeoneSubscribesTrigger::KEY)
+      ->withSubject(new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriber->getId()]))
+      ->withSubject(new Subject(SegmentSubject::KEY, ['segment_id' => $segmentId]))
+      ->create();
+
+    $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+
+    $completed = $this->worker->processTaskStrategy($task, microtime(true));
+    $this->assertTrue($completed);
+
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertSame(1, $workerCounts['processed_count']);
+    $this->assertSame(0, $workerCounts['created_count']);
+    $this->assertSame(1, $workerCounts['failed_count']);
+    $this->assertSame(1, $workerCounts['skipped_by_reason']['already_entered']);
+
+    $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
+    $this->assertCount(1, $runs);
+  }
+
+  private function getSegmentId(SegmentEntity $segment): int {
+    $id = $segment->getId();
+    if ($id === null) {
+      $this->fail('Segment ID is required for manual start tests.');
+    }
+    return $id;
+  }
+
+  /**
+   * @return array{processed_count: int, created_count: int, failed_count: int, skipped_by_reason: array<string, int>, completion_log_saved: bool}
+   */
+  private function getWorkerCounts(ScheduledTaskEntity $task): array {
+    $meta = $task->getMeta() ?? [];
+    $counts = isset($meta['worker_counts']) && is_array($meta['worker_counts']) ? $meta['worker_counts'] : [];
+    $skippedByReason = isset($counts['skipped_by_reason']) && is_array($counts['skipped_by_reason']) ? $counts['skipped_by_reason'] : [];
+    $skippedByReasonCounts = [];
+    foreach ($skippedByReason as $reason => $count) {
+      if (is_string($reason)) {
+        $skippedByReasonCounts[$reason] = $this->getInt($count);
+      }
+    }
+    return [
+      'processed_count' => $this->getInt($counts['processed_count'] ?? null),
+      'created_count' => $this->getInt($counts['created_count'] ?? null),
+      'failed_count' => $this->getInt($counts['failed_count'] ?? null),
+      'skipped_by_reason' => $skippedByReasonCounts,
+      'completion_log_saved' => (bool)($counts['completion_log_saved'] ?? false),
+    ];
+  }
+
+  /** @param mixed $value */
+  private function getInt($value): int {
+    if (is_numeric($value)) {
+      return (int)$value;
+    }
+    return 0;
+  }
+}

--- a/mailpoet/tests/integration/Cron/Workers/Automations/ManualAutomationStartWorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/Automations/ManualAutomationStartWorkerTest.php
@@ -2,22 +2,37 @@
 
 namespace MailPoet\Test\Cron\Workers\Automations;
 
+use Codeception\Stub\Expected;
+use MailPoet\Automation\Engine\Control\AutomationRunCreationResult;
+use MailPoet\Automation\Engine\Control\AutomationRunCreator;
+use MailPoet\Automation\Engine\Control\StepSchedulingResult;
+use MailPoet\Automation\Engine\Data\Automation as AutomationData;
+use MailPoet\Automation\Engine\Data\Filter;
+use MailPoet\Automation\Engine\Data\FilterGroup;
+use MailPoet\Automation\Engine\Data\Filters;
+use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\ManualStart\ManualStartService;
 use MailPoet\Automation\Engine\Storage\AutomationRunLogStorage;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
+use MailPoet\Cron\CronHelper;
 use MailPoet\Cron\Workers\Automations\ManualAutomationStartWorker;
+use MailPoet\Cron\Workers\SimpleWorker;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Logging\LogRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Test\DataFactories\Automation as AutomationFactory;
 use MailPoet\Test\DataFactories\AutomationRun;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Subscriber;
+use RuntimeException;
 
 class ManualAutomationStartWorkerTest extends \MailPoetTest {
   /** @var ManualStartService */
@@ -135,12 +150,389 @@ class ManualAutomationStartWorkerTest extends \MailPoetTest {
     $this->assertCount(1, $runs);
   }
 
+  public function testItRevalidatesDeletedListBeforeCreatingRuns(): void {
+    $segment = (new Segment())->create();
+    $segmentId = $this->getSegmentId($segment);
+    $subscriber = (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->manualStartService->preview($automation->getId(), $segmentId, null);
+    $start = $this->manualStartService->start($automation->getId(), $segmentId, null, $preview['preview_signature']);
+    $segment->setDeletedAt(new \DateTimeImmutable());
+    $this->entityManager->flush();
+
+    $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    $completed = $this->worker->processTaskStrategy($task, microtime(true));
+
+    $this->assertTrue($completed);
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertSame(1, $workerCounts['processed_count']);
+    $this->assertSame(0, $workerCounts['created_count']);
+    $this->assertSame(1, $workerCounts['failed_count']);
+    $this->assertSame(1, $workerCounts['skipped_by_reason']['not_in_list']);
+    $this->assertCount(0, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
+
+    $taskSubscriber = $this->getTaskSubscriber((int)$task->getId(), (int)$subscriber->getId());
+    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, $taskSubscriber->getProcessed());
+    $this->assertSame(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED, $taskSubscriber->getFailed());
+    $this->assertSame('skipped:not_in_list', $taskSubscriber->getError());
+  }
+
+  public function testItRevalidatesInvalidListTypeBeforeCreatingRuns(): void {
+    $segment = (new Segment())->create();
+    $segmentId = $this->getSegmentId($segment);
+    (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->manualStartService->preview($automation->getId(), $segmentId, null);
+    $start = $this->manualStartService->start($automation->getId(), $segmentId, null, $preview['preview_signature']);
+    $segment->setType(SegmentEntity::TYPE_DYNAMIC);
+    $this->entityManager->flush();
+
+    $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    $completed = $this->worker->processTaskStrategy($task, microtime(true));
+
+    $this->assertTrue($completed);
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertSame(1, $workerCounts['processed_count']);
+    $this->assertSame(0, $workerCounts['created_count']);
+    $this->assertSame(1, $workerCounts['failed_count']);
+    $this->assertSame(1, $workerCounts['skipped_by_reason']['not_in_list']);
+    $this->assertCount(0, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
+  }
+
+  public function testItPersistsProgressBeforeExecutionLimitCanInterruptNextSubscriber(): void {
+    $segment = (new Segment())->create();
+    $segmentId = $this->getSegmentId($segment);
+    $firstSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    $secondSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->manualStartService->preview($automation->getId(), $segmentId, null);
+    $start = $this->manualStartService->start($automation->getId(), $segmentId, null, $preview['preview_signature']);
+    $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+
+    $calls = 0;
+    $originalCronHelper = $this->replaceWorkerProperty(
+      $this->worker,
+      SimpleWorker::class,
+      'cronHelper',
+      $this->make(CronHelper::class, [
+        'enforceExecutionLimit' => Expected::exactly(2, function ($_timer = null) use (&$calls): void {
+          $calls++;
+          if ($calls === 2) {
+            throw new RuntimeException('time limit');
+          }
+        }),
+      ])
+    );
+
+    try {
+      $this->worker->processTaskStrategy($task, microtime(true));
+      $this->fail('Expected execution limit interruption.');
+    } catch (RuntimeException $exception) {
+      $this->assertSame('time limit', $exception->getMessage());
+    } finally {
+      $this->replaceWorkerProperty($this->worker, SimpleWorker::class, 'cronHelper', $originalCronHelper);
+    }
+
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertSame(1, $workerCounts['processed_count']);
+    $this->assertSame(1, $workerCounts['created_count']);
+    $this->assertSame(0, $workerCounts['failed_count']);
+    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, $this->getTaskSubscriber((int)$task->getId(), (int)$firstSubscriber->getId())->getProcessed());
+    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED, $this->getTaskSubscriber((int)$task->getId(), (int)$secondSubscriber->getId())->getProcessed());
+
+    $completed = $this->worker->processTaskStrategy($task, microtime(true));
+    $this->assertTrue($completed);
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertSame(2, $workerCounts['processed_count']);
+    $this->assertSame(2, $workerCounts['created_count']);
+    $this->assertSame(0, $workerCounts['failed_count']);
+    $this->assertCount(2, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
+  }
+
+  public function testCompletionLogSavedFlagIsNotSetWhenSavingLogFails(): void {
+    $segment = (new Segment())->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+    $task = $this->createManualStartTask($automation, $segment);
+
+    $originalLogRepository = $this->replaceWorkerProperty(
+      $this->worker,
+      ManualAutomationStartWorker::class,
+      'logRepository',
+      $this->make(LogRepository::class, [
+        'saveLog' => Expected::once(function (): void {
+          throw new RuntimeException('log failed');
+        }),
+      ])
+    );
+
+    try {
+      $this->worker->processTaskStrategy($task, microtime(true));
+      $this->fail('Expected completion log failure.');
+    } catch (RuntimeException $exception) {
+      $this->assertSame('log failed', $exception->getMessage());
+    } finally {
+      $this->replaceWorkerProperty($this->worker, ManualAutomationStartWorker::class, 'logRepository', $originalLogRepository);
+    }
+
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertFalse($workerCounts['completion_log_saved']);
+
+    $completed = $this->worker->processTaskStrategy($task, microtime(true));
+    $this->assertTrue($completed);
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertTrue($workerCounts['completion_log_saved']);
+  }
+
+  public function testItSkipsWhenAutomationIsInactiveBeforeWorkerRuns(): void {
+    $segment = (new Segment())->create();
+    $segmentId = $this->getSegmentId($segment);
+    (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->manualStartService->preview($automation->getId(), $segmentId, null);
+    $start = $this->manualStartService->start($automation->getId(), $segmentId, null, $preview['preview_signature']);
+    $automation->setStatus(AutomationData::STATUS_DRAFT);
+    $this->diContainer->get(AutomationStorage::class)->updateAutomation($automation);
+
+    $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    $completed = $this->worker->processTaskStrategy($task, microtime(true));
+
+    $this->assertTrue($completed);
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertSame(1, $workerCounts['processed_count']);
+    $this->assertSame(0, $workerCounts['created_count']);
+    $this->assertSame(1, $workerCounts['failed_count']);
+    $this->assertSame(1, $workerCounts['skipped_by_reason']['automation_inactive']);
+  }
+
+  public function testItSkipsSubscriberChangesBeforeWorkerRuns(): void {
+    $segment = (new Segment())->create();
+    $segmentId = $this->getSegmentId($segment);
+    $deletedSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    $unsubscribedSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    $removedFromListSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->manualStartService->preview($automation->getId(), $segmentId, null);
+    $start = $this->manualStartService->start($automation->getId(), $segmentId, null, $preview['preview_signature']);
+
+    $deletedSubscriber->setDeletedAt(new \DateTimeImmutable());
+    $unsubscribedSubscriber->setStatus(\MailPoet\Entities\SubscriberEntity::STATUS_UNSUBSCRIBED);
+    foreach ($removedFromListSubscriber->getSubscriberSegments() as $subscriberSegment) {
+      $subscriberSegment->setStatus(\MailPoet\Entities\SubscriberEntity::STATUS_UNSUBSCRIBED);
+    }
+    $this->entityManager->flush();
+
+    $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    $completed = $this->worker->processTaskStrategy($task, microtime(true));
+
+    $this->assertTrue($completed);
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertSame(3, $workerCounts['processed_count']);
+    $this->assertSame(0, $workerCounts['created_count']);
+    $this->assertSame(3, $workerCounts['failed_count']);
+    $this->assertSame(1, $workerCounts['skipped_by_reason']['deleted']);
+    $this->assertSame(1, $workerCounts['skipped_by_reason']['unsubscribed']);
+    $this->assertSame(1, $workerCounts['skipped_by_reason']['not_in_list']);
+  }
+
+  public function testItSkipsTriggerFilterMismatchBeforeCreatingRun(): void {
+    $segment = (new Segment())->create();
+    $segmentId = $this->getSegmentId($segment);
+    (new Subscriber())->withSegments([$segment])->create();
+    $unknownSegmentId = $segmentId + 100000;
+    $filters = new Filters('and', [
+      new FilterGroup('g1', 'and', [
+        new Filter('f1', 'enum_array', 'mailpoet:subscriber:segments', 'matches-any-of', ['value' => [$unknownSegmentId]]),
+      ]),
+    ]);
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withStep(new Step('trigger', Step::TYPE_TRIGGER, SomeoneSubscribesTrigger::KEY, [], [], $filters))
+      ->create();
+
+    $preview = $this->manualStartService->preview($automation->getId(), $segmentId, null);
+    $start = $this->manualStartService->start($automation->getId(), $segmentId, null, $preview['preview_signature']);
+    $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    $completed = $this->worker->processTaskStrategy($task, microtime(true));
+
+    $this->assertTrue($completed);
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertSame(1, $workerCounts['processed_count']);
+    $this->assertSame(0, $workerCounts['created_count']);
+    $this->assertSame(1, $workerCounts['failed_count']);
+    $this->assertSame(1, $workerCounts['skipped_by_reason']['trigger_filter_mismatch']);
+  }
+
+  public function testItSkipsRunCreateHookRejection(): void {
+    $segment = (new Segment())->create();
+    $segmentId = $this->getSegmentId($segment);
+    (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->manualStartService->preview($automation->getId(), $segmentId, null);
+    $start = $this->manualStartService->start($automation->getId(), $segmentId, null, $preview['preview_signature']);
+    $rejectRunCreation = function ($_createRun): bool {
+      return false;
+    };
+    add_filter(Hooks::AUTOMATION_RUN_CREATE, $rejectRunCreation);
+
+    $completed = false;
+    $task = null;
+    try {
+      $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+      $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+      $completed = $this->worker->processTaskStrategy($task, microtime(true));
+    } finally {
+      remove_filter(Hooks::AUTOMATION_RUN_CREATE, $rejectRunCreation);
+    }
+
+    $this->assertTrue($completed);
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertSame(1, $workerCounts['processed_count']);
+    $this->assertSame(0, $workerCounts['created_count']);
+    $this->assertSame(1, $workerCounts['failed_count']);
+    $this->assertSame(1, $workerCounts['skipped_by_reason']['run_create_hook_rejected']);
+  }
+
+  public function testItSkipsStepSchedulingFailure(): void {
+    $segment = (new Segment())->create();
+    $segmentId = $this->getSegmentId($segment);
+    (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->manualStartService->preview($automation->getId(), $segmentId, null);
+    $start = $this->manualStartService->start($automation->getId(), $segmentId, null, $preview['preview_signature']);
+    $originalRunCreator = $this->replaceWorkerProperty(
+      $this->worker,
+      ManualAutomationStartWorker::class,
+      'automationRunCreator',
+      $this->make(AutomationRunCreator::class, [
+        'createForAutomation' => Expected::once(
+          AutomationRunCreationResult::schedulingFailed(
+            123,
+            StepSchedulingResult::enqueueFailed('next-step')
+          )
+        ),
+      ])
+    );
+
+    $completed = false;
+    $task = null;
+    try {
+      $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+      $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+      $completed = $this->worker->processTaskStrategy($task, microtime(true));
+    } finally {
+      $this->replaceWorkerProperty($this->worker, ManualAutomationStartWorker::class, 'automationRunCreator', $originalRunCreator);
+    }
+
+    $this->assertTrue($completed);
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertSame(1, $workerCounts['processed_count']);
+    $this->assertSame(0, $workerCounts['created_count']);
+    $this->assertSame(1, $workerCounts['failed_count']);
+    $this->assertSame(1, $workerCounts['skipped_by_reason']['step_scheduling_failed']);
+  }
+
   private function getSegmentId(SegmentEntity $segment): int {
     $id = $segment->getId();
     if ($id === null) {
       $this->fail('Segment ID is required for manual start tests.');
     }
     return $id;
+  }
+
+  private function createManualStartTask(AutomationData $automation, SegmentEntity $segment): ScheduledTaskEntity {
+    $task = new ScheduledTaskEntity();
+    $task->setType(ManualAutomationStartWorker::TASK_TYPE);
+    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $task->setMeta([
+      'automation_id' => $automation->getId(),
+      'automation_version_id' => $automation->getVersionId(),
+      'segment_id' => $segment->getId(),
+      'filter_segment_id' => null,
+      'requested_by' => 1,
+      'worker_counts' => [
+        'processed_count' => 0,
+        'created_count' => 0,
+        'failed_count' => 0,
+        'skipped_by_reason' => [],
+        'completion_log_saved' => false,
+      ],
+    ]);
+    $this->entityManager->persist($task);
+    $this->entityManager->flush();
+    return $task;
+  }
+
+  private function getTaskSubscriber(int $taskId, int $subscriberId): ScheduledTaskSubscriberEntity {
+    $taskSubscriber = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->findOneBy([
+      'task' => $taskId,
+      'subscriber' => $subscriberId,
+    ]);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $taskSubscriber);
+    return $taskSubscriber;
+  }
+
+  /**
+   * @param class-string $className
+   * @param object $value
+   * @return object
+   */
+  private function replaceWorkerProperty(object $worker, string $className, string $propertyName, object $value): object {
+    $property = new \ReflectionProperty($className, $propertyName);
+    $property->setAccessible(true);
+    $previousValue = $property->getValue($worker);
+    if (!is_object($previousValue)) {
+      $this->fail("Expected $propertyName to contain an object.");
+    }
+    $property->setValue($worker, $value);
+    return $previousValue;
   }
 
   /**

--- a/mailpoet/tests/integration/Cron/Workers/Automations/ManualAutomationStartWorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/Automations/ManualAutomationStartWorkerTest.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Control\AutomationRunCreationResult;
 use MailPoet\Automation\Engine\Control\AutomationRunCreator;
 use MailPoet\Automation\Engine\Control\StepSchedulingResult;
 use MailPoet\Automation\Engine\Data\Automation as AutomationData;
+use MailPoet\Automation\Engine\Data\AutomationRun as AutomationRunData;
 use MailPoet\Automation\Engine\Data\Filter;
 use MailPoet\Automation\Engine\Data\FilterGroup;
 use MailPoet\Automation\Engine\Data\Filters;
@@ -181,6 +182,48 @@ class ManualAutomationStartWorkerTest extends \MailPoetTest {
 
     $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
     $this->assertCount(1, $runs);
+  }
+
+  public function testItAllowsSubscribersWithFailedOrCancelledPriorRuns(): void {
+    $segment = (new Segment())->create();
+    $segmentId = $this->getSegmentId($segment);
+    $failedSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    $cancelledSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    (new AutomationRun())
+      ->withAutomation($automation)
+      ->withTriggerKey(SomeoneSubscribesTrigger::KEY)
+      ->withStatus(AutomationRunData::STATUS_FAILED)
+      ->withSubject(new Subject(SubscriberSubject::KEY, ['subscriber_id' => $failedSubscriber->getId()]))
+      ->withSubject(new Subject(SegmentSubject::KEY, ['segment_id' => $segmentId]))
+      ->create();
+    (new AutomationRun())
+      ->withAutomation($automation)
+      ->withTriggerKey(SomeoneSubscribesTrigger::KEY)
+      ->withStatus(AutomationRunData::STATUS_CANCELLED)
+      ->withSubject(new Subject(SubscriberSubject::KEY, ['subscriber_id' => $cancelledSubscriber->getId()]))
+      ->withSubject(new Subject(SegmentSubject::KEY, ['segment_id' => $segmentId]))
+      ->create();
+
+    $preview = $this->manualStartService->preview($automation->getId(), $segmentId, null);
+    $this->assertSame(2, $preview['eligible_count']);
+    $this->assertSame(0, $preview['skipped_by_reason']['already_entered']);
+    $start = $this->manualStartService->start($automation->getId(), $segmentId, null, $preview['preview_signature']);
+
+    $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    $completed = $this->worker->processTaskStrategy($task, microtime(true));
+    $this->assertTrue($completed);
+
+    $this->scheduledTasksRepository->refresh($task);
+    $workerCounts = $this->getWorkerCounts($task);
+    $this->assertSame(2, $workerCounts['created_count']);
+    $this->assertSame(0, $workerCounts['failed_count']);
+    $this->assertCount(4, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
   }
 
   public function testItRevalidatesDeletedListBeforeCreatingRuns(): void {

--- a/mailpoet/tests/integration/Cron/Workers/SendingTaskSubscribersCleanupTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingTaskSubscribersCleanupTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Cron\Workers;
 
+use MailPoet\Cron\Workers\Automations\ManualAutomationStartWorker;
 use MailPoet\Cron\Workers\SendingTaskSubscribersCleanup;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
@@ -50,6 +51,29 @@ class SendingTaskSubscribersCleanupTest extends \MailPoetTest {
     $subscriber = $this->subscriberFactory->create();
     $oldTask = $this->taskFactory->create(
       'sending',
+      ScheduledTaskEntity::STATUS_COMPLETED,
+      null,
+      null,
+      null,
+      $now->copy()->subDays(90)
+    );
+    $this->taskSubscriberFactory->createProcessed($oldTask, $subscriber);
+
+    $task = new ScheduledTaskEntity();
+    $this->worker->processTaskStrategy($task, microtime(true));
+
+    $remaining = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->findAll();
+    verify(count($remaining))->equals(0);
+
+  }
+
+  public function testItDeletesOldCompletedManualStartTaskSubscribers() {
+    $now = Carbon::now();
+    Carbon::setTestNow($now);
+
+    $subscriber = $this->subscriberFactory->create();
+    $oldTask = $this->taskFactory->create(
+      ManualAutomationStartWorker::TASK_TYPE,
       ScheduledTaskEntity::STATUS_COMPLETED,
       null,
       null,

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationManualStartEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationManualStartEndpointTest.php
@@ -31,10 +31,14 @@ class AutomationManualStartEndpointTest extends AutomationTest {
   /** @var ScheduledTasksRepository */
   private $scheduledTasksRepository;
 
+  /** @var ManualStartAudienceRepository */
+  private $audienceRepository;
+
   public function _before() {
     parent::_before();
     $this->em = $this->diContainer->get(EntityManager::class);
     $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    $this->audienceRepository = $this->diContainer->get(ManualStartAudienceRepository::class);
   }
 
   public function testPreviewReturnsCountsAndStartQueuesEligibleSubscribers(): void {
@@ -280,6 +284,37 @@ class AutomationManualStartEndpointTest extends AutomationTest {
 
     $this->assertSame(ManualStartAudienceRepository::QUEUE_CHUNK_SIZE + 5, $start['queued_count']);
     $this->assertSame(ManualStartAudienceRepository::QUEUE_CHUNK_SIZE + 5, $this->countTaskSubscribers($start['task_id']));
+  }
+
+  public function testQueueChunksContinueWhenInsertIgnoreSkipsExistingRows(): void {
+    $segment = (new Segment())->create();
+    $firstSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    for ($i = 1; $i < ManualStartAudienceRepository::QUEUE_CHUNK_SIZE + 5; $i++) {
+      (new Subscriber())->withSegments([$segment])->create();
+    }
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+    $task = new ScheduledTaskEntity();
+    $task->setType(ManualAutomationStartWorker::TASK_TYPE);
+    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $task->setScheduledAt(new \DateTimeImmutable());
+    $this->em->persist($task);
+    $this->em->flush();
+
+    $this->em->persist(new ScheduledTaskSubscriberEntity($task, $firstSubscriber));
+    $this->em->flush();
+
+    $queuedCount = $this->audienceRepository->queueEligibleSubscribers(
+      $task,
+      $automation->getId(),
+      $segment,
+      null
+    );
+
+    $this->assertSame(ManualStartAudienceRepository::QUEUE_CHUNK_SIZE + 4, $queuedCount);
+    $this->assertSame(ManualStartAudienceRepository::QUEUE_CHUNK_SIZE + 5, $this->countTaskSubscribers((int)$task->getId()));
   }
 
   private function postPreview(int $automationId, ?int $segmentId, ?int $filterSegmentId = null, bool $includeFilterSegmentId = false): array {

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationManualStartEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationManualStartEndpointTest.php
@@ -129,6 +129,24 @@ class AutomationManualStartEndpointTest extends AutomationTest {
     $this->assertNotSame($preview['preview_signature'], $response['data']['preview']['preview_signature']);
   }
 
+  public function testStartReportsStalePreviewBeforeZeroEligibleAudience(): void {
+    $segment = (new Segment())->create();
+    $subscriber = (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->postPreview($automation->getId(), $segment->getId())['data'];
+    $subscriber->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $this->em->flush();
+
+    $response = $this->postStart($automation->getId(), $segment->getId(), $preview['preview_signature']);
+    $this->assertSame('manual_start_stale_preview', $response['code']);
+    $this->assertSame(409, $response['data']['status']);
+    $this->assertSame(0, $response['data']['preview']['eligible_count']);
+  }
+
   public function testPreviewAndStartAcceptExplicitNullFilterSegmentId(): void {
     $segment = (new Segment())->create();
     (new Subscriber())->withSegments([$segment])->create();
@@ -267,6 +285,36 @@ class AutomationManualStartEndpointTest extends AutomationTest {
     $start = $this->postStart($automation->getId(), $segment->getId(), 'signature');
     $this->assertSame('rest_forbidden', $start['code']);
     $this->assertSame(401, $start['data']['status']);
+  }
+
+  public function testPreviewAndStartRejectUsersWithoutAutomationCapability(): void {
+    $segment = (new Segment())->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+    $userId = wp_insert_user([
+      'user_login' => 'manual-start-subscriber',
+      'user_pass' => 'password',
+      'user_email' => 'manual-start-subscriber@example.com',
+      'role' => 'subscriber',
+    ]);
+    $this->assertIsNumeric($userId);
+
+    try {
+      wp_set_current_user((int)$userId);
+
+      $preview = $this->postPreview($automation->getId(), $segment->getId());
+      $this->assertSame('rest_forbidden', $preview['code']);
+      $this->assertSame(403, $preview['data']['status']);
+
+      $start = $this->postStart($automation->getId(), $segment->getId(), 'signature');
+      $this->assertSame('rest_forbidden', $start['code']);
+      $this->assertSame(403, $start['data']['status']);
+    } finally {
+      wp_set_current_user(1);
+      is_multisite() ? wpmu_delete_user((int)$userId) : wp_delete_user((int)$userId);
+    }
   }
 
   public function testStartQueuesSubscribersAcrossBoundedChunks(): void {

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationManualStartEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationManualStartEndpointTest.php
@@ -4,6 +4,8 @@ namespace MailPoet\REST\Automation\Automations;
 
 require_once __DIR__ . '/../AutomationTest.php';
 
+use MailPoet\Automation\Engine\Data\Automation as AutomationData;
+use MailPoet\Automation\Engine\Data\AutomationRun as AutomationRunData;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\ManualStart\ManualStartAudienceRepository;
@@ -111,6 +113,37 @@ class AutomationManualStartEndpointTest extends AutomationTest {
     $this->assertSame(409, $duplicate['data']['status']);
   }
 
+  public function testPreviewOnlySkipsSubscribersWithEnteredRunStatuses(): void {
+    $segment = (new Segment())->create();
+    $completedSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    $runningSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    $failedSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    $cancelledSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    $eligibleSubscriber = (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $this->createRunForSubscriber($automation, $segment, $completedSubscriber, AutomationRunData::STATUS_COMPLETE);
+    $this->createRunForSubscriber($automation, $segment, $runningSubscriber, AutomationRunData::STATUS_RUNNING);
+    $this->createRunForSubscriber($automation, $segment, $failedSubscriber, AutomationRunData::STATUS_FAILED);
+    $this->createRunForSubscriber($automation, $segment, $cancelledSubscriber, AutomationRunData::STATUS_CANCELLED);
+
+    $preview = $this->postPreview($automation->getId(), $segment->getId())['data'];
+    $this->assertSame(5, $preview['selected_count']);
+    $this->assertSame(3, $preview['eligible_count']);
+    $this->assertSame(2, $preview['skipped_by_reason']['already_entered']);
+
+    $start = $this->postStart($automation->getId(), $segment->getId(), $preview['preview_signature'])['data'];
+    $this->assertSame(3, $start['queued_count']);
+    $this->assertFalse($this->taskHasSubscriber($start['task_id'], (int)$completedSubscriber->getId()));
+    $this->assertFalse($this->taskHasSubscriber($start['task_id'], (int)$runningSubscriber->getId()));
+    $this->assertTrue($this->taskHasSubscriber($start['task_id'], (int)$failedSubscriber->getId()));
+    $this->assertTrue($this->taskHasSubscriber($start['task_id'], (int)$cancelledSubscriber->getId()));
+    $this->assertTrue($this->taskHasSubscriber($start['task_id'], (int)$eligibleSubscriber->getId()));
+  }
+
   public function testStartRejectsStalePreviewSignatureWithRefreshedPreview(): void {
     $segment = (new Segment())->create();
     (new Subscriber())->withSegments([$segment])->create();
@@ -188,12 +221,19 @@ class AutomationManualStartEndpointTest extends AutomationTest {
   public function testPreviewValidatesSupportedAutomationAndSegments(): void {
     $defaultSegment = (new Segment())->create();
     $dynamicSegment = (new Segment())->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    $deletedSegment = (new Segment())->create();
+    $deletedSegment->setDeletedAt(new \DateTimeImmutable());
+    $this->em->flush();
     $automation = (new AutomationFactory())
       ->withStatusActive()
       ->withSomeoneSubscribesTrigger()
       ->create();
 
     $response = $this->postPreview($automation->getId(), $dynamicSegment->getId());
+    $this->assertSame('manual_start_invalid_segment', $response['code']);
+    $this->assertSame(400, $response['data']['status']);
+
+    $response = $this->postPreview($automation->getId(), $deletedSegment->getId());
     $this->assertSame('manual_start_invalid_segment', $response['code']);
     $this->assertSame(400, $response['data']['status']);
 
@@ -264,9 +304,53 @@ class AutomationManualStartEndpointTest extends AutomationTest {
     $this->assertArrayHasKey('data', $allowedAfterFailed);
 
     $task->setStatus(ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING);
+    $task->setInProgress(true);
     $this->em->flush();
     $blockedWhileRunning = $this->postPreview($automation->getId(), $segment->getId());
     $this->assertSame('manual_start_in_progress', $blockedWhileRunning['code']);
+    $blockedStartWhileRunning = $this->postStart(
+      $automation->getId(),
+      $segment->getId(),
+      $preview['preview_signature']
+    );
+    $this->assertSame('manual_start_in_progress', $blockedStartWhileRunning['code']);
+  }
+
+  public function testStartRejectsWhenAnotherRequestHoldsQueueLock(): void {
+    $segment = (new Segment())->create();
+    (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->postPreview($automation->getId(), $segment->getId())['data'];
+    $lockName = sprintf('mailpoet_manual_start_%d', $automation->getId());
+    $lockConnection = new \mysqli(
+      (string)constant('DB_HOST'),
+      (string)constant('DB_USER'),
+      (string)constant('DB_PASSWORD'),
+      (string)constant('DB_NAME')
+    );
+    $lockNameSql = $lockConnection->real_escape_string($lockName);
+    $lockResult = $lockConnection->query("SELECT GET_LOCK('$lockNameSql', 0)");
+    $this->assertInstanceOf(\mysqli_result::class, $lockResult);
+    $lockRow = $lockResult->fetch_row();
+    $this->assertSame('1', $lockRow[0] ?? null);
+
+    try {
+      $response = $this->postStart(
+        $automation->getId(),
+        $segment->getId(),
+        $preview['preview_signature']
+      );
+    } finally {
+      $lockConnection->query("SELECT RELEASE_LOCK('$lockNameSql')");
+      $lockConnection->close();
+    }
+
+    $this->assertSame('manual_start_in_progress', $response['code']);
+    $this->assertSame(409, $response['data']['status']);
   }
 
   public function testPreviewAndStartRejectGuests(): void {
@@ -425,6 +509,16 @@ class AutomationManualStartEndpointTest extends AutomationTest {
     )->fetchOne();
 
     return $this->getInt($count) === 1;
+  }
+
+  private function createRunForSubscriber(AutomationData $automation, SegmentEntity $segment, SubscriberEntity $subscriber, string $status): void {
+    (new AutomationRun())
+      ->withAutomation($automation)
+      ->withTriggerKey(SomeoneSubscribesTrigger::KEY)
+      ->withStatus($status)
+      ->withSubject(new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriber->getId()]))
+      ->withSubject(new Subject(SegmentSubject::KEY, ['segment_id' => $segment->getId()]))
+      ->create();
   }
 
   /** @param mixed $value */

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationManualStartEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationManualStartEndpointTest.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../AutomationTest.php';
 
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\ManualStart\ManualStartAudienceRepository;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
@@ -18,6 +19,7 @@ use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\REST\Automation\AutomationTest;
 use MailPoet\Test\DataFactories\Automation as AutomationFactory;
 use MailPoet\Test\DataFactories\AutomationRun;
+use MailPoet\Test\DataFactories\DynamicSegment;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Subscriber;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -123,6 +125,44 @@ class AutomationManualStartEndpointTest extends AutomationTest {
     $this->assertNotSame($preview['preview_signature'], $response['data']['preview']['preview_signature']);
   }
 
+  public function testPreviewAndStartAcceptExplicitNullFilterSegmentId(): void {
+    $segment = (new Segment())->create();
+    (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->postPreview($automation->getId(), $segment->getId(), null, true)['data'];
+    $this->assertNull($preview['filter_segment_id']);
+    $this->assertSame(1, $preview['eligible_count']);
+
+    $start = $this->postStart($automation->getId(), $segment->getId(), $preview['preview_signature'], null, true)['data'];
+    $this->assertNull($start['filter_segment_id']);
+    $this->assertSame(1, $start['queued_count']);
+  }
+
+  public function testDynamicFilterNarrowsEligibleSubscribers(): void {
+    $segment = (new Segment())->create();
+    $filterSegment = (new DynamicSegment())->withEngagementScoreFilter(40, 'higherThan')->create();
+    $eligible = (new Subscriber())->withSegments([$segment])->withEngagementScore(50)->create();
+    (new Subscriber())->withSegments([$segment])->withEngagementScore(10)->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->postPreview($automation->getId(), $segment->getId(), $filterSegment->getId())['data'];
+    $this->assertSame($filterSegment->getId(), $preview['filter_segment_id']);
+    $this->assertSame(2, $preview['selected_count']);
+    $this->assertSame(1, $preview['eligible_count']);
+    $this->assertSame(1, $preview['skipped_by_reason']['dynamic_filter_mismatch']);
+
+    $start = $this->postStart($automation->getId(), $segment->getId(), $preview['preview_signature'], $filterSegment->getId())['data'];
+    $this->assertSame(1, $start['queued_count']);
+    $this->assertTrue($this->taskHasSubscriber($start['task_id'], (int)$eligible->getId()));
+  }
+
   public function testPreviewValidatesSupportedAutomationAndSegments(): void {
     $defaultSegment = (new Segment())->create();
     $dynamicSegment = (new Segment())->withType(SegmentEntity::TYPE_DYNAMIC)->create();
@@ -169,18 +209,91 @@ class AutomationManualStartEndpointTest extends AutomationTest {
     $this->assertSame(400, $response['data']['status']);
   }
 
-  private function postPreview(int $automationId, ?int $segmentId, ?int $filterSegmentId = null): array {
+  public function testManualStartActiveTaskBlocksOnlyInProgressTasks(): void {
+    $segment = (new Segment())->create();
+    $otherSegment = (new Segment())->create();
+    (new Subscriber())->withSegments([$segment])->create();
+    (new Subscriber())->withSegments([$otherSegment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->postPreview($automation->getId(), $segment->getId())['data'];
+    $start = $this->postStart($automation->getId(), $segment->getId(), $preview['preview_signature'])['data'];
+    $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+
+    $duplicateStart = $this->postStart($automation->getId(), $segment->getId(), $preview['preview_signature']);
+    $this->assertSame('manual_start_in_progress', $duplicateStart['code']);
+    $this->assertSame(409, $duplicateStart['data']['status']);
+
+    $otherListPreview = $this->postPreview($automation->getId(), $otherSegment->getId());
+    $this->assertSame('manual_start_in_progress', $otherListPreview['code']);
+
+    $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->em->flush();
+    $allowedAfterCompleted = $this->postPreview($automation->getId(), $segment->getId());
+    $this->assertArrayHasKey('data', $allowedAfterCompleted);
+
+    $task->setStatus('failed');
+    $this->em->flush();
+    $allowedAfterFailed = $this->postPreview($automation->getId(), $segment->getId());
+    $this->assertArrayHasKey('data', $allowedAfterFailed);
+
+    $task->setStatus(ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING);
+    $this->em->flush();
+    $blockedWhileRunning = $this->postPreview($automation->getId(), $segment->getId());
+    $this->assertSame('manual_start_in_progress', $blockedWhileRunning['code']);
+  }
+
+  public function testPreviewAndStartRejectGuests(): void {
+    $segment = (new Segment())->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    wp_set_current_user(0);
+
+    $preview = $this->postPreview($automation->getId(), $segment->getId());
+    $this->assertSame('rest_forbidden', $preview['code']);
+    $this->assertSame(401, $preview['data']['status']);
+
+    $start = $this->postStart($automation->getId(), $segment->getId(), 'signature');
+    $this->assertSame('rest_forbidden', $start['code']);
+    $this->assertSame(401, $start['data']['status']);
+  }
+
+  public function testStartQueuesSubscribersAcrossBoundedChunks(): void {
+    $segment = (new Segment())->create();
+    for ($i = 0; $i < ManualStartAudienceRepository::QUEUE_CHUNK_SIZE + 5; $i++) {
+      (new Subscriber())->withSegments([$segment])->create();
+    }
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->postPreview($automation->getId(), $segment->getId())['data'];
+    $start = $this->postStart($automation->getId(), $segment->getId(), $preview['preview_signature'])['data'];
+
+    $this->assertSame(ManualStartAudienceRepository::QUEUE_CHUNK_SIZE + 5, $start['queued_count']);
+    $this->assertSame(ManualStartAudienceRepository::QUEUE_CHUNK_SIZE + 5, $this->countTaskSubscribers($start['task_id']));
+  }
+
+  private function postPreview(int $automationId, ?int $segmentId, ?int $filterSegmentId = null, bool $includeFilterSegmentId = false): array {
     if ($segmentId === null) {
       $this->fail('Segment ID is required for manual start preview requests.');
     }
     $payload = ['segment_id' => $segmentId];
-    if ($filterSegmentId !== null) {
+    if ($filterSegmentId !== null || $includeFilterSegmentId) {
       $payload['filter_segment_id'] = $filterSegmentId;
     }
     return $this->post("/mailpoet/v1/automations/$automationId/manual-start/preview", ['json' => $payload]);
   }
 
-  private function postStart(int $automationId, ?int $segmentId, string $previewSignature, ?int $filterSegmentId = null): array {
+  private function postStart(int $automationId, ?int $segmentId, string $previewSignature, ?int $filterSegmentId = null, bool $includeFilterSegmentId = false): array {
     if ($segmentId === null) {
       $this->fail('Segment ID is required for manual start requests.');
     }
@@ -188,7 +301,7 @@ class AutomationManualStartEndpointTest extends AutomationTest {
       'segment_id' => $segmentId,
       'preview_signature' => $previewSignature,
     ];
-    if ($filterSegmentId !== null) {
+    if ($filterSegmentId !== null || $includeFilterSegmentId) {
       $payload['filter_segment_id'] = $filterSegmentId;
     }
     return $this->post("/mailpoet/v1/automations/$automationId/manual-start", ['json' => $payload]);

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationManualStartEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationManualStartEndpointTest.php
@@ -1,0 +1,241 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\REST\Automation\Automations;
+
+require_once __DIR__ . '/../AutomationTest.php';
+
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
+use MailPoet\Cron\Workers\Automations\ManualAutomationStartWorker;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\REST\Automation\AutomationTest;
+use MailPoet\Test\DataFactories\Automation as AutomationFactory;
+use MailPoet\Test\DataFactories\AutomationRun;
+use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Subscriber;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class AutomationManualStartEndpointTest extends AutomationTest {
+  /** @var EntityManager */
+  private $em;
+
+  /** @var ScheduledTasksRepository */
+  private $scheduledTasksRepository;
+
+  public function _before() {
+    parent::_before();
+    $this->em = $this->diContainer->get(EntityManager::class);
+    $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+  }
+
+  public function testPreviewReturnsCountsAndStartQueuesEligibleSubscribers(): void {
+    $segment = (new Segment())->create();
+    $eligible = (new Subscriber())->withSegments([$segment])->create();
+    $alreadyEntered = (new Subscriber())->withSegments([$segment])->create();
+    (new Subscriber())->withSegments([$segment])->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)->create();
+    (new Subscriber())->withSegments([$segment])->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)->create();
+    (new Subscriber())->withSegments([$segment])->withStatus(SubscriberEntity::STATUS_BOUNCED)->create();
+    (new Subscriber())->withSegments([$segment])->withStatus(SubscriberEntity::STATUS_INACTIVE)->create();
+    (new Subscriber())->withSegments([$segment])->withDeletedAt(new \DateTimeImmutable())->create();
+    (new Subscriber())->create();
+
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+    (new AutomationRun())
+      ->withAutomation($automation)
+      ->withTriggerKey(SomeoneSubscribesTrigger::KEY)
+      ->withSubject(new Subject(SubscriberSubject::KEY, ['subscriber_id' => $alreadyEntered->getId()]))
+      ->withSubject(new Subject(SegmentSubject::KEY, ['segment_id' => $segment->getId()]))
+      ->create();
+
+    $listing = $this->get('/mailpoet/v1/automations')['data'];
+    $item = $this->findAutomationListItem($listing['items'], $automation->getId());
+    $manualStart = $item['manual_start'] ?? null;
+    $this->assertIsArray($manualStart);
+    $this->assertSame([
+      'supported' => true,
+      'trigger_key' => SomeoneSubscribesTrigger::KEY,
+      'segment_ids' => null,
+    ], $manualStart);
+
+    $preview = $this->postPreview($automation->getId(), $segment->getId())['data'];
+    $this->assertSame($automation->getId(), $preview['automation_id']);
+    $this->assertSame($segment->getId(), $preview['segment_id']);
+    $this->assertNull($preview['filter_segment_id']);
+    $this->assertSame(7, $preview['selected_count']);
+    $this->assertSame(1, $preview['eligible_count']);
+    $this->assertSame(1, $preview['skipped_by_reason']['already_entered']);
+    $this->assertSame(1, $preview['skipped_by_reason']['unconfirmed']);
+    $this->assertSame(1, $preview['skipped_by_reason']['unsubscribed']);
+    $this->assertSame(1, $preview['skipped_by_reason']['bounced']);
+    $this->assertSame(1, $preview['skipped_by_reason']['not_subscribed']);
+    $this->assertSame(1, $preview['skipped_by_reason']['deleted']);
+    $this->assertContains('trigger_filter_mismatch', $preview['deferred_reason_keys']);
+    $this->assertFalse($preview['duplicate_in_progress']);
+
+    $start = $this->postStart($automation->getId(), $segment->getId(), $preview['preview_signature'])['data'];
+    $this->assertSame($automation->getId(), $start['automation_id']);
+    $this->assertSame($segment->getId(), $start['segment_id']);
+    $this->assertSame(7, $start['selected_count']);
+    $this->assertSame(1, $start['eligible_count']);
+    $this->assertSame(1, $start['queued_count']);
+    $this->assertGreaterThan(0, $start['task_id']);
+
+    $task = $this->scheduledTasksRepository->findOneById($start['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    $this->assertSame(ManualAutomationStartWorker::TASK_TYPE, $task->getType());
+    $this->assertSame(ScheduledTaskEntity::STATUS_SCHEDULED, $task->getStatus());
+    $taskMeta = $task->getMeta() ?? [];
+    $this->assertSame($automation->getId(), $this->getInt($taskMeta['automation_id'] ?? null));
+    $this->assertSame($automation->getVersionId(), $this->getInt($taskMeta['automation_version_id'] ?? null));
+    $this->assertSame(1, $this->countTaskSubscribers((int)$task->getId()));
+    $this->assertTrue($this->taskHasSubscriber((int)$task->getId(), (int)$eligible->getId()));
+
+    $duplicate = $this->postPreview($automation->getId(), $segment->getId());
+    $this->assertSame('manual_start_in_progress', $duplicate['code']);
+    $this->assertSame(409, $duplicate['data']['status']);
+  }
+
+  public function testStartRejectsStalePreviewSignatureWithRefreshedPreview(): void {
+    $segment = (new Segment())->create();
+    (new Subscriber())->withSegments([$segment])->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $preview = $this->postPreview($automation->getId(), $segment->getId())['data'];
+    (new Subscriber())->withSegments([$segment])->create();
+
+    $response = $this->postStart($automation->getId(), $segment->getId(), $preview['preview_signature']);
+    $this->assertSame('manual_start_stale_preview', $response['code']);
+    $this->assertSame(409, $response['data']['status']);
+    $this->assertSame(2, $response['data']['preview']['eligible_count']);
+    $this->assertNotSame($preview['preview_signature'], $response['data']['preview']['preview_signature']);
+  }
+
+  public function testPreviewValidatesSupportedAutomationAndSegments(): void {
+    $defaultSegment = (new Segment())->create();
+    $dynamicSegment = (new Segment())->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withSomeoneSubscribesTrigger()
+      ->create();
+
+    $response = $this->postPreview($automation->getId(), $dynamicSegment->getId());
+    $this->assertSame('manual_start_invalid_segment', $response['code']);
+    $this->assertSame(400, $response['data']['status']);
+
+    $unsupportedAutomation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withStep(new Step('trigger', Step::TYPE_TRIGGER, 'mailpoet:someone-unsubscribes', [], []))
+      ->create();
+    $response = $this->postPreview($unsupportedAutomation->getId(), $defaultSegment->getId());
+    $this->assertSame('manual_start_unsupported_trigger', $response['code']);
+    $this->assertSame(400, $response['data']['status']);
+  }
+
+  public function testPreviewRejectsListsNotAllowedByTriggerSettings(): void {
+    $allowedSegment = (new Segment())->create();
+    $blockedSegment = (new Segment())->create();
+    $automation = (new AutomationFactory())
+      ->withStatusActive()
+      ->withStep(new Step(
+        'trigger',
+        Step::TYPE_TRIGGER,
+        SomeoneSubscribesTrigger::KEY,
+        ['segment_ids' => [$allowedSegment->getId()]],
+        []
+      ))
+      ->create();
+
+    $listing = $this->get('/mailpoet/v1/automations')['data'];
+    $item = $this->findAutomationListItem($listing['items'], $automation->getId());
+    $manualStart = $item['manual_start'] ?? null;
+    $this->assertIsArray($manualStart);
+    $this->assertSame([$allowedSegment->getId()], $manualStart['segment_ids']);
+
+    $response = $this->postPreview($automation->getId(), $blockedSegment->getId());
+    $this->assertSame('manual_start_segment_not_allowed', $response['code']);
+    $this->assertSame(400, $response['data']['status']);
+  }
+
+  private function postPreview(int $automationId, ?int $segmentId, ?int $filterSegmentId = null): array {
+    if ($segmentId === null) {
+      $this->fail('Segment ID is required for manual start preview requests.');
+    }
+    $payload = ['segment_id' => $segmentId];
+    if ($filterSegmentId !== null) {
+      $payload['filter_segment_id'] = $filterSegmentId;
+    }
+    return $this->post("/mailpoet/v1/automations/$automationId/manual-start/preview", ['json' => $payload]);
+  }
+
+  private function postStart(int $automationId, ?int $segmentId, string $previewSignature, ?int $filterSegmentId = null): array {
+    if ($segmentId === null) {
+      $this->fail('Segment ID is required for manual start requests.');
+    }
+    $payload = [
+      'segment_id' => $segmentId,
+      'preview_signature' => $previewSignature,
+    ];
+    if ($filterSegmentId !== null) {
+      $payload['filter_segment_id'] = $filterSegmentId;
+    }
+    return $this->post("/mailpoet/v1/automations/$automationId/manual-start", ['json' => $payload]);
+  }
+
+  /**
+   * @param array<int, array<string, mixed>> $items
+   * @return array<string, mixed>
+   */
+  private function findAutomationListItem(array $items, int $automationId): array {
+    foreach ($items as $item) {
+      $id = $item['id'] ?? null;
+      if (is_numeric($id) && (int)$id === $automationId) {
+        return $item;
+      }
+    }
+    $this->fail('Automation list item not found.');
+  }
+
+  private function countTaskSubscribers(int $taskId): int {
+    $table = $this->em->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    $count = $this->em->getConnection()->executeQuery(
+      "SELECT COUNT(*) FROM $table WHERE task_id = :taskId",
+      ['taskId' => $taskId]
+    )->fetchOne();
+
+    return $this->getInt($count);
+  }
+
+  private function taskHasSubscriber(int $taskId, int $subscriberId): bool {
+    $table = $this->em->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    $count = $this->em->getConnection()->executeQuery(
+      "SELECT COUNT(*) FROM $table WHERE task_id = :taskId AND subscriber_id = :subscriberId",
+      [
+        'taskId' => $taskId,
+        'subscriberId' => $subscriberId,
+      ]
+    )->fetchOne();
+
+    return $this->getInt($count) === 1;
+  }
+
+  /** @param mixed $value */
+  private function getInt($value): int {
+    if (is_numeric($value)) {
+      return (int)$value;
+    }
+    return 0;
+  }
+}

--- a/mailpoet/tests/javascript/automation/listing/manual-start/api.spec.ts
+++ b/mailpoet/tests/javascript/automation/listing/manual-start/api.spec.ts
@@ -1,0 +1,121 @@
+import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
+import { registerApiErrorHandler } from '../../../../../assets/js/src/automation/listing/api-error-handler';
+import {
+  previewManualStart,
+  startManualStart,
+} from '../../../../../assets/js/src/automation/listing/manual-start/api';
+import type {
+  ManualStartPreview,
+  ManualStartResult,
+} from '../../../../../assets/js/src/automation/listing/manual-start/types';
+
+const preview: ManualStartPreview = {
+  preview_signature: 'signature',
+  automation_id: 7,
+  segment_id: 11,
+  filter_segment_id: null,
+  selected_count: 10,
+  eligible_count: 4,
+  skipped_by_reason: { already_entered: 2 },
+  deferred_reason_keys: ['trigger_filter_mismatch'],
+  duplicate_in_progress: false,
+};
+
+const result: ManualStartResult = {
+  task_id: 99,
+  automation_id: 7,
+  segment_id: 11,
+  filter_segment_id: null,
+  selected_count: 10,
+  eligible_count: 4,
+  queued_count: 4,
+  skipped_by_reason: { already_entered: 2 },
+};
+
+describe('automation manual-start API helpers', () => {
+  before(() => {
+    registerApiErrorHandler();
+  });
+
+  afterEach(() => {
+    apiFetch.setFetchHandler(async () => ({}));
+  });
+
+  it('normalizes preview responses and sends the abort signal', async () => {
+    const controller = new AbortController();
+    let capturedOptions: APIFetchOptions | undefined;
+    apiFetch.setFetchHandler(async (options) => {
+      capturedOptions = options;
+      return { data: preview };
+    });
+
+    const response = await previewManualStart(
+      7,
+      { segment_id: 11, filter_segment_id: null },
+      controller.signal,
+    );
+
+    expect(response).to.deep.equal(preview);
+    expect(capturedOptions?.path).to.contain(
+      '/automations/7/manual-start/preview',
+    );
+    expect(capturedOptions?.method).to.equal('POST');
+    expect(capturedOptions?.signal).to.equal(controller.signal);
+    expect(capturedOptions?.data).to.deep.equal({
+      segment_id: 11,
+      filter_segment_id: null,
+    });
+  });
+
+  it('normalizes start responses and posts the preview signature', async () => {
+    let capturedOptions: APIFetchOptions | undefined;
+    apiFetch.setFetchHandler(async (options) => {
+      capturedOptions = options;
+      return { data: result };
+    });
+
+    const response = await startManualStart(7, {
+      segment_id: 11,
+      filter_segment_id: null,
+      preview_signature: 'signature',
+    });
+
+    expect(response).to.deep.equal(result);
+    expect(capturedOptions?.path).to.contain('/automations/7/manual-start');
+    expect(capturedOptions?.method).to.equal('POST');
+    expect(capturedOptions?.data).to.deep.equal({
+      segment_id: 11,
+      filter_segment_id: null,
+      preview_signature: 'signature',
+    });
+  });
+
+  it('preserves structured manual-start 4xx errors through middleware', async () => {
+    apiFetch.setFetchHandler(async () => {
+      throw Object.assign(new Error('Refresh the preview.'), {
+        code: 'manual_start_stale_preview',
+        message: 'Refresh the preview.',
+        data: {
+          status: 409,
+          preview,
+        },
+      });
+    });
+
+    try {
+      await startManualStart(7, {
+        segment_id: 11,
+        filter_segment_id: null,
+        preview_signature: 'old-signature',
+      });
+      throw new Error('Expected manual-start API error.');
+    } catch (error) {
+      expect((error as { code?: string }).code).to.equal(
+        'manual_start_stale_preview',
+      );
+      expect(
+        (error as { data?: { preview?: ManualStartPreview } }).data?.preview,
+      ).to.deep.equal(preview);
+    }
+  });
+});

--- a/mailpoet/tests/javascript/automation/listing/manual-start/api.spec.ts
+++ b/mailpoet/tests/javascript/automation/listing/manual-start/api.spec.ts
@@ -67,6 +67,24 @@ describe('automation manual-start API helpers', () => {
     });
   });
 
+  it('rethrows aborted preview requests without manual-start error wrapping', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    apiFetch.setFetchHandler(async () => undefined);
+
+    try {
+      await previewManualStart(
+        7,
+        { segment_id: 11, filter_segment_id: null },
+        controller.signal,
+      );
+      throw new Error('Expected abort error.');
+    } catch (error) {
+      expect((error as { name?: string }).name).to.equal('AbortError');
+      expect((error as { code?: string }).code).to.equal(undefined);
+    }
+  });
+
   it('normalizes start responses and posts the preview signature', async () => {
     let capturedOptions: APIFetchOptions | undefined;
     apiFetch.setFetchHandler(async (options) => {

--- a/mailpoet/tests/javascript/automation/listing/manual-start/helpers.spec.ts
+++ b/mailpoet/tests/javascript/automation/listing/manual-start/helpers.spec.ts
@@ -1,0 +1,199 @@
+import { AutomationStatus } from '../../../../../assets/js/src/automation/listing/automation';
+import {
+  canConfirmManualStart,
+  getManualStartDefaultListOptions,
+  getManualStartDynamicSegmentOptions,
+  getManualStartErrorState,
+  getSegmentIdNumber,
+  isBlockingManualStartError,
+  isManualStartApiPath,
+  isManualStartSupported,
+  normalizeManualStartError,
+  normalizeSegmentId,
+  previewMatchesSelections,
+} from '../../../../../assets/js/src/automation/listing/manual-start/helpers';
+import type { AutomationItem } from '../../../../../assets/js/src/automation/listing/store/types';
+import type {
+  MailPoetSegment,
+  ManualStartMetadata,
+  ManualStartPreview,
+} from '../../../../../assets/js/src/automation/listing/manual-start/types';
+
+const metadata: ManualStartMetadata = {
+  supported: true,
+  trigger_key: 'mailpoet:someone-subscribes',
+  segment_ids: null,
+};
+
+const automation = (overrides: Partial<AutomationItem> = {}): AutomationItem =>
+  ({
+    id: 1,
+    name: 'Automation',
+    status: AutomationStatus.ACTIVE,
+    stats: {
+      totals: {
+        entered: 0,
+        in_progress: 0,
+        exited: 0,
+      },
+    },
+    manual_start: metadata,
+    ...overrides,
+  } as AutomationItem);
+
+const preview = (
+  overrides: Partial<ManualStartPreview> = {},
+): ManualStartPreview => ({
+  preview_signature: 'signature',
+  automation_id: 1,
+  segment_id: 1,
+  filter_segment_id: null,
+  selected_count: 10,
+  eligible_count: 5,
+  skipped_by_reason: {},
+  deferred_reason_keys: [],
+  duplicate_in_progress: false,
+  ...overrides,
+});
+
+const segments: MailPoetSegment[] = [
+  { id: '1', name: 'Newsletter', subscribers: '10', type: 'default' },
+  { id: '02', name: 'Customers', subscribers: '20', type: 'default' },
+  { id: '3', name: 'Engaged', subscribers: '5', type: 'dynamic' },
+  {
+    id: '4',
+    name: 'Deleted',
+    subscribers: '0',
+    type: 'default',
+    deleted_at: '2026-05-21 10:00:00',
+  },
+  { id: 'invalid', name: 'Invalid', subscribers: '0', type: 'default' },
+];
+
+describe('automation manual-start helpers', () => {
+  it('supports only active non-legacy automations with manual-start metadata', () => {
+    expect(isManualStartSupported(automation())).to.equal(true);
+    expect(
+      isManualStartSupported(automation({ status: AutomationStatus.DRAFT })),
+    ).to.equal(false);
+    expect(isManualStartSupported(automation({ isLegacy: true }))).to.equal(
+      false,
+    );
+    expect(
+      isManualStartSupported(
+        automation({ manual_start: { ...metadata, supported: false } }),
+      ),
+    ).to.equal(false);
+  });
+
+  it('normalizes segment IDs before comparison and API conversion', () => {
+    expect(normalizeSegmentId('02')).to.equal('2');
+    expect(normalizeSegmentId(3)).to.equal('3');
+    expect(normalizeSegmentId('not-a-number')).to.equal('');
+    expect(getSegmentIdNumber('02')).to.equal(2);
+    expect(getSegmentIdNumber('')).to.equal(null);
+  });
+
+  it('returns default-list options restricted by manual-start metadata', () => {
+    expect(getManualStartDefaultListOptions(segments, metadata)).to.deep.equal([
+      { id: '1', name: 'Newsletter', subscribers: '10' },
+      { id: '2', name: 'Customers', subscribers: '20' },
+    ]);
+
+    expect(
+      getManualStartDefaultListOptions(segments, {
+        ...metadata,
+        segment_ids: [2],
+      }),
+    ).to.deep.equal([{ id: '2', name: 'Customers', subscribers: '20' }]);
+
+    expect(
+      getManualStartDefaultListOptions(segments, {
+        ...metadata,
+        segment_ids: [],
+      }).map((segment) => segment.id),
+    ).to.deep.equal(['1', '2']);
+  });
+
+  it('returns only available dynamic segments for optional filters', () => {
+    expect(getManualStartDynamicSegmentOptions(segments)).to.deep.equal([
+      { id: '3', name: 'Engaged', subscribers: '5' },
+    ]);
+  });
+
+  it('matches previews to the current list and filter selections', () => {
+    expect(previewMatchesSelections(preview(), '1', '')).to.equal(true);
+    expect(
+      previewMatchesSelections(preview({ filter_segment_id: 3 }), '1', '03'),
+    ).to.equal(true);
+    expect(previewMatchesSelections(preview(), '2', '')).to.equal(false);
+    expect(previewMatchesSelections(preview(), '1', '3')).to.equal(false);
+  });
+
+  it('allows confirmation only for current previews with eligible subscribers', () => {
+    expect(canConfirmManualStart(preview(), '1', '')).to.equal(true);
+    expect(
+      canConfirmManualStart(preview({ eligible_count: 0 }), '1', ''),
+    ).to.equal(false);
+    expect(
+      canConfirmManualStart(preview({ duplicate_in_progress: true }), '1', ''),
+    ).to.equal(false);
+    expect(canConfirmManualStart(preview(), '2', '')).to.equal(false);
+  });
+
+  it('detects manual-start API paths for middleware error handling', () => {
+    expect(
+      isManualStartApiPath('/automations/12/manual-start/preview'),
+    ).to.equal(true);
+    expect(isManualStartApiPath('/automations/12/manual-start')).to.equal(true);
+    expect(
+      isManualStartApiPath('/mailpoet/v1/automations/12/manual-start'),
+    ).to.equal(true);
+    expect(isManualStartApiPath('/automations/12/duplicate')).to.equal(false);
+  });
+
+  it('preserves structured manual-start errors', () => {
+    const stalePreview = preview({ eligible_count: 6 });
+    const error = normalizeManualStartError({
+      code: 'manual_start_stale_preview',
+      message: 'Refresh the preview.',
+      data: {
+        status: 409,
+        preview: stalePreview,
+      },
+    });
+
+    expect(error.code).to.equal('manual_start_stale_preview');
+    expect(error.message).to.equal('Refresh the preview.');
+    expect(error.data.preview).to.deep.equal(stalePreview);
+    expect(getManualStartErrorState(error)).to.equal('stale-preview');
+    expect(isBlockingManualStartError(error)).to.equal(true);
+  });
+
+  it('maps known error codes to modal states', () => {
+    expect(
+      getManualStartErrorState({
+        code: 'manual_start_zero_eligible',
+        message: '',
+        data: { status: 422 },
+      }),
+    ).to.equal('zero-eligible');
+    expect(
+      getManualStartErrorState({
+        code: 'manual_start_in_progress',
+        message: '',
+        data: { status: 409 },
+      }),
+    ).to.equal('duplicate-in-progress');
+    expect(
+      getManualStartErrorState({
+        code: 'manual_start_invalid_segment',
+        message: '',
+        data: { status: 400 },
+      }),
+    ).to.equal('validation');
+    expect(getManualStartErrorState(normalizeManualStartError(null))).to.equal(
+      'unknown',
+    );
+  });
+});

--- a/mailpoet/tests/javascript/automation/listing/manual-start/helpers.spec.ts
+++ b/mailpoet/tests/javascript/automation/listing/manual-start/helpers.spec.ts
@@ -61,6 +61,13 @@ const segments: MailPoetSegment[] = [
   { id: '02', name: 'Customers', subscribers: '20', type: 'default' },
   { id: '3', name: 'Engaged', subscribers: '5', type: 'dynamic' },
   {
+    id: '5',
+    name: 'Deleted dynamic',
+    subscribers: '0',
+    type: 'dynamic',
+    deleted_at: '2026-05-21 10:00:00',
+  },
+  {
     id: '4',
     name: 'Deleted',
     subscribers: '0',

--- a/mailpoet/tests/javascript/automation/listing/manual-start/helpers.spec.ts
+++ b/mailpoet/tests/javascript/automation/listing/manual-start/helpers.spec.ts
@@ -165,6 +165,30 @@ describe('automation manual-start helpers', () => {
     expect(isBlockingManualStartError(error)).to.equal(true);
   });
 
+  it('ignores malformed preview data in manual-start errors', () => {
+    const error = normalizeManualStartError({
+      code: 'manual_start_stale_preview',
+      message: 'Refresh the preview.',
+      data: {
+        status: 409,
+        preview: {
+          preview_signature: 'signature',
+          automation_id: 1,
+          segment_id: 'not-a-number',
+          filter_segment_id: null,
+          selected_count: 10,
+          eligible_count: 5,
+          skipped_by_reason: {},
+          deferred_reason_keys: [],
+          duplicate_in_progress: false,
+        },
+      },
+    });
+
+    expect(error.data.status).to.equal(409);
+    expect(error.data.preview).to.equal(undefined);
+  });
+
   it('maps known error codes to modal states', () => {
     expect(
       getManualStartErrorState({

--- a/mailpoet/tests/javascript/automation/listing/manual-start/helpers.spec.ts
+++ b/mailpoet/tests/javascript/automation/listing/manual-start/helpers.spec.ts
@@ -6,7 +6,6 @@ import {
   getManualStartErrorState,
   getSegmentIdNumber,
   isBlockingManualStartError,
-  isManualStartApiPath,
   isManualStartSupported,
   normalizeManualStartError,
   normalizeSegmentId,
@@ -146,17 +145,6 @@ describe('automation manual-start helpers', () => {
       canConfirmManualStart(preview({ duplicate_in_progress: true }), '1', ''),
     ).to.equal(false);
     expect(canConfirmManualStart(preview(), '2', '')).to.equal(false);
-  });
-
-  it('detects manual-start API paths for middleware error handling', () => {
-    expect(
-      isManualStartApiPath('/automations/12/manual-start/preview'),
-    ).to.equal(true);
-    expect(isManualStartApiPath('/automations/12/manual-start')).to.equal(true);
-    expect(
-      isManualStartApiPath('/mailpoet/v1/automations/12/manual-start'),
-    ).to.equal(true);
-    expect(isManualStartApiPath('/automations/12/duplicate')).to.equal(false);
   });
 
   it('preserves structured manual-start errors', () => {

--- a/mailpoet/tests/javascript/automation/listing/manual-start/modal.spec.tsx
+++ b/mailpoet/tests/javascript/automation/listing/manual-start/modal.spec.tsx
@@ -1,0 +1,466 @@
+import Module from 'module';
+import React, { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+import sinon from 'sinon';
+import type { AutomationItem } from '../../../../../assets/js/src/automation/listing/store/types';
+import type {
+  ManualStartPreview,
+  ManualStartResult,
+} from '../../../../../assets/js/src/automation/listing/manual-start/types';
+import { AutomationStatus } from '../../../../../assets/js/src/automation/listing/automation';
+
+type ModuleLoader = (
+  request: string,
+  parent: { filename?: string } | undefined,
+  isMain: boolean,
+) => unknown;
+
+type SelectOption = {
+  value: string;
+  label: string;
+};
+
+const moduleLoadKey = '_load';
+const moduleWithLoader = Module as unknown as Record<string, ModuleLoader>;
+const originalLoad = moduleWithLoader[moduleLoadKey];
+let previewManualStart: sinon.SinonStub;
+let startManualStart: sinon.SinonStub;
+let ManualStartModal: React.ComponentType<{
+  automation: AutomationItem;
+  onClose: () => void;
+}>;
+
+function translate(text: string): string {
+  return text;
+}
+
+function plural(singular: string, pluralText: string, count: number): string {
+  return count === 1 ? singular : pluralText;
+}
+
+function sprintf(template: string, ...args: unknown[]): string {
+  return args.reduce<string>((message, arg, index) => {
+    const value = String(arg);
+    return message
+      .replace(`%${index + 1}$s`, value)
+      .replace(`%${index + 1}$d`, value)
+      .replace('%s', value)
+      .replace('%d', value);
+  }, template);
+}
+
+function Button({
+  children,
+  isBusy,
+  variant,
+  ...props
+}: {
+  children: ReactNode;
+  isBusy?: boolean;
+  variant?: string;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>): JSX.Element {
+  void isBusy;
+  void variant;
+  return (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  );
+}
+
+function Modal({
+  children,
+  title,
+}: {
+  children: ReactNode;
+  title: string;
+}): JSX.Element {
+  return (
+    <div role="dialog" aria-label={title}>
+      <h1 className="components-modal__header-heading">{title}</h1>
+      {children}
+    </div>
+  );
+}
+
+function ReactSelect({
+  inputId,
+  value,
+  options,
+  placeholder,
+  disabled,
+  isDisabled,
+  onChange,
+  'aria-label': ariaLabel,
+}: {
+  inputId: string;
+  value: SelectOption | null;
+  options: SelectOption[];
+  placeholder: string;
+  disabled?: boolean;
+  isDisabled?: boolean;
+  onChange: (option: SelectOption | null) => void;
+  'aria-label'?: string;
+}): JSX.Element {
+  return (
+    <select
+      id={inputId}
+      aria-label={ariaLabel ?? inputId}
+      value={value?.value ?? ''}
+      disabled={disabled || isDisabled}
+      onChange={(event) => {
+        const nextValue = event.currentTarget.value;
+        onChange(options.find((option) => option.value === nextValue) ?? null);
+      }}
+    >
+      <option value="">{placeholder}</option>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function Toggle({
+  checked,
+  disabled,
+  onCheck,
+  'aria-label': ariaLabel,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  onCheck: (checked: boolean) => void;
+  'aria-label': string;
+}): JSX.Element {
+  return (
+    <input
+      type="checkbox"
+      aria-label={ariaLabel}
+      checked={checked}
+      disabled={disabled}
+      onChange={(event) => onCheck(event.currentTarget.checked)}
+    />
+  );
+}
+
+function Tooltip({ children }: { children: ReactNode }): JSX.Element {
+  return <span>{children}</span>;
+}
+
+moduleWithLoader[moduleLoadKey] = function loadModule(request, parent, isMain) {
+  if (request === '@wordpress/components') {
+    return { Button, Modal, Spinner: () => <span>spinner</span> };
+  }
+  if (request === '@wordpress/i18n') {
+    return { __: translate, _n: plural, sprintf };
+  }
+  if (request === '@wordpress/icons') {
+    return { Icon: () => null, help: {} };
+  }
+  if (request === 'common/form/react-select/react-select') {
+    return { ReactSelect };
+  }
+  if (request === 'common/form/toggle/toggle') {
+    return { Toggle };
+  }
+  if (request === 'common/tooltip/tooltip') {
+    return { Tooltip };
+  }
+  if (
+    request === './api' &&
+    parent?.filename?.endsWith('manual-start/modal.tsx')
+  ) {
+    return {
+      previewManualStart: (...args: unknown[]) =>
+        previewManualStart(...args) as Promise<ManualStartPreview>,
+      startManualStart: (...args: unknown[]) =>
+        startManualStart(...args) as Promise<ManualStartResult>,
+    };
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+const preview = (
+  overrides: Partial<ManualStartPreview> = {},
+): ManualStartPreview => ({
+  preview_signature: 'signature',
+  automation_id: 7,
+  segment_id: 1,
+  filter_segment_id: null,
+  selected_count: 5,
+  eligible_count: 2,
+  skipped_by_reason: {},
+  deferred_reason_keys: [],
+  duplicate_in_progress: false,
+  ...overrides,
+});
+
+const result: ManualStartResult = {
+  task_id: 10,
+  automation_id: 7,
+  segment_id: 1,
+  filter_segment_id: null,
+  selected_count: 5,
+  eligible_count: 3,
+  queued_count: 3,
+  skipped_by_reason: {},
+};
+
+const automation = {
+  id: 7,
+  name: 'Automation',
+  status: AutomationStatus.ACTIVE,
+  stats: {
+    totals: {
+      entered: 0,
+      in_progress: 0,
+      exited: 0,
+    },
+  },
+  isLegacy: false,
+  manual_start: {
+    supported: true,
+    trigger_key: 'mailpoet:someone-subscribes',
+    segment_ids: null,
+  },
+} as AutomationItem;
+
+function getButton(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    (candidate) => candidate.textContent === text,
+  );
+  if (!button) {
+    throw new Error(`Button not found: ${text}`);
+  }
+  return button;
+}
+
+function getSelect(
+  container: HTMLElement,
+  selector: string,
+): HTMLSelectElement {
+  const select = container.querySelector<HTMLSelectElement>(selector);
+  if (!select) {
+    throw new Error(`Select not found: ${selector}`);
+  }
+  return select;
+}
+
+function getInput(container: HTMLElement, selector: string): HTMLInputElement {
+  const input = container.querySelector<HTMLInputElement>(selector);
+  if (!input) {
+    throw new Error(`Input not found: ${selector}`);
+  }
+  return input;
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+describe('ManualStartModal', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLElement;
+
+  before(async () => {
+    ({ ManualStartModal } = await import(
+      '../../../../../assets/js/src/automation/listing/manual-start/modal'
+    ));
+  });
+
+  after(() => {
+    moduleWithLoader[moduleLoadKey] = originalLoad;
+  });
+
+  beforeEach(() => {
+    dom = new JSDOM(
+      '<!doctype html><html><body><div id="root"></div></body></html>',
+    );
+    global.window = dom.window as unknown as Window & typeof globalThis;
+    global.document = dom.window.document;
+    global.HTMLElement = dom.window.HTMLElement;
+    global.Event = dom.window.Event;
+    global.MouseEvent = dom.window.MouseEvent;
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.mailpoet_segments = [
+      { id: '1', name: 'List', subscribers: '5', type: 'default' },
+    ];
+    previewManualStart = sinon.stub();
+    startManualStart = sinon.stub();
+    const rootElement = document.getElementById('root');
+    if (!rootElement) {
+      throw new Error('Root element not found');
+    }
+    container = rootElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    dom.window.close();
+  });
+
+  it('clears stale-preview errors after refreshing preview', async () => {
+    previewManualStart.onFirstCall().resolves(preview());
+    previewManualStart.onSecondCall().resolves(preview({ eligible_count: 3 }));
+    startManualStart.onFirstCall().rejects({
+      code: 'manual_start_stale_preview',
+      message: 'Refresh the preview.',
+      data: {
+        status: 409,
+        preview: preview({
+          preview_signature: 'next-signature',
+          eligible_count: 3,
+        }),
+      },
+    });
+    startManualStart.onSecondCall().resolves(result);
+
+    await act(async () => {
+      root.render(
+        <ManualStartModal automation={automation} onClose={() => undefined} />,
+      );
+    });
+
+    const list = getSelect(container, '#mailpoet-automation-manual-start-list');
+    await act(async () => {
+      list.value = '1';
+      list.dispatchEvent(new window.Event('change', { bubbles: true }));
+      await wait(500);
+    });
+
+    const queueButton = getButton(container, 'Queue subscribers');
+    expect(queueButton.disabled).to.equal(false);
+
+    await act(async () => {
+      queueButton.dispatchEvent(
+        new window.MouseEvent('click', { bubbles: true }),
+      );
+      await wait(50);
+    });
+    expect(getButton(container, 'Queue subscribers').disabled).to.equal(true);
+
+    await act(async () => {
+      expect(getButton(container, 'Refresh preview').disabled).to.equal(false);
+      getButton(container, 'Refresh preview').click();
+    });
+    await act(async () => {
+      await wait(500);
+    });
+    expect(previewManualStart.callCount).to.equal(2);
+    expect(getButton(container, 'Queue subscribers').disabled).to.equal(false);
+
+    await act(async () => {
+      getButton(container, 'Queue subscribers').dispatchEvent(
+        new window.MouseEvent('click', { bubbles: true }),
+      );
+      await wait(0);
+    });
+    expect(container.textContent).to.contain('MailPoet queued 3 subscribers');
+  });
+
+  it('disables queueing when no subscribers are eligible', async () => {
+    previewManualStart.resolves(preview({ eligible_count: 0 }));
+
+    await act(async () => {
+      root.render(
+        <ManualStartModal automation={automation} onClose={() => undefined} />,
+      );
+    });
+
+    const list = getSelect(container, '#mailpoet-automation-manual-start-list');
+    await act(async () => {
+      list.value = '1';
+      list.dispatchEvent(new window.Event('change', { bubbles: true }));
+      await wait(250);
+    });
+
+    expect(container.textContent).to.contain(
+      'No subscribers are eligible to start this automation',
+    );
+    expect(getButton(container, 'Queue subscribers').disabled).to.equal(true);
+  });
+
+  it('keeps queueing disabled while another manual start is in progress', async () => {
+    previewManualStart.onFirstCall().resolves(
+      preview({
+        duplicate_in_progress: true,
+      }),
+    );
+    previewManualStart.onSecondCall().resolves(preview());
+
+    await act(async () => {
+      root.render(
+        <ManualStartModal automation={automation} onClose={() => undefined} />,
+      );
+    });
+
+    const list = getSelect(container, '#mailpoet-automation-manual-start-list');
+    await act(async () => {
+      list.value = '1';
+      list.dispatchEvent(new window.Event('change', { bubbles: true }));
+      await wait(250);
+    });
+
+    expect(container.textContent).to.contain(
+      'Subscribers are already queued for this automation',
+    );
+    expect(getButton(container, 'Queue subscribers').disabled).to.equal(true);
+    expect(getButton(container, 'Refresh preview').disabled).to.equal(false);
+
+    await act(async () => {
+      getButton(container, 'Refresh preview').click();
+    });
+    await act(async () => {
+      await wait(500);
+    });
+
+    expect(previewManualStart.callCount).to.equal(2);
+    expect(container.textContent).not.to.contain(
+      'Subscribers are already queued for this automation',
+    );
+    expect(getButton(container, 'Queue subscribers').disabled).to.equal(false);
+  });
+
+  it('requires a segment when the segment filter is enabled', async () => {
+    window.mailpoet_segments = [
+      { id: '1', name: 'List', subscribers: '5', type: 'default' },
+      { id: '2', name: 'Engaged', subscribers: '2', type: 'dynamic' },
+    ];
+    previewManualStart.resolves(preview());
+
+    await act(async () => {
+      root.render(
+        <ManualStartModal automation={automation} onClose={() => undefined} />,
+      );
+    });
+
+    const list = getSelect(container, '#mailpoet-automation-manual-start-list');
+    await act(async () => {
+      list.value = '1';
+      list.dispatchEvent(new window.Event('change', { bubbles: true }));
+      await wait(250);
+    });
+
+    const filterToggle = getInput(
+      container,
+      'input[aria-label="Filter by segment"]',
+    );
+    await act(async () => {
+      filterToggle.click();
+    });
+
+    expect(container.textContent).to.contain(
+      'Choose a segment filter to preview eligible subscribers',
+    );
+    expect(getButton(container, 'Queue subscribers').disabled).to.equal(true);
+  });
+});

--- a/mailpoet/tests/unit/Automation/Engine/Data/SubjectTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Data/SubjectTest.php
@@ -15,4 +15,26 @@ class SubjectTest extends \MailPoetUnitTest {
       $subject->getHash()
     );
   }
+
+  public function testSubscriberSubjectSqlHashExpressionUsesSubjectHashHelper(): void {
+    $subscriberId = 123;
+    $subject = new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriberId]);
+    $serializedArgs = sprintf('a:1:{s:13:"subscriber_id";i:%d;}', $subscriberId);
+
+    $this->assertSame(
+      $subject->getHash(),
+      md5(SubscriberSubject::KEY . $serializedArgs)
+    );
+    $this->assertSame(
+      Subject::getHashSqlExpression(':subjectKey', 'serialized_args'),
+      'MD5(CONCAT(:subjectKey, serialized_args))'
+    );
+    $this->assertSame(
+      Subject::getHashSqlExpression(
+        ':subjectKey',
+        "CONCAT('a:1:{s:13:\"subscriber_id\";i:', subscribers.id, ';}')"
+      ),
+      SubscriberSubject::getHashSqlExpression('subscribers.id', ':subjectKey')
+    );
+  }
 }

--- a/mailpoet/tests/unit/Automation/Engine/Data/SubjectTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Data/SubjectTest.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Engine\Data;
+
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+
+class SubjectTest extends \MailPoetUnitTest {
+  public function testSubscriberSubjectHashMatchesManualStartSqlFormat(): void {
+    $subscriberId = 123;
+    $subject = new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriberId]);
+
+    $this->assertSame(
+      md5(SubscriberSubject::KEY . 'a:1:{s:13:"subscriber_id";i:123;}'),
+      $subject->getHash()
+    );
+  }
+}

--- a/mailpoet/tsconfig.json
+++ b/mailpoet/tsconfig.json
@@ -4,6 +4,7 @@
     "assets/js/src/**/*",
     "assets/js/src/**/*.json",
     "tests/javascript/**/*.ts",
+    "tests/javascript/**/*.tsx",
     "tests/javascript-newsletter-editor/**/*.ts"
   ],
   "compilerOptions": {


### PR DESCRIPTION
## Description

Adds a manual start flow for eligible subscriber automations, allowing admins to queue existing subscribers from a specific list, optionally narrowed by a dynamic segment.

The flow adds:

- skip counts for ineligible subscribers and already-entered subscribers
- a modal with preview, zero-eligible, stale-preview, in-progress, skipped-reason, and queued-success states

## Code review notes

We allow only one scheduled/running manual start per automation. This avoids overlapping manual-start audiences.

Dynamic segments only narrow the selected concrete list. 

## QA notes

1. Go to MailPoet > Automations.
2. Confirm that an active automation with a `Someone subscribes` trigger shows the `Start automation for existing subscribers` row action.
3. Open the action and choose a list.
4. Confirm the modal previews' estimated recipients and skipped subscribers.
5. Enable `Filter by segment`, choose a dynamic segment, and confirm the preview changes.
6. Queue subscribers and confirm the success state shows the queued count, task ID, selected list, and optional segment filter.
7. Reopen the same automation while the manual-start task is scheduled/running and confirm the flow is blocked with an in-progress message.
8. Try a list with no eligible subscribers and confirm queueing stays disabled with the zero-eligible message.

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-8102/manually-start-subscriber-automations-for-existing-audiences

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="268" height="214" alt="Screenshot 2026-05-21 at 14 38 18" src="https://github.com/user-attachments/assets/fb3ac74e-c240-4edf-91e9-090492a24401" />

---

<img width="632" height="507" alt="Screenshot 2026-05-21 at 14 39 17" src="https://github.com/user-attachments/assets/3a883267-36c6-4112-9fbd-c98dc6b39e07" />

---

<img width="668" height="754" alt="Screenshot 2026-05-21 at 14 34 23" src="https://github.com/user-attachments/assets/1064a3d7-aec3-4691-98c2-17171220e0e0" />


## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-8102-manual-start-existing-subscribers)

_The latest successful build from `add/STOMAIL-8102-manual-start-existing-subscribers` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->