### PR TITLE
Fix post-checkout hook ./do path

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -5,4 +5,6 @@
 
 installIfUpdates
 
+pushd mailpoet
 ./do cleanup:cached-files
+popd


### PR DESCRIPTION
## Description

The husky `post-checkout` hook called `./do cleanup:cached-files` from the working-tree root, but `do` lives at `mailpoet/do`. Every `git checkout` failed the hook with `./do: No such file or directory`, and `cleanup:cached-files` never ran. Wrap the call in `pushd mailpoet` / `popd`, matching the pattern already used in `.husky/common.sh`.

## Code review notes

_N/A_

## QA notes

With `MP_GIT_HOOKS_ENABLE=true` in `mailpoet/.env`, from the repo root:

```
sh -e .husky/post-checkout HEAD HEAD 1
```

- On `trunk`: `./do: No such file or directory`, exit 1.
- On this branch: three cleanup steps run, exit 0.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/husky-post-checkout-do-path)

_The latest successful build from `fix/husky-post-checkout-do-path` will be used. If none is available, the link won't work._