### PR TITLE
Update WordPress compatibility to 7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1200,7 +1200,7 @@ workflows:
           mysql_image: mysql:5.6
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.8.3
+          wordpress_version: 6.9.4
           requires:
             - build
       - performance_tests:
@@ -1238,7 +1238,7 @@ workflows:
           automate_woo_version: 6.2.4
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.8.3
+          wordpress_version: 6.9.4
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.6
           requires:
@@ -1300,7 +1300,7 @@ workflows:
           automate_woo_version: 6.2.4
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.8.3
+          wordpress_version: 6.9.4
           requires:
             - build_premium
       - integration_tests:
@@ -1311,7 +1311,7 @@ workflows:
           automate_woo_version: 6.2.4
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.8.3
+          wordpress_version: 6.9.4
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.6
           requires:

--- a/mailpoet/changelog/2026-05-22-10-49-46-updated-wordpress-compatibility-to-version-70.md
+++ b/mailpoet/changelog/2026-05-22-10-49-46-updated-wordpress-compatibility-to-version-70.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+WordPress compatibility to version 7.0

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -7,7 +7,7 @@
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
  * Author URI: https://www.mailpoet.com
- * Requires at least: 6.8
+ * Requires at least: 6.9
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
@@ -27,7 +27,7 @@ $mailpoetPlugin = [
   'initializer' => dirname(__FILE__) . '/mailpoet_initializer.php',
 ];
 
-const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.8'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.9'; // L-1 version, not the latest
 const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.6'; // L-1 version, not the latest
 
 

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -1,8 +1,8 @@
 === MailPoet - Newsletters, Email Marketing, and Automation ===
 Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
-Requires at least: 6.8
-Tested up to: 6.9
+Requires at least: 6.9
+Tested up to: 7.0
 Stable tag: 5.27.0
 Requires PHP: 7.4
 License: GPLv3

--- a/mailpoet/tests/acceptance/Newsletters/EditorImageBlockCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorImageBlockCest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use Facebook\WebDriver\Exception\TimeoutException;
 use MailPoet\Test\DataFactories\Newsletter;
 
 class EditorImageBlockCest {
@@ -13,8 +14,17 @@ class EditorImageBlockCest {
       ->create();
     $i->login();
     $i->amEditingNewsletter($newsletter->getId());
-    $i->dragAndDrop('#automation_editor_block_image', '#mce_0');
-    $i->waitForText('Add images');
+    for ($attempt = 1; $attempt <= 3; $attempt++) {
+      $i->dragAndDrop('#automation_editor_block_image', '#mce_0');
+      try {
+        $i->waitForText('Add images');
+        break;
+      } catch (TimeoutException $e) {
+        if ($attempt === 3) {
+          throw $e;
+        }
+      }
+    }
     $i->click('Media Library');
     $i->waitForElementClickable('.thumbnail');
     $i->click('.thumbnail');

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -58,6 +58,7 @@ class SubscribersListingCest {
     $i->amOnMailpoetPage('Subscribers');
     $i->waitForText('All Tags');
     $i->selectOption('[data-automation-id="listing_filter_tag"]', $tag->getName());
+    $i->waitForListingItemsToLoad();
     $i->waitForText('wp@mailpoet.com');
     $i->dontSee('wp@example.com');
     $i->waitForText('My Tag');


### PR DESCRIPTION
## Description

Declares compatibility with WordPress 7.0, updates the minimum required WordPress version to 6.9, and updates oldest nightly test runs to WordPress 6.9.4.

This branch also includes a temporary final commit that enables the full CircleCI suite on this feature branch.

## Code review notes

The final commit is temporary and should be dropped before merge after the full CI validation run is complete.

## QA notes

Verify the plugin metadata declares WordPress 6.9 as the minimum required version and WordPress 7.0 as tested.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1078

## Linked tickets

_N/A_

## After-merge notes

Drop the temporary full-CI commit before merge.

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/wp-70-compatibility)

_The latest successful build from `update/wp-70-compatibility` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
2 issues found.
- Suggestion (2):
  1. Temporary final commit enabling full CircleCI suite should be removed before merge.
  2. Checklist items not completed: translations, test coverage, and TypeScript checks require follow-up.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->