### PR TITLE
Fix order review URL tag test skip

### DIFF
--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
@@ -77,14 +77,14 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
   }
 
   public function testItRegistersOrderReviewUrlTagForOrderAutomations(): void {
-    if (!$this->diContainer->get(OrderReviewUrl::class)->isSupported()) {
-      $this->markTestSkipped('WooCommerce order review URL helper is not available.');
-    }
-
     $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
     $registry->unregister('[woocommerce/order-review-url]');
 
-    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+    $orderReviewUrl = $this->createMock(OrderReviewUrl::class);
+    $orderReviewUrl->method('isSupported')->willReturn(true);
+    $personalizationManager = $this->getServiceWithOverrides(PersonalizationTagManager::class, [
+      'orderReviewUrl' => $orderReviewUrl,
+    ]);
     $personalizationManager->extendWooCommerceTagsForMailPoet($registry, [OrderSubject::KEY]);
 
     $tag = $registry->get_by_token('[woocommerce/order-review-url]');


### PR DESCRIPTION
## Description

Fix the order review URL personalization tag registration test so it no longer skips when WooCommerce review URL support is unavailable in the current integration-test environment. Trunk CI rejects unexpected skipped tests, which caused the base and multisite integration jobs to fail.

## Code review notes

The test now injects a mocked supported `OrderReviewUrl` dependency, keeping the assertion focused on MailPoet's tag registration logic instead of the host WooCommerce feature/page state.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

MPI-330

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/order-review-url-tag-skip)

_The latest successful build from `fix/order-review-url-tag-skip` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

This PR successfully fixes the test infrastructure issue where `testItRegistersOrderReviewUrlTagForOrderAutomations()` was unexpectedly skipped in CI environments where WooCommerce review URL support was unavailable. The solution properly injects a mocked `OrderReviewUrl` dependency that returns `true` for `isSupported()`, ensuring the test deterministically verifies MailPoet's tag registration logic independent of the host environment's WooCommerce configuration. The test structure, mock injection pattern, and assertions are all correctly implemented.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->