### PR TITLE
Harden WooCommerce feature utility checks

### DIFF
--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -131,7 +131,7 @@ class Helper {
   }
 
   private function isCustomerReviewRequestFeatureEnabled(): bool {
-    if (!class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
+    if (!$this->canUseWooCommerceFeatureUtilities()) {
       return false;
     }
 
@@ -438,10 +438,22 @@ class Helper {
   }
 
   public function isWooCommerceEmailImprovementsEnabled(): bool {
-    if (!class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
+    if (!$this->canUseWooCommerceFeatureUtilities()) {
       return false;
     }
     return \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled('email_improvements');
+  }
+
+  private function canUseWooCommerceFeatureUtilities(): bool {
+    if (!$this->isWooCommerceActive()) {
+      return false;
+    }
+
+    if (!class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
+      return false;
+    }
+
+    return function_exists('wc_get_container');
   }
 
   public function wcPlaceholderImgSrc(string $size = 'woocommerce_thumbnail'): string {


### PR DESCRIPTION
## Description

MailPoet admin pages can fatal when WooCommerce utilities are autoloadable but WooCommerce is not fully active and `wc_get_container()` is unavailable. Guard feature utility calls behind WooCommerce active and container checks.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

https://wordpress.org/support/topic/mailpoet-not-working-with-wordpress-7-0/

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**No issues found.**

The PR appropriately hardens WooCommerce feature utility checks by:

1. **Introducing a centralized safety check** - A new private `canUseWooCommerceFeatureUtilities()` method validates three conditions before using WooCommerce's `FeaturesUtil`:
   - WooCommerce is active
   - The `\Automattic\WooCommerce\Utilities\FeaturesUtil` class exists
   - The `wc_get_container()` function is available

2. **Consistently applying guards** - Both methods that access `FeaturesUtil` (`isCustomerReviewRequestFeatureEnabled()` and `isWooCommerceEmailImprovementsEnabled()`) properly call this safety check before attempting to call the utility.

3. **Preventing fatal errors** - The implementation prevents the reported issue where MailPoet admin pages would fatal when WooCommerce utilities are autoloadable but the plugin is not fully activated.

The code is well-structured, the implementation is straightforward, and the checks are properly ordered. No test coverage, documentation, or logic issues were identified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->