### PR TITLE
Add debugging-failed-tests skill; split running-tests out of writing-tests

### DIFF
--- a/.ai/skills/debugging-failed-tests/SKILL.md
+++ b/.ai/skills/debugging-failed-tests/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: debugging-failed-tests
+description: Use when investigating a failing test — reported via a CircleCI job/build URL, or output from a local test run. Triggers on phrases like "this test failed", "debug this CI failure", "why did the nightly fail?", "investigate the failure on <branch>", or any message pasting a CircleCI URL with failure context. Guides the investigator from failure signal → reproduction → root cause → fix applied and verified locally. Stops there — committing, opening a PR, or writing a changelog is the caller's call (see `creating-pull-requests`, `writing-changelog`).
+---
+
+# Debugging Failed Tests
+
+## Overview
+
+A test failed and we need to find out why and fix it. The failure can come from a pasted CircleCI job URL, or a local run that just blew up. This skill walks through gathering context, reproducing the failure locally, forming a root-cause hypothesis, applying a fix, and verifying it with the targeted test suite. **Stops there** — whether to commit, open a PR, or add a changelog is the caller's call (see `creating-pull-requests`, `writing-changelog`, `mailpoet-dev-cycle`).
+
+**Working assumption:** every failure is a real regression until evidence proves otherwise. Do not pre-emptively label something flaky.
+
+## Inputs
+
+One of:
+
+- **A CircleCI build/job URL.** Everything else (suite, plugin, WP/WC/PHP versions, beta/RC flag, branch, SHA) is derived in Step 1.
+- **Failing test output from a local run.** No URL; the target branch is the current branch (`git rev-parse --abbrev-ref HEAD`).
+
+### CircleCI access
+
+CircleCI calls go through the `.ai/skills/debugging-failed-tests/circleci-api.sh` wrapper. It handles auth — treat it as a black box. Do **not** invoke `curl` against CircleCI directly, do **not** look up the token yourself (env vars, config files, the wrapper script — anywhere), and do **not** copy the wrapper's error output verbatim into chat or commits. If the wrapper exits saying the token isn't configured, stop and report "CircleCI token not configured locally — see `.ai/skills/debugging-failed-tests/circleci-api.sh` for setup" (no paths, no env-var names, no guesses).
+
+See `references/circleci-api.md` for the useful endpoints (job, tests, artifacts, workflow siblings, insights). Read it once — it answers most "which endpoint do I call?" questions.
+
+## Heads-up: not every failed CI job is a test failure
+
+A failed CircleCI job can also be: a composer/npm install failure, an asset-build failure, a lint/QA gate failure, an OOM, or `infrastructure_fail`. In those cases skip Steps 3–6 — read the failing step's output directly, fix the build/install/lint issue, and rerun. The "When NOT to apply a fix" rules still apply. `infrastructure_fail` is CircleCI's problem, not yours; retry the job before debugging.
+
+## Step 0: Is this already known?
+
+Do this **first** — before any CI fetching. It is cheap and routinely saves time: another engineer may be in flight on the same fix. Skipping straight to investigation is the most common time-waster in this workflow.
+
+1. **Existing fix in flight** — `gh pr list --state open --search "<method-or-class-name>"`. Use the test method name _or_ the class name (drop `Test.php` / `Cest.php`). Don't paste the full path — `gh` searches title/body/branch, not paths.
+2. **Is this test brand new?** — `git log --diff-filter=A -- <test-file-path>` shows the commit that introduced the file. If the file was added in the failing range, the test itself may simply be broken from birth.
+3. **Recent author of the production code under test** — once you know what the test exercises (see Step 4.1), `git log -1 --format='%an' -- <production-file>` gives you the last author. Then `gh pr list --state open --author <github-handle>` checks whether they already have something in flight. (Skip this in Step 0 if you don't yet know the target — circle back from Step 4.)
+
+If a relevant PR exists, stop and report the link instead of starting parallel work.
+
+## Step 1: Gather failure context
+
+1. **Get structured failure data first.** Hit the `tests` endpoint — it returns one row per test with `name`, `classname`, `result`, `message`. Filter to `result != "success"` and you have your repro list. Much cheaper than scrolling step logs. (See `references/circleci-api.md`.) Capture: failing test name(s), the commit SHA the job ran against, **and the branch the job ran against** (`pipeline.vcs.branch` on the job payload).
+2. **If the `message` names a `file:line`, open it immediately.** A rich exception (`TimeoutException at FooCest.php:32`, an explicit assertion line, etc.) usually carries enough to hypothesise from the test source alone — artifacts and step logs add little. Save the heavier fetching for opaque or empty messages.
+3. **Acceptance failures with opaque messages: fetch artifacts.** When the message is empty or unhelpful (common for selector timeouts), Codeception's `*.fail.png` screenshots and `*.fail.html` page dumps usually reveal the issue without re-running locally (missing element, wrong text, redirect, JS error). See `references/circleci-api.md` for the artifacts endpoint and download recipe.
+4. **Identify the suite** from the failing path:
+   - `tests/unit/*Test.php` → unit
+   - `tests/integration/*Test.php` → integration
+   - `tests/acceptance/*Cest.php` → acceptance
+   - `tests/javascript/*.spec.ts` → JavaScript
+5. **Identify the plugin:** path under `mailpoet/` (free) or `mailpoet-premium/` (premium). Match the plugin to the repo — never mix free fixes into premium changes or vice versa.
+6. **Capture the WP / WC / PHP versions.** The Codeception entrypoint (`tests_env/docker/codeception/docker-entrypoint.sh`) prints them near the start of the failing step's output — look for `WORDPRESS VERSION:`, `TEST RUNNER PHP VERSION:`, and the WooCommerce zip/download lines. The v2 API does not surface versions; the easiest source is the raw step log via the job's web UI.
+7. **Check sibling jobs in the same workflow — but only if they fail with the _same_ symptom.** Same test name, same error class, same step. If multiple integration shards blow up on the same fixture, or all WC-beta jobs go red together, the root cause is shared and the investigation collapses. If the sibling failures look unrelated (different suite, different error), treat them as independent — do **not** conflate them. See `references/circleci-api.md` for the workflow/job endpoints.
+8. **Flag beta/RC runs.** If a captured version is a beta or RC (e.g. `9.5.0-beta.1`, `6.8-RC1`), or the job name contains `_wordpress_beta` / `_woocommerce_beta`, mark the run for the dedicated Step 4 branch.
+9. **Now open the test source and the production code it exercises** — _before_ moving to Step 2. Most failures are diagnosable from the test source plus the rich error message; you'll waste time if you keep churning CI endpoints with the test file still unopened. See the "Finding the production code the test exercises" hint under Step 4.1 for how to pick the right production file.
+
+## Step 2: Get onto the right branch
+
+The fix needs to land on the branch where the failure occurred — _if_ the caller later decides to commit.
+
+- **Job ran against `trunk`** → use the `starting-branch` skill to create a fix branch. If the failing test's last touching commit references a Linear ticket (e.g. `git log -1 --format=%B -- <test-file> | grep -oE 'MAILPOET-[0-9]+'`), pass that to `starting-branch`. Otherwise a short descriptive slug like `fix/<suite>-<short-test-name>` is fine. (We never want `HEAD` to be `trunk` while editing.)
+- **Job ran against a feature branch** → `git fetch && git switch <branch>`. Do not create a fresh fix branch on top — the failure belongs to in-flight work and the fix should land on the same branch.
+
+For local failures with no CI URL, the target branch is whatever `git rev-parse --abbrev-ref HEAD` reports.
+
+## Step 3: Reproduce locally
+
+Non-negotiable before forming a root-cause hypothesis. Repro commands per suite live in the `running-tests` skill.
+
+If **3 consecutive local runs pass**, that is a strong signal of environment drift or true flakiness — proceed to Step 4 with that hypothesis. Do not assume the test is fine just because it's green on your laptop.
+
+## Step 4: Form a hypothesis — investigate in this priority order
+
+These are the common root causes, in rough order of frequency.
+
+### 1. Recent commit regression (start here)
+
+Identify what changed recently. Walk the recent history of the failing test file and the production code it exercises (the last ~30 commits is usually plenty). If Step 1 surfaced a last-green SHA via the insights endpoint, look at the diff across the green→red range — that's a much tighter window than chasing the whole history.
+
+For a broader sweep — especially useful when a non-test job fell over and the smoking gun is often a newly-added test file missing an `@group` annotation or guard — enumerate every file changed in the green→red range via GitHub's compare API. Works without a local checkout of the failing SHA:
+
+`gh api repos/mailpoet/mailpoet/compare/<last-green-sha>...<failing-sha>`
+
+**Finding the production code the test exercises:**
+
+- Read the test's `use` statements at the top — the namespaced classes under test are usually obvious.
+- For a `FooTest`, the target class is almost always `Foo`.
+- For integration tests that exercise multiple classes, look at what the test instantiates directly or resolves from the DI container.
+
+If the suspect range is wide and the diff is too noisy to read by eye, run `git bisect` between the failing and last-green SHAs — it lands on the offending commit deterministically. The non-obvious bit is wiring `bisect run` to the project's pnpm test command:
+
+`git bisect run pnpm test:<suite> --file=<path-to-failing-test>`
+
+Reset with `git bisect reset` when done. For acceptance/integration the `bisect run` step is slow per iteration; only reach for it when eyeballing the diff hasn't worked.
+
+### 2. Flaky test
+
+Suspect this only if (a) local re-runs are inconsistent across the 3 attempts from Step 3, (b) CircleCI history for the same test shows recent intermittent failures (insights endpoint — see `references/circleci-api.md`), or (c) the failure mode points to timing/ordering/external state.
+
+**Before settling on a test-only fix (e.g. "just bump the timeout"), do this:**
+
+1. Read the _full_ client/server code path the test exercises end-to-end — not just the test. Trace every async call, every store action, every redirect, every page reload.
+2. Ask: would a _real user_ hit this race if the network/server were slow? If yes, the production code has the bug — harden it. The test fix is secondary.
+3. Only after the above: if the production code is genuinely correct and the test simply made unsafe timing assumptions, harden the test (longer timeout, explicit `waitFor*`, etc.).
+
+A timeout bump that papers over a real production race is worse than no fix — it hides the bug from CI and from real users.
+
+### 3. Environment drift
+
+Dependency bumps (WP, WC, PHP), test container changes, generated/prefixed file mismatches. Diff the environment-affecting files across the green→red range — `composer.json`, `composer.lock`, `package.json`, `pnpm-lock.yaml`, `.wp-env.json`, and anything under `tests_env/`.
+
+### 4. Pre-existing latent bug exposed
+
+A seemingly unrelated change altered test order, fixture data, or timing, exposing an older bug. Treat the older bug as the real fix target; the recent commit is just the trigger.
+
+### 5. Beta / RC of WordPress or WooCommerce
+
+Only when Step 1 flagged the run as beta/RC. See the dedicated section below — investigate both directions, but **the default fix target is still our plugin or test**, not the upstream beta.
+
+### Beta / RC runs (WordPress or WooCommerce)
+
+If the failing CI job ran against a beta or release candidate:
+
+1. **Confirm the beta/RC version** from the entrypoint output. Note the exact version string.
+2. **Reproduce locally against the same version** — `pnpm test:<suite> --wordpress-version=<ver>` (or the WC equivalent; see the `running-tests` skill for the full flag surface). If it passes against the stable version but fails against the beta/RC, the version is implicated.
+3. **Read the release notes** for breaking changes or deprecations in the area the failing test exercises (hooks, REST routes, function signatures, block API, HPOS, etc.):
+   - WordPress betas/RCs: [`wordpress.org/news`](https://wordpress.org/news/category/releases/), [Trac](https://core.trac.wordpress.org/), and the [`WordPress/wordpress-develop`](https://github.com/WordPress/wordpress-develop) GitHub repo.
+   - WooCommerce betas/RCs: [`woocommerce/woocommerce` releases](https://github.com/woocommerce/woocommerce/releases).
+4. **Search for an existing upstream issue** describing the same regression or BC change. **Do not file new upstream issues** — only reference existing ones in your report. If you find nothing, say so explicitly.
+5. **Decide the fix direction — in this priority:**
+   - **Adapt our code or test** to the new behaviour if it's a legitimate change (deprecation, new signature, intentional behaviour change). Default and preferred outcome.
+   - **Ship a plugin-side workaround** if the change looks like an unintentional upstream regression but adapting cleanly isn't feasible. Guard the workaround with a version check (`version_compare()` or feature detection) so it activates only on affected versions — never branch on "is this a beta".
+
+## Step 5: Implement the fix
+
+- Prefer product-code fixes over test-only fixes when the underlying problem is a real bug.
+- Test-only hardening is appropriate when the production code is correct and the test simply made unsafe assumptions (ordering, timing, isolation).
+- If the only viable fix lands in restricted territory, **stop** — see "When NOT to apply a fix" below.
+
+## Step 6: Verify locally
+
+Run the failing suite scoped to the failing test — exact commands per suite (and premium variants) are in the `running-tests` skill. The targeted suite must be green before reporting the fix as done.
+
+## When NOT to apply a fix
+
+Stop and report findings — root cause, why no fix was applied, suggested next steps — when:
+
+- The root cause is in `vendor/`, `vendor-prefixed/`, `generated/`, `lib-3rd-party/`, WordPress core, or a third-party library.
+- The fix requires a DB migration, schema change, public API change (`lib/API/MP/`), DI container change, or modifications to `.wp-env.json` / `tests_env/` / CI config. (These are "Ask First" territory per the project guidelines.)
+- The failure cannot be reproduced locally after reasonable effort _and_ the CircleCI artifacts do not clarify the cause.
+
+In each case, the report should make a reviewer's life easy: link to the failure, summarise the root cause, list the options considered, and call out confidence and unresolved questions.
+
+## Suite-specific hints
+
+### Unit (`tests/unit/`)
+
+Pure PHP — failures are almost always logic, mock drift, or static state leakage. Common causes: mock signatures drifted from real classes after a refactor; direct WP function calls bypassing the `WP\Functions` wrapper; static properties / singletons not reset between tests.
+
+### Integration (`tests/integration/`)
+
+Real DB + WP via the `tests_env/` docker-compose stack (separate from wp-env). `pnpm shell:test` drops into the tests_env WordPress container if you need to inspect DB state directly. Common causes: Doctrine entity ↔ migration drift; fixture/teardown leaks between tests; assumptions about row order or auto-increment IDs. **Never** run `./do test:integration` without `--skip-deps` — it can wipe `vendor-prefixed/` on PHP 8.4. Use `pnpm test:integration` (which passes `--skip-deps` by default).
+
+### Acceptance (`tests/acceptance/`)
+
+Selenium + browser via tests_env. **The slowest suite to reproduce** — that's why Step 1.2 says to fetch artifacts first. Common causes: timing / missing `waitFor*` calls; selectors broken by recent React/UI changes; React-rendered text changes that break text-based locators. If it looks like timing flakiness, investigate whether the production code has a real race (e.g. AJAX response handling order) before adding a wait.
+
+### JavaScript (`tests/javascript/`)
+
+Mocha runs the whole suite — isolate the failing spec from the output. Common causes: TypeScript type drift after shared package changes; stale fixture/mock data after API or entity shape changes; stale `assets/dist/` when tests import from compiled output (run `pnpm compile:js`).
+
+### Premium variants
+
+A failure in the premium suite may indicate a regression in the free plugin (premium extends free). When the root cause turns out to be in `mailpoet/`, the fix lands in the free repo, and the premium repo may need a companion change.
+
+## Outcome
+
+Once the targeted suite is green locally, this skill is done. Hand back to the caller with a short summary: failing test, root cause, what was changed, what was verified. Likely next-step skills the caller may want: `creating-pull-requests`, `writing-changelog`, `mailpoet-dev-cycle`.
+
+## Related Skills
+
+- `running-tests` — exact repro commands per suite.
+- `starting-branch` — used in Step 2 when the failure originated on `trunk`.
+- `creating-pull-requests` — draft PR after the fix.
+- `writing-changelog` — if the fix is user-facing.
+- `mailpoet-beta-compat-test` — when failures stem from a WP/WC beta or RC.

--- a/.ai/skills/debugging-failed-tests/circleci-api.sh
+++ b/.ai/skills/debugging-failed-tests/circleci-api.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Authenticated curl wrapper for the CircleCI API.
+#
+# Reads the CircleCI API token from (in order):
+#   1. $CIRCLECI_TOKEN environment variable
+#   2. WP_CIRCLECI_TOKEN in <repo>/mailpoet/.env
+#
+# The token is passed to curl via --config on stdin so it never appears in
+# process argv, shell history, or transcript output.
+#
+# Usage (run from the repo root):
+#   .ai/skills/debugging-failed-tests/circleci-api.sh <path-or-url> [extra curl args...]
+#
+# Examples:
+#   .ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/project/gh/mailpoet/mailpoet/job/12345
+#   .ai/skills/debugging-failed-tests/circleci-api.sh https://output.circle-artifacts.com/.../shot.png -o shot.png
+#
+# A first argument starting with "/" is appended to https://circleci.com;
+# anything else must be a full http(s) URL (artifact hosts work too).
+
+set -euo pipefail
+
+die() { printf 'circleci-api.sh: %s\n' "$*" >&2; exit 1; }
+
+[ $# -ge 1 ] || die "missing URL or path argument (see header comment for usage)"
+
+target=$1
+shift
+
+case "$target" in
+  http://*|https://*) url=$target ;;
+  /*)                  url="https://circleci.com$target" ;;
+  *) die "first argument must be a full http(s) URL or a path starting with '/'" ;;
+esac
+
+repo_root=$(cd "$(dirname "$0")/../../.." && pwd)
+env_file="$repo_root/mailpoet/.env"
+
+token=${CIRCLECI_TOKEN:-}
+if [ -z "$token" ] && [ -r "$env_file" ]; then
+  line=$(grep -E '^[[:space:]]*WP_CIRCLECI_TOKEN=' "$env_file" | head -n1 || true)
+  if [ -n "$line" ]; then
+    val=${line#*=}
+    val=${val%$'\r'}
+    val=${val#\"}; val=${val%\"}
+    val=${val#\'}; val=${val%\'}
+    token=$val
+  fi
+fi
+token=${token%$'\n'}
+
+[ -n "$token" ] || die "no CircleCI token found. Set one of:
+  - CIRCLECI_TOKEN in your shell environment, or
+  - WP_CIRCLECI_TOKEN=<your-token> in $env_file
+Get a personal API token at https://app.circleci.com/settings/user/tokens"
+
+# Pass the token via curl's --config on stdin (here-string). Bash sets up the
+# redirection inside the current process — the token never enters argv of
+# curl or any child process, so it cannot leak through 'ps' or shell tracing
+# of curl itself.
+exec curl --fail-with-body --silent --show-error \
+  --config /dev/stdin \
+  "$@" "$url" <<< "header = \"Circle-Token: $token\""

--- a/.ai/skills/debugging-failed-tests/references/circleci-api.md
+++ b/.ai/skills/debugging-failed-tests/references/circleci-api.md
@@ -1,0 +1,86 @@
+# CircleCI API — useful endpoints
+
+All calls go through `.ai/skills/debugging-failed-tests/circleci-api.sh` from the repo root. The wrapper handles auth — do not read or pass tokens yourself. Pass a path starting with `/` (it expands to `https://circleci.com<path>`) or a full URL (for artifact downloads from `output.circle-artifacts.com`).
+
+Output is JSON on stdout; pipe to `jq` for structured access.
+
+## Identifying a job from a URL
+
+CircleCI URLs come in two shapes:
+
+- `https://app.circleci.com/pipelines/github/mailpoet/mailpoet/<pipeline-num>/workflows/<workflow-uuid>/jobs/<job-number>`
+- `https://circleci.com/gh/mailpoet/mailpoet/<job-number>` (legacy)
+
+The trailing integer is the **job number** — that's what every endpoint below wants.
+
+## Job details — branch, SHA, status
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/project/gh/mailpoet/mailpoet/job/<job-number>
+```
+
+Useful fields:
+
+- `status` — `success`, `failed`, `running`, `infrastructure_fail`, `canceled`. An `infrastructure_fail` is CircleCI's problem; retry the job before debugging.
+- `pipeline.id` — needed if you want to walk the workflow (see below).
+- `pipeline.vcs.revision` — the commit SHA the job ran against.
+- `pipeline.vcs.branch` — the branch the job ran against.
+- `web_url` — the human URL of the job (handy to paste into a report).
+- `parallel_runs` — Codeception parallel-shard count.
+
+## Test failures (structured)
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/project/gh/mailpoet/mailpoet/<job-number>/tests
+```
+
+One entry per test with `name`, `classname`, `result` (`success` / `failure` / `error` / `skipped`), `message`, `run_time`. Filter to `result != "success"` and you have your exact repro list — far cheaper than scrolling step logs.
+
+```bash
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/project/gh/mailpoet/mailpoet/<job-number>/tests \
+  | jq '.items[] | select(.result != "success") | {classname, name, message}'
+```
+
+## Artifacts (screenshots, HTML dumps, browser logs)
+
+List artifacts:
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/project/gh/mailpoet/mailpoet/<job-number>/artifacts
+```
+
+Returns `{ items: [{ path, url, node_index }] }`. For acceptance failures, the `*.fail.png` and `*.fail.html` artifacts under `tests/_output/` are usually decisive.
+
+Download an individual artifact (use the full URL from the listing):
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh "<artifact-url-from-listing>" -o <local-name>
+```
+
+## Sibling jobs in the same workflow
+
+When other parallel jobs failed alongside yours, the root cause is often shared (e.g. WC beta broke the whole matrix, a fixture changed and every shard tripped on it).
+
+Walk pipeline → workflows → jobs:
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/pipeline/<pipeline-id>/workflow
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/workflow/<workflow-id>/job
+```
+
+## Test history (is this a long-running flake?)
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh "/api/v2/insights/gh/mailpoet/mailpoet/workflows/<workflow-name>?branch=trunk"
+```
+
+Lists recent runs of the named workflow on a given branch with `status`, `duration`, `created_at`. Useful for distinguishing "first failure ever" from "been flaking for days", and for spotting the last known-good SHA to use as the floor of a `git bisect` or a `git diff <last-green>..<failing>`.
+
+## Things the v2 API does NOT give you
+
+- **WP / WC / PHP versions** used by the test container — these are printed in the raw step log by `tests_env/docker/codeception/docker-entrypoint.sh`, not surfaced as JSON fields. Easiest source: open the job's web URL and read the top of the failing step's output.
+- **The CircleCI YAML config that ran** — if you need to understand the job matrix, read `.circleci/config.yml` at the failing SHA (`git show <sha>:.circleci/config.yml`).
+
+## If the wrapper fails
+
+If `.ai/skills/debugging-failed-tests/circleci-api.sh` exits non-zero saying the token is not configured, stop and report "CircleCI token not configured locally — see `.ai/skills/debugging-failed-tests/circleci-api.sh` for setup". Do not try to set up auth in the user's environment, do not paste paths or env-var names, do not guess.

--- a/.ai/skills/mailpoet-dev-cycle/SKILL.md
+++ b/.ai/skills/mailpoet-dev-cycle/SKILL.md
@@ -86,7 +86,7 @@ Before committing, run these from the repo root:
 
 - [ ] `pnpm qa` -- all PHP and frontend QA checks pass
 - [ ] `pnpm qa:fix` -- formatting is clean
-- [ ] Run relevant tests (see the `writing-tests` skill for commands)
+- [ ] Run relevant tests (see the `runnig-tests` skill for commands)
 
 ## Premium Plugin
 

--- a/.ai/skills/running-tests/SKILL.md
+++ b/.ai/skills/running-tests/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: running-tests
+description: Use when running MailPoet tests — executing a full suite, running a single file or single test, running in debug/multisite mode, or shelling into the test container. Triggers on phrases like "run the unit tests", "run this test file", "execute the integration suite", "kick off acceptance tests", "rerun the failed tests". Does not cover authoring tests (see writing-tests) or investigating a failed CI run (see debugging-failed-tests).
+---
+
+# Running Tests
+
+## Overview
+
+MailPoet has six test suites across two plugins (free `mailpoet/`, premium `mailpoet-premium/`). Unit and JavaScript run on the host; integration, acceptance, and performance run inside the `tests_env/` Docker stack — separate from the wp-env dev stack. A set of `pnpm test:*` wrappers from the monorepo root hides most of that. Start with those; drop down to plugin-level `./do` calls only for the few helpers without a `pnpm` equivalent.
+
+## Most common invocations
+
+```bash
+pnpm test:unit --file=tests/unit/<Path>Test.php
+pnpm test:integration --file=tests/integration/<Path>Test.php
+pnpm test:acceptance --file=tests/acceptance/<Path>Cest.php
+pnpm test:integration --file=tests/integration/<Path>Test.php:testMethodName   # one method
+pnpm test:integration:premium --file=tests/integration/<Path>Test.php          # premium variant
+```
+
+That covers ~90% of typical traffic. The rest of this skill handles the long tail.
+
+## Quick reference
+
+| Suite             | Whole suite                                  | Single file                                                     | Runs in | Plugin    | Typical time on M1                 |
+| ----------------- | -------------------------------------------- | --------------------------------------------------------------- | ------- | --------- | ---------------------------------- |
+| Unit              | `pnpm test:unit`                             | `pnpm test:unit --file=tests/unit/<Path>Test.php`               | Host    | Free only | ~30s full / sub-second per file    |
+| Integration       | `pnpm test:integration`                      | `pnpm test:integration --file=tests/integration/<Path>Test.php` | Docker  | Both      | ~5–10min full / ~30s per file      |
+| Acceptance        | `pnpm test:acceptance`                       | `pnpm test:acceptance --file=tests/acceptance/<Path>Cest.php`   | Docker  | Both      | many hours full / ~1–2min per file |
+| JavaScript        | `pnpm test:javascript`                       | (no per-file flag — see JavaScript section below)               | Host    | Free only | ~30s full                          |
+| Newsletter Editor | `cd mailpoet && ./do test:newsletter-editor` | (Robo-only)                                                     | Host    | Free only | rare                               |
+| Performance       | `cd mailpoet && ./do test:performance ...`   | —                                                               | Docker  | Free only | on demand                          |
+
+Times are rough; first run on a cold Docker stack pays an extra 1–2min for container build/pull.
+
+**Premium variants:** replace `test:unit` / `test:integration` / `test:acceptance` with `test:unit:premium` / `test:integration:premium` / `test:acceptance:premium`. Paths are relative to whichever plugin is being tested.
+
+**Single test method** (unit, integration, acceptance): append `:methodName` to the file path.
+
+```bash
+pnpm test:integration --file=tests/integration/Logging/LogHandlerTest.php:testItStoresLog
+pnpm test:acceptance --file=tests/acceptance/Misc/WordPressSiteEditorCest.php:editWithFSE
+```
+
+## Flags
+
+`pnpm` forwards extra args transparently — `pnpm test:integration --file=X --debug` ends up as `cd mailpoet && ./do test:integration --skip-deps --file=X --debug`. Every flag below works through the `pnpm` wrapper.
+
+Source of truth: `mailpoet/RoboFile.php` (search for `public function test*`).
+
+- `--file=<path>[:method]` — all suites. Run a single file, or one method within it.
+- `--debug` — unit, integration (incl. woo/base variants). Codeception verbose mode: full stack traces, per-step output. Not on acceptance.
+- `--group=<name>` — integration, acceptance (incl. multisite). Filter to tests tagged `@group <name>` (e.g. `woo`, `failed`).
+- `--skip-group=<name>` — integration only. Exclude a group.
+- `--multisite` — integration (incl. woo/base). Acceptance has its own task (`./do test:acceptance-multisite`). Vestigial on unit — accepted by the signature but the suite never boots WP, so it has no effect.
+- `--stop-on-fail` — integration only. Halt on the first failure.
+- `--skip-plugins` — integration, acceptance. Don't load extra plugins (WC, etc.).
+- `--enable-hpos` / `--disable-hpos` / `--enable-hpos-sync` — integration (incl. variants), acceptance (incl. multisite). Toggle WooCommerce High-Performance Order Storage for the run. Use when your change touches WC order data paths.
+- `--wordpress-version=<ver>` — integration, acceptance. Run against a specific WP version, including beta/RC — see [[mailpoet-beta-compat-test]].
+- `--timeout=<seconds>` — acceptance, acceptance-multisite. Per-test timeout override.
+- `--skip-deps` — integration, acceptance (incl. multisite). Skip in-container `composer install`. The `pnpm test:integration` / `:acceptance` wrappers (and their premium variants) pass this by default.
+- `--xml[=path]` — all suites. Write JUnit XML output. Used by CI; rarely needed locally.
+
+When the wrapper isn't enough — direct Codeception access, artifact inspection, or DB poking — shell in (see "Shelling in" below).
+
+## Suite essentials
+
+### Unit — `pnpm test:unit`
+
+Host-side, no WP, no DB. Free plugin only (premium has no unit suite). Re-run only what failed last time with `cd mailpoet && ./do test:failed-unit` — Codeception keeps the failure list under `tests/_output/` (via the `@group failed` mechanism).
+
+### Integration — `pnpm test:integration`
+
+Real WP + DB, Docker-backed. The default integration run loads WooCommerce; two narrower entrypoints let you scope:
+
+- `cd mailpoet && ./do test:woo-integration` — only WC-tagged tests, WC loaded.
+- `cd mailpoet && ./do test:base-integration` — only non-WC tests, WC not loaded.
+
+Pick `test:woo-integration` when iterating on WC integration code; pick `test:base-integration` when you suspect WC is contaminating an otherwise WC-independent test. Otherwise stick to the default.
+
+Multisite: `pnpm test:integration --multisite`. Re-run failed: `cd mailpoet && ./do test:failed-integration`.
+
+### Acceptance — `pnpm test:acceptance`
+
+Selenium + Chrome in Docker. The slowest suite by a wide margin. Target the file you care about; do not run the whole thing on a whim.
+
+- Multisite: `cd mailpoet && ./do test:acceptance-multisite --skip-deps --file=...`.
+- Watch the run live: VNC to `localhost:5900`, password `secret` (macOS: `open vnc://localhost:5900`; Linux/Windows: any VNC client).
+- **Failure artifacts** land in `mailpoet/tests/_output/` (premium equivalent under `mailpoet-premium/`): `*.fail.png` screenshots, `*.fail.html` page dumps, Codeception logs. Look here _before_ re-running — the screenshot usually tells you the story. For full failure investigation, hand off to [[debugging-failed-tests]].
+
+### JavaScript — `pnpm test:javascript`
+
+Mocha + Chai + Sinon, host-side, free only. The wrapper has no `--file` flag — it runs the whole `mailpoet/tests/javascript/` tree.
+
+To focus on a single spec, either add `describe.only(...)` or `it.only(...)` to the spec and re-run (don't commit the `.only`), or invoke Mocha directly:
+
+```bash
+cd mailpoet
+# Single file:
+./node_modules/.bin/mocha --require tests/javascript/mocha-env.mjs \
+  --extension spec.ts tests/javascript/path/to/foo.spec.ts
+
+# Filter by test name across the tree:
+./node_modules/.bin/mocha --require tests/javascript/mocha-env.mjs \
+  --extension spec.ts --recursive tests/javascript --grep "my describe block"
+```
+
+Add `--inspect-brk` to the same command and attach Node DevTools (`chrome://inspect`) or a VS Code "Node: Attach" config to debug.
+
+**Stale `assets/dist/`:** a handful of specs import from compiled output. If a test reports `X is not a function` against code that obviously exports `X`, run `pnpm compile:js` and retry before going hunting.
+
+### Newsletter Editor (legacy) — `cd mailpoet && ./do test:newsletter-editor`
+
+Mocha suite covering the Backbone newsletter editor under `mailpoet/tests/javascript-newsletter-editor/`. Free plugin only.
+
+**Do not add new tests here.** The Backbone editor is being replaced by the block-based editor at `mailpoet/assets/js/src/mailpoet-email-editor-integration/`. Run this suite only when you've actually modified the legacy editor — otherwise it's slow noise.
+
+### Performance — `cd mailpoet && ./do test:performance`
+
+k6 + Playwright, Docker-backed. Free plugin only. Runs against a live MailPoet instance you supply (the test is the load generator, not a fixture). Three-step lifecycle:
+
+```bash
+cd mailpoet
+./do test:performance-setup                                       # one-time prep (seed data, etc.)
+./do test:performance --url=<wp-url> --us=<user> --pw=<pass>      # actual run
+./do test:performance-clean                                       # tear down test data
+```
+
+Optional flags on `test:performance`:
+
+- `--head` — run the Playwright browser headed (default headless).
+- `--scenario=<name>` — restrict to one scenario from `mailpoet/tests/performance/scenarios.js`.
+- Positional `<path>` (before `--`) — point at a different scenarios file.
+
+Cloud mode kicks in automatically when `K6_CLOUD_TOKEN` is set; results upload to k6 Cloud instead of printing locally. Full signature: `testPerformance` in `mailpoet/RoboFile.php`.
+
+## Shelling in
+
+```bash
+pnpm shell:test                                             # bash into tests_env wordpress container
+cd /wp-core/wp-content/plugins/mailpoet                     # or mailpoet-premium
+./do test:integration --skip-deps --file=tests/integration/...
+```
+
+Useful when:
+
+- Running Codeception directly (`../tests_env/vendor/bin/codecept ...`) — e.g. for a flag the Robo wrapper doesn't expose.
+- Inspecting DB state mid-debug via `wp db query "..."` against the test database.
+- Iterating on the test runner itself.
+
+### The `--skip-deps` footgun
+
+When invoking `./do test:*` inside the container, **always pass `--skip-deps`**. Without it the prefixer runs again on PHP 8.4 and can wipe `mailpoet/vendor-prefixed/`. Recovery: `pnpm bootstrap`.
+
+This is why the host-side `pnpm test:integration` / `pnpm test:acceptance` (and their `:premium` variants) pass `--skip-deps` automatically. `pnpm test:unit` and `pnpm test:javascript` don't need it — they don't run in Docker. Use `pnpm test:install-deps` only when you actually want to refresh the container's deps (e.g. after a `composer.json` bump).
+
+## Common failure modes
+
+| Symptom                                                 | Likely cause / fix                                                                                                                                                                        |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Cannot connect to the Docker daemon" on a Docker suite | Docker Desktop / OrbStack isn't running. Start it, then re-run.                                                                                                                           |
+| First integration/acceptance run takes minutes to start | First-time container build/pull. Tail the test stack from the repo root: `docker compose -f tests_env/docker/docker-compose.yml logs -f` (not `pnpm env:logs` — that's the wp-env stack). |
+| `vendor-prefixed/` disappeared after a test run         | Ran `./do test:*` without `--skip-deps` on PHP 8.4. Recover with `pnpm bootstrap`.                                                                                                        |
+| Acceptance run starts but every test fails at login     | Test WordPress site is in a broken state. `cd mailpoet && ./do reset:test-docker` drops the test volumes (keeps images) and rebuilds.                                                     |
+| Docker is genuinely confused (zombies, weird state)     | `cd mailpoet && ./do delete:docker` does the harder reset: stops containers, drops volumes, **removes images** (next run will re-pull/build, ~1–2min). Does not touch the wp-env stack.   |
+| JS test errors with `X is not a function` for real code | `assets/dist/` is stale. Run `pnpm compile:js` and re-run.                                                                                                                                |
+| WC-related integration failures (orders, HPOS)          | Toggle HPOS for the run: `--enable-hpos`, `--disable-hpos`, or `--enable-hpos-sync`.                                                                                                      |
+| "Unknown option --file" or similar                      | Wrong wrapper for the suite (e.g. JavaScript has no `--file`). Check the Quick Reference.                                                                                                 |
+| Test passes locally but failed on CI                    | Hand off to [[debugging-failed-tests]] with the CI job URL, branch name, failing test path, and any WP/WC version overrides the CI run used.                                              |
+
+### Interrupting a long run
+
+Ctrl-C is fine, but it can leave Selenium / Chrome containers running for an acceptance run. They usually self-correct on the next invocation; if things look off, `./do reset:test-docker` is the soft reset and `./do delete:docker` is the hard one.
+
+## Verification
+
+Read the final pass/fail summary line before reporting a run as green. "No output" or "command returned" is not evidence — look for `OK (N tests, M assertions)` (PHPUnit/Codeception) or the equivalent green line. For finishing-a-branch workflows, the canonical pre-push gate is `pnpm qa` plus the suite(s) touched by your change.

--- a/.ai/skills/writing-tests/SKILL.md
+++ b/.ai/skills/writing-tests/SKILL.md
@@ -1,103 +1,80 @@
 ---
 name: writing-tests
-description: 'Use when writing, running, or debugging tests. Use when asked to add test coverage, fix a failing test, or run a test suite.'
+description: 'Use when authoring tests for MailPoet — adding a new test case, picking the right test type, choosing a name, structuring the file, deciding what belongs in unit vs integration vs acceptance. For invoking the test runner (running a file, the whole suite, premium variants, debug mode) see running-tests. For investigating a CI failure see debugging-failed-tests.'
 ---
 
-# Writing and Running Tests
+# Writing Tests
 
 ## Overview
 
-MailPoet has six test types across two plugins (free `mailpoet/` and premium `mailpoet-premium/`).
-
-**Running tests:** Use the `pnpm test:*` scripts from the monorepo root for the common suites. Integration, acceptance, and performance tests require Docker. A few specialist helpers do not have `pnpm` wrappers yet; those are called out below as plugin-level Robo-only commands.
+MailPoet has six test suites across two plugins. This skill is about **authoring** them — where the file belongs, what to extend, how to name and structure it, what kind of test belongs where. For invoking the test runner, see [[running-tests]].
 
 ## Guidelines
 
-- **Prefer smaller tests over big ones.** Keep tests focused, short, and linear. Avoid control structures like `if`, `for`, or `while` in tests — if you need a loop, you probably need separate test cases instead.
-- **Use descriptive test names.** The test name should make it obvious what failed and why when you read it in CI output. Describe the scenario and expected outcome, not the method being tested.
-- **Prefer self-explanatory tests over comments.** Comments can be useful, but first try to refactor the test so the comment isn't needed — better naming, extracting helpers, or splitting into smaller tests.
-- **In E2E tests use `$i->wantTo(...)` instead of comments** — `wantTo` output is visible in test results, comments are not.
-- **Prefer unit > integration > E2E.** Unit tests are fast and cheap. E2E tests are slow and expensive — don't add them unless you need to test a real browser flow.
-- **Avoid brittle selectors in E2E tests.** Don't rely on long CSS selector chains or DOM structure of 3rd party components — these break when libraries update. Prefer `data-automation-id` attributes, ARIA roles, or short stable selectors. If a 3rd party component doesn't expose good hooks, add a `data-automation-id` or wrapper in the production code.
-- **Fight flakiness in E2E tests.** Always wait for the page/element to be ready before interacting. Use `waitForElement`, `waitForText`, or similar helpers — never assume the page is loaded. Think about what could make the test fail intermittently and guard against it.
-- **Always run tests before committing.** Never commit a test you haven't seen pass. If a test can't be run locally, say so — don't assume it works.
-- **Prefer TDD.** Write the test first, see it fail, then write the code that makes it pass. The failing test proves the test actually tests something.
+- **Prefer smaller tests over big ones.** Keep them focused, short, and linear. Avoid `if` / `for` / `while` inside a test — if you need a loop you probably need separate test cases instead. Why: loops hide which case actually failed, and one fix accidentally masks another.
+- **Use descriptive test names.** The name should make it obvious from CI output what failed and why. Describe the scenario and expected outcome, not the method being tested. A reader who has never seen the file should be able to guess the intent from the name alone.
+- **Prefer self-explanatory tests over comments.** First try to refactor — better naming, extract helpers, split into smaller tests — so the comment becomes unnecessary. A comment that survives that pass is usually worth keeping; one that doesn't is a code smell pointing at the test itself.
+- **In acceptance tests use `$i->wantTo(...)` instead of comments.** `wantTo` text shows up in the Codeception output, plain comments don't. The output is the only thing a future debugger sees.
+- **Prefer unit > integration > acceptance.** Unit tests are fast and cheap; acceptance tests are slow, flaky, and expensive to maintain. Only reach for acceptance when you genuinely need a real browser flow.
+- **Avoid brittle selectors in acceptance tests.** Long CSS chains and 3rd-party DOM structure break on library updates. Prefer `data-automation-id` attributes, ARIA roles, or short stable selectors. If a 3rd-party component doesn't expose good hooks, add a `data-automation-id` (or a thin wrapper) in the production code so the test has something stable to grab.
+- **Defend against flakiness in acceptance tests.** Always wait for the page / element to be ready before interacting (`waitForElement`, `waitForText`, …) — never assume the page is loaded. When writing a test, deliberately ask "what could make this fail intermittently?" and guard against it.
+- **Always run the test before committing.** Never commit a test you haven't seen pass at least once. If it can't be run locally, say so out loud — don't assume it works.
+- **Prefer TDD.** Write the failing test first, see it fail (this proves the test actually tests something), then write the code that makes it pass.
 
-## Test Types
+## Picking the right suite
 
-### PHP Unit Tests
+| You need to test…                                                   | Use                           | Why                                                                           |
+| ------------------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------- |
+| Pure PHP logic with no WP / DB dependency                           | Unit                          | Fastest, no Docker, runs on the host                                          |
+| Behaviour that hits WP APIs, the DB, or our Doctrine repositories   | Integration                   | Real WordPress + DB inside Docker                                             |
+| A real browser flow (forms, redirects, JS, multi-page interactions) | Acceptance                    | Only place to drive an actual browser                                         |
+| Frontend React/TS logic without a real browser                      | JavaScript                    | Mocha-based, host-side                                                        |
+| The legacy Backbone newsletter editor                               | _do not write new tests here_ | The Backbone editor is being replaced — extend the block-based editor instead |
+| Load / scale behaviour                                              | Performance                   | k6 + Playwright; only for perf work                                           |
 
-Fast, isolated tests. No WordPress, no database. Run directly on the host machine via the root `pnpm` wrapper. **Free plugin only** — premium has no unit tests.
+When two options would work, choose the one further up the table — cheaper to run, cheaper to maintain.
 
-- **Location:** `mailpoet/tests/unit/`
-- **File pattern:** `*Test.php`
-- **Base class:** `MailPoetUnitTest`
-- **Run all:** `pnpm test:unit`
-- **Run one file:** `pnpm test:unit --file=tests/unit/WooCommerce/TransactionalEmails/FontFamilyValidatorTest.php`
-- **Debug mode:** `pnpm test:unit --debug --file=tests/unit/...`
-- **Re-run failed:** `cd mailpoet && ./do test:failed-unit` (Robo-only)
+## Where new tests go and what they extend
 
-### PHP Integration Tests
+### PHP unit (`mailpoet/tests/unit/`)
 
-Tests with WordPress and database, run inside Docker. Slower than unit tests. Run from the monorepo root.
+- File pattern `*Test.php`, base class `MailPoetUnitTest`.
+- **Free plugin only** — premium has no unit suite. If your test needs to live in `mailpoet-premium/`, it has to be an integration test.
+- No WordPress runtime, no DB. Mock the `WP\Functions` wrapper for any WP call (which is why production code must go through that wrapper — see AGENTS.md).
 
-- **Location:** `mailpoet/tests/integration/` and `mailpoet-premium/tests/integration/`
-- **File pattern:** `*Test.php`
-- **Base class:** `\MailPoetTest` (extends Codeception)
-- **Run all:** `pnpm test:integration`
-- **Run one file:** `pnpm test:integration --file=tests/integration/Logging/LogHandlerTest.php`
-- **Debug mode:** `pnpm test:integration --debug --file=tests/integration/...`
-- **Re-run failed:** `cd mailpoet && ./do test:failed-integration` (Robo-only)
-- **Variants:**
-  - `cd mailpoet && ./do test:woo-integration` — with WooCommerce loaded (Robo-only)
-  - `cd mailpoet && ./do test:base-integration` — without WooCommerce (Robo-only)
-  - `pnpm test:integration --multisite` — WordPress multisite
+### PHP integration (`mailpoet/tests/integration/` and `mailpoet-premium/tests/integration/`)
 
-The `pnpm test:*` scripts already pass `--skip-deps` by default to avoid rebuilding Docker containers every run.
+- File pattern `*Test.php`, base class `\MailPoetTest` (extends Codeception's WP integration).
+- WordPress and DB are live — write tests against the real Doctrine repositories where you can. Mock the seams that aren't under test.
+- Multisite-specific behaviour: there's a multisite mode (see `running-tests` for how to invoke it); when authoring, guard multisite-only code paths so non-multisite runs of the same file still pass.
 
-### PHP Acceptance Tests (E2E)
+### PHP acceptance (`mailpoet/tests/acceptance/` and `mailpoet-premium/tests/acceptance/`)
 
-Browser-based end-to-end tests using Selenium and Chrome in Docker. **The slowest test type** — only add these when testing a real browser flow that can't be covered by unit or integration tests. Run from the monorepo root.
+- File pattern `*Cest.php`. Each test method takes the `AcceptanceTester $i` parameter.
+- Use `$i->wantTo("describe the scenario")` at the top of each method — it lands in the run output and is the only documentation a future debugger sees.
+- Anchor on `data-automation-id` / ARIA selectors, not DOM structure.
+- Always wait explicitly for the element you're about to interact with.
 
-- **Location:** `mailpoet/tests/acceptance/` and `mailpoet-premium/tests/acceptance/`
-- **File pattern:** `*Cest.php`
-- **Run all:** `pnpm test:acceptance`
-- **Run one file:** `pnpm test:acceptance --file=tests/acceptance/Misc/WordPressSiteEditorCest.php`
-- **Multisite:** `cd mailpoet && ./do test:acceptance-multisite --skip-deps --file ...` (Robo-only)
-- **Reset Docker:** `cd mailpoet && ./do delete:docker` — if you get unexpected errors, delete the Docker runtime and start fresh (Robo-only)
-- **Watch tests in browser:** The browser runs in Docker. Connect via VNC at `vnc://localhost:5900` (password: `secret`).
+### JavaScript (`mailpoet/tests/javascript/`)
 
-### JavaScript Tests
+- File pattern `*.spec.ts`. Mocha + Chai + Sinon.
+- **Free plugin only.**
+- Test logic, not the DOM. For DOM-level flows, prefer an acceptance test.
 
-Frontend tests using Mocha + Chai + Sinon. **Free plugin only.**
+### Test data builders
 
-- **Location:** `mailpoet/tests/javascript/`
-- **File pattern:** `*.spec.ts`
-- **Run:** `pnpm test:javascript`
+Place reusable test fixtures under `tests/DataFactories/`. If you find yourself constructing the same shape twice, lift it into a factory the next test in this area will thank you for.
 
-### Newsletter Editor JavaScript Tests (Legacy)
+## Common mistakes when authoring tests
 
-Legacy Mocha test suite for the newsletter editor. **Do not write new tests here** — only modify existing ones if necessary. **Free plugin only.**
+- **Writing the test after the code "just to have a test".** That doesn't prove the test tests anything; tests-after answer "what does this code do?" instead of "what should this code do?". Write the failing test first.
+- **Picking acceptance for something a unit test could cover.** Acceptance tests are the most expensive thing you own. Push every assertion as far down the pyramid as it can go.
+- **Asserting on long error message strings.** Error text changes; assert on the structured behaviour (exception type, status code, stored DB state) instead.
+- **Sharing state across test methods within a file.** Each test must set up and tear down its own state. State leakage between tests is the #1 cause of "passes alone, fails in the suite" reports.
+- **Calling WordPress functions directly in production code.** Test pain here is a code smell — the production code should go through `WP\Functions` so the test can mock it. Fix the production code rather than working around it in the test.
 
-- **Location:** `mailpoet/tests/javascript-newsletter-editor/`
-- **Run:** `cd mailpoet && ./do test:newsletter-editor` (Robo-only)
+## Related skills
 
-### Performance Tests
-
-Load and performance testing with k6 and Playwright. **Free plugin only.**
-
-- **Location:** `mailpoet/tests/performance/`
-- **Setup:** `cd mailpoet && ./do test:performance-setup` (Robo-only)
-- **Run:** `cd mailpoet && ./do test:performance --url=... --us=... --pw=...` (Robo-only)
-- **Cleanup:** `cd mailpoet && ./do test:performance-clean` (Robo-only)
-
-## Quick Reference
-
-| Type              | Command                                      | Runs in | Plugin    |
-| ----------------- | -------------------------------------------- | ------- | --------- |
-| Unit              | `pnpm test:unit`                             | Local   | Free only |
-| Integration       | `pnpm test:integration`                      | Docker  | Both      |
-| Acceptance        | `pnpm test:acceptance`                       | Docker  | Both      |
-| JavaScript        | `pnpm test:javascript`                       | Local   | Free only |
-| Newsletter Editor | `cd mailpoet && ./do test:newsletter-editor` | Local   | Free only |
-| Performance       | `cd mailpoet && ./do test:performance`       | Docker  | Free only |
+- [[running-tests]] — how to actually invoke the test runner (single file, whole suite, premium variants, debug mode, multisite, Docker shell).
+- [[debugging-failed-tests]] — investigating a CircleCI failure and shipping a fix.
+- [[mailpoet-dev-cycle]] — the broader lint/format/test loop you should run before pushing.


### PR DESCRIPTION
## Description

Adds a `debugging-failed-tests` skill so an agent can take a CircleCI URL (or a local failing test) and walk it through to a fix.

Example trigger:

> Investigate this CI failure: https://circleci.com/gh/mailpoet/mailpoet/411320

Also splits `writing-tests` into separate `running-tests` (runner reference) and `writing-tests` (authoring guide) — see commit messages.

### Testing

Ran the skill against 4 real CircleCI failures with a Sonnet subagent, compared against a no-skill baseline. The skill clearly helped on the harder cases (a non-test integration job crash, a recurring acceptance failure with empty messages), producing more accurate root causes and avoiding the watchdog stalls the no-skill baseline hit. On straightforward failures with rich error messages, both runs reached the same fix; the skill added ~10–200ken overhead but no quality loss.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:test-debug-skill)

_The latest successful build from `test-debug-skill` will be used. If none is available, the link won't work._