### PR TITLE
Add debugging-failed-tests skill

### DIFF
--- a/.ai/skills/debugging-failed-tests/SKILL.md
+++ b/.ai/skills/debugging-failed-tests/SKILL.md
@@ -62,7 +62,7 @@ For acceptance the per-iteration cost makes this a last resort. `git bisect rese
 
 ## Reproducing locally
 
-Repro commands per suite (and premium variants, debug/multisite flags) live in the `running-tests` skill. Defer there.
+Repro commands per suite (and premium variants, debug/multisite flags) live in the [[running-tests]] skill. Defer there.
 
 Don't reproduce as a habit — reproduce when the source doesn't tell you enough, or when you're verifying a fix.
 
@@ -70,7 +70,7 @@ Don't reproduce as a habit — reproduce when the source doesn't tell you enough
 
 Before claiming done, prove both directions:
 
-1. **Reproduce the failure on the un-fixed code.** `git stash` your change, run the failing test, confirm it fails the same way it failed in CI.
+1. **Reproduce the failure on the un-fixed code.** `git stash --include-untracked` your change (the `--include-untracked` is important — a fix that adds a new fixture or helper file would otherwise stay in place and the run wouldn't actually be un-fixed). Run the failing test, confirm it fails the same way it failed in CI.
 2. **Reapply the fix.** `git stash pop`, run the failing test again, confirm it passes.
 
 A green run on its own does not prove your change is what fixed it. This matters most when the failure looked flaky or intermittent — those are the cases most likely to pass for unrelated reasons.
@@ -95,18 +95,18 @@ DI container changes are fine — they don't belong on this list.
 
 ## Branch hygiene
 
-If the failure ran against `trunk`, use the `starting-branch` skill to create a fix branch **before** editing — never land fixes directly on `trunk`. If it ran against a feature branch, `git fetch && git switch <branch>` and work on top of it; the fix belongs with the in-flight work.
+If the failure ran against `trunk`, use the [[starting-branch]] skill to create a fix branch **before** editing — never land fixes directly on `trunk`. If it ran against a feature branch, `git fetch && git switch <branch>` and work on top of it; the fix belongs with the in-flight work.
 
 For local failures, the target is whatever branch you're already on.
 
 ## Outcome
 
-Once the targeted suite is green locally and you've verified both directions, hand back with a short summary: failing test, root cause, what was changed, what was verified. Likely next-step skills: `creating-pull-requests`, `writing-changelog`, `mailpoet-dev-cycle`.
+Once the targeted suite is green locally and you've verified both directions, hand back with a short summary: failing test, root cause, what was changed, what was verified. Likely next-step skills: [[creating-pull-requests]], [[writing-changelog]], [[mailpoet-dev-cycle]].
 
 ## Related skills
 
-- `running-tests` — exact repro commands per suite, premium variants, debug/multisite modes.
-- `starting-branch` — used when the failure originated on `trunk`.
-- `creating-pull-requests` — draft PR after the fix.
-- `writing-changelog` — when the fix is user-facing.
-- `mailpoet-beta-compat-test` — broader beta/RC compatibility testing.
+- [[running-tests]] — exact repro commands per suite, premium variants, debug/multisite modes.
+- [[starting-branch]] — used when the failure originated on `trunk`.
+- [[creating-pull-requests]] — draft PR after the fix.
+- [[writing-changelog]] — when the fix is user-facing.
+- [[mailpoet-beta-compat-test]] — broader beta/RC compatibility testing.

--- a/.ai/skills/debugging-failed-tests/SKILL.md
+++ b/.ai/skills/debugging-failed-tests/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: debugging-failed-tests
+description: Use when investigating a failing test — reported via a CircleCI job/build URL, or output from a local test run. Triggers on phrases like "this test failed", "debug this CI failure", "why did the nightly fail?", "investigate the failure on <branch>", or any message pasting a CircleCI URL with failure context. Guides the investigator to diagnose, fix, and verify the fix locally. Stops there — committing, opening a PR, or writing a changelog is the caller's call (see `creating-pull-requests`, `writing-changelog`).
+---
+
+# Debugging Failed Tests
+
+A test failed. The input is either a CircleCI URL or a failure dump pasted into chat. This skill takes you from "something is red" to "I have a fix and I've proven it works." It stops at "verified locally" — commits, PRs, and changelogs are the caller's call.
+
+## Working assumption
+
+Every failure is a real regression until evidence proves otherwise. Don't pre-emptively label something flaky.
+
+## Principles
+
+Three things shape every move below:
+
+1. **Read the source before you run anything.** The test file plus the production code it exercises usually tells you what happened in under a minute. Reproducing locally — especially acceptance — costs minutes. Save the runs for verifying fixes or for when reading wasn't enough.
+
+2. **Default suspicion is product code, not test.** When something looks flaky, trace the path end-to-end (every async call, every store action, every redirect). Ask: would a real user with a slow network hit this? If yes, the bug is in product code and the test is just exposing it. React re-render races and transient erroneous UI states are common acceptance-test culprits — fast clicks reveal what real users see momentarily. A timeout bump that hides a real race is worse than no fix.
+
+3. **Prefer cheap signals.** Rich error message → open the file. Opaque acceptance failure → fetch artifacts (screenshots, page dumps) before reproducing. Reproduce only when the source doesn't answer the question, or to verify a fix. Reach for `git bisect` only when eyeballing the diff hasn't worked.
+
+A premium-suite failure may originate in the free plugin — keep that possibility live when investigating premium-only reds.
+
+## Inputs
+
+- **A CircleCI URL.** Everything else (suite, plugin, WP/WC/PHP versions, beta/RC flag, branch, SHA, failing test) is derivable from the API. See `references/circleci.md`.
+- **A failure dump from a local run.** Target branch is whatever `git rev-parse --abbrev-ref HEAD` reports.
+
+## Where to start, by input
+
+- **CircleCI URL** → fetch the tests endpoint first (`references/circleci.md`). It returns one row per test with `name`, `classname`, `result`, `message`. Filter to `result != "success"` to surface every non-passing row (`failure`, `error`, and `skipped`). MailPoet does not allow skipped tests on `trunk` or release branches outside `tests/_support/CheckSkippedTestsExtension`'s allowlist — so on those branches a `skipped` row is itself a signal worth investigating, not noise. If `message` names a `file:line`, jump to it. If the message is empty or generic and the suite is acceptance, fetch `*.fail.png` / `*.fail.html` artifacts before anything else.
+- **Local failure dump** → open the file the error points at. You don't need CircleCI at all.
+- **CircleCI URL, tests endpoint reports 0 failures, job still red** → it's a _non-test_ CI failure. Common causes: composer/npm install bombed, asset build broke, lint/QA gate caught something, OOM, or `infrastructure_fail`. Read the failing step's raw output and fix the build/install/lint issue directly. For `infrastructure_fail`, retry the job before investigating — it's CircleCI's problem. The investigation flow below doesn't apply.
+
+## Investigation moves
+
+Pick whichever the failure signal makes cheapest. Not a sequence.
+
+**Existing fix in flight (trunk failures only).** `gh pr list --state open --search "<method-or-class-name>"`. Use the test method or class name, not the file path — `gh` searches title/body/branch, not paths. On feature-branch failures, skip — the failure is by definition tied to in-flight work that belongs to whoever owns the branch.
+
+**What changed recently.** `git log --oneline -10 -- <test-file>` and the same for the production file the test exercises. Most regressions are in the last 1–2 commits to one of those. If neither shows anything, widen to the directory or walk the green→red commit range via the compare API:
+
+```
+gh api repos/mailpoet/mailpoet/compare/<last-green-sha>...<failing-sha>
+```
+
+Lists every file changed across the range without needing a local checkout of the failing SHA. The last-green SHA comes from the CircleCI insights endpoint (`references/circleci.md`).
+
+**Environment drift.** WP/WC/PHP versions print at the start of the failing step in the CircleCI log — the Codeception entrypoint logs `WORDPRESS VERSION:`, `TEST RUNNER PHP VERSION:`, and the WooCommerce version. If the run is against a WordPress or WooCommerce beta/RC (job name often contains `_wordpress_beta` / `_woocommerce_beta`, or the version string ends in `-beta.N` / `-RC1`), see `references/beta-rc-failures.md`.
+
+**Frequency check (transient-looking failures).** When the failure looks environmental — network blip, external service 4xx/5xx, container-level glitch — the rerun-vs-fix call depends on how often it's happening. Hit the CircleCI insights endpoint (`references/circleci.md`) for the same workflow on the same branch: if the same failure shape recurs across multiple recent runs, fix it at the source (mock the outbound call, stub the service, filter the gate). If it's a one-off in months of green runs, recommend a rerun and move on.
+
+**`git bisect` between last-green and failing SHA.** Only when eyeballing the diff didn't work. The form wired to project commands:
+
+```
+git bisect run pnpm test:<suite> --file=<path-to-failing-test>
+```
+
+For acceptance the per-iteration cost makes this a last resort. `git bisect reset` when done.
+
+## Reproducing locally
+
+Repro commands per suite (and premium variants, debug/multisite flags) live in the `running-tests` skill. Defer there.
+
+Don't reproduce as a habit — reproduce when the source doesn't tell you enough, or when you're verifying a fix.
+
+## Verifying the fix
+
+Before claiming done, prove both directions:
+
+1. **Reproduce the failure on the un-fixed code.** `git stash` your change, run the failing test, confirm it fails the same way it failed in CI.
+2. **Reapply the fix.** `git stash pop`, run the failing test again, confirm it passes.
+
+A green run on its own does not prove your change is what fixed it. This matters most when the failure looked flaky or intermittent — those are the cases most likely to pass for unrelated reasons.
+
+## When NOT to apply a fix
+
+Stop and report findings — root cause, why no fix was applied, options considered, confidence, unknowns — when:
+
+- The bug is in `vendor/`, `vendor-prefixed/`, `lib-3rd-party/`, `generated/`, or WordPress / WooCommerce core.
+- The fix needs a DB migration, schema change, public API change (`lib/API/MP/`), or modifications to `.wp-env.json`, `tests_env/`, or CI config. These are "ask first" territory per project guidelines.
+- The fix requires a judgment call that should be a human/team decision (which deprecated API to migrate to, which behaviour to preserve, etc.).
+- You can't reproduce locally after reasonable effort AND the CircleCI artifacts don't clarify enough — you'd be guessing.
+- The failure-data sources contradict each other (e.g. the `failed` artifact lists a test but the tests endpoint and JUnit report it as passing, or there's no `.fail.png` / `.fail.html` for an assertion). The signal is broken — stop and report rather than chase a guess.
+
+DI container changes are fine — they don't belong on this list.
+
+## Tools worth knowing
+
+- `circleci-api.sh` — the auth wrapper for CircleCI. Treat as a black box: don't curl CircleCI directly, don't read or pass the token yourself, don't paste the wrapper's error output into chat or commits. If the wrapper says the token isn't configured, stop and report exactly that — see the script header for setup.
+- `gh api compare` — green→red file enumeration without a local checkout.
+- `git bisect run pnpm test:<suite> --file=<...>` — the form wired to project commands.
+
+## Branch hygiene
+
+If the failure ran against `trunk`, use the `starting-branch` skill to create a fix branch **before** editing — never land fixes directly on `trunk`. If it ran against a feature branch, `git fetch && git switch <branch>` and work on top of it; the fix belongs with the in-flight work.
+
+For local failures, the target is whatever branch you're already on.
+
+## Outcome
+
+Once the targeted suite is green locally and you've verified both directions, hand back with a short summary: failing test, root cause, what was changed, what was verified. Likely next-step skills: `creating-pull-requests`, `writing-changelog`, `mailpoet-dev-cycle`.
+
+## Related skills
+
+- `running-tests` — exact repro commands per suite, premium variants, debug/multisite modes.
+- `starting-branch` — used when the failure originated on `trunk`.
+- `creating-pull-requests` — draft PR after the fix.
+- `writing-changelog` — when the fix is user-facing.
+- `mailpoet-beta-compat-test` — broader beta/RC compatibility testing.

--- a/.ai/skills/debugging-failed-tests/circleci-api.sh
+++ b/.ai/skills/debugging-failed-tests/circleci-api.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Authenticated curl wrapper for the CircleCI API.
+#
+# Reads the CircleCI API token from (in order):
+#   1. $CIRCLECI_TOKEN environment variable
+#   2. WP_CIRCLECI_TOKEN in <repo>/mailpoet/.env
+#
+# The token is passed to curl via --config on stdin so it never appears in
+# process argv, shell history, or transcript output.
+#
+# Usage (run from the repo root):
+#   .ai/skills/debugging-failed-tests/circleci-api.sh <path-or-url> [extra curl args...]
+#
+# Examples:
+#   .ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/project/gh/mailpoet/mailpoet/job/12345
+#   .ai/skills/debugging-failed-tests/circleci-api.sh https://output.circle-artifacts.com/.../shot.png -o shot.png
+#
+# A first argument starting with "/" is appended to https://circleci.com;
+# anything else must be a full http(s) URL (artifact hosts work too).
+
+set -euo pipefail
+
+die() { printf 'circleci-api.sh: %s\n' "$*" >&2; exit 1; }
+
+[ $# -ge 1 ] || die "missing URL or path argument (see header comment for usage)"
+
+target=$1
+shift
+
+case "$target" in
+  http://*|https://*) url=$target ;;
+  /*)                  url="https://circleci.com$target" ;;
+  *) die "first argument must be a full http(s) URL or a path starting with '/'" ;;
+esac
+
+repo_root=$(cd "$(dirname "$0")/../../.." && pwd)
+env_file="$repo_root/mailpoet/.env"
+
+token=${CIRCLECI_TOKEN:-}
+if [ -z "$token" ] && [ -r "$env_file" ]; then
+  line=$(grep -E '^[[:space:]]*WP_CIRCLECI_TOKEN=' "$env_file" | head -n1 || true)
+  if [ -n "$line" ]; then
+    val=${line#*=}
+    val=${val%$'\r'}
+    val=${val#\"}; val=${val%\"}
+    val=${val#\'}; val=${val%\'}
+    token=$val
+  fi
+fi
+token=${token%$'\n'}
+
+[ -n "$token" ] || die "no CircleCI token found. Set one of:
+  - CIRCLECI_TOKEN in your shell environment, or
+  - WP_CIRCLECI_TOKEN=<your-token> in $env_file
+Get a personal API token at https://app.circleci.com/settings/user/tokens"
+
+# Pass the token via curl's --config on stdin (here-string). Bash sets up the
+# redirection inside the current process — the token never enters argv of
+# curl or any child process, so it cannot leak through 'ps' or shell tracing
+# of curl itself.
+exec curl --fail-with-body --silent --show-error \
+  --config /dev/stdin \
+  "$@" "$url" <<< "header = \"Circle-Token: $token\""

--- a/.ai/skills/debugging-failed-tests/references/beta-rc-failures.md
+++ b/.ai/skills/debugging-failed-tests/references/beta-rc-failures.md
@@ -1,0 +1,28 @@
+# Beta / RC failures (WordPress or WooCommerce)
+
+Nightly CircleCI runs target the latest WordPress and WooCommerce betas / release candidates. A red run on those jobs may be upstream incompatibility, not a regression in our code.
+
+## Spotting a beta/RC run
+
+- The job name often contains `_wordpress_beta` or `_woocommerce_beta`.
+- The version printed at the start of the failing step is authoritative — `WORDPRESS VERSION: 6.8-RC1`, `9.5.0-beta.1`, etc. (printed by `tests_env/docker/codeception/docker-entrypoint.sh`).
+
+## Investigating
+
+1. **Confirm the exact beta/RC version** from the entrypoint output.
+2. **Reproduce locally against the same version.** See the `running-tests` skill for the WP / WC version flags. If it passes on stable and fails on beta/RC, the version is implicated.
+3. **Read the release notes** for breaking changes or deprecations in the area the failing test exercises (hooks, REST routes, function signatures, block API, HPOS, etc.):
+   - WordPress: [wordpress.org/news/category/releases](https://wordpress.org/news/category/releases/), [Trac](https://core.trac.wordpress.org/), [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop)
+   - WooCommerce: [woocommerce/woocommerce releases](https://github.com/woocommerce/woocommerce/releases)
+4. **Search for an existing upstream issue** describing the same regression or BC change. **Do not file new upstream issues from this skill** — only reference existing ones in the report. If you find nothing, say so explicitly.
+
+## Fix direction (priority order)
+
+1. **Adapt our code or our test** to the new behaviour if it's a legitimate change (deprecation, new signature, intentional behaviour change). Default and preferred.
+2. **Plugin-side workaround** if the change looks like an unintentional upstream regression but adapting cleanly isn't feasible. Guard the workaround with a version check (`version_compare()`, or feature detection) so it activates only on affected versions — **never** branch on "is this a beta."
+
+The default fix target is still our plugin or our test, not the upstream beta.
+
+## Related
+
+- `mailpoet-beta-compat-test` — broader compatibility-testing flow when a new beta/RC ships.

--- a/.ai/skills/debugging-failed-tests/references/beta-rc-failures.md
+++ b/.ai/skills/debugging-failed-tests/references/beta-rc-failures.md
@@ -10,7 +10,7 @@ Nightly CircleCI runs target the latest WordPress and WooCommerce betas / releas
 ## Investigating
 
 1. **Confirm the exact beta/RC version** from the entrypoint output.
-2. **Reproduce locally against the same version.** See the `running-tests` skill for the WP / WC version flags. If it passes on stable and fails on beta/RC, the version is implicated.
+2. **Reproduce locally against the same version.** See the [[running-tests]] skill for the WP / WC version flags. If it passes on stable and fails on beta/RC, the version is implicated.
 3. **Read the release notes** for breaking changes or deprecations in the area the failing test exercises (hooks, REST routes, function signatures, block API, HPOS, etc.):
    - WordPress: [wordpress.org/news/category/releases](https://wordpress.org/news/category/releases/), [Trac](https://core.trac.wordpress.org/), [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop)
    - WooCommerce: [woocommerce/woocommerce releases](https://github.com/woocommerce/woocommerce/releases)
@@ -25,4 +25,4 @@ The default fix target is still our plugin or our test, not the upstream beta.
 
 ## Related
 
-- `mailpoet-beta-compat-test` — broader compatibility-testing flow when a new beta/RC ships.
+- [[mailpoet-beta-compat-test]] — broader compatibility-testing flow when a new beta/RC ships.

--- a/.ai/skills/debugging-failed-tests/references/circleci.md
+++ b/.ai/skills/debugging-failed-tests/references/circleci.md
@@ -13,7 +13,7 @@ CircleCI URLs come in two shapes:
 
 The trailing integer is the **job number** — that's what every endpoint below wants.
 
-## Job details — branch, SHA, status
+## Job details — status, pipeline id
 
 ```
 .ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/project/gh/mailpoet/mailpoet/job/<job-number>
@@ -22,11 +22,23 @@ The trailing integer is the **job number** — that's what every endpoint below 
 Useful fields:
 
 - `status` — `success`, `failed`, `running`, `infrastructure_fail`, `canceled`. `infrastructure_fail` is CircleCI's problem; retry the job before debugging.
-- `pipeline.id` — needed to walk the workflow (siblings).
-- `pipeline.vcs.revision` — the commit SHA the job ran against.
-- `pipeline.vcs.branch` — the branch the job ran against.
+- `pipeline.id` — the pipeline UUID. Feed this into the **Pipeline details** call below to get the commit SHA and branch, and into the **Sibling jobs** call further down.
 - `web_url` — the human URL of the job (handy to paste into a report).
 - `parallel_runs` — Codeception parallel-shard count.
+
+The job endpoint does NOT carry the commit SHA or branch directly — only `pipeline.id`. Use the pipeline endpoint below.
+
+## Pipeline details — SHA, branch, commit message
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/pipeline/<pipeline-id>
+```
+
+Useful fields:
+
+- `vcs.revision` — the commit SHA the pipeline ran against.
+- `vcs.branch` — the branch the pipeline ran against.
+- `vcs.commit.subject` / `vcs.commit.body` — the commit message (handy for spotting "what changed" without leaving the API).
 
 ## Test failures (structured)
 

--- a/.ai/skills/debugging-failed-tests/references/circleci.md
+++ b/.ai/skills/debugging-failed-tests/references/circleci.md
@@ -1,0 +1,86 @@
+# CircleCI API — useful endpoints
+
+All calls go through `.ai/skills/debugging-failed-tests/circleci-api.sh` from the repo root. The wrapper handles auth — do not read or pass tokens yourself. Pass a path starting with `/` (it expands to `https://circleci.com<path>`) or a full URL (for artifact downloads from `output.circle-artifacts.com`).
+
+Output is JSON on stdout; pipe to `jq` for structured access.
+
+## Identifying a job from a URL
+
+CircleCI URLs come in two shapes:
+
+- `https://app.circleci.com/pipelines/github/mailpoet/mailpoet/<pipeline-num>/workflows/<workflow-uuid>/jobs/<job-number>`
+- `https://circleci.com/gh/mailpoet/mailpoet/<job-number>` (legacy)
+
+The trailing integer is the **job number** — that's what every endpoint below wants.
+
+## Job details — branch, SHA, status
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/project/gh/mailpoet/mailpoet/job/<job-number>
+```
+
+Useful fields:
+
+- `status` — `success`, `failed`, `running`, `infrastructure_fail`, `canceled`. `infrastructure_fail` is CircleCI's problem; retry the job before debugging.
+- `pipeline.id` — needed to walk the workflow (siblings).
+- `pipeline.vcs.revision` — the commit SHA the job ran against.
+- `pipeline.vcs.branch` — the branch the job ran against.
+- `web_url` — the human URL of the job (handy to paste into a report).
+- `parallel_runs` — Codeception parallel-shard count.
+
+## Test failures (structured)
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/project/gh/mailpoet/mailpoet/<job-number>/tests
+```
+
+One entry per test with `name`, `classname`, `result` (`success` / `failure` / `error` / `skipped`), `message`, `run_time`. Filter to `result != "success"` to surface every non-passing row — far cheaper than scrolling step logs. See the main `SKILL.md` for how to read each row (especially `skipped` on trunk).
+
+```bash
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/project/gh/mailpoet/mailpoet/<job-number>/tests \
+  | jq '.items[] | select(.result != "success") | {classname, name, result, message}'
+```
+
+If this endpoint returns zero non-success rows yet the job is red, the failure is in a build/install/lint/infrastructure step. Read the failing step's raw output via the job's web URL.
+
+## Artifacts (screenshots, HTML dumps, browser logs)
+
+List artifacts:
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/project/gh/mailpoet/mailpoet/<job-number>/artifacts
+```
+
+Returns `{ items: [{ path, url, node_index }] }`. For acceptance failures the `*.fail.png` (screenshot at failure) and `*.fail.html` (page DOM) artifacts under `tests/_output/` are usually decisive.
+
+Download an individual artifact (use the full URL from the listing):
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh "<artifact-url-from-listing>" -o <local-name>
+```
+
+## Sibling jobs in the same workflow
+
+When other parallel jobs failed alongside yours and the symptom looks the same (same test name or same error class), the root cause is shared (e.g. WC beta broke the whole matrix, a fixture changed and every shard tripped on it). If the sibling failures look unrelated, treat them as independent — don't conflate.
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/pipeline/<pipeline-id>/workflow
+.ai/skills/debugging-failed-tests/circleci-api.sh /api/v2/workflow/<workflow-id>/job
+```
+
+## Test history (is this a long-running flake?)
+
+```
+.ai/skills/debugging-failed-tests/circleci-api.sh "/api/v2/insights/gh/mailpoet/mailpoet/workflows/<workflow-name>?branch=trunk"
+```
+
+Lists recent runs of the named workflow on a given branch with `status`, `duration`, `created_at`. Useful for distinguishing "first failure ever" from "been flaking for days", and for spotting the last known-good SHA to use as the floor of a `git bisect` or a `git diff <last-green>..<failing>`.
+
+## Things the v2 API does NOT give you
+
+- **WP / WC / PHP versions** used by the test container — these are printed in the raw step log by `tests_env/docker/codeception/docker-entrypoint.sh`, not surfaced as JSON. Easiest source: open the job's web URL and read the top of the failing step's output (`WORDPRESS VERSION:`, `TEST RUNNER PHP VERSION:`, WooCommerce version).
+- **The CircleCI YAML that ran** — if you need to understand the job matrix, read `.circleci/config.yml` at the failing SHA (`git show <sha>:.circleci/config.yml`).
+
+## If the wrapper fails
+
+If the wrapper exits non-zero saying the token is not configured, stop and report exactly: "CircleCI token not configured locally — see `.ai/skills/debugging-failed-tests/circleci-api.sh` for setup". Do not attempt to set up auth in the user's environment, do not paste paths or env-var names, do not guess.

--- a/.ai/skills/mailpoet-dev-cycle/SKILL.md
+++ b/.ai/skills/mailpoet-dev-cycle/SKILL.md
@@ -86,7 +86,7 @@ Before committing, run these from the repo root:
 
 - [ ] `pnpm qa` -- all PHP and frontend QA checks pass
 - [ ] `pnpm qa:fix` -- formatting is clean
-- [ ] Run relevant tests (see the `writing-tests` skill for commands)
+- [ ] Run relevant tests (see the `runnig-tests` skill for commands)
 
 ## Premium Plugin
 

--- a/.ai/skills/mailpoet-dev-cycle/SKILL.md
+++ b/.ai/skills/mailpoet-dev-cycle/SKILL.md
@@ -86,7 +86,7 @@ Before committing, run these from the repo root:
 
 - [ ] `pnpm qa` -- all PHP and frontend QA checks pass
 - [ ] `pnpm qa:fix` -- formatting is clean
-- [ ] Run relevant tests (see the `runnig-tests` skill for commands)
+- [ ] Run relevant tests (see the `running-tests` skill for commands)
 
 ## Premium Plugin
 

--- a/.ai/skills/running-tests/SKILL.md
+++ b/.ai/skills/running-tests/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: running-tests
+description: Use when running MailPoet tests — executing a full suite, running a single file or single test, running in debug/multisite mode, or shelling into the test container. Triggers on phrases like "run the unit tests", "run this test file", "execute the integration suite", "kick off acceptance tests", "rerun the failed tests". Does not cover authoring tests (see writing-tests) or investigating a failed CI run (see debugging-failed-tests).
+---
+
+# Running Tests
+
+## Overview
+
+MailPoet has six test suites across two plugins (free `mailpoet/`, premium `mailpoet-premium/`). Unit and JavaScript run on the host; integration, acceptance, and performance run inside the `tests_env/` Docker stack — separate from the wp-env dev stack. A set of `pnpm test:*` wrappers from the monorepo root hides most of that. Start with those; drop down to plugin-level `./do` calls only for the few helpers without a `pnpm` equivalent.
+
+## Most common invocations
+
+```bash
+pnpm test:unit --file=tests/unit/<Path>Test.php
+pnpm test:integration --file=tests/integration/<Path>Test.php
+pnpm test:acceptance --file=tests/acceptance/<Path>Cest.php
+pnpm test:integration --file=tests/integration/<Path>Test.php:testMethodName   # one method
+pnpm test:integration:premium --file=tests/integration/<Path>Test.php          # premium variant
+```
+
+That covers ~90% of typical traffic. The rest of this skill handles the long tail.
+
+## Quick reference
+
+| Suite             | Whole suite                                  | Single file                                                     | Runs in | Plugin    | Typical time on M1                 |
+| ----------------- | -------------------------------------------- | --------------------------------------------------------------- | ------- | --------- | ---------------------------------- |
+| Unit              | `pnpm test:unit`                             | `pnpm test:unit --file=tests/unit/<Path>Test.php`               | Host    | Free only | ~30s full / sub-second per file    |
+| Integration       | `pnpm test:integration`                      | `pnpm test:integration --file=tests/integration/<Path>Test.php` | Docker  | Both      | ~5–10min full / ~30s per file      |
+| Acceptance        | `pnpm test:acceptance`                       | `pnpm test:acceptance --file=tests/acceptance/<Path>Cest.php`   | Docker  | Both      | many hours full / ~1–2min per file |
+| JavaScript        | `pnpm test:javascript`                       | (no per-file flag — see JavaScript section below)               | Host    | Free only | ~30s full                          |
+| Newsletter Editor | `cd mailpoet && ./do test:newsletter-editor` | (Robo-only)                                                     | Host    | Free only | rare                               |
+| Performance       | `cd mailpoet && ./do test:performance ...`   | —                                                               | Docker  | Free only | on demand                          |
+
+Times are rough; first run on a cold Docker stack pays an extra 1–2min for container build/pull.
+
+**Premium variants:** replace `test:unit` / `test:integration` / `test:acceptance` with `test:unit:premium` / `test:integration:premium` / `test:acceptance:premium`. Paths are relative to whichever plugin is being tested.
+
+**Single test method** (unit, integration, acceptance): append `:methodName` to the file path.
+
+```bash
+pnpm test:integration --file=tests/integration/Logging/LogHandlerTest.php:testItStoresLog
+pnpm test:acceptance --file=tests/acceptance/Misc/WordPressSiteEditorCest.php:editWithFSE
+```
+
+## Flags
+
+`pnpm` forwards extra args transparently — `pnpm test:integration --file=X --debug` ends up as `cd mailpoet && ./do test:integration --skip-deps --file=X --debug`. Every flag below works through the `pnpm` wrapper.
+
+Source of truth: `mailpoet/RoboFile.php` (search for `public function test*`).
+
+- `--file=<path>[:method]` — all suites. Run a single file, or one method within it.
+- `--debug` — unit, integration (incl. woo/base variants). Codeception verbose mode: full stack traces, per-step output. Not on acceptance.
+- `--group=<name>` — integration, acceptance (incl. multisite). Filter to tests tagged `@group <name>` (e.g. `woo`, `failed`).
+- `--skip-group=<name>` — integration only. Exclude a group.
+- `--multisite` — integration (incl. woo/base). Acceptance has its own task (`./do test:acceptance-multisite`). Vestigial on unit — accepted by the signature but the suite never boots WP, so it has no effect.
+- `--stop-on-fail` — integration only. Halt on the first failure.
+- `--skip-plugins` — integration, acceptance. Don't load extra plugins (WC, etc.).
+- `--enable-hpos` / `--disable-hpos` / `--enable-hpos-sync` — integration (incl. variants), acceptance (incl. multisite). Toggle WooCommerce High-Performance Order Storage for the run. Use when your change touches WC order data paths.
+- `--wordpress-version=<ver>` — integration, acceptance. Run against a specific WP version, including beta/RC — see [[mailpoet-beta-compat-test]].
+- `--timeout=<seconds>` — acceptance, acceptance-multisite. Per-test timeout override.
+- `--skip-deps` — integration, acceptance (incl. multisite). Skip in-container `composer install`. The `pnpm test:integration` / `:acceptance` wrappers (and their premium variants) pass this by default.
+- `--xml[=path]` — all suites. Write JUnit XML output. Used by CI; rarely needed locally.
+
+When the wrapper isn't enough — direct Codeception access, artifact inspection, or DB poking — shell in (see "Shelling in" below).
+
+## Suite essentials
+
+### Unit — `pnpm test:unit`
+
+Host-side, no WP, no DB. Free plugin only (premium has no unit suite). Re-run only what failed last time with `cd mailpoet && ./do test:failed-unit` — Codeception keeps the failure list under `tests/_output/` (via the `@group failed` mechanism).
+
+### Integration — `pnpm test:integration`
+
+Real WP + DB, Docker-backed. The default integration run loads WooCommerce; two narrower entrypoints let you scope:
+
+- `cd mailpoet && ./do test:woo-integration` — only WC-tagged tests, WC loaded.
+- `cd mailpoet && ./do test:base-integration` — only non-WC tests, WC not loaded.
+
+Pick `test:woo-integration` when iterating on WC integration code; pick `test:base-integration` when you suspect WC is contaminating an otherwise WC-independent test. Otherwise stick to the default.
+
+Multisite: `pnpm test:integration --multisite`. Re-run failed: `cd mailpoet && ./do test:failed-integration`.
+
+### Acceptance — `pnpm test:acceptance`
+
+Selenium + Chrome in Docker. The slowest suite by a wide margin. Target the file you care about; do not run the whole thing on a whim.
+
+- Multisite: `cd mailpoet && ./do test:acceptance-multisite --skip-deps --file=...`.
+- Watch the run live: VNC to `localhost:5900`, password `secret` (macOS: `open vnc://localhost:5900`; Linux/Windows: any VNC client).
+- **Failure artifacts** land in `mailpoet/tests/_output/` (premium equivalent under `mailpoet-premium/`): `*.fail.png` screenshots, `*.fail.html` page dumps, Codeception logs. Look here _before_ re-running — the screenshot usually tells you the story. For full failure investigation, hand off to [[debugging-failed-tests]].
+
+### JavaScript — `pnpm test:javascript`
+
+Mocha + Chai + Sinon, host-side, free only. The wrapper has no `--file` flag — it runs the whole `mailpoet/tests/javascript/` tree.
+
+To focus on a single spec, either add `describe.only(...)` or `it.only(...)` to the spec and re-run (don't commit the `.only`), or invoke Mocha directly:
+
+```bash
+cd mailpoet
+# Single file:
+./node_modules/.bin/mocha --require tests/javascript/mocha-env.mjs \
+  --extension spec.ts tests/javascript/path/to/foo.spec.ts
+
+# Filter by test name across the tree:
+./node_modules/.bin/mocha --require tests/javascript/mocha-env.mjs \
+  --extension spec.ts --recursive tests/javascript --grep "my describe block"
+```
+
+Add `--inspect-brk` to the same command and attach Node DevTools (`chrome://inspect`) or a VS Code "Node: Attach" config to debug.
+
+**Stale `assets/dist/`:** a handful of specs import from compiled output. If a test reports `X is not a function` against code that obviously exports `X`, run `pnpm compile:js` and retry before going hunting.
+
+### Newsletter Editor (legacy) — `cd mailpoet && ./do test:newsletter-editor`
+
+Mocha suite covering the Backbone newsletter editor under `mailpoet/tests/javascript-newsletter-editor/`. Free plugin only.
+
+**Do not add new tests here.** The Backbone editor is being replaced by the block-based editor at `mailpoet/assets/js/src/mailpoet-email-editor-integration/`. Run this suite only when you've actually modified the legacy editor — otherwise it's slow noise.
+
+### Performance — `cd mailpoet && ./do test:performance`
+
+k6 + Playwright, Docker-backed. Free plugin only. Runs against a live MailPoet instance you supply (the test is the load generator, not a fixture). Three-step lifecycle:
+
+```bash
+cd mailpoet
+./do test:performance-setup                                       # one-time prep (seed data, etc.)
+./do test:performance --url=<wp-url> --us=<user> --pw=<pass>      # actual run
+./do test:performance-clean                                       # tear down test data
+```
+
+Optional flags on `test:performance`:
+
+- `--head` — run the Playwright browser headed (default headless).
+- `--scenario=<name>` — restrict to one scenario from `mailpoet/tests/performance/scenarios.js`.
+- Positional `<path>` (before `--`) — point at a different scenarios file.
+
+Cloud mode kicks in automatically when `K6_CLOUD_TOKEN` is set; results upload to k6 Cloud instead of printing locally. Full signature: `testPerformance` in `mailpoet/RoboFile.php`.
+
+## Shelling in
+
+```bash
+pnpm shell:test                                             # bash into tests_env wordpress container
+cd /wp-core/wp-content/plugins/mailpoet                     # or mailpoet-premium
+./do test:integration --skip-deps --file=tests/integration/...
+```
+
+Useful when:
+
+- Running Codeception directly (`../tests_env/vendor/bin/codecept ...`) — e.g. for a flag the Robo wrapper doesn't expose.
+- Inspecting DB state mid-debug via `wp db query "..."` against the test database.
+- Iterating on the test runner itself.
+
+### The `--skip-deps` footgun
+
+When invoking `./do test:*` inside the container, **always pass `--skip-deps`**. Without it the prefixer runs again on PHP 8.4 and can wipe `mailpoet/vendor-prefixed/`. Recovery: `pnpm bootstrap`.
+
+This is why the host-side `pnpm test:integration` / `pnpm test:acceptance` (and their `:premium` variants) pass `--skip-deps` automatically. `pnpm test:unit` and `pnpm test:javascript` don't need it — they don't run in Docker. Use `pnpm test:install-deps` only when you actually want to refresh the container's deps (e.g. after a `composer.json` bump).
+
+## Common failure modes
+
+| Symptom                                                 | Likely cause / fix                                                                                                                                                                        |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Cannot connect to the Docker daemon" on a Docker suite | Docker Desktop / OrbStack isn't running. Start it, then re-run.                                                                                                                           |
+| First integration/acceptance run takes minutes to start | First-time container build/pull. Tail the test stack from the repo root: `docker compose -f tests_env/docker/docker-compose.yml logs -f` (not `pnpm env:logs` — that's the wp-env stack). |
+| `vendor-prefixed/` disappeared after a test run         | Ran `./do test:*` without `--skip-deps` on PHP 8.4. Recover with `pnpm bootstrap`.                                                                                                        |
+| Acceptance run starts but every test fails at login     | Test WordPress site is in a broken state. `cd mailpoet && ./do reset:test-docker` drops the test volumes (keeps images) and rebuilds.                                                     |
+| Docker is genuinely confused (zombies, weird state)     | `cd mailpoet && ./do delete:docker` does the harder reset: stops containers, drops volumes, **removes images** (next run will re-pull/build, ~1–2min). Does not touch the wp-env stack.   |
+| JS test errors with `X is not a function` for real code | `assets/dist/` is stale. Run `pnpm compile:js` and re-run.                                                                                                                                |
+| WC-related integration failures (orders, HPOS)          | Toggle HPOS for the run: `--enable-hpos`, `--disable-hpos`, or `--enable-hpos-sync`.                                                                                                      |
+| "Unknown option --file" or similar                      | Wrong wrapper for the suite (e.g. JavaScript has no `--file`). Check the Quick Reference.                                                                                                 |
+| Test passes locally but failed on CI                    | Hand off to [[debugging-failed-tests]] with the CI job URL, branch name, failing test path, and any WP/WC version overrides the CI run used.                                              |
+
+### Interrupting a long run
+
+Ctrl-C is fine, but it can leave Selenium / Chrome containers running for an acceptance run. They usually self-correct on the next invocation; if things look off, `./do reset:test-docker` is the soft reset and `./do delete:docker` is the hard one.
+
+## Verification
+
+Read the final pass/fail summary line before reporting a run as green. "No output" or "command returned" is not evidence — look for `OK (N tests, M assertions)` (PHPUnit/Codeception) or the equivalent green line. For finishing-a-branch workflows, the canonical pre-push gate is `pnpm qa` plus the suite(s) touched by your change.

--- a/.ai/skills/writing-tests/SKILL.md
+++ b/.ai/skills/writing-tests/SKILL.md
@@ -1,103 +1,80 @@
 ---
 name: writing-tests
-description: 'Use when writing, running, or debugging tests. Use when asked to add test coverage, fix a failing test, or run a test suite.'
+description: 'Use when authoring tests for MailPoet — adding a new test case, picking the right test type, choosing a name, structuring the file, deciding what belongs in unit vs integration vs acceptance. For invoking the test runner (running a file, the whole suite, premium variants, debug mode) see running-tests. For investigating a CI failure see debugging-failed-tests.'
 ---
 
-# Writing and Running Tests
+# Writing Tests
 
 ## Overview
 
-MailPoet has six test types across two plugins (free `mailpoet/` and premium `mailpoet-premium/`).
-
-**Running tests:** Use the `pnpm test:*` scripts from the monorepo root for the common suites. Integration, acceptance, and performance tests require Docker. A few specialist helpers do not have `pnpm` wrappers yet; those are called out below as plugin-level Robo-only commands.
+MailPoet has six test suites across two plugins. This skill is about **authoring** them — where the file belongs, what to extend, how to name and structure it, what kind of test belongs where. For invoking the test runner, see [[running-tests]].
 
 ## Guidelines
 
-- **Prefer smaller tests over big ones.** Keep tests focused, short, and linear. Avoid control structures like `if`, `for`, or `while` in tests — if you need a loop, you probably need separate test cases instead.
-- **Use descriptive test names.** The test name should make it obvious what failed and why when you read it in CI output. Describe the scenario and expected outcome, not the method being tested.
-- **Prefer self-explanatory tests over comments.** Comments can be useful, but first try to refactor the test so the comment isn't needed — better naming, extracting helpers, or splitting into smaller tests.
-- **In E2E tests use `$i->wantTo(...)` instead of comments** — `wantTo` output is visible in test results, comments are not.
-- **Prefer unit > integration > E2E.** Unit tests are fast and cheap. E2E tests are slow and expensive — don't add them unless you need to test a real browser flow.
-- **Avoid brittle selectors in E2E tests.** Don't rely on long CSS selector chains or DOM structure of 3rd party components — these break when libraries update. Prefer `data-automation-id` attributes, ARIA roles, or short stable selectors. If a 3rd party component doesn't expose good hooks, add a `data-automation-id` or wrapper in the production code.
-- **Fight flakiness in E2E tests.** Always wait for the page/element to be ready before interacting. Use `waitForElement`, `waitForText`, or similar helpers — never assume the page is loaded. Think about what could make the test fail intermittently and guard against it.
-- **Always run tests before committing.** Never commit a test you haven't seen pass. If a test can't be run locally, say so — don't assume it works.
-- **Prefer TDD.** Write the test first, see it fail, then write the code that makes it pass. The failing test proves the test actually tests something.
+- **Prefer smaller tests over big ones.** Keep them focused, short, and linear. Avoid `if` / `for` / `while` inside a test — if you need a loop you probably need separate test cases instead. Why: loops hide which case actually failed, and one fix accidentally masks another.
+- **Use descriptive test names.** The name should make it obvious from CI output what failed and why. Describe the scenario and expected outcome, not the method being tested. A reader who has never seen the file should be able to guess the intent from the name alone.
+- **Prefer self-explanatory tests over comments.** First try to refactor — better naming, extract helpers, split into smaller tests — so the comment becomes unnecessary. A comment that survives that pass is usually worth keeping; one that doesn't is a code smell pointing at the test itself.
+- **In acceptance tests use `$i->wantTo(...)` instead of comments.** `wantTo` text shows up in the Codeception output, plain comments don't. The output is the only thing a future debugger sees.
+- **Prefer unit > integration > acceptance.** Unit tests are fast and cheap; acceptance tests are slow, flaky, and expensive to maintain. Only reach for acceptance when you genuinely need a real browser flow.
+- **Avoid brittle selectors in acceptance tests.** Long CSS chains and 3rd-party DOM structure break on library updates. Prefer `data-automation-id` attributes, ARIA roles, or short stable selectors. If a 3rd-party component doesn't expose good hooks, add a `data-automation-id` (or a thin wrapper) in the production code so the test has something stable to grab.
+- **Defend against flakiness in acceptance tests.** Always wait for the page / element to be ready before interacting (`waitForElement`, `waitForText`, …) — never assume the page is loaded. When writing a test, deliberately ask "what could make this fail intermittently?" and guard against it.
+- **Always run the test before committing.** Never commit a test you haven't seen pass at least once. If it can't be run locally, say so out loud — don't assume it works.
+- **Prefer TDD.** Write the failing test first, see it fail (this proves the test actually tests something), then write the code that makes it pass.
 
-## Test Types
+## Picking the right suite
 
-### PHP Unit Tests
+| You need to test…                                                   | Use                           | Why                                                                           |
+| ------------------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------- |
+| Pure PHP logic with no WP / DB dependency                           | Unit                          | Fastest, no Docker, runs on the host                                          |
+| Behaviour that hits WP APIs, the DB, or our Doctrine repositories   | Integration                   | Real WordPress + DB inside Docker                                             |
+| A real browser flow (forms, redirects, JS, multi-page interactions) | Acceptance                    | Only place to drive an actual browser                                         |
+| Frontend React/TS logic without a real browser                      | JavaScript                    | Mocha-based, host-side                                                        |
+| The legacy Backbone newsletter editor                               | _do not write new tests here_ | The Backbone editor is being replaced — extend the block-based editor instead |
+| Load / scale behaviour                                              | Performance                   | k6 + Playwright; only for perf work                                           |
 
-Fast, isolated tests. No WordPress, no database. Run directly on the host machine via the root `pnpm` wrapper. **Free plugin only** — premium has no unit tests.
+When two options would work, choose the one further up the table — cheaper to run, cheaper to maintain.
 
-- **Location:** `mailpoet/tests/unit/`
-- **File pattern:** `*Test.php`
-- **Base class:** `MailPoetUnitTest`
-- **Run all:** `pnpm test:unit`
-- **Run one file:** `pnpm test:unit --file=tests/unit/WooCommerce/TransactionalEmails/FontFamilyValidatorTest.php`
-- **Debug mode:** `pnpm test:unit --debug --file=tests/unit/...`
-- **Re-run failed:** `cd mailpoet && ./do test:failed-unit` (Robo-only)
+## Where new tests go and what they extend
 
-### PHP Integration Tests
+### PHP unit (`mailpoet/tests/unit/`)
 
-Tests with WordPress and database, run inside Docker. Slower than unit tests. Run from the monorepo root.
+- File pattern `*Test.php`, base class `MailPoetUnitTest`.
+- **Free plugin only** — premium has no unit suite. If your test needs to live in `mailpoet-premium/`, it has to be an integration test.
+- No WordPress runtime, no DB. Mock the `WP\Functions` wrapper for any WP call (which is why production code must go through that wrapper — see AGENTS.md).
 
-- **Location:** `mailpoet/tests/integration/` and `mailpoet-premium/tests/integration/`
-- **File pattern:** `*Test.php`
-- **Base class:** `\MailPoetTest` (extends Codeception)
-- **Run all:** `pnpm test:integration`
-- **Run one file:** `pnpm test:integration --file=tests/integration/Logging/LogHandlerTest.php`
-- **Debug mode:** `pnpm test:integration --debug --file=tests/integration/...`
-- **Re-run failed:** `cd mailpoet && ./do test:failed-integration` (Robo-only)
-- **Variants:**
-  - `cd mailpoet && ./do test:woo-integration` — with WooCommerce loaded (Robo-only)
-  - `cd mailpoet && ./do test:base-integration` — without WooCommerce (Robo-only)
-  - `pnpm test:integration --multisite` — WordPress multisite
+### PHP integration (`mailpoet/tests/integration/` and `mailpoet-premium/tests/integration/`)
 
-The `pnpm test:*` scripts already pass `--skip-deps` by default to avoid rebuilding Docker containers every run.
+- File pattern `*Test.php`, base class `\MailPoetTest` (extends Codeception's WP integration).
+- WordPress and DB are live — write tests against the real Doctrine repositories where you can. Mock the seams that aren't under test.
+- Multisite-specific behaviour: there's a multisite mode (see `running-tests` for how to invoke it); when authoring, guard multisite-only code paths so non-multisite runs of the same file still pass.
 
-### PHP Acceptance Tests (E2E)
+### PHP acceptance (`mailpoet/tests/acceptance/` and `mailpoet-premium/tests/acceptance/`)
 
-Browser-based end-to-end tests using Selenium and Chrome in Docker. **The slowest test type** — only add these when testing a real browser flow that can't be covered by unit or integration tests. Run from the monorepo root.
+- File pattern `*Cest.php`. Each test method takes the `AcceptanceTester $i` parameter.
+- Use `$i->wantTo("describe the scenario")` at the top of each method — it lands in the run output and is the only documentation a future debugger sees.
+- Anchor on `data-automation-id` / ARIA selectors, not DOM structure.
+- Always wait explicitly for the element you're about to interact with.
 
-- **Location:** `mailpoet/tests/acceptance/` and `mailpoet-premium/tests/acceptance/`
-- **File pattern:** `*Cest.php`
-- **Run all:** `pnpm test:acceptance`
-- **Run one file:** `pnpm test:acceptance --file=tests/acceptance/Misc/WordPressSiteEditorCest.php`
-- **Multisite:** `cd mailpoet && ./do test:acceptance-multisite --skip-deps --file ...` (Robo-only)
-- **Reset Docker:** `cd mailpoet && ./do delete:docker` — if you get unexpected errors, delete the Docker runtime and start fresh (Robo-only)
-- **Watch tests in browser:** The browser runs in Docker. Connect via VNC at `vnc://localhost:5900` (password: `secret`).
+### JavaScript (`mailpoet/tests/javascript/`)
 
-### JavaScript Tests
+- File pattern `*.spec.ts`. Mocha + Chai + Sinon.
+- **Free plugin only.**
+- Test logic, not the DOM. For DOM-level flows, prefer an acceptance test.
 
-Frontend tests using Mocha + Chai + Sinon. **Free plugin only.**
+### Test data builders
 
-- **Location:** `mailpoet/tests/javascript/`
-- **File pattern:** `*.spec.ts`
-- **Run:** `pnpm test:javascript`
+Place reusable test fixtures under `tests/DataFactories/`. If you find yourself constructing the same shape twice, lift it into a factory the next test in this area will thank you for.
 
-### Newsletter Editor JavaScript Tests (Legacy)
+## Common mistakes when authoring tests
 
-Legacy Mocha test suite for the newsletter editor. **Do not write new tests here** — only modify existing ones if necessary. **Free plugin only.**
+- **Writing the test after the code "just to have a test".** That doesn't prove the test tests anything; tests-after answer "what does this code do?" instead of "what should this code do?". Write the failing test first.
+- **Picking acceptance for something a unit test could cover.** Acceptance tests are the most expensive thing you own. Push every assertion as far down the pyramid as it can go.
+- **Asserting on long error message strings.** Error text changes; assert on the structured behaviour (exception type, status code, stored DB state) instead.
+- **Sharing state across test methods within a file.** Each test must set up and tear down its own state. State leakage between tests is the #1 cause of "passes alone, fails in the suite" reports.
+- **Calling WordPress functions directly in production code.** Test pain here is a code smell — the production code should go through `WP\Functions` so the test can mock it. Fix the production code rather than working around it in the test.
 
-- **Location:** `mailpoet/tests/javascript-newsletter-editor/`
-- **Run:** `cd mailpoet && ./do test:newsletter-editor` (Robo-only)
+## Related skills
 
-### Performance Tests
-
-Load and performance testing with k6 and Playwright. **Free plugin only.**
-
-- **Location:** `mailpoet/tests/performance/`
-- **Setup:** `cd mailpoet && ./do test:performance-setup` (Robo-only)
-- **Run:** `cd mailpoet && ./do test:performance --url=... --us=... --pw=...` (Robo-only)
-- **Cleanup:** `cd mailpoet && ./do test:performance-clean` (Robo-only)
-
-## Quick Reference
-
-| Type              | Command                                      | Runs in | Plugin    |
-| ----------------- | -------------------------------------------- | ------- | --------- |
-| Unit              | `pnpm test:unit`                             | Local   | Free only |
-| Integration       | `pnpm test:integration`                      | Docker  | Both      |
-| Acceptance        | `pnpm test:acceptance`                       | Docker  | Both      |
-| JavaScript        | `pnpm test:javascript`                       | Local   | Free only |
-| Newsletter Editor | `cd mailpoet && ./do test:newsletter-editor` | Local   | Free only |
-| Performance       | `cd mailpoet && ./do test:performance`       | Docker  | Free only |
+- [[running-tests]] — how to actually invoke the test runner (single file, whole suite, premium variants, debug mode, multisite, Docker shell).
+- [[debugging-failed-tests]] — investigating a CircleCI failure and shipping a fix.
+- [[mailpoet-dev-cycle]] — the broader lint/format/test loop you should run before pushing.


### PR DESCRIPTION
## Description

Adds a `debugging-failed-tests` skill so an agent can take a CircleCI URL (or a local failing test) and walk it through to a fix.

Example trigger:

> Investigate this CI failure: https://circleci.com/gh/mailpoet/mailpoet/411320

Also splits `writing-tests` into separate `running-tests` (runner reference) and `writing-tests` (authoring guide) — see commit messages.

## Code review notes

_N/A_

## QA notes

Tested against 4 real CircleCI failures ([411320](https://circleci.com/gh/mailpoet/mailpoet/411320), [400296](https://circleci.com/gh/mailpoet/mailpoet/400296), [412985](https://circleci.com/gh/mailpoet/mailpoet/412985), [413313](https://circleci.com/gh/mailpoet/mailpoet/413313)) with a Sonnet subagent, comparing the skill to a no-skill baseline. The skill clearly helped on the harder cases — 412985's "0 failures yet red build" and 413313's integration crash that recorded no test results — where the no-skill baseline either stalled or settled on a plausible-but-wrong hypothesis. On straightforward failures with rich error messages (411320, 400296), both runs reached the same fix; the skill added ~10–200ken overhead but no quality loss.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:test-debug-skill)

_The latest successful build from `test-debug-skill` will be used. If none is available, the link won't work._