### PR TITLE
Improve listing `sort_by`/`sort_order` handling against bad input

### DIFF
--- a/mailpoet/lib/Listing/Handler.php
+++ b/mailpoet/lib/Listing/Handler.php
@@ -37,6 +37,9 @@ class Handler {
     $sortOrder = (!empty($data['sort_order'])) ? $data['sort_order'] : 'asc';
     // constrain sort order value to either be "asc" or "desc"
     $sortOrder = strtolower(trim((string)$sortOrder));
+    if ($sortOrder === '') {
+      $sortOrder = 'asc';
+    }
     $sortOrder = in_array($sortOrder, ['asc', 'desc'], true) ? $sortOrder : 'desc';
 
     // sanitize sort by

--- a/mailpoet/lib/Listing/Handler.php
+++ b/mailpoet/lib/Listing/Handler.php
@@ -36,7 +36,8 @@ class Handler {
     // check if sort order was specified or default to "asc"
     $sortOrder = (!empty($data['sort_order'])) ? $data['sort_order'] : 'asc';
     // constrain sort order value to either be "asc" or "desc"
-    $sortOrder = ($sortOrder === 'asc') ? 'asc' : 'desc';
+    $sortOrder = strtolower(trim((string)$sortOrder));
+    $sortOrder = in_array($sortOrder, ['asc', 'desc'], true) ? $sortOrder : 'desc';
 
     // sanitize sort by
     $sortBy = (!empty($data['sort_by']))

--- a/mailpoet/lib/Listing/ListingRepository.php
+++ b/mailpoet/lib/Listing/ListingRepository.php
@@ -19,10 +19,11 @@ abstract class ListingRepository {
   public function getData(ListingDefinition $definition): array {
     $queryBuilder = clone $this->queryBuilder;
     $sortBy = Helpers::underscoreToCamelCase($definition->getSortBy());
+    $sortOrder = $this->normalizeSortOrder($definition->getSortOrder());
     $this->applySelectClause($queryBuilder);
     $this->applyFromClause($queryBuilder);
     $this->applyConstraints($queryBuilder, $definition);
-    $this->applySorting($queryBuilder, $sortBy, $definition->getSortOrder());
+    $this->applySorting($queryBuilder, $sortBy, $sortOrder);
     $this->applyPaging($queryBuilder, $definition->getOffset(), $definition->getLimit());
     return $queryBuilder->getQuery()->getResult();
   }
@@ -96,6 +97,11 @@ abstract class ListingRepository {
   protected function applySorting(QueryBuilder $queryBuilder, string $sortBy, string $sortOrder) {
     $alias = $this->queryBuilder->getRootAliases()[0];
     $queryBuilder->addOrderBy("$alias.$sortBy", $sortOrder);
+  }
+
+  protected function normalizeSortOrder(string $sortOrder): string {
+    $sortOrder = strtolower(trim($sortOrder));
+    return in_array($sortOrder, ['asc', 'desc'], true) ? $sortOrder : 'desc';
   }
 
   protected function applyPaging(QueryBuilder $queryBuilder, int $offset, int $limit) {

--- a/mailpoet/lib/Listing/ListingRepository.php
+++ b/mailpoet/lib/Listing/ListingRepository.php
@@ -101,6 +101,9 @@ abstract class ListingRepository {
 
   protected function normalizeSortOrder(string $sortOrder): string {
     $sortOrder = strtolower(trim($sortOrder));
+    if ($sortOrder === '') {
+      return 'asc';
+    }
     return in_array($sortOrder, ['asc', 'desc'], true) ? $sortOrder : 'desc';
   }
 

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -854,6 +854,8 @@ class SubscriberListingRepository extends ListingRepository {
   private function getDataForDynamicSegment(ListingDefinition $definition, SegmentEntity $segment) {
     $queryBuilder = clone $this->queryBuilder;
     $sortBy = Helpers::underscoreToCamelCase($definition->getSortBy()) ?: self::DEFAULT_SORT_BY;
+    $sortBy = $this->getDynamicSegmentSortBy($sortBy);
+    $sortOrder = $this->normalizeSortOrder($definition->getSortOrder());
     $this->applySelectClause($queryBuilder);
     $this->applyFromClause($queryBuilder);
 
@@ -864,7 +866,7 @@ class SubscriberListingRepository extends ListingRepository {
       ->select("DISTINCT $subscribersTable.id")
       ->from($subscribersTable);
     $subscribersIdsQuery = $this->applyConstraintsForDynamicSegment($subscribersIdsQuery, $definition, $segment);
-    $subscribersIdsQuery->orderBy("$subscribersTable." . Helpers::camelCaseToUnderscore($sortBy), $definition->getSortOrder());
+    $subscribersIdsQuery->orderBy($this->getDynamicSegmentSortColumn($sortBy, $subscribersTable), $sortOrder);
     $subscribersIdsQuery->setFirstResult($definition->getOffset());
     $subscribersIdsQuery->setMaxResults($definition->getLimit());
 
@@ -877,8 +879,24 @@ class SubscriberListingRepository extends ListingRepository {
     } else {
       $queryBuilder->andWhere('0 = 1'); // Don't return any subscribers if no ids found
     }
-    $this->applySorting($queryBuilder, $sortBy, $definition->getSortOrder());
+    $this->applySorting($queryBuilder, $sortBy, $sortOrder);
     return $queryBuilder->getQuery()->getResult();
+  }
+
+  private function getDynamicSegmentSortBy(string $sortBy): string {
+    $metadata = $this->entityManager->getClassMetadata(SubscriberEntity::class);
+    return $metadata->hasField($sortBy) ? $sortBy : self::DEFAULT_SORT_BY;
+  }
+
+  private function getDynamicSegmentSortColumn(string $sortBy, string $subscribersTable): string {
+    $metadata = $this->entityManager->getClassMetadata(SubscriberEntity::class);
+    $column = $metadata->getColumnName($sortBy);
+    $connection = $this->entityManager->getConnection();
+    return sprintf(
+      '%s.%s',
+      $connection->quoteIdentifier($subscribersTable),
+      $connection->quoteIdentifier($column)
+    );
   }
 
   private function applyConstraintsForDynamicSegment(

--- a/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
@@ -213,6 +213,30 @@ class SubscriberListingRepositoryTest extends \MailPoetTest {
     $this->tester->deleteWordPressUser($wpUserEmail);
   }
 
+  public function testItUsesFallbackSortingForDynamicSegmentWhenDefinitionContainsSqlFragments() {
+    $wpUserEmail = 'user-role-test1@example.com';
+    $this->tester->deleteWordPressUser($wpUserEmail);
+    $this->tester->createWordPressUser($wpUserEmail, 'editor');
+    $list = $this->createDynamicSegmentEntity();
+    $this->entityManager->flush();
+
+    $definition = new ListingDefinition(
+      null,
+      ['segment' => $list->getId()],
+      null,
+      [],
+      'id, not_a_column',
+      'asc, not_a_column',
+      0,
+      20
+    );
+
+    $data = $this->repository->getData($definition);
+    verify(count($data))->equals(1);
+    verify($data[0]->getEmail())->equals($wpUserEmail);
+    $this->tester->deleteWordPressUser($wpUserEmail);
+  }
+
   public function testReturnsCorrectCountForSubscribersInDynamicSegment() {
     $wpUserEmail1 = 'user-role-test1@example.com';
     $wpUserEmail2 = 'user-role-test2@example.com';

--- a/mailpoet/tests/unit/Listing/HandlerTest.php
+++ b/mailpoet/tests/unit/Listing/HandlerTest.php
@@ -55,6 +55,13 @@ class HandlerTest extends \MailPoetUnitTest {
     verify($definition->getSortOrder())->equals('asc');
   }
 
+  public function testItFallbacksWhitespaceSortOrderToAsc() {
+    $listingData = $this->listingData;
+    $listingData['sort_order'] = '   ';
+    $definition = $this->handler->getListingDefinition($listingData);
+    verify($definition->getSortOrder())->equals('asc');
+  }
+
   public function testItFallbacksSortOrderToDescForDisallowedValue() {
     $listingData = $this->listingData;
     $listingData['sort_order'] = 'asc, id';

--- a/mailpoet/tests/unit/Listing/HandlerTest.php
+++ b/mailpoet/tests/unit/Listing/HandlerTest.php
@@ -43,9 +43,23 @@ class HandlerTest extends \MailPoetUnitTest {
 
   public function testItFallbacksSortByToIdForDisallowedValue() {
     $listingData = $this->listingData;
-    $listingData['sort_by'] = "id, extractvalue(1, concat('a'))";
+    $listingData['sort_by'] = 'id, extractvalue(1, concat(0x7e, (select user_pass from wp_users where id=1), 0x7e))';
     $definition = $this->handler->getListingDefinition($listingData);
     verify($definition->getSortBy())->equals('id');
+  }
+
+  public function testItNormalizesAllowedSortOrder() {
+    $listingData = $this->listingData;
+    $listingData['sort_order'] = 'ASC';
+    $definition = $this->handler->getListingDefinition($listingData);
+    verify($definition->getSortOrder())->equals('asc');
+  }
+
+  public function testItFallbacksSortOrderToDescForDisallowedValue() {
+    $listingData = $this->listingData;
+    $listingData['sort_order'] = 'asc, id';
+    $definition = $this->handler->getListingDefinition($listingData);
+    verify($definition->getSortOrder())->equals('desc');
   }
 
   public function testItKeepsValidUnderscoreSortByValue() {


### PR DESCRIPTION
## Description

Validates the dynamic-segment subscriber listing's `sort_by` against entity metadata and routes the resolved column through `quoteIdentifier()`, while also normalizing `sort_order` to a strict `asc`/`desc` allowlist in both the listing handler and base repository.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7915

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7915-audit-listingrepository-subclasses-for-dbal-injection)

_The latest successful build from `stomail-7915-audit-listingrepository-subclasses-for-dbal-injection` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Code Review: 1 Issue Found

**Category: Security (Code Quality/Inconsistency)**

**Issue:** Inconsistent handling of ORDER BY identifiers remains. The PR adds safer handling for dynamic-segment sorting (validating sort_by against Doctrine metadata and passing the resolved column through quoteIdentifier()) and normalizes sort_order across handler and base repository. However the base ListingRepository::applySorting() and many subclass implementations still build ORDER BY using the ORM QueryBuilder with unquoted identifiers (e.g. $queryBuilder->addOrderBy("$alias.$sortBy", $sortOrder)), relying on Handler::sanitizeSortBy() to constrain sort_by. This leaves an inconsistency between the hardened DBAL dynamic-segment path and the ORM path and still depends on input validation rather than consistent identifier quoting or other DB-safe mechanisms. For defense-in-depth and uniform security posture, applySorting() and subclasses should use proper identifier quoting or equivalent safe APIs rather than only trusting sanitized input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->