### PR TITLE
Add post notifications help link to ALC settings

### DIFF
--- a/mailpoet/assets/css/src/mixins/_animations.scss
+++ b/mailpoet/assets/css/src/mixins/_animations.scss
@@ -7,6 +7,7 @@
   &.mailpoet_closed {
     max-height: 0;
     opacity: 0;
+    overflow: hidden;
   }
 }
 

--- a/mailpoet/changelog/2026-05-26-07-09-13-improved-automatic-latest-content-block-settings-with-a-pos.md
+++ b/mailpoet/changelog/2026-05-26-07-09-13-improved-automatic-latest-content-block-settings-with-a-pos.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+A link to learn more about Automatic Latest Content block in its settings

--- a/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/blocks/automated-latest-content-layout.spec.js
+++ b/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/blocks/automated-latest-content-layout.spec.js
@@ -467,6 +467,20 @@ describe('Automated latest content layout', function () {
         view.render();
       });
 
+      it('shows a link to post notifications documentation', function () {
+        var link = view.$(
+          '.mailpoet_automated_latest_content_post_notifications_help',
+        );
+
+        expect(link).to.have.length(1);
+        expect(link.text()).to.contain('Learn more');
+        expect(link.attr('href')).to.equal(
+          'https://kb.mailpoet.com/article/238-faq-post-notifications',
+        );
+        expect(link.attr('target')).to.equal('_blank');
+        expect(link.attr('rel')).to.equal('noopener noreferrer');
+      });
+
       it('changes the model if post amount changes', function () {
         var newValue = '11';
         view

--- a/mailpoet/views/newsletter/templates/blocks/automatedLatestContent/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/automatedLatestContent/settings.hbs
@@ -295,7 +295,8 @@
     </div>
 </div>
 
-<div class="mailpoet_form_field">
+<div class="mailpoet_form_field mailpoet-flex mailpoet-grid-space-between-vertical-center">
     <input type="button" class="button button-primary mailpoet_done_editing" value="<%= __('Done') | escape('html_attr') %>" />
+    <a href="https://kb.mailpoet.com/article/238-faq-post-notifications" class="mailpoet_automated_latest_content_post_notifications_help" target="_blank" rel="noopener noreferrer"><%= __('Learn more') %></a>
 </div>
 

--- a/mailpoet/views/newsletter/templates/blocks/automatedLatestContentLayout/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/automatedLatestContentLayout/settings.hbs
@@ -327,7 +327,8 @@
     </div>
 </div>
 
-<div class="mailpoet_form_field">
+<div class="mailpoet_form_field mailpoet-flex mailpoet-grid-space-between-vertical-center">
     <input type="button" data-automation-id="alc_settings_done" class="button button-primary mailpoet_done_editing" value="<%= __('Done') | escape('html_attr') %>" />
+    <a href="https://kb.mailpoet.com/article/238-faq-post-notifications" class="mailpoet_automated_latest_content_post_notifications_help" target="_blank" rel="noopener noreferrer"><%= __('Learn more') %></a>
 </div>
 


### PR DESCRIPTION
## Description

Adds a “Learn more” link to the Automatic Latest Content block settings, pointing users to the Post Notifications FAQ.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7658

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="363" height="382" alt="Screenshot 2026-05-26 at 09 56 25" src="https://github.com/user-attachments/assets/c7cf5672-4d78-494b-8191-0a511da18647" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
