### PR TITLE
Embed CircleCI build URL in slack failure body

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ slack-fail-post-step: &slack-fail-post-step
                 "fields": [
                   {
                     "type": "mrkdwn",
-                    "text": "*Job*: ${CIRCLE_JOB}"
+                    "text": "*Job*: <${CIRCLE_BUILD_URL}|${CIRCLE_JOB}>"
                   },
                   {
                     "type": "mrkdwn",


### PR DESCRIPTION
## Description

The CircleCI Slack-failure notification puts the build URL only in a "View Job" button (an `actions` block). The button works in the Slack UI, but **a bot fetching the message via the Slack Web API cannot extract the URL** — `actions` blocks get stripped/transformed on `conversations.history` calls, so the URL is gone by the time downstream tooling sees the JSON.

Context: We are experimenting with a bot that would pick such failures, analyze them, and attempt to fix them.

This PR puts the build URL into the message body itself, so it survives any API round-trip:

- Before: `*Job*: ${CIRCLE_JOB}` (plain text, URL only in the button)
- After: `*Job*: <${CIRCLE_BUILD_URL}|${CIRCLE_JOB}>` (mrkdwn link inside a `section` block — extractable from the API response with a simple regex like `<(https://circleci\.com/[^|>]+)\|`)

The "View Job" button is kept as-is for humans clicking in the Slack UI.

## Code review notes

_N/A_

## QA notes

Tested live on a throwaway branch (`test/slack-build-url`) that forced `static_analysis` to fail. The failure message was posted to `#mailpoet-dev-feeds` with the new format; screenshots below. The throwaway branch is not merged.

To re-verify after merge, the next real trunk/release failure should:

- Show the job name as a clickable link in the Slack message body
- Still render the "View Job" button
- Return the build URL inside the section's `text` field when fetched via `conversations.history`

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="705" height="162" alt="Screenshot 2026-05-26 at 15 06 36" src="https://github.com/user-attachments/assets/95da9ad0-6409-46c4-afa9-a82ebfdf093e" /> | <img width="825" height="163" alt="Screenshot 2026-05-26 at 14 50 27" src="https://github.com/user-attachments/assets/a586684f-8f98-4c92-8f2f-9d67c960675e" />|

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/circleci-slack-failure-include-build-url)

_The latest successful build from `update/circleci-slack-failure-include-build-url` will be used. If none is available, the link won't work._