### PR TITLE
Force Action Scheduler DB store in tests_env

### DIFF
--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -59,6 +59,21 @@ wp core version
 echo "TEST RUNNER PHP VERSION:"
 php --version
 
+# Force Action Scheduler to use the DB store. Tests deactivate WC often, which
+# wipes the migration_status option and reverts AS to the HybridStore — whose
+# claim path races on the legacy wpPostStore when async queue-runner requests
+# overlap during a test ("Unable to claim actions. Database error.").
+mkdir -p /wp-core/wp-content/mu-plugins
+cat > /wp-core/wp-content/mu-plugins/mailpoet-test-action-scheduler-store.php <<'PHP'
+<?php
+add_filter('action_scheduler_store_class', static function () {
+    return 'ActionScheduler_DBStore';
+}, 200);
+add_filter('action_scheduler_logger_class', static function () {
+    return 'ActionScheduler_DBLogger';
+}, 200);
+PHP
+
 # Load Composer dependencies
 # Set SKIP_DEPS environment flag to not download them. E.g. you have downloaded them yourself
 # Example: docker compose run -e SKIP_DEPS=1 codeception ...


### PR DESCRIPTION
## Description

This PR prevents `RuntimeException: Unable to claim actions. Database error.` we were occasionally getting in acceptance tests ([e.g. build 414073](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/23576/workflows/c221e712-fea6-4f10-9577-127becce62f7):).

The Action Scheduler sometimes attempts to use the legacy wpPostStore because we deactivate Woo and AutomateWoo plugins quite often, and that deactivation deletes the `migration_complete` option, which causes the ActionScheduler to attempt to use the wrong store in a parallel request, and we got a logged error. 

Fixed by adding a filter that forces Action Scheduler to use the correct store even when migration is marked as not completed.

We can't simply mark migration completed because plugin deactivation wipes that, and we would have to do that over and over.

## Code review notes

The filter priority is 200 to beat both `DataController::set_store_class` (100, when migration is complete) and `Migration\Controller::get_store_class` (100, during migration). 

## QA notes

_N/A_


## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/action-scheduler-migration-in-tests-bootstrap)

_The latest successful build from `fix/action-scheduler-migration-in-tests-bootstrap` will be used. If none is available, the link won't work._