### PR TITLE
Prepare MailPoet types for React 19

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/automation/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/index.tsx
@@ -44,7 +44,7 @@ export function Automation({
   });
 
   // handle automation scrolling, dragging, and horizontal scroll centering
-  const automationRef = useRef<HTMLDivElement>();
+  const automationRef = useRef<HTMLDivElement | null>(null);
   useAutomationScroll(scroll ? automationRef : undefined);
   useAutomationScrollCenter(automationRef);
   useAutomationDragToScroll(drag ? automationRef : undefined);

--- a/mailpoet/assets/js/src/automation/editor/components/automation/use-automation-drag-to-scroll.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/use-automation-drag-to-scroll.ts
@@ -1,10 +1,10 @@
-import { MutableRefObject, useEffect, useRef } from 'react';
+import { type RefObject, useEffect, useRef } from 'react';
 
 // Handle automation dragging to move the flow in a drag-to-scroll fashion.
 // Use animation frames to sync with browser repaints for smooth scrolling.
 // This handles mouse & trackpad. On touch devices, the drag runs natively.
 export const useAutomationDragToScroll = (
-  automationRef?: MutableRefObject<HTMLDivElement>,
+  automationRef?: RefObject<HTMLDivElement | null>,
 ): void => {
   // Using a ref here is crucial to avoid re-rendering the component tree
   // on every mouse move event. The event handlers must not modify state.

--- a/mailpoet/assets/js/src/automation/editor/components/automation/use-automation-scroll-center.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/use-automation-scroll-center.ts
@@ -1,7 +1,7 @@
-import { MutableRefObject, useEffect, useState } from 'react';
+import { type RefObject, useEffect, useState } from 'react';
 
 export const useAutomationScrollCenter = (
-  automationRef: MutableRefObject<HTMLDivElement>,
+  automationRef: RefObject<HTMLDivElement | null>,
 ) => {
   // We need to trigger one more render to center the scroll, because the sidebar
   // is using a React Portal, and it is not in the layout after the first render.

--- a/mailpoet/assets/js/src/automation/editor/components/automation/use-automation-scroll.ts
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/use-automation-scroll.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useEffect } from 'react';
+import { type RefObject, useEffect } from 'react';
 
 const findClosestScrollable = (element: HTMLElement): HTMLElement | null => {
   const style = window.getComputedStyle(element);
@@ -20,7 +20,7 @@ const findClosestScrollable = (element: HTMLElement): HTMLElement | null => {
 // Handle automation scrolling, including both X and Y axes simultaneously.
 // Use animation frames to sync with browser repaints for smooth scrolling.
 export const useAutomationScroll = (
-  automationRef?: MutableRefObject<HTMLDivElement>,
+  automationRef?: RefObject<HTMLDivElement | null>,
 ): void =>
   useEffect(() => {
     const automation = automationRef?.current;

--- a/mailpoet/assets/js/src/common/tabs/routed-tabs.tsx
+++ b/mailpoet/assets/js/src/common/tabs/routed-tabs.tsx
@@ -1,4 +1,4 @@
-import { Children, ReactElement } from 'react';
+import { Children } from 'react';
 import {
   BrowserRouter,
   HashRouter,
@@ -11,7 +11,7 @@ import {
 } from 'react-router-dom';
 import { noop } from 'lodash';
 
-import { Props as TabProps, Tabs } from './tabs';
+import { isTabElement, type Props as TabProps, Tabs } from './tabs';
 
 function RouterAwareTabs(
   props: TabProps & {
@@ -57,12 +57,18 @@ function RoutedTabs({
   children,
 }: Props) {
   const keyPathMap: { [key: string]: string } = {};
-  Children.map(children, (child: ReactElement) => {
-    if (child) {
-      keyPathMap[child.key] = `${routerPrefix}${
-        child.props.route || child.key
-      }`;
+  Children.forEach(children, (child) => {
+    if (!child) {
+      return;
     }
+
+    if (!isTabElement(child)) {
+      throw new Error(
+        'Child components of <RoutedTabs> must be instances of <Tab>',
+      );
+    }
+
+    keyPathMap[child.key] = `${routerPrefix}${child.props.route || child.key}`;
   });
 
   if (!keyPathMap[activeKey]) {

--- a/mailpoet/assets/js/src/common/tabs/tab.tsx
+++ b/mailpoet/assets/js/src/common/tabs/tab.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 
 /* eslint-disable react/no-unused-prop-types -- all properties are used in the Tabs component */
-type Props = {
+export type TabProps = {
   title?: string;
   iconStart?: JSX.Element;
   iconEnd?: JSX.Element;
@@ -11,6 +11,6 @@ type Props = {
   className?: string;
 };
 
-export function Tab({ children }: Props) {
+export function Tab({ children }: TabProps) {
   return <>{children}</>;
 }

--- a/mailpoet/assets/js/src/common/tabs/tabs.tsx
+++ b/mailpoet/assets/js/src/common/tabs/tabs.tsx
@@ -2,24 +2,29 @@ import classnames from 'classnames';
 import {
   Children,
   isValidElement,
-  ReactElement,
+  type ReactElement,
   ReactNode,
   useEffect,
   useState,
 } from 'react';
 import { noop } from 'lodash';
 
-import { Tab } from './tab';
+import { Tab, type TabProps } from './tab';
 
-const validateChildren = (children: ReactNode): ReactElement[] => {
-  const keys = {};
-  const validChildren: ReactElement[] = [];
-  Children.map(children, (child: ReactElement) => {
+type TabElement = ReactElement<TabProps, typeof Tab>;
+
+const isTabElement = (child: ReactNode): child is TabElement =>
+  isValidElement<TabProps>(child) && child.type === Tab;
+
+const validateChildren = (children: ReactNode): TabElement[] => {
+  const keys: Record<string, boolean> = {};
+  const validChildren: TabElement[] = [];
+  Children.forEach(children, (child) => {
     if (!child) {
       return;
     }
 
-    if (child.type !== Tab) {
+    if (!isTabElement(child)) {
       throw new Error('Child components of <Tabs> must be instances of <Tab>');
     }
 
@@ -40,8 +45,8 @@ const validateChildren = (children: ReactNode): ReactElement[] => {
 
 const getActiveChild = (
   activeTab: string,
-  children: ReactElement[],
-): ReactElement => {
+  children: TabElement[],
+): TabElement => {
   const activeChild = children.find(
     (child) => isValidElement(child) && child.key === activeTab,
   );
@@ -83,11 +88,15 @@ export function Tabs({
   const validChildren = validateChildren(children);
   const activeChild = getActiveChild(activeTab, validChildren);
 
-  const title = (props) => (
+  const renderTitle = ({
+    iconStart,
+    title: tabTitle,
+    iconEnd,
+  }: TabProps): JSX.Element => (
     <>
-      {props.iconStart}
-      {props.title && <span data-title={props.title}>{props.title}</span>}
-      {props.iconEnd}
+      {iconStart}
+      {tabTitle && <span data-title={tabTitle}>{tabTitle}</span>}
+      {iconEnd}
     </>
   );
 
@@ -97,7 +106,7 @@ export function Tabs({
       data-automation-id={automationId}
     >
       <div className="components-tab-panel__tabs">
-        {validChildren.map((child: ReactElement) => (
+        {validChildren.map((child) => (
           <button
             key={child.key}
             className={classnames(
@@ -111,7 +120,7 @@ export function Tabs({
             onClick={() => switchTab(child.key.toString())}
             data-automation-id={child.props.automationId}
           >
-            {title(child.props)}
+            {renderTitle(child.props)}
           </button>
         ))}
       </div>
@@ -122,3 +131,4 @@ export function Tabs({
 }
 
 export type { Props };
+export { isTabElement };

--- a/mailpoet/assets/js/src/common/tag/tags.tsx
+++ b/mailpoet/assets/js/src/common/tag/tags.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Tag, TagVariant } from './tag';
 import { Tooltip } from '../tooltip/tooltip';
@@ -55,33 +55,38 @@ function Tags({ children, tags, dimension, variant, isInverted }: TagProps) {
     <div className="mailpoet-tags">
       {children}
       {tags.map((item) => {
-        const tag = (
+        const renderTag = (
+          tooltipAttributes: {
+            'data-tip'?: boolean;
+            'data-tooltip-id'?: string;
+          } = {},
+        ) => (
           <Tag
             key={item.name}
             dimension={dimension}
             variant={variant || 'list'}
             isInverted={isInverted}
+            {...tooltipAttributes}
           >
             {item.name}
           </Tag>
         );
         if (!item.target) {
           if (!item.tooltip) {
-            return tag;
+            return renderTag();
           }
           const randomId = Math.random().toString(36).substring(2, 15);
           const tooltipId = `tag-tooltip-${randomId}`;
-          const tagWithTooltip = React.cloneElement(tag, {
-            'data-tip': true,
-            'data-tooltip-id': tooltipId,
-          });
 
           return (
             <div key={randomId}>
               <Tooltip id={tooltipId} place="top">
                 {item.tooltip}
               </Tooltip>
-              {tagWithTooltip}
+              {renderTag({
+                'data-tip': true,
+                'data-tooltip-id': tooltipId,
+              })}
             </div>
           );
         }
@@ -97,7 +102,7 @@ function Tags({ children, tags, dimension, variant, isInverted }: TagProps) {
               </Tooltip>
             )}
             <a data-tip="" data-tooltip-id={tooltipId} href={item.target}>
-              {tag}
+              {renderTag()}
             </a>
           </div>
         );


### PR DESCRIPTION
## Description

Prepare the MailPoet React/TypeScript code highlighted in the React 19 audit for stricter React 19 typings.

This updates tab child element typing, avoids cloning tag elements for tooltip attributes, and switches automation editor refs to nullable `RefObject` types.

## Code review notes

This is a type-compatibility follow-up for the React 19 audit. The audit did not identify MailPoet legacy DOM render API usage, so this PR only targets the type-sensitive patterns it called out.

## QA notes

Smoke test tab navigation in MailPoet admin pages that use `Tabs` or `RoutedTabs`, such as Help or Settings.

Check list/tag rendering where tooltips are shown and verify the tooltip target still appears on hover.

Open the automation editor and verify wheel scrolling, drag-to-scroll, and initial centering still work.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/react-19-mailpoet-types)

_The latest successful build from `update/react-19-mailpoet-types` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The PR successfully implements React 19 type compatibility updates across all modified files:

**Automation Editor** - The ref handling correctly uses `RefObject<HTMLDivElement | null>` across all three hooks (`useAutomationScroll`, `useAutomationScrollCenter`, `useAutomationDragToScroll`). Each hook safely accesses the ref via optional chaining (`automationRef?.current`), with proper dependency array handling in useEffect calls.

**Tabs Component** - Implements strong type safety with a `TabElement` type alias and exported `isTabElement` type guard. The `validateChildren` function properly validates children as Tab instances and returns a strongly-typed `TabElement[]` array. All subsequent operations use the validated typed children.

**Tab Component** - Correctly exports the `TabProps` type for external consumption by other components like `RoutedTabs`.

**RoutedTabs Component** - Properly leverages the exported `isTabElement` type guard to validate child components before accessing their properties, with explicit error messages for validation failures.

**Tags Component** - Successfully removes the `React.cloneElement` dependency by introducing a clean `renderTag` helper function that accepts optional tooltip attributes and applies them via spread syntax, maintaining all existing functionality while improving React 19 compatibility.

All changes maintain backward compatibility, include proper null checks and type guards, and follow TypeScript and React best practices. No type-suppression comments are needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6798?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->