### PR TITLE
Honor Styles in Sign-up Confirmation email

### DIFF
--- a/mailpoet/changelog/2026-05-28-08-51-10-fixed-sign-up-confirmation-email-template-now-respects-s.md
+++ b/mailpoet/changelog/2026-05-28-08-51-10-fixed-sign-up-confirmation-email-template-now-respects-s.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Sign-up Confirmation email template now respects Styles sidebar settings for content background, text color, and font

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -202,7 +202,7 @@ class Renderer {
     foreach ($styles as $selector => $style) {
       switch ($selector) {
         case 'text':
-          $selector = 'td.mailpoet_paragraph, td.mailpoet_blockquote, li.mailpoet_paragraph';
+          $selector = 'td.mailpoet_paragraph, td.mailpoet_blockquote, li.mailpoet_paragraph, td.mailpoet_footer';
           break;
         case 'body':
           $selector = 'body, .mailpoet-wrapper';

--- a/mailpoet/lib/Subscribers/ConfirmationEmailTemplate/template-confirmation.json
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailTemplate/template-confirmation.json
@@ -14,7 +14,7 @@
           "columnLayout": false,
           "orientation": "horizontal",
           "image": { "src": null, "display": "scale" },
-          "styles": { "block": { "backgroundColor": "#ffffff" } },
+          "styles": { "block": { "backgroundColor": "transparent" } },
           "blocks": [
             {
               "type": "container",
@@ -49,7 +49,7 @@
           "columnLayout": false,
           "orientation": "horizontal",
           "image": { "src": null, "display": "scale" },
-          "styles": { "block": { "backgroundColor": "#ffffff" } },
+          "styles": { "block": { "backgroundColor": "transparent" } },
           "blocks": [
             {
               "type": "container",
@@ -107,8 +107,6 @@
                   "styles": {
                     "block": { "backgroundColor": "transparent" },
                     "text": {
-                      "fontColor": "#222222",
-                      "fontFamily": "Verdana",
                       "fontSize": "10px",
                       "textAlign": "left"
                     },

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailCustomizerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailCustomizerTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Subscribers;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\Util\pQuery\pQuery;
 
 class ConfirmationEmailCustomizerTest extends \MailPoetTest {
 
@@ -110,6 +111,27 @@ class ConfirmationEmailCustomizerTest extends \MailPoetTest {
     verify($renderedContent['html'])->stringContainsString($this->partialTemplateContent);
     verify($renderedContent['text'])->stringContainsString($this->partialTemplateContent);
     verify($renderedContent['subject'])->stringContainsString($subject);
+  }
+
+  public function testItRendersDefaultTemplateWithGlobalContentAndFooterStyles() {
+    $controller = $this->generateController();
+    $newsletter = $controller->getNewsletter();
+    $body = $newsletter->getBody();
+    $body['globalStyles']['wrapper']['backgroundColor'] = '#f0e1d2';
+    $body['globalStyles']['text']['fontColor'] = '#b00020';
+    $body['globalStyles']['text']['fontFamily'] = 'Permanent Marker';
+    $newsletter->setBody($body);
+
+    $renderedContent = (array)$controller->render($newsletter);
+    $html = $renderedContent['html'];
+    $DOM = (new pQuery())->parseStr($html);
+    $contentWrapperStyle = $DOM('table.mailpoet_content-wrapper', 0)->attr('style');
+    $footerStyle = $DOM('td.mailpoet_footer', 0)->attr('style');
+
+    verify($contentWrapperStyle)->stringContainsString('background-color:#f0e1d2');
+    verify($footerStyle)->stringContainsString('color:#b00020');
+    verify($footerStyle)->stringContainsString('Permanent Marker');
+    verify($html)->stringNotContainsString('background-color:#ffffff!important');
   }
 
   private function generateController(): ConfirmationEmailCustomizer {

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailCustomizerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailCustomizerTest.php
@@ -125,8 +125,8 @@ class ConfirmationEmailCustomizerTest extends \MailPoetTest {
     $renderedContent = (array)$controller->render($newsletter);
     $html = $renderedContent['html'];
     $DOM = (new pQuery())->parseStr($html);
-    $contentWrapperStyle = $DOM('table.mailpoet_content-wrapper', 0)->attr('style');
-    $footerStyle = $DOM('td.mailpoet_footer', 0)->attr('style');
+    $contentWrapperStyle = $DOM->query('table.mailpoet_content-wrapper')->attr('style');
+    $footerStyle = $DOM->query('td.mailpoet_footer')->attr('style');
 
     verify($contentWrapperStyle)->stringContainsString('background-color:#f0e1d2');
     verify($footerStyle)->stringContainsString('color:#b00020');

--- a/mailpoet/views/newsletter/templates/components/styles.hbs
+++ b/mailpoet/views/newsletter/templates/components/styles.hbs
@@ -1,6 +1,8 @@
 <style type="text/css">
     .mailpoet_text_block .mailpoet_content,
-    .mailpoet_text_block .mailpoet_content p {
+    .mailpoet_text_block .mailpoet_content p,
+    .mailpoet_footer_block .mailpoet_content,
+    .mailpoet_footer_block .mailpoet_content p {
         color: {{ text.fontColor }};
         font-size: {{ text.fontSize }};
         font-family: {{fontWithFallback text.fontFamily }};


### PR DESCRIPTION
## Description

Fixes [STOMAIL-8105](https://linear.app/a8c/issue/STOMAIL-8105). In MailPoet → Settings → Sign-up Confirmation → "Open template editor", three Styles sidebar settings were silently ignored on the Sign-up Confirmation template:

- **Content Background** — preview and sent email always rendered with a white content area regardless of the selected color.
- **Text color** — the footer paragraph ("If you have received this email in error…") kept its hardcoded color.
- **Text font** — the same footer paragraph kept its hardcoded font.

Body text honored both Text color and Text font correctly; only the footer was stuck.

### Root cause

- The confirmation template (`template-confirmation.json`) had two container blocks with `styles.block.backgroundColor: "#ffffff"`. `Columns/Renderer::getBackgroundCss()` emits these as inline `background-color:#ffffff !important` on the inner `<td class="mailpoet_content">`, which overrode the wrapper rule from the user's chosen Content Background.
- The same template's footer block hardcoded `text.fontColor` and `text.fontFamily`. Those won via inline style over any cascade.
- Removing the footer's local overrides was not enough on its own: the editor's global text rule (`views/newsletter/templates/components/styles.hbs`) only targeted `.mailpoet_text_block`, and the PHP renderer's global text selector (`Renderer.php`) only targeted `td.mailpoet_paragraph, td.mailpoet_blockquote, li.mailpoet_paragraph`. The footer block's class (`mailpoet_footer_block` in the canvas, `td.mailpoet_footer` in the sent email) was not covered by either rule, so global Text never reached the footer.

### Fix

- `template-confirmation.json` — switch both white container `backgroundColor` values to `"transparent"`; drop the hardcoded `fontColor`/`fontFamily` from the footer block (keep `fontSize: 10px` and `textAlign: left`, which are intentionally footer-specific).
- `views/newsletter/templates/components/styles.hbs` — add `.mailpoet_footer_block .mailpoet_content` to the global text rule so the editor canvas cascades global Text into the footer.
- `lib/Newsletter/Renderer/Renderer.php` — add `td.mailpoet_footer` to the global text CSS selector so the PHP-rendered (and sent) email cascades global Text into the footer.

## Code review notes

- The fix touches both render pipelines: the **editor canvas** uses Handlebars templates in `views/newsletter/templates/`, the **sent email** (and the editor's "Preview" button) uses the PHP `Renderer` class. Both needed the global text selector expanded.
- The new global selectors (`.mailpoet_footer_block` and `td.mailpoet_footer`) are deliberately low-specificity. Templates that explicitly set local `fontFamily`/`fontColor` on their footer (which is what the Footer block's JS model defaults to) still win via source order — the local `<style>` block in `views/.../blocks/footer/block.hbs` is emitted after the global one. So this should not change behavior for any existing template that hasn't explicitly opted out of the local override.
- The new fallback also relies on the footer's local CSS emitting empty values (`color: ;`, `font-family: ;`) when the model has no local font/color, so browsers discard those declarations and the global rule wins. Verified: with the template change applied, the Footer model's `_getDefaults` merge (shallow `$.extend`) does not refill missing keys when the template provides a partial `styles.text`.

## QA notes

To reproduce the bug on `trunk`:

1. MailPoet → Settings → Sign-up Confirmation.
2. Enable "Enable visual subscription confirmation emails".
3. Open template editor → sidebar → Styles.
4. Set Content Background to any non-white color → email body stays white.
5. Set Text → font to "Permanent Marker" (or any non-Verdana) → body changes, footer paragraph stays Verdana.
6. Set Text → color to red → body changes, footer paragraph stays `#222222`.

To verify the fix:

- **Fresh init path** (most common — new users / first enable): Delete the persisted customizer newsletter and reset the saved ID so the template is read fresh from the JSON file:
  ```bash
  pnpm wp eval 'global $wpdb; $wpdb->delete($wpdb->prefix . "mailpoet_newsletters", ["type" => "confirmation_email"]);'
  pnpm wp eval 'require_once WP_PLUGIN_DIR . "/mailpoet/mailpoet.php"; MailPoet\DI\ContainerWrapper::getInstance()->get(MailPoet\Settings\SettingsController::class)->set("signup_confirmation.transactional_email_id", false);'
  ```
  Reopen the template editor and repeat steps 4–6. Content background, footer color, and footer font should all follow the global Styles selection in both the editor canvas and the sent email.
- **Sent-email path**: with custom Styles applied in the editor, trigger a sign-up so a confirmation email is sent. The Mailpit-captured (or actually received) email should reflect the same colors and font on both the body and the footer.

Automated coverage already in tree continues to pass: `FooterTest` (6 tests), `Newsletter/RendererTest` (43 tests, 175 assertions), `Subscribers/ConfirmationEmailCustomizerTest` (8 tests).

## Linked PRs

_N/A_

## Linked tickets

- [STOMAIL-8105](https://linear.app/a8c/issue/STOMAIL-8105/design-css-bugs-in-confirmation-email-template)

## After-merge notes

Existing users who already have a saved confirmation customizer newsletter will keep the old persisted body (with the white container backgrounds and the hardcoded footer styles) because `ConfirmationEmailCustomizer::fetchEmailTemplate()` only reads the JSON file on first init. The fix is correct for new installs and any user who hasn't yet enabled visual confirmation emails. For existing users we should consider one of:

- A one-time migration that updates the persisted `confirmation_email` newsletter body to match the fixed template (cleanest for affected users, but writes to user data).
- A "reset to default" affordance in the editor UI so users can opt in (lower risk, requires user action).
- A release-note line directing affected users to delete & re-enable.

Flagging here for product/triage rather than bundling into this PR.

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8105-confirmation-email-background-and-footer-font)

_The latest successful build from `fix/stomail-8105-confirmation-email-background-and-footer-font` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->