### PR TITLE
Remove duplicate subscriber trash actions

### DIFF
--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -1016,8 +1016,7 @@ function SubscriberList() {
       {
         id: 'trash',
         label: __('Move to trash', 'mailpoet'),
-        context: 'single',
-        supportsBulk: false,
+        supportsBulk: true,
         isEligible: () => group !== 'trash',
         callback: (targets) => {
           void handleBulkAction('trash', targets);
@@ -1026,8 +1025,7 @@ function SubscriberList() {
       {
         id: 'restore',
         label: __('Restore', 'mailpoet'),
-        context: 'single',
-        supportsBulk: false,
+        supportsBulk: true,
         isEligible: () => group === 'trash',
         callback: (targets) => {
           void handleBulkAction('restore', targets);
@@ -1036,12 +1034,11 @@ function SubscriberList() {
       {
         id: 'delete',
         label: __('Delete permanently', 'mailpoet'),
-        context: 'single',
-        supportsBulk: false,
+        supportsBulk: true,
         isDestructive: true,
         isEligible: (item) => group === 'trash' && isItemDeletable(item),
         callback: (targets) => {
-          void handleBulkAction('delete', targets);
+          void handleBulkAction('delete', targets.filter(isItemDeletable));
         },
       },
       {
@@ -1112,37 +1109,6 @@ function SubscriberList() {
         supportsBulk: true,
         isEligible: () => group !== 'trash',
         callback: (targets) => openPendingAction('removeTag', targets),
-      },
-      {
-        id: 'bulkTrash',
-        label: __('Move to trash', 'mailpoet'),
-        context: 'list',
-        supportsBulk: true,
-        isEligible: () => group !== 'trash',
-        callback: (targets) => {
-          void handleBulkAction('trash', targets);
-        },
-      },
-      {
-        id: 'bulkRestore',
-        label: __('Restore', 'mailpoet'),
-        context: 'list',
-        supportsBulk: true,
-        isEligible: () => group === 'trash',
-        callback: (targets) => {
-          void handleBulkAction('restore', targets);
-        },
-      },
-      {
-        id: 'bulkDelete',
-        label: __('Delete permanently', 'mailpoet'),
-        context: 'list',
-        supportsBulk: true,
-        isDestructive: true,
-        isEligible: (item) => group === 'trash' && isItemDeletable(item),
-        callback: (targets) => {
-          void handleBulkAction('delete', targets.filter(isItemDeletable));
-        },
       },
     ],
     [

--- a/mailpoet/changelog/2026-05-28-09-36-07-fixed-remove-duplicate-move-to-trash-actions-from-the-su.md
+++ b/mailpoet/changelog/2026-05-28-09-36-07-fixed-remove-duplicate-move-to-trash-actions-from-the-su.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Remove duplicate Move to trash actions from the Subscribers page


### PR DESCRIPTION
## Description

Removes duplicate destructive row actions from the Subscribers DataViews action menu while keeping the same actions available for bulk selections.

## Code review notes

DataViews does not use the action `context` value to filter row menus. The shared trash, restore, and delete actions now support bulk selection directly so each operation is defined once.

## QA notes

1. Open MailPoet > Subscribers.
2. Open a subscriber row Actions menu and confirm Move to trash appears once.
3. Select a subscriber and confirm the bulk toolbar still shows Move to trash.
4. Move a subscriber to trash, open the Trash tab, and confirm Restore and Delete permanently appear once.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8110

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="213" height="422" alt="Screenshot 2026-05-28 at 12 20 27" src="https://github.com/user-attachments/assets/0443498a-ae9b-4ef2-bbc4-c767f864986a" />


## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8110-duplicate-trash-actions)

_The latest successful build from `fix/stomail-8110-duplicate-trash-actions` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**1 issue found**

**Category: Suggestion**

The delete action consolidation introduces defensive filtering (`targets.filter(isItemDeletable)`) at execution time, but provides no user feedback if selected subscribers are silently excluded from deletion. While the `isEligible` callback should prevent ineligible items from being selected initially, the filtering at execution time could mask cases where subscriber eligibility changes between selection and action execution. The user sees 5 subscribers selected but only 3 get deleted without notification of the 2 that were excluded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->