### PR TITLE
Ensure WooCommerce dummy objects in preview are non-persistable

### DIFF
--- a/mailpoet/changelog/2026-06-02-14-55-56-fixed-prevent-the-email-preview-from-overwriting-or-read.md
+++ b/mailpoet/changelog/2026-06-02-14-55-56-fixed-prevent-the-email-preview-from-overwriting-or-read.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Prevent the email preview from overwriting or reading from an existing order whose id collides with the preview dummy order id

--- a/mailpoet/lib/Newsletter/Preview/WooCommerceDummyData.php
+++ b/mailpoet/lib/Newsletter/Preview/WooCommerceDummyData.php
@@ -29,10 +29,20 @@ class WooCommerceDummyData {
     }
 
     try {
+      // Keep the id at 0 so the order can't read from or write to a real order;
+      // get_order_number() provides the display number.
       $order = new class extends \WC_Order {
         use NonPersistablePreviewData;
+
+        public function get_order_number() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- overrides WC_Order::get_order_number().
+          return '12345';
+        }
+
+        /** @return array<int, \stdClass> */
+        public function get_customer_order_notes() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- overrides WC_Order::get_customer_order_notes(), at id 0 the parent would return every order note on the site.
+          return [];
+        }
       };
-      $order->set_id(12345);
 
       $this->setOrderAddress($order);
       $this->addOrderItems($order);

--- a/mailpoet/lib/Newsletter/Preview/WooCommerceDummyData.php
+++ b/mailpoet/lib/Newsletter/Preview/WooCommerceDummyData.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Newsletter\Preview;
 
+use MailPoet\WooCommerce\NonPersistablePreviewData;
 use MailPoet\WP\Functions as WPFunctions;
 
 /**
@@ -28,7 +29,9 @@ class WooCommerceDummyData {
     }
 
     try {
-      $order = new \WC_Order();
+      $order = new class extends \WC_Order {
+        use NonPersistablePreviewData;
+      };
       $order->set_id(12345);
 
       $this->setOrderAddress($order);
@@ -53,7 +56,9 @@ class WooCommerceDummyData {
 
     try {
       $address = $this->getAddress();
-      $customer = new \WC_Customer();
+      $customer = new class extends \WC_Customer {
+        use NonPersistablePreviewData;
+      };
       $customer->set_id(0);
 
       // Set basic info
@@ -220,7 +225,9 @@ class WooCommerceDummyData {
     }
 
     // Fallback: create default dummy product
-    $product = new \WC_Product();
+    $product = new class extends \WC_Product {
+      use NonPersistablePreviewData;
+    };
     $product->set_name(__('Dummy Product', 'woocommerce'));
     $product->set_price('25');
 
@@ -243,7 +250,9 @@ class WooCommerceDummyData {
     }
 
     // Fallback: create default dummy variation
-    $variation = new \WC_Product_Variation();
+    $variation = new class extends \WC_Product_Variation {
+      use NonPersistablePreviewData;
+    };
     $variation->set_name(__('Dummy Product Variation', 'woocommerce'));
     $variation->set_price('20');
 

--- a/mailpoet/lib/WooCommerce/NonPersistablePreviewData.php
+++ b/mailpoet/lib/WooCommerce/NonPersistablePreviewData.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use MailPoet\Logging\LoggerFactory;
+
+/**
+ * Makes an in-memory WooCommerce data object (order, customer, product, ...)
+ * safe to use as email or automation preview sample data.
+ *
+ * Preview helpers assign the object a placeholder ID (e.g. 12345) so templates
+ * render realistic content. Without this trait two things go wrong if a hook or
+ * integration touches the object while the preview renders:
+ *
+ *  - save() / save_meta_data() / delete() treat the placeholder ID as an
+ *    existing record and overwrite or remove the real order/customer 12345.
+ *  - read_meta_data() lazy-loads the real record's meta from the database,
+ *    leaking it into the preview.
+ *
+ * Mixing this trait into a thin subclass of the WooCommerce type turns those
+ * operations into safe no-ops.
+ */
+trait NonPersistablePreviewData {
+  // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- declares the WC_Data::get_id() dependency.
+  abstract public function get_id();
+
+  /**
+   * @return int|string The placeholder ID; nothing is written to the database.
+   */
+  public function save() {
+    $this->logPreviewPersistAttempt('save');
+    return $this->get_id();
+  }
+
+  public function save_meta_data() { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- overrides WC_Data::save_meta_data().
+    $this->logPreviewPersistAttempt('save_meta_data');
+  }
+
+  /**
+   * @param bool $forceDelete
+   * @return bool Always false; preview data is never removed from the database.
+   */
+  public function delete($forceDelete = false) {
+    $this->logPreviewPersistAttempt('delete');
+    return false;
+  }
+
+  /**
+   * Prevents lazy-loading the real record's meta for the placeholder ID.
+   *
+   * @param bool $forceRead
+   */
+  public function read_meta_data($forceRead = false) { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- overrides WC_Data::read_meta_data().
+    if (!is_array($this->meta_data)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      $this->meta_data = []; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    }
+  }
+
+  private function logPreviewPersistAttempt(string $method): void {
+    try {
+      LoggerFactory::getInstance()->getLogger(LoggerFactory::TOPIC_EMAIL_EDITOR)->error(
+        sprintf(
+          'Blocked %s() on preview-only WooCommerce data (%s, ID %s). An integration tried to persist email-preview sample data.',
+          $method,
+          static::class,
+          (string)$this->get_id()
+        )
+      );
+    } catch (\Throwable $e) {
+      // Ignore: logging failures must not affect preview rendering.
+    }
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Preview/WooCommerceDummyDataTest.php
+++ b/mailpoet/tests/integration/Newsletter/Preview/WooCommerceDummyDataTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Preview;
+
+class WooCommerceDummyDataTest extends \MailPoetTest {
+  /** @var WooCommerceDummyData */
+  private $dummyData;
+
+  public function _before() {
+    parent::_before();
+    if (!class_exists(\WC_Order::class)) {
+      $this->markTestSkipped('WooCommerce is not active.');
+    }
+    $this->dummyData = $this->diContainer->get(WooCommerceDummyData::class);
+  }
+
+  public function testDummyOrderSaveDoesNotPersistToDatabase(): void {
+    $order = $this->dummyData->getOrder();
+    $this->assertInstanceOf(\WC_Order::class, $order);
+
+    $placeholderId = $order->get_id();
+    $this->assertGreaterThan(0, $placeholderId);
+
+    // save() must be a no-op: it returns the placeholder ID but writes nothing.
+    $this->assertSame($placeholderId, $order->save());
+    $this->assertFalse(wc_get_order($placeholderId));
+  }
+
+  public function testDummyOrderSaveCannotOverwriteARealOrder(): void {
+    $realOrder = $this->tester->createWooCommerceOrder(['billing_email' => 'real-customer@example.com']);
+    $realOrderId = $realOrder->get_id();
+
+    // Simulate a stray preview hook that points the dummy order at a real order
+    // ID and then persists it. Before the fix this overwrote the real order.
+    $dummyOrder = $this->dummyData->getOrder();
+    $this->assertInstanceOf(\WC_Order::class, $dummyOrder);
+    $dummyOrder->set_id($realOrderId);
+    $dummyOrder->set_billing_email('john@company.com');
+    $dummyOrder->set_billing_first_name('John');
+    $dummyOrder->save();
+    $dummyOrder->save_meta_data();
+
+    $reloaded = wc_get_order($realOrderId);
+    $this->assertInstanceOf(\WC_Order::class, $reloaded);
+    $this->assertSame('real-customer@example.com', $reloaded->get_billing_email());
+  }
+
+  public function testDummyOrderDeleteCannotRemoveARealOrder(): void {
+    $realOrder = $this->tester->createWooCommerceOrder(['billing_email' => 'keep-me@example.com']);
+    $realOrderId = $realOrder->get_id();
+
+    $dummyOrder = $this->dummyData->getOrder();
+    $this->assertInstanceOf(\WC_Order::class, $dummyOrder);
+    $dummyOrder->set_id($realOrderId);
+    $this->assertFalse($dummyOrder->delete(true));
+
+    $this->assertInstanceOf(\WC_Order::class, wc_get_order($realOrderId));
+  }
+
+  public function testDummyOrderDoesNotLeakRealOrderMeta(): void {
+    $realOrder = $this->tester->createWooCommerceOrder();
+    $realOrder->update_meta_data('_secret_preview_leak', 'sensitive-value');
+    $realOrder->save();
+    $realOrderId = $realOrder->get_id();
+
+    $dummyOrder = $this->dummyData->getOrder();
+    $this->assertInstanceOf(\WC_Order::class, $dummyOrder);
+    $dummyOrder->set_id($realOrderId);
+
+    // read_meta_data() is neutralised, so meta is never lazy-loaded from the DB.
+    $this->assertSame('', $dummyOrder->get_meta('_secret_preview_leak'));
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Preview/WooCommerceDummyDataTest.php
+++ b/mailpoet/tests/integration/Newsletter/Preview/WooCommerceDummyDataTest.php
@@ -18,12 +18,15 @@ class WooCommerceDummyDataTest extends \MailPoetTest {
     $order = $this->dummyData->getOrder();
     $this->assertInstanceOf(\WC_Order::class, $order);
 
-    $placeholderId = $order->get_id();
-    $this->assertGreaterThan(0, $placeholderId);
+    // The id stays 0 so the order can never touch a real row; the display
+    // number is surfaced through get_order_number() instead.
+    $this->assertSame(0, $order->get_id());
+    $this->assertSame('12345', $order->get_order_number());
 
-    // save() must be a no-op: it returns the placeholder ID but writes nothing.
-    $this->assertSame($placeholderId, $order->save());
-    $this->assertFalse(wc_get_order($placeholderId));
+    // save() must be a no-op: it returns the id (0) and creates no order.
+    $ordersBefore = wc_get_orders(['limit' => -1, 'return' => 'ids']);
+    $this->assertSame(0, $order->save());
+    $this->assertSame($ordersBefore, wc_get_orders(['limit' => -1, 'return' => 'ids']));
   }
 
   public function testDummyOrderSaveCannotOverwriteARealOrder(): void {


### PR DESCRIPTION
## Description

MailPoet's email previews build a fake `WC_Order` with a hardcoded ID (`12345`) and placeholder data. MailPoet never saves it - but if any preview hook or integration calls `save()` on it, WooCommerce treats `12345` as a real order and **overwrites the real order** with the placeholder data. `delete()` could remove a real order, and reading its meta could leak a real order's data.

This makes the preview objects non-persistable, mirroring WooCommerce's fix https://github.com/woocommerce/woocommerce/pull/65407.

- New `NonPersistablePreviewData` trait: `save()`, `save_meta_data()`, `delete()` become no-ops, `read_meta_data()` can't lazy-load real data, and a warning is logged if something tries to persist.
- Applied to the dummy order, customer, product, variation.

Objects still behave like real WC objects for rendering - they just can't write to the database.

## Code review notes

_N/A_

## QA notes

1. Create a new automation with order trigger.
2. Design the email content with the block editor.
3. Add Personalization some tags for Order, Customer, and Products (Order Items) to the email content.
4. Send a test email and confirm the email renders the dummy data correctly.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1084

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8111-prevent-email-preview-dummy-orders-from-mutating-real-orders)

_The latest successful build from `stomail-8111-prevent-email-preview-dummy-orders-from-mutating-real-orders` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

The implementation correctly prevents WooCommerce dummy objects from persisting to the database. While the dummy products and variations do not have explicit IDs set (unlike the order with ID 12345 and customer with ID 0), this is acceptable because:

1. WooCommerce product objects initialize with ID 0 by default when not loaded from the database
2. The `NonPersistablePreviewData` trait blocks all persistence operations (save, save_meta_data, delete) regardless of the ID value
3. The logging in `logPreviewPersistAttempt()` is wrapped in a try-catch that swallows any errors, so incomplete ID logging won't break preview rendering
4. The comprehensive test suite validates that the trait prevents persistence, blocks overwrites to real objects, prevents deletions, and blocks meta data leakage
5. The implementation mirrors WooCommerce's own fix (PR `#65407`) for this security concern

The code is production-ready within the stated scope, though the PR notes indicate changelog, i18n, tests, and TypeScript considerations remain to be completed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->