### PR TITLE
Fix Unicode public share redirects

### DIFF
--- a/mailpoet/changelog/2026-06-02-08-55-21-fixed-archive-links-for-emails-with-unicode-subject-char.md
+++ b/mailpoet/changelog/2026-06-02-08-55-21-fixed-archive-links-for-emails-with-unicode-subject-char.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Archive links for emails with Unicode subject characters

--- a/mailpoet/lib/Newsletter/Sharing/PublicEmailController.php
+++ b/mailpoet/lib/Newsletter/Sharing/PublicEmailController.php
@@ -59,7 +59,8 @@ class PublicEmailController {
   }
 
   public function isCanonicalIdentifier(string $identifier, NewsletterEntity $newsletter): bool {
-    return $identifier === $this->newsletterUrl->getPublicShareIdentifier($newsletter);
+    return $this->normalizeIdentifierForCanonicalComparison($identifier)
+      === $this->normalizeIdentifierForCanonicalComparison($this->newsletterUrl->getPublicShareIdentifier($newsletter));
   }
 
   public function getCanonicalUrl(NewsletterEntity $newsletter): string {
@@ -72,5 +73,14 @@ class PublicEmailController {
     $html = $this->viewInBrowserRenderer->renderPublicShare($newsletter, $queue);
     $html = $this->shareMetadataBuilder->injectShareToolbar($html, $newsletter, $canonicalUrl);
     return $this->shareMetadataBuilder->injectMetadata($html, $newsletter, $canonicalUrl);
+  }
+
+  private function normalizeIdentifierForCanonicalComparison(string $identifier): string {
+    // Normalize only URL percent-escape hex digits, e.g. %F0 -> %f0.
+    // The slug text remains strict so genuinely stale slugs still redirect.
+    $normalized = preg_replace_callback('/%[0-9A-Fa-f]{2}/', function (array $matches): string {
+      return strtolower($matches[0]);
+    }, $identifier);
+    return is_string($normalized) ? $normalized : $identifier;
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailControllerTest.php
@@ -124,4 +124,25 @@ class PublicEmailControllerTest extends \MailPoetTest {
     $this->diContainer->get(PublicEmailController::class)
       ->getNewsletter($this->diContainer->get(NewsletterUrl::class)->getPublicShareIdentifier($newsletter));
   }
+
+  public function testItTreatsPercentEncodedUnicodeIdentifierAsCanonicalRegardlessOfHexCase() {
+    $newsletter = (new Newsletter())
+      ->withSubject('🌍-s4f-update-03-25')
+      ->withSentStatus()
+      ->withOptions([
+        NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY => ShareVisibility::VISIBILITY_PUBLIC,
+      ])
+      ->create();
+    $newsletterUrl = $this->diContainer->get(NewsletterUrl::class);
+    $identifier = $newsletterUrl->getPublicShareIdentifier($newsletter);
+    $identifierWithUppercaseEscapes = str_replace(
+      ['%f0', '%9f', '%8c', '%8d'],
+      ['%F0', '%9F', '%8C', '%8D'],
+      $identifier
+    );
+
+    verify($identifierWithUppercaseEscapes)->notEquals($identifier);
+    verify($this->diContainer->get(PublicEmailController::class)
+      ->isCanonicalIdentifier($identifierWithUppercaseEscapes, $newsletter))->true();
+  }
 }


### PR DESCRIPTION
## Description

Fixes archive/public share links for emails whose subject slug contains percent-encoded Unicode characters (from emojis). The canonical identifier check now treats equivalent percent-escape casing as the same identifier, preventing redirect loops while preserving redirects for genuinely stale slugs.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8116

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8116-archive-redirect-loop-for-unicode-public-email-slugs)

_The latest successful build from `fix/stomail-8116-archive-redirect-loop-for-unicode-public-email-slugs` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->