### PR TITLE
Update WC tested up to 10.8

### DIFF
--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,7 +11,7 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 10.6
+ * WC requires at least: 10.7
  * WC tested up to: 10.8
  *
  * @package WordPress

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -28,7 +28,7 @@ $mailpoetPlugin = [
 ];
 
 const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.9'; // L-1 version, not the latest
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.6'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.7'; // L-1 version, not the latest
 
 
 // Display WP version error notice

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -12,7 +12,7 @@
  * Domain Path: /lang
  *
  * WC requires at least: 10.6
- * WC tested up to: 10.7
+ * WC tested up to: 10.8
  *
  * @package WordPress
  * @author MailPoet


### PR DESCRIPTION
Bumps the plugin compatibility for WooCommerce 10.8:

- `WC tested up to`: 10.7 → 10.8
- `WC requires at least`: 10.6 → 10.7
- `MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION`: 10.6 → 10.7

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/wc-tested-up-to-10-8)

_The latest successful build from `update/wc-tested-up-to-10-8` will be used. If none is available, the link won't work._