### PR TITLE
Disable performance_latest step in nightly workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1203,15 +1203,18 @@ workflows:
           wordpress_version: 6.9.4
           requires:
             - build
-      - performance_tests:
-          <<: *slack-fail-post-step
-          name: performance_latest
-          url: https://mpperftesting.com
-          us: $WP_TEST_PERFORMANCE_US
-          pw: $WP_TEST_PERFORMANCE_PW
-          scenario: nightlytests
-          requires:
-            - build
+      # Disabled: the performance testing site https://mpperftesting.com is no longer
+      # available (the domain has expired), so this step always fails. Re-enable once a
+      # valid performance testing URL is configured.
+      #      - performance_tests:
+      #          <<: *slack-fail-post-step
+      #          name: performance_latest
+      #          url: https://mpperftesting.com
+      #          us: $WP_TEST_PERFORMANCE_US
+      #          pw: $WP_TEST_PERFORMANCE_PW
+      #          scenario: nightlytests
+      #          requires:
+      #            - build
       - unit_tests:
           <<: *slack-fail-post-step
           name: unit_latest


### PR DESCRIPTION
## Description

The `performance_latest` step in the `nightly` workflow points at `https://mpperftesting.com`, which is no longer reachable — the domain has expired. As a result the step fails on every nightly run (e.g. [this job](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/23614/workflows/51148796-7900-49fa-836a-7d830b115847/jobs/414776)).

This PR comments out the `performance_latest` invocation in the `nightly` workflow so the nightly stops failing. The `performance_tests` job definition is left in place, so the step can be re-enabled by uncommenting the workflow block once a valid performance testing URL is configured.

## Code review notes

Only the workflow invocation is commented out; the reusable `performance_tests` job (and its `./do test:performance` command) is intentionally kept so re-enabling is a one-line uncomment. I checked `.circleci/` and `.github/` — this was the only live performance-test step.

## QA notes

CI-only change. Verify the `nightly` workflow still parses and no longer schedules `performance_latest`.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

Re-enable `performance_latest` once a valid performance testing URL replaces the expired `mpperftesting.com`.

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/disable-performance-nightly-expired-domain)

_The latest successful build from `fix/disable-performance-nightly-expired-domain` will be used. If none is available, the link won't work._