### PR TITLE
Add email content to welcome automation templates

### DIFF
--- a/mailpoet/changelog/2026-06-03-14-00-35-added-email-content-for-welcome-automation-templates.md
+++ b/mailpoet/changelog/2026-06-03-14-00-35-added-email-content-for-welcome-automation-templates.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Email content for welcome automation templates

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -22,7 +22,6 @@ class TemplatesFactory {
   private $woocommerceSubscriptions;
 
   /** @var EmailFactory */
-  /** @phpstan-ignore-next-line Property is reserved for future use */
   private $emailFactory;
 
   /** @var WooCommerceBookingsHelper */
@@ -121,13 +120,22 @@ class TemplatesFactory {
         'Send a welcome email when someone subscribes to your list. Optionally, you can choose to send this email after a specified period.',
         'mailpoet'
       ),
-      function (): Automation {
+      function (bool $preview = false): Automation {
+        $emailArgs = $this->createBlockEditorEmailArgs(
+          $preview,
+          'welcome-email-content',
+          __('Welcome email', 'mailpoet'),
+          __('Welcome to our community!', 'mailpoet'),
+          __('Thanks for subscribing', 'mailpoet'),
+          'subscriber-welcome-email'
+        );
+
         return $this->builder->createFromSequence(
           __('Welcome new subscribers', 'mailpoet'),
           [
             ['key' => 'mailpoet:someone-subscribes'],
             ['key' => 'core:delay', 'args' => ['delay' => 1, 'delay_type' => 'MINUTES']],
-            ['key' => 'mailpoet:send-email'],
+            ['key' => 'mailpoet:send-email', 'args' => $emailArgs],
           ],
           [
             'mailpoet:run-once-per-subscriber' => true,
@@ -819,5 +827,41 @@ class TemplatesFactory {
       AutomationTemplate::TYPE_PREMIUM,
       'calendar'
     );
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function createBlockEditorEmailArgs(
+    bool $preview,
+    string $pattern,
+    string $name,
+    string $subject,
+    string $preheader,
+    string $templateSlug
+  ): array {
+    $args = [
+      'name' => $name,
+      'subject' => $subject,
+      'preheader' => $preheader,
+    ];
+
+    if ($preview) {
+      return $args;
+    }
+
+    $emailIds = $this->emailFactory->createBlockEditorEmail([
+      'pattern' => $pattern,
+      'subject' => $subject,
+      'preheader' => $preheader,
+    ]);
+    if (
+      !is_array($emailIds)
+      || !is_int($emailIds['email_id'] ?? null)
+      || !is_int($emailIds['email_wp_post_id'] ?? null)
+    ) {
+      throw new \RuntimeException(sprintf('Could not create the %s block editor email.', $templateSlug));
+    }
+    return array_merge($args, $emailIds);
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -161,13 +161,22 @@ class TemplatesFactory {
         'Send a welcome email when a new WordPress user registers to your website. Optionally, you can choose to send this email after a specified period.',
         'mailpoet'
       ),
-      function (): Automation {
+      function (bool $preview = false): Automation {
+        $emailArgs = $this->createBlockEditorEmailArgs(
+          $preview,
+          'welcome-email-content',
+          __('Welcome email', 'mailpoet'),
+          __('Welcome to our community!', 'mailpoet'),
+          __('Thanks for joining us', 'mailpoet'),
+          'user-welcome-email'
+        );
+
         return $this->builder->createFromSequence(
           __('Welcome new WordPress users', 'mailpoet'),
           [
             ['key' => 'mailpoet:wp-user-registered'],
             ['key' => 'core:delay', 'args' => ['delay' => 1, 'delay_type' => 'MINUTES']],
-            ['key' => 'mailpoet:send-email'],
+            ['key' => 'mailpoet:send-email', 'args' => $emailArgs],
           ],
           [
             'mailpoet:run-once-per-subscriber' => true,

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EducationalCampaignPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EducationalCampaignPattern.php
@@ -26,14 +26,14 @@ class EducationalCampaignPattern extends Pattern {
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
       <!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: PRODUCT NAME is placeholder text that merchants replace with their own content. */
-      __('How to Get the Most from PRODUCT NAME', 'mailpoet') . '</h1>
+      /* translators: %s: Site title personalization tag */
+      sprintf(__('How to Get the Most from %s', 'mailpoet'), '<!--[mailpoet/site-title]-->') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
-      /* translators: PRODUCT NAME is placeholder text that merchants replace with their own content. */
-      __('Our latest guide walks you through expert tips to make the most out of your PRODUCT NAME.', 'mailpoet') . '</p>
+      /* translators: %s: Site title personalization tag */
+      sprintf(__('Our latest guide walks you through tips to make the most from %s.', 'mailpoet'), '<!--[mailpoet/site-title]-->') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:heading -->
@@ -57,9 +57,9 @@ class EducationalCampaignPattern extends Pattern {
       <!-- /wp:heading -->
 
       <!-- wp:paragraph -->
-      <p>' .
+      <p><em>' .
       /* translators: Placeholder text that merchants replace with their own content. */
-      __('BRIEF DESCRIPTION', 'mailpoet') . '</p>
+      __('Brief description', 'mailpoet') . '</em></p>
       <!-- /wp:paragraph -->
       </div>
       <!-- /wp:column -->
@@ -79,9 +79,9 @@ class EducationalCampaignPattern extends Pattern {
       <!-- /wp:heading -->
 
       <!-- wp:paragraph -->
-      <p>' .
+      <p><em>' .
       /* translators: Placeholder text that merchants replace with their own content. */
-      __('BRIEF DESCRIPTION', 'mailpoet') . '</p>
+      __('Brief description', 'mailpoet') . '</em></p>
       <!-- /wp:paragraph -->
       </div>
       <!-- /wp:column -->
@@ -116,9 +116,9 @@ class EducationalCampaignPattern extends Pattern {
       <!-- /wp:heading -->
 
       <!-- wp:paragraph -->
-      <p>' .
+      <p><em>' .
       /* translators: Placeholder text that merchants replace with their own content. */
-      __('BRIEF DESCRIPTION', 'mailpoet') . '</p>
+      __('Brief description', 'mailpoet') . '</em></p>
       <!-- /wp:paragraph -->
       </div>
       <!-- /wp:column -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
@@ -32,8 +32,15 @@ class WelcomeEmailPattern extends Pattern {
 
       <!-- wp:paragraph -->
       <p>' .
-      /* translators: %s: Subscriber first name personalization tag */
-      sprintf(__('Hi %s, we are so glad to have you onboard.', 'mailpoet'), '<!--[mailpoet/subscriber-firstname default="subscriber"]-->') . '</p>
+      sprintf(
+        /* translators: %s: Subscriber first name personalization tag */
+        __('Hi %s, we are so glad to have you onboard.', 'mailpoet'),
+        sprintf(
+          '<!--[mailpoet/subscriber-firstname default="%s"]-->',
+          /* translators: Default placeholder used when no subscriber name is available in "Hi %s" */
+          esc_attr(_x('there', 'subscriber name placeholder', 'mailpoet'))
+        )
+      ) . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:image {"sizeSlug":"full"} -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
@@ -26,14 +26,14 @@ class WelcomeEmailPattern extends Pattern {
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
       <!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading ">' .
-      /* translators: %s: Store name personalization tag */
-      sprintf(__('Welcome to %s!', 'mailpoet'), '<!--[woocommerce/store-name]-->') . '</h1>
+      /* translators: %s: Site title personalization tag */
+      sprintf(__('Welcome to %s!', 'mailpoet'), '<!--[mailpoet/site-title]-->') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph -->
       <p>' .
-      /* translators: %s: Customer full name personalization tag */
-      sprintf(__('Hi %s, we are so glad to have you onboard.', 'mailpoet'), '<!--[woocommerce/customer-full-name]-->') . '</p>
+      /* translators: %s: Subscriber first name personalization tag */
+      sprintf(__('Hi %s, we are so glad to have you onboard.', 'mailpoet'), '<!--[mailpoet/subscriber-firstname default="subscriber"]-->') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:image {"sizeSlug":"full"} -->
@@ -60,7 +60,7 @@ class WelcomeEmailPattern extends Pattern {
       <!-- /wp:paragraph -->
 
       <!-- wp:paragraph -->
-      <p>–<!--[woocommerce/site-title]--></p>
+      <p>–<!--[mailpoet/site-title]--></p>
       <!-- /wp:paragraph -->
     </div>
     <!-- /wp:group -->

--- a/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
@@ -41,6 +41,9 @@ class CreateAutomationEmailWithBlockEditorCest {
     $i->fillField('"From" email address', 'test@mailpoet.com');
     $i->fillField('Subject', 'Automation-Block-Editor-Subject');
 
+    $i->wantTo('Delete the pre-filled welcome email to choose an editor');
+    $this->deleteAssignedEmail($i);
+
     $i->wantTo('Verify that choosing the new editor redirects to block editor');
     $i->see('Design with the new editor');
     $i->see('Design with the classic editor');
@@ -128,6 +131,9 @@ class CreateAutomationEmailWithBlockEditorCest {
     $i->fillField('"From" email address', 'test@mailpoet.com');
     $i->fillField('Subject', 'Legacy-Editor-Subject');
 
+    $i->wantTo('Delete the pre-filled welcome email to choose an editor');
+    $this->deleteAssignedEmail($i);
+
     $i->wantTo('Verify that choosing the classic editor redirects to legacy newsletter editor');
     $i->see('Design with the new editor');
     $i->see('Design with the classic editor');
@@ -141,6 +147,14 @@ class CreateAutomationEmailWithBlockEditorCest {
     $i->wantTo('Verify we are in the legacy newsletter editor interface');
     $i->dontSeeElement('[name="editor-canvas"]'); // Block editor iframe should not be present
     $i->seeElement('#mailpoet_editor');
+  }
+
+  private function deleteAssignedEmail(\AcceptanceTester $i): void {
+    $i->waitForElementVisible('[aria-label="Delete email"]');
+    $i->click('[aria-label="Delete email"]');
+    $i->waitForText('This removes the email from the automation step.');
+    $i->click('Delete email', '.components-modal__frame');
+    $i->waitForText('Design with the classic editor');
   }
 
   private function closeTemplateSelectionModal(\AcceptanceTester $i): void {

--- a/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
@@ -48,6 +48,9 @@ class CreateEmailAutomationAndWalkThroughCest {
     $i->fillField('"From" email address', 'test@mailpoet.com');
     $i->fillField('Subject', 'Automation-Test-Subject');
 
+    $i->wantTo('Delete the pre-filled welcome email to design it manually');
+    $this->deleteAssignedEmail($i);
+
     $i->click('Design with the classic editor');
     $i->waitForText('Newsletters');
     $i->click('Newsletters');
@@ -123,6 +126,14 @@ class CreateEmailAutomationAndWalkThroughCest {
     $i->amOnMailboxAppPage();
     $i->see('Inbox (1)');
     $i->see('Automation-Test-Subject');
+  }
+
+  private function deleteAssignedEmail(\AcceptanceTester $i): void {
+    $i->waitForElementVisible('[aria-label="Delete email"]');
+    $i->click('[aria-label="Delete email"]');
+    $i->waitForText('This removes the email from the automation step.');
+    $i->click('Delete email', '.components-modal__frame');
+    $i->waitForText('Design with the classic editor');
   }
 
   private function grabAutomationIdFromCurrentUrl(\AcceptanceTester $i): string {

--- a/mailpoet/tests/acceptance/Misc/MailpoetMenuCest.php
+++ b/mailpoet/tests/acceptance/Misc/MailpoetMenuCest.php
@@ -75,7 +75,7 @@ class MailpoetMenuCest {
     $i->wantTo('Check if the menu is still selected if I go to the choose template page');
     $i->waitForText('Send email');
     $i->click('Send email');
-    $i->waitForText('Design with the classic editor');
+    $this->deleteAssignedEmail($i);
     $i->fillField('"From" name', 'From Test');
     $i->fillField('"From" email address', 'test@mailpoet.com');
     $i->fillField('Subject', 'Automation-Test-Subject');
@@ -233,6 +233,14 @@ class MailpoetMenuCest {
     $i->amOnAdminPage('admin.php?page=mailpoet-landingpage');
     $i->waitForElement('#mailpoet_landingpage_container');
     $this->assertSelectedMailPoetTopMenu($i);
+  }
+
+  private function deleteAssignedEmail(\AcceptanceTester $i): void {
+    $i->waitForElementVisible('[aria-label="Delete email"]');
+    $i->click('[aria-label="Delete email"]');
+    $i->waitForText('This removes the email from the automation step.');
+    $i->click('Delete email', '.components-modal__frame');
+    $i->waitForText('Design with the classic editor');
   }
 
   private function clickMenuItem(\AcceptanceTester $i, string $label): void {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -1,0 +1,150 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\MailPoet\Templates;
+
+use MailPoet\Automation\Engine\Data\AutomationTemplate;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Templates\AutomationBuilder;
+use MailPoet\Automation\Integrations\MailPoet\Templates\EmailFactory;
+use MailPoet\Automation\Integrations\MailPoet\Templates\TemplatesFactory;
+use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+use MailPoet\WooCommerce\WooCommerceBookings\Helper as WooCommerceBookingsHelper;
+use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WooCommerceSubscriptions;
+use MailPoetTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class TemplatesFactoryTest extends MailPoetTest {
+  /** @var AutomationBuilder */
+  private $builder;
+
+  /** @var MockObject&EmailFactory */
+  private $emailFactory;
+
+  public function _before(): void {
+    parent::_before();
+    $this->builder = $this->diContainer->get(AutomationBuilder::class);
+    $this->emailFactory = $this->createMock(EmailFactory::class);
+  }
+
+  /**
+   * @dataProvider welcomeTemplateEmailData
+   */
+  public function testWelcomeTemplateCreatesBlockEditorEmail(
+    string $slug,
+    string $expectedTriggerKey,
+    string $expectedName,
+    string $expectedSubject,
+    string $expectedPreheader
+  ): void {
+    $this->emailFactory->expects($this->once())
+      ->method('createBlockEditorEmail')
+      ->with($this->callback(function (array $data) use ($expectedSubject, $expectedPreheader): bool {
+        return ($data['pattern'] ?? null) === 'welcome-email-content'
+          && ($data['subject'] ?? null) === $expectedSubject
+          && ($data['preheader'] ?? null) === $expectedPreheader;
+      }))
+      ->willReturn([
+        'email_id' => 123,
+        'email_wp_post_id' => 456,
+      ]);
+
+    $factory = $this->createFactory();
+    $template = $this->findTemplateBySlug($factory->createTemplates(), $slug);
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation();
+
+    $this->assertNotNull($this->getFirstStepByKey($automation->getSteps(), $expectedTriggerKey));
+    $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertNotNull($sendEmailStep);
+
+    $args = $sendEmailStep->getArgs();
+    $this->assertSame($expectedName, $args['name']);
+    $this->assertSame($expectedSubject, $args['subject']);
+    $this->assertSame($expectedPreheader, $args['preheader']);
+    $this->assertSame(123, $args['email_id']);
+    $this->assertSame(456, $args['email_wp_post_id']);
+  }
+
+  /**
+   * @dataProvider welcomeTemplateEmailData
+   */
+  public function testWelcomeTemplatePreviewDoesNotCreatePersistentEmail(
+    string $slug,
+    string $expectedTriggerKey,
+    string $expectedName,
+    string $expectedSubject,
+    string $expectedPreheader
+  ): void {
+    $this->emailFactory->expects($this->never())->method('createBlockEditorEmail');
+
+    $factory = $this->createFactory();
+    $template = $this->findTemplateBySlug($factory->createTemplates(), $slug);
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation(true);
+
+    $this->assertNotNull($this->getFirstStepByKey($automation->getSteps(), $expectedTriggerKey));
+    $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertNotNull($sendEmailStep);
+
+    $args = $sendEmailStep->getArgs();
+    $this->assertSame($expectedName, $args['name']);
+    $this->assertSame($expectedSubject, $args['subject']);
+    $this->assertSame($expectedPreheader, $args['preheader']);
+    $this->assertArrayNotHasKey('email_id', $args);
+    $this->assertArrayNotHasKey('email_wp_post_id', $args);
+  }
+
+  public function welcomeTemplateEmailData(): array {
+    return [
+      'subscriber welcome email' => [
+        'subscriber-welcome-email',
+        'mailpoet:someone-subscribes',
+        'Welcome email',
+        'Welcome to our community!',
+        'Thanks for subscribing',
+      ],
+    ];
+  }
+
+  private function createFactory(): TemplatesFactory {
+    $woocommerce = $this->createMock(WooCommerce::class);
+    $woocommerce->method('isWooCommerceActive')->willReturn(false);
+    $woocommerceSubscriptions = $this->createMock(WooCommerceSubscriptions::class);
+    $woocommerceSubscriptions->method('isWooCommerceSubscriptionsActive')->willReturn(false);
+    $bookingsHelper = $this->createMock(WooCommerceBookingsHelper::class);
+    $bookingsHelper->method('isWooCommerceBookingsActive')->willReturn(false);
+    $woocommerceHelper = $this->createMock(WooCommerceHelper::class);
+
+    return new TemplatesFactory(
+      $this->builder,
+      $woocommerce,
+      $woocommerceSubscriptions,
+      $this->emailFactory,
+      $bookingsHelper,
+      $woocommerceHelper
+    );
+  }
+
+  /**
+   * @param AutomationTemplate[] $templates
+   */
+  private function findTemplateBySlug(array $templates, string $slug): ?AutomationTemplate {
+    foreach ($templates as $template) {
+      if ($template->getSlug() === $slug) {
+        return $template;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @param Step[] $steps
+   */
+  private function getFirstStepByKey(array $steps, string $key): ?Step {
+    $matches = array_values(array_filter($steps, fn(Step $step) => $step->getKey() === $key));
+    return $matches[0] ?? null;
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -106,6 +106,13 @@ class TemplatesFactoryTest extends MailPoetTest {
         'Welcome to our community!',
         'Thanks for subscribing',
       ],
+      'user welcome email' => [
+        'user-welcome-email',
+        'mailpoet:wp-user-registered',
+        'Welcome email',
+        'Welcome to our community!',
+        'Thanks for joining us',
+      ],
     ];
   }
 


### PR DESCRIPTION
## Description

Adds email content to the two welcome automation templates (new subscribers, new WordPress users). Each `send-email` step now creates a block-editor email from the `welcome-email-content` pattern when the automation is created, while template previews stay side-effect free via a new `$preview` flag.

Also fixes the welcome email pattern to use MailPoet-native personalization tags (`mailpoet/site-title`, `mailpoet/subscriber-firstname`) instead of WooCommerce tags. The Woo tags never resolved here: the customer tag has no order/customer subject in welcome flows, and the store/site tags aren't even registered when WooCommerce is inactive.

## Code review notes

The `$preview` flag is the key mechanism: the template GET endpoint passes `preview=true` (no DB writes), the create-from-template flow defaults to `false` (persists the email). Validation passes without `email_id` because `ValidStepArgsRule` is value-driven and `required` is inline, consistent with the pre-existing no-args templates.

## QA notes

- Creating an automation from each welcome template attaches a populated block-editor email.
- Previewing a template does not create newsletter rows.
- Welcome email renders site title / subscriber first name correctly on a non-WooCommerce site.

## Linked PRs

mailpoet/mailpoet-premium#1086

## Linked tickets

STOMAIL-8119

## Screenshots

<img width="1191" height="1012" alt="Screenshot 2026-06-04 at 10 23 51" src="https://github.com/user-attachments/assets/fc0b1d60-5c55-4c66-95e0-b3fdb1eac12b" />

<img width="1376" height="1232" alt="Screenshot 2026-06-04 at 11 20 56" src="https://github.com/user-attachments/assets/0f4c20d0-ed2d-4e4d-b7dc-95c0e0479f50" />

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8119-add-email-templates-for-welcome-automations)

_The latest successful build from `stomail-8119-add-email-templates-for-welcome-automations` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

This PR successfully adds email content generation to welcome automation templates while maintaining preview mode as side-effect free. The implementation includes proper validation of generated email IDs, replacement of WooCommerce-specific personalization tags with MailPoet-native alternatives for cross-platform compatibility, and comprehensive test coverage (both integration and acceptance tests) to verify the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->