### PR TITLE
Add delete email control to automation email step

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/email-panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/email-panel.tsx
@@ -1,7 +1,13 @@
-import { ComponentProps } from 'react';
-import { PanelBody, TextareaControl, TextControl } from '@wordpress/components';
+import { ComponentProps, useState } from 'react';
+import {
+  __experimentalConfirmDialog as ConfirmDialog,
+  PanelBody,
+  TextareaControl,
+  TextControl,
+} from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { Icon, trash } from '@wordpress/icons';
 import { isEmail } from 'common/functions';
 import { ShortcodeHelpText } from './shortcode-help-text';
 import { SenderDomainNotice } from '../../../components/sender-domain-notice';
@@ -9,6 +15,7 @@ import { PlainBodyTitle } from '../../../../../editor/components';
 import { storeName } from '../../../../../editor/store';
 import { StepName } from '../../../../../editor/components/panel/step-name';
 import { EditNewsletter } from './edit-newsletter';
+import { TitleActionButton } from '../../../../../editor/components/panel/title-action-button';
 
 function SingleLineTextareaControl(
   props: ComponentProps<typeof TextareaControl>,
@@ -33,6 +40,62 @@ function SingleLineTextareaControl(
   );
 }
 
+function DeleteEmailButton({
+  stepId,
+  hasEmail,
+}: {
+  stepId: string;
+  hasEmail: boolean;
+}): JSX.Element | null {
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+
+  if (!hasEmail) {
+    return null;
+  }
+
+  const deleteEmail = () => {
+    setShowConfirmDialog(false);
+    void dispatch(storeName).updateStepArgs(stepId, 'email_id', undefined);
+    void dispatch(storeName).updateStepArgs(
+      stepId,
+      'email_wp_post_id',
+      undefined,
+    );
+    void dispatch(storeName).updateStepArgs(
+      stepId,
+      'stepDuplicated',
+      undefined,
+    );
+  };
+
+  return (
+    <>
+      <ConfirmDialog
+        isOpen={showConfirmDialog}
+        title={__('Delete email', 'mailpoet')}
+        confirmButtonText={__('Delete email', 'mailpoet')}
+        onConfirm={deleteEmail}
+        onCancel={() => setShowConfirmDialog(false)}
+        __experimentalHideHeader={false}
+      >
+        {__(
+          'This removes the email from the automation step. Save the automation to make this change permanent.',
+          'mailpoet',
+        )}
+      </ConfirmDialog>
+      <TitleActionButton
+        label={__('Delete email', 'mailpoet')}
+        showTooltip
+        variant="tertiary"
+        isDestructive
+        onClick={() => setShowConfirmDialog(true)}
+      >
+        <Icon icon={trash} size={16} />
+      </TitleActionButton>
+    </>
+  );
+}
+
 export function EmailPanel(): JSX.Element {
   const { selectedStep, errors, isGarden } = useSelect(
     (select) => ({
@@ -51,6 +114,7 @@ export function EmailPanel(): JSX.Element {
   const senderAddressErrorMessage = errorFields?.sender_address ?? '';
   const subjectErrorMessage = errorFields?.subject ?? '';
   const showSenderDetailsFields = !isGarden;
+  const hasEmail = !!selectedStep.args.email_id;
 
   return (
     <PanelBody opened>
@@ -153,7 +217,9 @@ export function EmailPanel(): JSX.Element {
         help={<ShortcodeHelpText />}
       />
       <div className="mailpoet-automation-email-content-separator" />
-      <PlainBodyTitle title={__('Email', 'mailpoet')} />
+      <PlainBodyTitle title={__('Email', 'mailpoet')}>
+        <DeleteEmailButton stepId={selectedStep.id} hasEmail={hasEmail} />
+      </PlainBodyTitle>
       <EditNewsletter />
     </PanelBody>
   );

--- a/mailpoet/changelog/2026-06-04-09-49-31-added-delete-email-control-in-automation-send-email-step.md
+++ b/mailpoet/changelog/2026-06-04-09-49-31-added-delete-email-control-in-automation-send-email-step.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Delete email button in automation's "Send email" settings


### PR DESCRIPTION
## Description

Adds a small trash icon to the automation Send email step's Email section. Confirming the dialog detaches the email in editor state; saving the automation persists the change.

## Code review notes

The confirm action clears `email_id`, `email_wp_post_id`, and `stepDuplicated`; it does not call newsletter deletion APIs.

## QA notes

- `pnpm qa:prettier`
- `pnpm qa:js`
- `pnpm compile:js`
- `pnpm test:javascript`

`pnpm qa` was skipped per request after reporting pre-existing PHPCS issues in `mailpoet/tests/plugins`.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8132](https://linear.app/a8c/issue/STOMAIL-8132/add-delete-email-button-to-automation-send-email-step)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="321" height="372" alt="Screenshot 2026-06-04 at 12 01 24" src="https://github.com/user-attachments/assets/fc0477fb-edfc-402c-b855-edbd5f90bf79" />

<img width="1078" height="536" alt="Screenshot 2026-06-04 at 12 01 28" src="https://github.com/user-attachments/assets/8a7f0d06-7aa9-47e2-8133-e69a7a403ddb" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8132-add-delete-email-button-to-automation-send-email-step)

_The latest successful build from `stomail-8132-add-delete-email-button-to-automation-send-email-step` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Issues Found: 1**

**Category: Code Quality**
- **Unused variable** (Line 103): The variable `selectedStepType` is destructured from the `useSelect` hook but is never used in the component. It should be removed from the selector to improve code cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->