### PR TITLE
Limit manage subscription save to editable fields

### DIFF
--- a/mailpoet/changelog/2026-06-04-13-10-44-fixed-an-issue-where-saving-subscription-preferences-cou.md
+++ b/mailpoet/changelog/2026-06-04-13-10-44-fixed-an-issue-where-saving-subscription-preferences-cou.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+An issue where saving subscription preferences could change other subscriber details

--- a/mailpoet/lib/Subscription/Manage.php
+++ b/mailpoet/lib/Subscription/Manage.php
@@ -112,7 +112,7 @@ class Manage {
             && $subscriber instanceof SubscriberEntity
             && $subscriber->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED
           );
-          $subscriber = $this->subscriberSaveController->createOrUpdate($this->filterOutReservedColumns($subscriberData), $subscriber);
+          $subscriber = $this->subscriberSaveController->createOrUpdate($this->filterToEditableFields($subscriberData), $subscriber);
           if ($shouldTrackUnsubscribe) {
             $this->unsubscribesTracker->track(
               (int)$subscriber->getId(),
@@ -248,17 +248,17 @@ class Manage {
   }
 
   /**
-   * The manage-subscription form only edits name, email, subscription choices
-   * and global status. Reuse the save controller's reserved-column filter so
-   * system-maintained columns are left untouched, but keep `status`, which is
-   * editable here and is already validated by hasInvalidStatus().
+   * The manage-subscription form only edits the subscriber's name, email and
+   * global status. Subscription choices and custom fields are handled
+   * separately. Keep only those fields when saving the subscriber so any other
+   * submitted key is ignored. `status` is already validated by
+   * hasInvalidStatus().
    */
-  private function filterOutReservedColumns(array $subscriberData): array {
-    $filtered = $this->subscriberSaveController->filterOutReservedColumns($subscriberData);
-    if (array_key_exists('status', $subscriberData)) {
-      $filtered['status'] = $subscriberData['status'];
-    }
-    return $filtered;
+  private function filterToEditableFields(array $subscriberData): array {
+    return array_intersect_key(
+      $subscriberData,
+      array_flip(['email', 'first_name', 'last_name', 'status'])
+    );
   }
 
   private function hasInvalidStatus(array $subscriberData): bool {

--- a/mailpoet/lib/Subscription/Manage.php
+++ b/mailpoet/lib/Subscription/Manage.php
@@ -112,7 +112,7 @@ class Manage {
             && $subscriber instanceof SubscriberEntity
             && $subscriber->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED
           );
-          $subscriber = $this->subscriberSaveController->createOrUpdate($subscriberData, $subscriber);
+          $subscriber = $this->subscriberSaveController->createOrUpdate($this->filterOutReservedColumns($subscriberData), $subscriber);
           if ($shouldTrackUnsubscribe) {
             $this->unsubscribesTracker->track(
               (int)$subscriber->getId(),
@@ -245,6 +245,20 @@ class Manage {
         ? $this->getCurrentSubscribedSegmentIds($subscriber)
         : array_diff($subscribeIds, $currentSegmentIds)
     );
+  }
+
+  /**
+   * The manage-subscription form only edits name, email, subscription choices
+   * and global status. Reuse the save controller's reserved-column filter so
+   * system-maintained columns are left untouched, but keep `status`, which is
+   * editable here and is already validated by hasInvalidStatus().
+   */
+  private function filterOutReservedColumns(array $subscriberData): array {
+    $filtered = $this->subscriberSaveController->filterOutReservedColumns($subscriberData);
+    if (array_key_exists('status', $subscriberData)) {
+      $filtered['status'] = $subscriberData['status'];
+    }
+    return $filtered;
   }
 
   private function hasInvalidStatus(array $subscriberData): bool {

--- a/mailpoet/tests/integration/Subscription/ManageTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageTest.php
@@ -10,6 +10,7 @@ use MailPoet\Form\Util\FieldNameObfuscator;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\NewSubscriberNotificationMailer;
+use MailPoet\Subscribers\Source;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscription\Manage;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
@@ -520,6 +521,9 @@ class ManageTest extends \MailPoetTest {
   }
 
   public function testItIgnoresReservedColumnsInSubmittedData(): void {
+    $this->subscriber->setSource(Source::FORM);
+    $this->entityManager->flush();
+
     $manage = $this->getManageService();
     $_POST['action'] = 'mailpoet_subscription_update';
     $_POST['token'] = 'token';
@@ -528,13 +532,14 @@ class ManageTest extends \MailPoetTest {
       'last_name' => 'John',
       'email' => 'john.doe@example.com',
       'status' => SubscriberEntity::STATUS_SUBSCRIBED,
-      // reserved columns that the manage form never edits
+      // fields the manage form never edits
       'wp_user_id' => 1,
       'is_woocommerce_user' => 1,
       'subscribed_ip' => '88.88.88.88',
       'confirmed_ip' => '88.88.88.88',
       'confirmed_at' => '2003-04-05 06:07:08',
       'created_at' => '2004-05-06 07:08:09',
+      'source' => 'forged_source',
     ];
 
     $manage->onSave();
@@ -543,12 +548,13 @@ class ManageTest extends \MailPoetTest {
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     // The editable fields are still applied.
     verify($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
-    // Reserved columns are left untouched.
+    // Non-editable fields are left untouched.
     verify($subscriber->getWpUserId())->null();
     verify($subscriber->getIsWoocommerceUser())->equals(false);
     verify($subscriber->getSubscribedIp())->null();
     verify($subscriber->getConfirmedIp())->null();
     verify($subscriber->getConfirmedAt())->null();
+    verify($subscriber->getSource())->equals(Source::FORM);
     $createdAt = $subscriber->getCreatedAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $createdAt);
     verify($createdAt->format('Y-m-d'))->notEquals('2004-05-06');

--- a/mailpoet/tests/integration/Subscription/ManageTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageTest.php
@@ -519,6 +519,41 @@ class ManageTest extends \MailPoetTest {
     verify($welcomeSegmentIds)->equals($expectedSegmentIds);
   }
 
+  public function testItIgnoresReservedColumnsInSubmittedData(): void {
+    $manage = $this->getManageService();
+    $_POST['action'] = 'mailpoet_subscription_update';
+    $_POST['token'] = 'token';
+    $_POST['data'] = [
+      'first_name' => 'John',
+      'last_name' => 'John',
+      'email' => 'john.doe@example.com',
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      // reserved columns that the manage form never edits
+      'wp_user_id' => 1,
+      'is_woocommerce_user' => 1,
+      'subscribed_ip' => '88.88.88.88',
+      'confirmed_ip' => '88.88.88.88',
+      'confirmed_at' => '2003-04-05 06:07:08',
+      'created_at' => '2004-05-06 07:08:09',
+    ];
+
+    $manage->onSave();
+
+    $subscriber = $this->subscribersRepository->findOneById($this->subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    // The editable fields are still applied.
+    verify($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+    // Reserved columns are left untouched.
+    verify($subscriber->getWpUserId())->null();
+    verify($subscriber->getIsWoocommerceUser())->equals(false);
+    verify($subscriber->getSubscribedIp())->null();
+    verify($subscriber->getConfirmedIp())->null();
+    verify($subscriber->getConfirmedAt())->null();
+    $createdAt = $subscriber->getCreatedAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $createdAt);
+    verify($createdAt->format('Y-m-d'))->notEquals('2004-05-06');
+  }
+
   public function testItRedirectsWithErrorAndDoesNotSaveWhenTokenVerificationFails(): void {
     $redirectParams = null;
     $manage = $this->getManageService([


### PR DESCRIPTION
## Description

The manage subscription form lets a subscriber update their name, email, list choices and global subscription status. When the form is saved, the handler passed the whole submitted payload to the subscriber save routine, so any extra field included in the request was written to the subscriber record — including columns the form never exposes (for example `wp_user_id`, `subscribed_ip`, `confirmed_ip`, `confirmed_at`, `created_at`, `is_woocommerce_user`).

This restricts the save to the fields the form actually edits, so unrelated subscriber columns are left unchanged. Name, email, list choices and status keep working exactly as before.

## Code review notes

The save controller already has `filterOutReservedColumns()`, used on the normal subscribe path. I reuse it here. That helper also strips `status`, but `status` is legitimately editable on this form (subscribe / unsubscribe) and is already validated earlier by `hasInvalidStatus()`, so it is re-added after filtering.

The guard is applied in the manage handler rather than in `SubscriberSaveController::createOrUpdate()` on purpose — the admin subscriber editor uses the same `createOrUpdate()` and legitimately sets fields like `status` and `wp_user_id`, so changing the shared method would break admin functionality.

## QA notes

Automated: `pnpm test:integration --file=tests/integration/Subscription/ManageTest.php` — 16 tests pass, including the new `testItIgnoresReservedColumnsInSubmittedData`.

Manual:
1. Open the manage subscription page for a subscriber (via a manage link).
2. Change the name, list choices and the global status, then save.
3. Confirm those changes apply as before and the page behaves normally.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8133

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I added sufficient test coverage

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8133-manage-subscription-ignore-reserved-fields)

_The latest successful build from `fix/stomail-8133-manage-subscription-ignore-reserved-fields` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

Issue counts by category:
- Bug: 0
- Security: 0
- Performance: 0
- Suggestion: 0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->