### PR TITLE
Fix git hooks to work with git worktrees

### DIFF
--- a/.husky/common.sh
+++ b/.husky/common.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 
-. "$(dirname "$0")/../mailpoet/.env"
+# Git runs hooks with the working directory at the worktree root, so $PWD/mailpoet
+# points at the worktree that triggered the hook — the same dir ./do uses.
+ENV_DIR="$PWD/mailpoet"
+# .env is gitignored, so fresh clones and new worktrees don't have one yet. Seed
+# it from the sample so sourcing it below (and ./do, which loads .env on every
+# run) doesn't fail.
+if [ ! -f "$ENV_DIR/.env" ] && [ -f "$ENV_DIR/.env.sample" ]; then
+  cp "$ENV_DIR/.env.sample" "$ENV_DIR/.env"
+fi
+
+. "$ENV_DIR/.env"
 
 export MP_GIT_HOOKS_ENABLE="${MP_GIT_HOOKS_ENABLE:-true}"
 export MP_GIT_HOOKS_ESLINT="${MP_GIT_HOOKS_ESLINT:-true}"


### PR DESCRIPTION
## Why

Creating a new git worktree fataled in the `post-checkout` hook: a fresh worktree has no `mailpoet/.env` (it's gitignored), so `./do` threw `Dotenvexception\InvalidPathException`. This seeds `.env` from `.env.sample` in `common.sh` when missing, anchored on `$PWD/mailpoet` so it works correctly inside worktrees (where hooks run from the main checkout's `.husky`).

## Test

```sh
cd <your mailpoet repo>
git worktree add -b env-seed-test /tmp/mp-worktree-test trunk
ls -l /tmp/mp-worktree-test/mailpoet/.env   # should exist, no Dotenv fatal during add

# cleanup
git worktree remove --force /tmp/mp-worktree-test
git branch -D env-seed-test
```

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/seed-env-in-git-hooks)

_The latest successful build from `fix/seed-env-in-git-hooks` will be used. If none is available, the link won't work._