### PR TITLE
Differentiate 2nd abandoned cart email and use live cart products

### DIFF
--- a/mailpoet/changelog/2026-06-03-14-24-12-added-email-content-for-abandoned-cart-reminder-automati.md
+++ b/mailpoet/changelog/2026-06-03-14-24-12-added-email-content-for-abandoned-cart-reminder-automati.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Email content for abandoned cart reminder automation

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -342,17 +342,23 @@ class TemplatesFactory {
         'Nudge your shoppers to complete the purchase after they have added a product to the cart but haven’t completed the order.',
         'mailpoet'
       ),
-      function (): Automation {
+      function (bool $preview = false): Automation {
+        $emailArgs = $this->createBlockEditorEmailArgs(
+          $preview,
+          'abandoned-cart-content',
+          __('Abandoned cart reminder', 'mailpoet'),
+          __('You left something behind!', 'mailpoet'),
+          __('Complete your purchase today', 'mailpoet'),
+          'abandoned-cart'
+        );
+
         return $this->builder->createFromSequence(
           __('Abandoned cart reminder', 'mailpoet'),
           [
             ['key' => 'woocommerce:abandoned-cart'],
             [
               'key' => 'mailpoet:send-email',
-              'args' => [
-                'name' => __('Abandoned cart', 'mailpoet'),
-                'subject' => __('Looks like you forgot something', 'mailpoet'),
-              ],
+              'args' => $emailArgs,
             ],
           ]
         );

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbandonedCartReminderPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbandonedCartReminderPattern.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
+
+/**
+ * Second abandoned cart reminder email pattern for cart recovery.
+ */
+class AbandonedCartReminderPattern extends AbstractAbandonedCartPattern {
+  protected $name = 'abandoned-cart-reminder-content';
+
+  protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return $this->buildContent($this->getProductPlaceholderBlocks(['newsletter.jpg']));
+  }
+
+  public function get_email_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return $this->buildContent($this->getProductCollectionBlock());
+  }
+
+  private function buildContent(string $productSection): string {
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading ">' . __('Still thinking it over?', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph -->
+      <p>' . __('The items in your cart are still here — but we can’t hold them forever. Popular pieces tend to sell out quickly, so now’s a great time to come back and make them yours.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      ' . $productSection . '
+
+      <!-- wp:paragraph -->
+      <p>' . __('Checkout only takes a minute, and it’s always secure. If anything’s holding you back, just reply to this email — we’re happy to help.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    /* translators: Name of a content pattern used as starting content of an email */
+    return __('Abandoned Cart Reminder', 'mailpoet');
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -3,6 +3,7 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartPattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartReminderPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartWithDiscountPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AskForReviewPostPurchasePattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EducationalCampaignPattern;
@@ -48,6 +49,12 @@ class PatternsController {
   /**
    * Get the content of a pattern by name.
    *
+   * Returns the email content (get_email_content()), which uses dynamic blocks
+   * such as the WooCommerce product collection bound to the customer's cart
+   * instead of the static placeholders shown in the editor's pattern preview.
+   * For patterns without an email-specific variant this is identical to the
+   * preview content.
+   *
    * @param string $patternName The pattern name (e.g., 'welcome-email-content')
    * @return string|null The pattern content or null if not found
    */
@@ -60,12 +67,20 @@ class PatternsController {
         $patternData = $this->wp->applyFilters('mailpoet_email_editor_integration_register_pattern', [
           'name' => $pattern->get_namespace() . '/' . $pattern->get_name(),
           'properties' => $pattern->get_properties(),
+          'email_content' => $pattern->get_email_content(),
         ], $pattern);
 
-        if (!is_array($patternData) || !isset($patternData['properties']) || !is_array($patternData['properties'])) {
+        if (!is_array($patternData)) {
           return null;
         }
-        $content = $patternData['properties']['content'] ?? null;
+
+        $emailContent = $patternData['email_content'] ?? null;
+        if (is_string($emailContent) && $emailContent !== '') {
+          return $emailContent;
+        }
+
+        $properties = $patternData['properties'] ?? null;
+        $content = is_array($properties) ? ($properties['content'] ?? null) : null;
         return is_string($content) ? $content : null;
       }
     }
@@ -96,6 +111,7 @@ class PatternsController {
         new PostPurchaseThankYouPattern($this->cdnAssetUrl),
         new ProductPurchaseFollowUpPattern($this->cdnAssetUrl),
         new AbandonedCartPattern($this->cdnAssetUrl),
+        new AbandonedCartReminderPattern($this->cdnAssetUrl),
       ]);
 
       if ($this->wooCommerceHelper->wcSupportsOrderReviewUrl()) {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -4,9 +4,11 @@ namespace MailPoet\Test\Automation\Integrations\MailPoet\Templates;
 
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Templates\AutomationBuilder;
 use MailPoet\Automation\Integrations\MailPoet\Templates\EmailFactory;
 use MailPoet\Automation\Integrations\MailPoet\Templates\TemplatesFactory;
+use MailPoet\Automation\Integrations\WooCommerce\Triggers\AbandonedCart\AbandonedCartTrigger;
 use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WooCommerce\WooCommerceBookings\Helper as WooCommerceBookingsHelper;
@@ -117,6 +119,7 @@ class TemplatesFactoryTest extends MailPoetTest {
   }
 
   public function testAbandonedCartTemplateCreatesBlockEditorEmail(): void {
+    $this->ensureAbandonedCartTriggerRegistered();
     $this->emailFactory->expects($this->once())
       ->method('createBlockEditorEmail')
       ->with([
@@ -164,6 +167,17 @@ class TemplatesFactoryTest extends MailPoetTest {
     $this->assertSame('Complete your purchase today', $args['preheader']);
     $this->assertArrayNotHasKey('email_id', $args);
     $this->assertArrayNotHasKey('email_wp_post_id', $args);
+  }
+
+  // WooCommerce automation triggers are registered once into the shared Registry at engine init.
+  // A test running earlier in the suite can leave the Registry without them, which would make
+  // createFromSequence() silently drop the trigger step. Re-register it so this test does not
+  // depend on suite ordering.
+  private function ensureAbandonedCartTriggerRegistered(): void {
+    $registry = $this->diContainer->get(Registry::class);
+    if ($registry->getStep(AbandonedCartTrigger::KEY) === null) {
+      $registry->addTrigger($this->diContainer->get(AbandonedCartTrigger::class));
+    }
   }
 
   private function createFactory(): TemplatesFactory {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -116,14 +116,65 @@ class TemplatesFactoryTest extends MailPoetTest {
     ];
   }
 
+  public function testAbandonedCartTemplateCreatesBlockEditorEmail(): void {
+    $this->emailFactory->expects($this->once())
+      ->method('createBlockEditorEmail')
+      ->with([
+        'pattern' => 'abandoned-cart-content',
+        'subject' => 'You left something behind!',
+        'preheader' => 'Complete your purchase today',
+      ])
+      ->willReturn([
+        'email_id' => 123,
+        'email_wp_post_id' => 456,
+      ]);
+
+    $factory = $this->createFactory();
+    $template = $this->findTemplateBySlug($factory->createTemplates(), 'abandoned-cart');
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation();
+    $this->assertNotNull($this->getFirstStepByKey($automation->getSteps(), 'woocommerce:abandoned-cart'));
+
+    $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertInstanceOf(Step::class, $sendEmailStep);
+    $args = $sendEmailStep->getArgs();
+
+    $this->assertSame('Abandoned cart reminder', $args['name']);
+    $this->assertSame('You left something behind!', $args['subject']);
+    $this->assertSame('Complete your purchase today', $args['preheader']);
+    $this->assertSame(123, $args['email_id']);
+    $this->assertSame(456, $args['email_wp_post_id']);
+  }
+
+  public function testAbandonedCartTemplatePreviewDoesNotCreatePersistentEmail(): void {
+    $this->emailFactory->expects($this->never())->method('createBlockEditorEmail');
+
+    $factory = $this->createFactory();
+    $template = $this->findTemplateBySlug($factory->createTemplates(), 'abandoned-cart');
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation(true);
+    $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertInstanceOf(Step::class, $sendEmailStep);
+    $args = $sendEmailStep->getArgs();
+
+    $this->assertSame('Abandoned cart reminder', $args['name']);
+    $this->assertSame('You left something behind!', $args['subject']);
+    $this->assertSame('Complete your purchase today', $args['preheader']);
+    $this->assertArrayNotHasKey('email_id', $args);
+    $this->assertArrayNotHasKey('email_wp_post_id', $args);
+  }
+
   private function createFactory(): TemplatesFactory {
     $woocommerce = $this->createMock(WooCommerce::class);
-    $woocommerce->method('isWooCommerceActive')->willReturn(false);
+    $woocommerce->method('isWooCommerceActive')->willReturn(true);
     $woocommerceSubscriptions = $this->createMock(WooCommerceSubscriptions::class);
     $woocommerceSubscriptions->method('isWooCommerceSubscriptionsActive')->willReturn(false);
     $bookingsHelper = $this->createMock(WooCommerceBookingsHelper::class);
     $bookingsHelper->method('isWooCommerceBookingsActive')->willReturn(false);
     $woocommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $woocommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(false);
 
     return new TemplatesFactory(
       $this->builder,

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -45,6 +45,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/product-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
+    $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
 
     // WooCommerce 10.8.0+ patterns (uses generated coupon block)
     $this->assertContains('mailpoet/welcome-with-discount-email-content', $patternNames);
@@ -52,7 +53,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(16, $blockPatterns);
+    $this->assertCount(17, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
@@ -131,6 +132,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/product-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
+    $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
 
     // Should NOT include generated coupon block patterns (require WooCommerce 10.8.0+)
     $this->assertNotContains('mailpoet/welcome-with-discount-email-content', $patternNames);
@@ -138,7 +140,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count (all patterns except 3 coupon patterns)
-    $this->assertCount(13, $blockPatterns);
+    $this->assertCount(14, $blockPatterns);
   }
 
   /**
@@ -271,6 +273,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertNotContains('mailpoet/win-back-customer', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-content', $patternNames);
+    $this->assertNotContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count (only non-WooCommerce patterns)
@@ -335,6 +338,7 @@ class PatternsControllerTest extends \MailPoetTest {
       'mailpoet/product-purchase-follow-up',
       'mailpoet/win-back-customer',
       'mailpoet/abandoned-cart-content',
+      'mailpoet/abandoned-cart-reminder-content',
       'mailpoet/abandoned-cart-with-discount-content',
     ];
 


### PR DESCRIPTION
## Description

Part of the abandoned cart automation series (STOMAIL-8121).

- Adds a distinct `AbandonedCartReminderPattern` (`abandoned-cart-reminder-content`) so the second reminder email no longer duplicates the first.
- `PatternsController::getPatternContent()` now returns the email content (`get_email_content()`), so automation emails embed the live WooCommerce product-collection cart block instead of static product placeholders.

## Code review notes

The `getPatternContent()` change applies to **all** automation-created emails, not just abandoned cart. For patterns without an email-specific variant, `get_email_content()` defaults to `get_content()`, so only product/cart patterns change behaviour.

## QA notes

In the Abandoned cart campaign automation, the 1st and 2nd reminder emails should now have distinct content, and product blocks should reflect the customer's actual cart rather than placeholders.

## Linked PRs

Premium: mailpoet/mailpoet-premium#1088

## Linked tickets

STOMAIL-8121

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8121-add-email-templates-for-abandoned-cart-automations)

_The latest successful build from `stomail-8121-add-email-templates-for-abandoned-cart-automations` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->