### PR TITLE
Fix automation email menu selection

### DIFF
--- a/mailpoet/changelog/2026-06-04-14-19-22-improved-automations-menu-highlighting-when-editing-automat.md
+++ b/mailpoet/changelog/2026-06-04-14-19-22-improved-automations-menu-highlighting-when-editing-automat.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Automations menu highlighting when editing automation emails

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -31,6 +31,7 @@ use MailPoet\AdminPages\Pages\WooCommerceSetup;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\Form\Util\CustomFonts;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Util\License\Features\CapabilitiesManager;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WPCOM\DotcomHelperFunctions;
@@ -758,11 +759,12 @@ class Menu {
       return $parentFile;
     }
 
-    // In case we are on the email editor page, we want to highlight the Emails menu item
+    // In case we are on the email editor page, we want to highlight the related MailPoet menu item
     if ($this->emailEditor->isEditorPage(false)) {
-      $plugin_page = self::EMAILS_PAGE_SLUG;
-      $submenu_file = self::EMAILS_PAGE_SLUG;
-      return self::EMAILS_PAGE_SLUG;
+      $emailEditorMenuPageSlug = $this->getEmailEditorMenuPageSlug();
+      $plugin_page = $emailEditorMenuPageSlug;
+      $submenu_file = $emailEditorMenuPageSlug;
+      return $emailEditorMenuPageSlug;
     }
 
     if ($parentFile === self::MAIN_PAGE_SLUG || !self::isOnMailPoetAdminPage()) {
@@ -789,6 +791,22 @@ class Menu {
       $plugin_page = self::MAIN_PAGE_SLUG;
     }
     return $parentFile;
+  }
+
+  private function getEmailEditorMenuPageSlug(): string {
+    // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- is_numeric guard plus int cast is the sanitization
+    $rawPostId = $_GET['post'] ?? null;
+    $postId = is_numeric($rawPostId) ? (int)$rawPostId : 0;
+    if (!$postId) {
+      return self::EMAILS_PAGE_SLUG;
+    }
+
+    $newslettersRepository = $this->container->get(NewslettersRepository::class);
+    $newsletter = $newslettersRepository->findOneBy(['wpPost' => $postId]);
+    if ($newsletter && ($newsletter->isAutomation() || $newsletter->isAutomationTransactional())) {
+      return self::AUTOMATIONS_PAGE_SLUG;
+    }
+    return self::EMAILS_PAGE_SLUG;
   }
 
   public static function isOnMailPoetAutomationPage(): bool {

--- a/mailpoet/tests/integration/Config/MenuTest.php
+++ b/mailpoet/tests/integration/Config/MenuTest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Config;
 use Codeception\Util\Stub;
 use MailPoet\Config\Menu;
 use MailPoet\Config\ServicesChecker;
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Test\DataFactories\Newsletter;
 
 class MenuTest extends \MailPoetTest {
   public function testItReturnsTrueIfCurrentPageBelongsToMailpoet() {
@@ -55,5 +58,67 @@ class MenuTest extends \MailPoetTest {
     );
     $menu->checkPremiumKey($checker);
     verify($menu->premiumKeyValid)->false();
+  }
+
+  public function testItHighlightsAutomationsWhenEditingAutomationEmail() {
+    $this->assertEmailEditorMenuPage(NewsletterEntity::TYPE_AUTOMATION, Menu::AUTOMATIONS_PAGE_SLUG);
+  }
+
+  public function testItHighlightsEmailsWhenEditingStandardEmail() {
+    $this->assertEmailEditorMenuPage(NewsletterEntity::TYPE_STANDARD, Menu::EMAILS_PAGE_SLUG);
+  }
+
+  private function assertEmailEditorMenuPage(string $newsletterType, string $expectedMenuPageSlug): void {
+    global $plugin_page, $submenu_file;
+
+    $postId = wp_insert_post([
+      'post_title' => 'MailPoet email',
+      'post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
+      'post_status' => 'private',
+    ]);
+    verify($postId)->greaterThan(0);
+
+    (new Newsletter())
+      ->withType($newsletterType)
+      ->withWpPostId($postId)
+      ->create();
+
+    $previousPost = $_GET['post'] ?? null;
+    $previousAction = $_GET['action'] ?? null;
+    $previousPluginPage = $plugin_page ?? null;
+    $previousSubmenuFile = $submenu_file ?? null;
+    $_GET['post'] = (string)$postId;
+    $_GET['action'] = 'edit';
+
+    $menu = $this->diContainer->get(Menu::class);
+    $emailEditorProperty = new \ReflectionProperty(Menu::class, 'emailEditor');
+    $emailEditorProperty->setAccessible(true);
+    $previousEmailEditor = $emailEditorProperty->getValue($menu);
+
+    try {
+      $emailEditor = Stub::makeEmpty(EmailEditor::class, ['isEditorPage' => true], $this);
+      $emailEditorProperty->setValue($menu, $emailEditor);
+      $parentFile = $menu->highlightNestedMailPoetSubmenus(
+        'edit.php?post_type=' . EmailEditor::MAILPOET_EMAIL_POST_TYPE
+      );
+
+      verify($parentFile)->equals($expectedMenuPageSlug);
+      verify($plugin_page)->equals($expectedMenuPageSlug);
+      verify($submenu_file)->equals($expectedMenuPageSlug);
+    } finally {
+      if ($previousPost === null) {
+        unset($_GET['post']);
+      } else {
+        $_GET['post'] = $previousPost;
+      }
+      if ($previousAction === null) {
+        unset($_GET['action']);
+      } else {
+        $_GET['action'] = $previousAction;
+      }
+      $plugin_page = $previousPluginPage;
+      $submenu_file = $previousSubmenuFile;
+      $emailEditorProperty->setValue($menu, $previousEmailEditor);
+    }
   }
 }


### PR DESCRIPTION
## Description

Fixes MailPoet admin menu highlighting so automation emails opened in the block email editor select Automations instead of Emails.

## Code review notes

_N/A_

## QA notes

- Targeted integration coverage passes.
- Full QA currently stops on unrelated PHPCS violations in bundled WooCommerce/vendor test-plugin files.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8134

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
|   <img width="1205" height="701" alt="Screenshot 2026-06-04 at 16 10 35" src="https://github.com/user-attachments/assets/222a5b68-2493-407b-99c0-f67028faa1e8" />  |  <img width="1206" height="675" alt="Screenshot 2026-06-04 at 16 11 01" src="https://github.com/user-attachments/assets/75b0d6e5-a9f7-4468-b221-ef197ae288db" />   |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=&lt;type&gt; --description=&lt;description&gt;`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->