### PR TITLE
Add email content for post-purchase automation templates

### DIFF
--- a/mailpoet/changelog/2026-06-03-14-31-02-added-email-content-for-post-purchase-automation-templat.md
+++ b/mailpoet/changelog/2026-06-03-14-31-02-added-email-content-for-post-purchase-automation-templat.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Email content for post-purchase automation templates

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -246,7 +246,16 @@ class TemplatesFactory {
         'Welcome your first-time customers by sending an email with a special offer for their next purchase. Make them feel appreciated within your brand.',
         'mailpoet'
       ),
-      function (): Automation {
+      function (bool $preview = false): Automation {
+        $emailArgs = $this->createBlockEditorEmailArgs(
+          $preview,
+          'first-purchase-thank-you',
+          __('First purchase thank you', 'mailpoet'),
+          __('Thank you for your first order!', 'mailpoet'),
+          __('Welcome to the family! Check out what’s next for you.', 'mailpoet'),
+          'first-purchase'
+        );
+
         return $this->builder->createFromSequence(
           __('Celebrate first-time buyers', 'mailpoet'),
           [
@@ -266,10 +275,7 @@ class TemplatesFactory {
             ],
             [
               'key' => 'mailpoet:send-email',
-              'args' => [
-                'name' => __('Thank you', 'mailpoet'),
-                'subject' => __('Thank You for Choosing Us!', 'mailpoet'),
-              ],
+              'args' => $emailArgs,
             ],
           ],
           [

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -492,7 +492,16 @@ class TemplatesFactory {
         'Share care instructions or simply thank the customer for making an order.',
         'mailpoet'
       ),
-      function (): Automation {
+      function (bool $preview = false): Automation {
+        $emailArgs = $this->createBlockEditorEmailArgs(
+          $preview,
+          'category-purchase-follow-up',
+          __('Important information about your order', 'mailpoet'),
+          __('Important information about your order', 'mailpoet'),
+          __('A few details about your purchase', 'mailpoet'),
+          'purchased-in-category'
+        );
+
         return $this->builder->createFromSequence(
           __('Purchased in a category', 'mailpoet'),
           [
@@ -501,10 +510,7 @@ class TemplatesFactory {
             ],
             [
               'key' => 'mailpoet:send-email',
-              'args' => [
-                'name' => __('Important information about your order', 'mailpoet'),
-                'subject' => __('Important information about your order', 'mailpoet'),
-              ],
+              'args' => $emailArgs,
             ],
           ]
         );

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -452,7 +452,16 @@ class TemplatesFactory {
         'Share care instructions or simply thank the customer for making an order.',
         'mailpoet'
       ),
-      function (): Automation {
+      function (bool $preview = false): Automation {
+        $emailArgs = $this->createBlockEditorEmailArgs(
+          $preview,
+          'tag-purchase-follow-up',
+          __('Important information about your order', 'mailpoet'),
+          __('Important information about your order', 'mailpoet'),
+          __('A few details about your purchase', 'mailpoet'),
+          'purchased-product-with-tag'
+        );
+
         return $this->builder->createFromSequence(
           __('Purchased a product with a tag', 'mailpoet'),
           [
@@ -461,10 +470,7 @@ class TemplatesFactory {
             ],
             [
               'key' => 'mailpoet:send-email',
-              'args' => [
-                'name' => __('Important information about your order', 'mailpoet'),
-                'subject' => __('Important information about your order', 'mailpoet'),
-              ],
+              'args' => $emailArgs,
             ],
           ]
         );

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -412,7 +412,16 @@ class TemplatesFactory {
         'Share care instructions or simply thank the customer for making an order.',
         'mailpoet'
       ),
-      function (): Automation {
+      function (bool $preview = false): Automation {
+        $emailArgs = $this->createBlockEditorEmailArgs(
+          $preview,
+          'product-purchase-follow-up',
+          __('Important information about your order', 'mailpoet'),
+          __('Important information about your order', 'mailpoet'),
+          __('A few details about your purchase', 'mailpoet'),
+          'purchased-product'
+        );
+
         return $this->builder->createFromSequence(
           __('Purchased a product', 'mailpoet'),
           [
@@ -421,10 +430,7 @@ class TemplatesFactory {
             ],
             [
               'key' => 'mailpoet:send-email',
-              'args' => [
-                'name' => __('Important information about your order', 'mailpoet'),
-                'subject' => __('Important information about your order', 'mailpoet'),
-              ],
+              'args' => $emailArgs,
             ],
           ]
         );

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -227,6 +227,14 @@ class TemplatesFactoryTest extends MailPoetTest {
         'Important information about your order',
         'A few details about your purchase',
       ],
+      'purchased in category' => [
+        'purchased-in-category',
+        'woocommerce:buys-from-a-category',
+        'category-purchase-follow-up',
+        'Important information about your order',
+        'Important information about your order',
+        'A few details about your purchase',
+      ],
     ];
   }
 

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -211,6 +211,14 @@ class TemplatesFactoryTest extends MailPoetTest {
         'Thank you for your first order!',
         'Welcome to the family! Check out what’s next for you.',
       ],
+      'purchased product' => [
+        'purchased-product',
+        'woocommerce:buys-a-product',
+        'product-purchase-follow-up',
+        'Important information about your order',
+        'Important information about your order',
+        'A few details about your purchase',
+      ],
     ];
   }
 

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -9,6 +9,10 @@ use MailPoet\Automation\Engine\Templates\AutomationBuilder;
 use MailPoet\Automation\Integrations\MailPoet\Templates\EmailFactory;
 use MailPoet\Automation\Integrations\MailPoet\Templates\TemplatesFactory;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\AbandonedCart\AbandonedCartTrigger;
+use MailPoet\Automation\Integrations\WooCommerce\Triggers\BuysAProductTrigger;
+use MailPoet\Automation\Integrations\WooCommerce\Triggers\BuysFromACategoryTrigger;
+use MailPoet\Automation\Integrations\WooCommerce\Triggers\BuysFromATagTrigger;
+use MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderCompletedTrigger;
 use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WooCommerce\WooCommerceBookings\Helper as WooCommerceBookingsHelper;
@@ -118,6 +122,98 @@ class TemplatesFactoryTest extends MailPoetTest {
     ];
   }
 
+  /**
+   * The first purchase template filters on WooCommerce order fields, which can
+   * only be built with an active WooCommerce, so these tests run in the woo jobs.
+   *
+   * @group woo
+   * @dataProvider postPurchaseTemplateEmailData
+   */
+  public function testPostPurchaseTemplateCreatesBlockEditorEmail(
+    string $slug,
+    string $expectedTriggerKey,
+    string $expectedPattern,
+    string $expectedName,
+    string $expectedSubject,
+    string $expectedPreheader
+  ): void {
+    $this->ensureWooCommerceTriggerRegistered($expectedTriggerKey);
+    $this->emailFactory->expects($this->once())
+      ->method('createBlockEditorEmail')
+      ->with([
+        'pattern' => $expectedPattern,
+        'subject' => $expectedSubject,
+        'preheader' => $expectedPreheader,
+      ])
+      ->willReturn([
+        'email_id' => 123,
+        'email_wp_post_id' => 456,
+      ]);
+
+    $factory = $this->createFactory();
+    $template = $this->findTemplateBySlug($factory->createTemplates(), $slug);
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation();
+
+    $this->assertNotNull($this->getFirstStepByKey($automation->getSteps(), $expectedTriggerKey));
+    $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertInstanceOf(Step::class, $sendEmailStep);
+    $args = $sendEmailStep->getArgs();
+
+    $this->assertSame($expectedName, $args['name']);
+    $this->assertSame($expectedSubject, $args['subject']);
+    $this->assertSame($expectedPreheader, $args['preheader']);
+    $this->assertSame(123, $args['email_id']);
+    $this->assertSame(456, $args['email_wp_post_id']);
+  }
+
+  /**
+   * @group woo
+   * @dataProvider postPurchaseTemplateEmailData
+   */
+  public function testPostPurchaseTemplatePreviewDoesNotCreatePersistentEmail(
+    string $slug,
+    string $expectedTriggerKey,
+    string $expectedPattern,
+    string $expectedName,
+    string $expectedSubject,
+    string $expectedPreheader
+  ): void {
+    $this->ensureWooCommerceTriggerRegistered($expectedTriggerKey);
+    $this->emailFactory->expects($this->never())->method('createBlockEditorEmail');
+
+    $factory = $this->createFactory();
+    $template = $this->findTemplateBySlug($factory->createTemplates(), $slug);
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation(true);
+
+    $this->assertNotNull($this->getFirstStepByKey($automation->getSteps(), $expectedTriggerKey));
+    $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertInstanceOf(Step::class, $sendEmailStep);
+    $args = $sendEmailStep->getArgs();
+
+    $this->assertSame($expectedName, $args['name']);
+    $this->assertSame($expectedSubject, $args['subject']);
+    $this->assertSame($expectedPreheader, $args['preheader']);
+    $this->assertArrayNotHasKey('email_id', $args);
+    $this->assertArrayNotHasKey('email_wp_post_id', $args);
+  }
+
+  public function postPurchaseTemplateEmailData(): array {
+    return [
+      'first purchase' => [
+        'first-purchase',
+        'woocommerce:order-completed',
+        'first-purchase-thank-you',
+        'First purchase thank you',
+        'Thank you for your first order!',
+        'Welcome to the family! Check out what’s next for you.',
+      ],
+    ];
+  }
+
   public function testAbandonedCartTemplateCreatesBlockEditorEmail(): void {
     $this->ensureAbandonedCartTriggerRegistered();
     $this->emailFactory->expects($this->once())
@@ -171,12 +267,25 @@ class TemplatesFactoryTest extends MailPoetTest {
 
   // WooCommerce automation triggers are registered once into the shared Registry at engine init.
   // A test running earlier in the suite can leave the Registry without them, which would make
-  // createFromSequence() silently drop the trigger step. Re-register it so this test does not
+  // createFromSequence() silently drop the trigger step. Re-register them so these tests do not
   // depend on suite ordering.
   private function ensureAbandonedCartTriggerRegistered(): void {
     $registry = $this->diContainer->get(Registry::class);
     if ($registry->getStep(AbandonedCartTrigger::KEY) === null) {
       $registry->addTrigger($this->diContainer->get(AbandonedCartTrigger::class));
+    }
+  }
+
+  private function ensureWooCommerceTriggerRegistered(string $triggerKey): void {
+    $triggerClasses = [
+      'woocommerce:order-completed' => OrderCompletedTrigger::class,
+      BuysAProductTrigger::KEY => BuysAProductTrigger::class,
+      BuysFromATagTrigger::KEY => BuysFromATagTrigger::class,
+      BuysFromACategoryTrigger::KEY => BuysFromACategoryTrigger::class,
+    ];
+    $registry = $this->diContainer->get(Registry::class);
+    if ($registry->getStep($triggerKey) === null) {
+      $registry->addTrigger($this->diContainer->get($triggerClasses[$triggerKey]));
     }
   }
 

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -219,6 +219,14 @@ class TemplatesFactoryTest extends MailPoetTest {
         'Important information about your order',
         'A few details about your purchase',
       ],
+      'purchased product with tag' => [
+        'purchased-product-with-tag',
+        'woocommerce:buys-from-a-tag',
+        'tag-purchase-follow-up',
+        'Important information about your order',
+        'Important information about your order',
+        'A few details about your purchase',
+      ],
     ];
   }
 


### PR DESCRIPTION
## Description

Wires the four post-purchase automation templates (first purchase, purchased a product, purchased a product with a tag, purchased in a category) to create real block-editor emails from their patterns, replacing the previous plain name/subject args.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

- Based on #6828 (order-aware product recommendations) — merge that PR first.

## Linked tickets

STOMAIL-8122

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8122-add-email-templates-for-post-purchase-automations)

_The latest successful build from `stomail-8122-add-email-templates-for-post-purchase-automations` will be used. If none is available, the link won't work._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->