### PR TITLE
Fix REST URLs for plain permalinks

### DIFF
--- a/mailpoet/assets/js/src/automation/listing/store/legacy-api.tsx
+++ b/mailpoet/assets/js/src/automation/listing/store/legacy-api.tsx
@@ -1,5 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import { buildRestApiPath } from 'common/dataviews';
 import { api } from '../../config';
 import { AutomationStatus } from '../automation';
 
@@ -66,11 +67,14 @@ export async function getLegacyNewsletters(
   do {
     // eslint-disable-next-line no-await-in-loop
     const response = await apiFetch<ListingResponse>({
-      url: addQueryArgs(`${api.root}/mailpoet/v1/newsletters`, {
-        type,
-        page,
-        per_page: LEGACY_AUTOMATIONS_PER_PAGE,
-      }),
+      url: buildRestApiPath(
+        api.root,
+        addQueryArgs('/mailpoet/v1/newsletters', {
+          type,
+          page,
+          per_page: LEGACY_AUTOMATIONS_PER_PAGE,
+        }),
+      ),
       method: 'GET',
       headers: {
         'X-WP-Nonce': api.nonce,

--- a/mailpoet/assets/js/src/common/dataviews/index.ts
+++ b/mailpoet/assets/js/src/common/dataviews/index.ts
@@ -1,6 +1,7 @@
 export { useDataViewsQuery } from './use-dataviews-query';
 export type { LoadListing } from './use-dataviews-query';
 export {
+  buildRestApiPath,
   configureRestApi,
   createRestListingLoader,
   restPost,

--- a/mailpoet/assets/js/src/common/dataviews/rest-listing.ts
+++ b/mailpoet/assets/js/src/common/dataviews/rest-listing.ts
@@ -31,18 +31,25 @@ function ensureLeadingSlash(value: string): string {
   return value.startsWith('/') ? value : `/${value}`;
 }
 
+export function buildRestApiPath(root: string, path: string): string {
+  const normalizedRoot = ensureTrailingSlash(root);
+  const normalizedPath = ensureLeadingSlash(path).slice(1);
+  const querySafePath = normalizedRoot.includes('?')
+    ? normalizedPath.replace('?', '&')
+    : normalizedPath;
+  return `${normalizedRoot}${querySafePath}`;
+}
+
 function configureMiddleware(): void {
   if (isConfigured) return;
 
   apiFetch.use((options, next) => {
     const path = typeof options.path === 'string' ? options.path : '';
     const hasUrl = typeof options.url === 'string' && options.url.length > 0;
-    const normalizedPath = path ? ensureLeadingSlash(path) : path;
-    const root = ensureTrailingSlash(configuredRoot);
 
     return next({
       ...options,
-      ...(hasUrl ? {} : { path: `${root}${normalizedPath.slice(1)}` }),
+      ...(hasUrl ? {} : { path: buildRestApiPath(configuredRoot, path) }),
     });
   });
 

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/recipients-row.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/recipients-row.tsx
@@ -21,6 +21,7 @@ import { store as editorStore } from '@wordpress/editor';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { MailPoet } from 'mailpoet';
+import { buildRestApiPath } from 'common/dataviews';
 
 type Segment = {
   id: string;
@@ -57,10 +58,13 @@ async function fetchSegmentPage<T>(
   page: number,
 ): Promise<ListingResponse<T>> {
   return apiFetch<ListingResponse<T>>({
-    url: addQueryArgs(`${window.mailpoet_segments_api.root}${path}`, {
-      page,
-      per_page: SEGMENTS_PER_PAGE,
-    }),
+    url: buildRestApiPath(
+      window.mailpoet_segments_api.root,
+      addQueryArgs(path, {
+        page,
+        per_page: SEGMENTS_PER_PAGE,
+      }),
+    ),
     method: 'GET',
     headers: {
       'X-WP-Nonce': window.mailpoet_segments_api.nonce,

--- a/mailpoet/changelog/2026-06-08-12-20-56-fixed-fix-mailpoet-rest-endpoints-on-sites-using-plain-p.md
+++ b/mailpoet/changelog/2026-06-08-12-20-56-fixed-fix-mailpoet-rest-endpoints-on-sites-using-plain-p.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix MailPoet REST endpoints on sites using plain permalinks

--- a/mailpoet/tests/javascript/common/dataviews/rest-listing.spec.ts
+++ b/mailpoet/tests/javascript/common/dataviews/rest-listing.spec.ts
@@ -1,0 +1,27 @@
+import { buildRestApiPath } from '../../../../assets/js/src/common/dataviews/rest-listing';
+
+describe('DataViews REST listing API', () => {
+  describe('buildRestApiPath', () => {
+    it('builds a request path for pretty permalinks', () => {
+      const path = buildRestApiPath(
+        'https://example.com/wp-json',
+        '/mailpoet/v1/subscribers?page=1&per_page=20',
+      );
+
+      expect(path).to.equal(
+        'https://example.com/wp-json/mailpoet/v1/subscribers?page=1&per_page=20',
+      );
+    });
+
+    it('keeps query arguments outside rest_route for plain permalinks', () => {
+      const path = buildRestApiPath(
+        'https://example.com/index.php?rest_route=',
+        '/mailpoet/v1/subscribers?page=1&per_page=20',
+      );
+
+      expect(path).to.equal(
+        'https://example.com/index.php?rest_route=/mailpoet/v1/subscribers&page=1&per_page=20',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fix MailPoet REST listing URLs for sites using plain permalinks so query arguments stay outside `rest_route`.

## Code review notes

_N/A_

## QA notes

1. Set permalinks to Plain.
2. Ensure that all MailPoet listing pages work.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8141

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="1150" height="613" alt="Screenshot 2026-06-08 at 15 04 55" src="https://github.com/user-attachments/assets/42e269b1-a5c9-41ea-a2ef-4296430a0172" /> | <img width="1309" height="550" alt="Screenshot 2026-06-08 at 14 54 21" src="https://github.com/user-attachments/assets/b699a5b5-c83d-468a-a1d2-917a7953ffe6" /> |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

1 issue found: Bug

This PR fixes a bug where MailPoet REST endpoints returned 404 errors when sites used Plain permalinks. The issue occurred because query parameters were being included in the `rest_route` parameter instead of remaining outside it. 

The fix introduces a new `buildRestApiPath()` helper function that properly merges REST root paths with query parameters, ensuring query arguments remain outside the `rest_route` parameter to avoid route-level 404 errors. This helper is then applied to REST endpoint URL construction in multiple files (legacy-api.tsx and recipients-row.tsx) and is exported via the dataviews module for broader use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->