### PR TITLE
Fix Amazon SES error mapping

### DIFF
--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/AmazonSESMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/AmazonSESMapper.php
@@ -26,13 +26,20 @@ class AmazonSESMapper {
    * @return MailerError
    */
   public function getErrorFromResponse($response, $subscriber) {
-    $message = ($response) ?
-      $response->Error->Message->__toString() : // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      // translators: %s is the name of the method.
-      sprintf(__('%s has returned an unknown error.', 'mailpoet'), Mailer::METHOD_AMAZONSES);
+    // translators: %s is the name of the method.
+    $message = sprintf(__('%s has returned an unknown error.', 'mailpoet'), Mailer::METHOD_AMAZONSES);
+    $code = null;
+    if ($response && isset($response->Error)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      if (isset($response->Error->Message) && (string)$response->Error->Message !== '') { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        $message = (string)$response->Error->Message; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      }
+      if (isset($response->Error->Code) && (string)$response->Error->Code !== '') { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        $code = (string)$response->Error->Code; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      }
+    }
 
     $level = MailerError::LEVEL_HARD;
-    if ($response && $response->Error->Code->__toString() === 'MessageRejected') { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    if ($code === 'MessageRejected') {
       $level = MailerError::LEVEL_SOFT;
     }
     $subscriberErrors = [new SubscriberError($subscriber, null)];

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/AmazonSESMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/AmazonSESMapperTest.php
@@ -42,6 +42,25 @@ class AmazonSESMapperTest extends \MailPoetUnitTest {
     verify($error->getLevel())->equals(MailerError::LEVEL_SOFT);
   }
 
+  public function testGetUnknownErrorWhenResponseMessageIsMissing() {
+    unset($this->responseData['Error']['Message']);
+    $response = $this->buildXmlResponseFromArray($this->responseData, new SimpleXMLElement('<response/>'));
+    $error = $this->mapper->getErrorFromResponse($response, 'john@rambo.com');
+    verify($error->getMessage())->equals('AmazonSES has returned an unknown error.');
+  }
+
+  public function testGetUnknownErrorWhenResponseErrorIsMissing() {
+    $error = $this->mapper->getErrorFromResponse(new SimpleXMLElement('<response/>'), 'john@rambo.com');
+    verify($error->getMessage())->equals('AmazonSES has returned an unknown error.');
+  }
+
+  public function testGetHardErrorWhenResponseCodeIsMissing() {
+    unset($this->responseData['Error']['Code']);
+    $response = $this->buildXmlResponseFromArray($this->responseData, new SimpleXMLElement('<response/>'));
+    $error = $this->mapper->getErrorFromResponse($response, 'john@rambo.com');
+    verify($error->getLevel())->equals(MailerError::LEVEL_HARD);
+  }
+
   /**
    * @return SimpleXMLElement
    */


### PR DESCRIPTION
## Description

Fixes Amazon SES error mapping when SES returns XML without `Error`, `Error.Message`, or `Error.Code`. Missing messages now use the existing unknown-error text, and missing codes remain hard errors.

## Code review notes

_N/A_

## QA notes

- `pnpm test:unit --file=tests/unit/Mailer/Methods/ErrorMappers/AmazonSESMapperTest.php`
- `pnpm test:integration --file=tests/integration/Mailer/Methods/AmazonSESTest.php` (1 live-AWS test skipped without `WP_TEST_MAILER_ENABLE_SENDING=true`)
- `./do qa:prettier-check`
- Scoped PHPCS on changed files
- `./do qa` did not complete: repo-wide PHPCS emitted existing bundled test plugin/vendor violations and the Robo process ran out of memory collecting output

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8142

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8142-fix-amazon-ses-error-mapping-for-missing-response-fields)

_The latest successful build from `stomail-8142-fix-amazon-ses-error-mapping-for-missing-response-fields` will be used. If none is available, the link won't work._