### PR TITLE
Minor WordPress 7.0 UI fixes

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -8,7 +8,7 @@
   align-items: center;
 
   .mailpoet-page-header-content {
-    align-items: center;
+    align-items: baseline;
     display: flex;
     flex-wrap: wrap;
     gap: 4px;
@@ -36,7 +36,6 @@
 @include respond-to(small-screen) {
   .mailpoet-subscribers-page-header {
     .mailpoet-page-header-content {
-      align-items: flex-start;
       flex-direction: column;
     }
   }

--- a/mailpoet/assets/css/src/generic/_buttons.scss
+++ b/mailpoet/assets/css/src/generic/_buttons.scss
@@ -37,6 +37,10 @@
   &:not(.mailpoet-full-width) + .mailpoet-button:not(.mailpoet-full-width) {
     margin-left: $grid-gap;
   }
+
+  &.button-link {
+    border: 0 !important;
+  }
 }
 
 .mailpoet-button-with-spinner {

--- a/mailpoet/assets/js/src/segments/static/fields.ts
+++ b/mailpoet/assets/js/src/segments/static/fields.ts
@@ -55,28 +55,11 @@ export const segmentFields: Field<SegmentListingItem>[] = [
           { 'data-automation-id': `segment_name_${item.name}` },
           title,
         );
-      const legacyViewSubscribersAction = createElement(
-        'div',
-        { className: 'mailpoet-listing-actions-holder' },
-        createElement(
-          'div',
-          { className: 'mailpoet-listing-actions' },
-          createElement(
-            'a',
-            {
-              'data-automation-id': `view_subscribers_${item.name}`,
-              href: item.subscribers_url,
-            },
-            MailPoet.I18n.t('viewSubscribers'),
-          ),
-        ),
-      );
       if (item.type === 'wp_users' || item.type === 'woocommerce_users') {
         return createElement(
           'div',
           null,
           wrapLegacyNameSelector(createElement('span', props, ...children)),
-          legacyViewSubscribersAction,
         );
       }
       return createElement(
@@ -89,7 +72,6 @@ export const segmentFields: Field<SegmentListingItem>[] = [
             ...children,
           ),
         ),
-        legacyViewSubscribersAction,
       );
     },
   },

--- a/mailpoet/tests/acceptance/Settings/WooCommerceSetupPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceSetupPageCest.php
@@ -51,8 +51,7 @@ class WooCommerceSetupPageCest {
     $i->waitForText('Welcome to MailPoet', 10, '.mailpoet-homepage__container');
     $i->amOnMailpoetPage('Lists');
     $i->waitForText('WooCommerce Customers');
-    $i->moveMouseOver('[data-automation-id="segment_name_WooCommerce Customers"]');
-    $i->click('[data-automation-id="view_subscribers_WooCommerce Customers"]');
+    $i->clickItemRowActionByItemName('WooCommerce Customers', 'View subscribers');
     $i->waitForListingItemsToLoad();
 
     $i->triggerMailPoetActionScheduler();

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -22,7 +22,11 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, waitForDataViews } from '../utils/helpers.js';
+import {
+  login,
+  waitForDataViews,
+  clickMenuItemByText,
+} from '../utils/helpers.js';
 
 export async function listsViewSubscribers() {
   const page = await browser.newPage();
@@ -42,18 +46,24 @@ export async function listsViewSubscribers() {
       fullPage: fullPageSet,
     });
 
-    // Click to view subscribers of the default list "Newsletter mailing list"
+    // Open the row actions menu for the default list "Newsletter mailing list"
+    // and click the "View subscribers" DataViews action.
     await page.waitForSelector(
       '[data-automation-id="segment_name_' + defaultListName + '"]',
     );
-    await page
-      .locator('[data-automation-id="segment_name_' + defaultListName + '"]')
-      .hover();
-    await page
-      .locator(
-        '[data-automation-id="view_subscribers_' + defaultListName + '"]',
-      )
-      .click();
+    await page.evaluate((listName) => {
+      const nameCell = document.querySelector(
+        '[data-automation-id="segment_name_' + listName + '"]',
+      );
+      const row = nameCell ? nameCell.closest('tr') : null;
+      const actionsToggle = row
+        ? row.querySelector('button[aria-haspopup="menu"]')
+        : null;
+      if (actionsToggle) {
+        actionsToggle.click();
+      }
+    }, defaultListName);
+    await clickMenuItemByText(page, 'View subscribers');
 
     // Wait for the page to load
     await waitForDataViews(page, '.mailpoet-subscribers-dataviews');


### PR DESCRIPTION
## Description

- Removed borders on link-like buttons
- Vertically align title buttons on Subscribers page
- Remove legacy "View subscribers" link as it's also part of native DataViews actions 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wp7-ui-fixes)

_The latest successful build from `wp7-ui-fixes` will be used. If none is available, the link won't work._