### PR TITLE
Fix notification history title overflow

### DIFF
--- a/mailpoet/assets/js/src/newsletters/listings/notification-history.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification-history.tsx
@@ -43,16 +43,15 @@ function buildFields(
               .newsletter_rendered_subject) ||
           item.subject;
         return (
-          <strong>
-            <a
-              href={item.preview_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              data-automation-id={`listing_item_${item.id}`}
-            >
-              {subject}
-            </a>
-          </strong>
+          <a
+            className="mailpoet-listing-title"
+            href={item.preview_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-automation-id={`listing_item_${item.id}`}
+          >
+            {subject}
+          </a>
         );
       },
     },

--- a/mailpoet/changelog/2026-06-08-20-29-52-fixed-post-notification-history-titles-overflowing-into-.md
+++ b/mailpoet/changelog/2026-06-08-20-29-52-fixed-post-notification-history-titles-overflowing-into-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Post notification history titles overflowing into other columns


### PR DESCRIPTION
## Description

Fixes post notification history titles overflowing into adjacent columns by rendering the title link with the same listing title class as other email listings.

## Code review notes

The history listing had an extra wrapper around a plain link, so the title link did not match the DOM used by the email listings where DataViews ellipsis behavior works correctly.

## QA notes

- `pnpm compile:js`
- `pnpm qa:js`
- `pnpm test:javascript`
- `./do qa:prettier-check`
- Full `./do qa` skipped per request after PHP lint completed and PHPCS started.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8145](https://linear.app/a8c/issue/STOMAIL-8145/post-notification-history-title-overflows-into-columns)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

| Before | After | 
| ----- | ----- |
|  <img width="1426" height="638" alt="Screenshot 2026-06-08 at 22 31 04" src="https://github.com/user-attachments/assets/21e8dde9-d783-4a51-9c76-33ccd66e0ba2" /> | <img width="1418" height="627" alt="Screenshot 2026-06-08 at 22 29 40" src="https://github.com/user-attachments/assets/905934f8-239a-40de-9ab2-143acfb7fbed" /> |



## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8145-post-notification-history-title-overflows-into-columns)

_The latest successful build from `fix/stomail-8145-post-notification-history-title-overflows-into-columns` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The PR successfully fixes the notification history title overflow issue by removing unnecessary DOM nesting and standardizing the markup to match other listings in the codebase. The change maintains visual consistency through CSS styling while enabling proper text ellipsis behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->