### PR TITLE
Exclude WooCommerceDummyDataTest from no-Woo integration job

### DIFF
--- a/mailpoet/tests/integration/Newsletter/Preview/WooCommerceDummyDataTest.php
+++ b/mailpoet/tests/integration/Newsletter/Preview/WooCommerceDummyDataTest.php
@@ -2,6 +2,9 @@
 
 namespace MailPoet\Newsletter\Preview;
 
+/**
+ * @group woo
+ */
 class WooCommerceDummyDataTest extends \MailPoetTest {
   /** @var WooCommerceDummyData */
   private $dummyData;


### PR DESCRIPTION
## Description

`WooCommerceDummyDataTest` calls `markTestSkipped('WooCommerce is not active.')` in `_before()` when `\WC_Order` is absent. The `integration_test_base` CI job runs the integration suite with `skip_group: woo` and `skip_plugins: 1` (WooCommerce not loaded), so the test skipped — and `CheckSkippedTestsExtension` forbids skipped tests on `trunk`/`release`, failing the job.

Adding the class-level `@group woo` annotation excludes the class from the no-Woo base job so it only runs where WooCommerce is present, matching the convention used by other WooCommerce-dependent integration tests.

Example failure: https://app.circleci.com/pipelines/github/mailpoet/mailpoet/23659/workflows/400bd1d8-deb8-4b4b-a854-251e22018abf/jobs/415668

## Code review notes

_N/A_

## QA notes

Test-only change; verifiable by the `integration_test_base` job passing.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8149

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8149-fix-integration_test_base-failure-woocommercedummydatatest)

_The latest successful build from `stomail-8149-fix-integration_test_base-failure-woocommercedummydatatest` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test organization and categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->