### PR TITLE
Increase MailPoet test coverage

### DIFF
--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/CommentSubjectToSubscriberSubjectTransformerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/CommentSubjectToSubscriberSubjectTransformerTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\MailPoet\SubjectTransformers;
+
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\CommentSubjectToSubscriberSubjectTransformer;
+use MailPoet\Automation\Integrations\WordPress\Subjects\CommentSubject;
+use MailPoet\Test\DataFactories\Subscriber;
+
+class CommentSubjectToSubscriberSubjectTransformerTest extends \MailPoetTest {
+  public function testTransformReturnsSubscriberSubjectForExistingCommentAuthorEmail(): void {
+    $email = 'comment-author-' . uniqid() . '@example.com';
+    $subscriber = (new Subscriber())->withEmail($email)->create();
+    $commentId = wp_insert_comment([
+      'comment_author_email' => $email,
+    ]);
+    $this->assertNotFalse($commentId);
+
+    $subject = $this->transform(new Subject(CommentSubject::KEY, ['comment_id' => $commentId]));
+
+    $this->assertInstanceOf(Subject::class, $subject);
+    $this->assertSame(SubscriberSubject::KEY, $subject->getKey());
+    $this->assertSame(['subscriber_id' => $subscriber->getId()], $subject->getArgs());
+  }
+
+  public function testTransformReturnsNullWhenCommentDoesNotExist(): void {
+    $this->assertNull($this->transform(new Subject(CommentSubject::KEY, ['comment_id' => 999999])));
+  }
+
+  public function testTransformReturnsNullWhenCommentEmailIsInvalid(): void {
+    $commentId = wp_insert_comment([
+      'comment_author_email' => 'not-an-email',
+    ]);
+    $this->assertNotFalse($commentId);
+
+    $this->assertNull($this->transform(new Subject(CommentSubject::KEY, ['comment_id' => $commentId])));
+  }
+
+  public function testTransformReturnsNullWhenSubscriberDoesNotExist(): void {
+    $commentId = wp_insert_comment([
+      'comment_author_email' => 'missing-subscriber-' . uniqid() . '@example.com',
+    ]);
+    $this->assertNotFalse($commentId);
+
+    $this->assertNull($this->transform(new Subject(CommentSubject::KEY, ['comment_id' => $commentId])));
+  }
+
+  public function testTransformRejectsDifferentSubject(): void {
+    $this->expectException(\InvalidArgumentException::class);
+
+    $this->transform(new Subject(SubscriberSubject::KEY, ['comment_id' => 123]));
+  }
+
+  private function transform(Subject $subject): ?Subject {
+    $transformer = $this->diContainer->get(CommentSubjectToSubscriberSubjectTransformer::class);
+    return $transformer->transform($subject);
+  }
+}

--- a/mailpoet/tests/javascript/automation/integrations/mailpoet/analytics/formatter/calculate-percentage.spec.ts
+++ b/mailpoet/tests/javascript/automation/integrations/mailpoet/analytics/formatter/calculate-percentage.spec.ts
@@ -1,0 +1,19 @@
+import { calculatePercentage } from '../../../../../../../assets/js/src/automation/integrations/mailpoet/analytics/formatter/calculate-percentage';
+
+describe('automation analytics percentage formatter', () => {
+  it('returns 0 when the base is 0', () => {
+    expect(calculatePercentage(25, 0)).to.equal(0);
+  });
+
+  it('calculates a percentage from the provided value and base', () => {
+    expect(calculatePercentage(25, 200)).to.equal(12.5);
+  });
+
+  it('calculates positive comparison deltas', () => {
+    expect(calculatePercentage(125, 100, true)).to.equal(25);
+  });
+
+  it('calculates negative comparison deltas', () => {
+    expect(calculatePercentage(75, 100, true)).to.equal(-25);
+  });
+});

--- a/mailpoet/tests/unit/Automation/Engine/Utils/JsonTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Utils/JsonTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Engine\Utils;
+
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
+use MailPoet\Automation\Engine\Utils\Json;
+
+class JsonTest extends \MailPoetUnitTest {
+  public function testEncodeAlwaysReturnsObjectJson(): void {
+    $this->assertSame('{}', Json::encode([]));
+  }
+
+  public function testEncodePreservesZeroFractionAndUnescapedSlashes(): void {
+    $json = Json::encode([
+      'price' => 1.0,
+      'url' => 'https://example.com/newsletters/1',
+    ]);
+
+    $this->assertSame('{"price":1.0,"url":"https://example.com/newsletters/1"}', $json);
+  }
+
+  public function testEncodeEscapesHtmlTags(): void {
+    $json = Json::encode([
+      'html' => '<strong>Hi</strong>',
+    ]);
+
+    $this->assertSame('{"html":"\u003Cstrong\u003EHi\u003C/strong\u003E"}', $json);
+  }
+
+  public function testDecodeReturnsAssociativeArray(): void {
+    $decoded = Json::decode('{"newsletter_id":123,"filters":{"status":"active"}}');
+
+    $this->assertSame([
+      'newsletter_id' => 123,
+      'filters' => [
+        'status' => 'active',
+      ],
+    ], $decoded);
+  }
+
+  public function testDecodeRejectsInvalidJson(): void {
+    $this->expectException(InvalidStateException::class);
+
+    Json::decode('{"newsletter_id":');
+  }
+
+  public function testDecodeRejectsScalarJson(): void {
+    $this->expectException(UnexpectedValueException::class);
+
+    Json::decode('"newsletter"');
+  }
+}


### PR DESCRIPTION
## Description

Adds focused test coverage for MailPoet automation JSON handling, comment-to-subscriber subject transformation, and automation analytics percentage formatting.

## Code review notes

_N/A_

## QA notes

- `pnpm test:unit --file=tests/unit/Automation/Engine/Utils/JsonTest.php`
- `pnpm test:integration --file=tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/CommentSubjectToSubscriberSubjectTransformerTest.php`
- `pnpm test:javascript`
- Scoped PHPStan for the new PHP tests
- PHPCS/ESLint for the new files

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1089

## Linked tickets

STOMAIL-8147

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

1 issue found:

**Suggestion** - Magic numbers used in tests: The integration test file contains hardcoded magic numbers (999999 on line 28 and 123 on line 52) which could be extracted into named constants or descriptive variables for improved code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->