### PR TITLE
Add order-aware product recommendations to automation emails

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -15,9 +15,11 @@ import { withSatismeterSurvey } from './satismeter-survey';
 import './index.scss';
 import { emailValidationRule } from './validate-email-content';
 import { registerCouponCodeRestrictToSubscriberExtension } from './coupon-code-restrict-to-subscriber-control';
+import { registerOrderProductCollectionsWhenAvailable } from './order-product-collections';
 
 registerTranslations();
 registerCouponCodeRestrictToSubscriberExtension();
+registerOrderProductCollectionsWhenAvailable();
 
 addFilter(
   'woocommerce_email_editor_wrap_editor_component',

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/order-product-collections.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/order-product-collections.ts
@@ -1,0 +1,160 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Order-aware product collections for automation emails.
+ *
+ * The collection slugs must match
+ * MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor,
+ * which fills the marked blocks with products derived from the order that
+ * triggered the email at send time. Registering the collections here gives the
+ * blocks a visible name, description, and preview notice in the editor, so
+ * merchants can see the products are picked per order.
+ */
+
+type ProductCollectionConfig = {
+  name: string;
+  title: string;
+  description: string;
+  keywords: string[];
+  scope: string[];
+  preview: {
+    initialPreviewState: {
+      isPreview: boolean;
+      previewMessage: string;
+    };
+  };
+  attributes: {
+    query: Record<string, unknown>;
+  };
+};
+
+type WcBlocksRegistry = {
+  __experimentalRegisterProductCollection?: (
+    config: ProductCollectionConfig,
+  ) => void;
+};
+
+const getRegisterProductCollection = ():
+  | ((config: ProductCollectionConfig) => void)
+  | undefined => {
+  const wc = (
+    window as unknown as { wc?: { wcBlocksRegistry?: WcBlocksRegistry } }
+  ).wc;
+  // eslint-disable-next-line no-underscore-dangle -- the WooCommerce API is named with the experimental prefix.
+  return wc?.wcBlocksRegistry?.__experimentalRegisterProductCollection;
+};
+
+const collectionQueryDefaults = {
+  perPage: 4,
+  pages: 1,
+  offset: 0,
+  postType: 'product',
+  order: 'desc',
+  orderBy: 'popularity',
+  search: '',
+  exclude: [],
+  inherit: false,
+  taxQuery: [],
+  isProductCollectionBlock: true,
+  featured: false,
+  woocommerceOnSale: false,
+  woocommerceStockStatus: ['instock', 'onbackorder'],
+  woocommerceAttributes: [],
+  woocommerceHandPickedProducts: [],
+  filterable: false,
+};
+
+const getOrderProductCollections = (): ProductCollectionConfig[] => [
+  {
+    name: 'mailpoet/product-collection/order-cross-sells',
+    title: __('Goes well with the order', 'mailpoet'),
+    description: __(
+      'Shows cross-sells of the products from the order that triggered the automation. When the purchased products have no cross-sells, their related products are shown instead.',
+      'mailpoet',
+    ),
+    keywords: ['cross-sells', 'order', 'automation'],
+    scope: ['inserter', 'block'],
+    preview: {
+      initialPreviewState: {
+        isPreview: true,
+        previewMessage: __(
+          'Sample products are shown in the editor. Each customer will see products that go well with their own order.',
+          'mailpoet',
+        ),
+      },
+    },
+    attributes: { query: { ...collectionQueryDefaults } },
+  },
+  {
+    name: 'mailpoet/product-collection/order-same-tag',
+    title: __('More with the same tag', 'mailpoet'),
+    description: __(
+      'Shows other products sharing tags with the products from the order that triggered the automation.',
+      'mailpoet',
+    ),
+    keywords: ['tag', 'order', 'automation'],
+    scope: ['inserter', 'block'],
+    preview: {
+      initialPreviewState: {
+        isPreview: true,
+        previewMessage: __(
+          'Sample products are shown in the editor. Each customer will see products with the same tags as their own order.',
+          'mailpoet',
+        ),
+      },
+    },
+    attributes: { query: { ...collectionQueryDefaults } },
+  },
+  {
+    name: 'mailpoet/product-collection/order-same-category',
+    title: __('More from the same category', 'mailpoet'),
+    description: __(
+      'Shows other products from the categories of the products from the order that triggered the automation.',
+      'mailpoet',
+    ),
+    keywords: ['category', 'order', 'automation'],
+    scope: ['inserter', 'block'],
+    preview: {
+      initialPreviewState: {
+        isPreview: true,
+        previewMessage: __(
+          'Sample products are shown in the editor. Each customer will see products from the same categories as their own order.',
+          'mailpoet',
+        ),
+      },
+    },
+    attributes: { query: { ...collectionQueryDefaults } },
+  },
+];
+
+export const registerOrderProductCollections = (): boolean => {
+  const registerProductCollection = getRegisterProductCollection();
+  if (!registerProductCollection) {
+    return false;
+  }
+
+  getOrderProductCollections().forEach((collection) => {
+    try {
+      registerProductCollection(collection);
+    } catch (error) {
+      // An already registered collection (e.g., after a hot reload) must not break the editor.
+      // eslint-disable-next-line no-console -- surface the failure to developers without crashing.
+      console.warn('MailPoet: could not register product collection', error);
+    }
+  });
+  return true;
+};
+
+export const registerOrderProductCollectionsWhenAvailable = (
+  attempts = 20,
+): void => {
+  if (attempts <= 0 || registerOrderProductCollections()) {
+    return;
+  }
+
+  // The wc-blocks-registry script may load after this bundle; WooCommerce may also be inactive.
+  setTimeout(
+    () => registerOrderProductCollectionsWhenAvailable(attempts - 1),
+    250,
+  );
+};

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/order-product-collections.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/order-product-collections.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { category, Icon, loop, tag } from '@wordpress/icons';
 
 /**
  * Order-aware product collections for automation emails.
@@ -14,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 type ProductCollectionConfig = {
   name: string;
   title: string;
+  icon: JSX.Element;
   description: string;
   keywords: string[];
   scope: string[];
@@ -68,6 +70,7 @@ const getOrderProductCollections = (): ProductCollectionConfig[] => [
   {
     name: 'mailpoet/product-collection/order-cross-sells',
     title: __('Goes well with the order', 'mailpoet'),
+    icon: <Icon icon={loop} />,
     description: __(
       'Shows cross-sells of the products from the order that triggered the automation. When the purchased products have no cross-sells, their related products are shown instead.',
       'mailpoet',
@@ -88,6 +91,7 @@ const getOrderProductCollections = (): ProductCollectionConfig[] => [
   {
     name: 'mailpoet/product-collection/order-same-tag',
     title: __('More with the same tag', 'mailpoet'),
+    icon: <Icon icon={tag} />,
     description: __(
       'Shows other products sharing tags with the products from the order that triggered the automation.',
       'mailpoet',
@@ -108,6 +112,7 @@ const getOrderProductCollections = (): ProductCollectionConfig[] => [
   {
     name: 'mailpoet/product-collection/order-same-category',
     title: __('More from the same category', 'mailpoet'),
+    icon: <Icon icon={category} />,
     description: __(
       'Shows other products from the categories of the products from the order that triggered the automation.',
       'mailpoet',

--- a/mailpoet/changelog/2026-06-05-12-05-13-added-order-aware-product-recommendations-to-post-purcha.md
+++ b/mailpoet/changelog/2026-06-05-12-05-13-added-order-aware-product-recommendations-to-post-purcha.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Order-aware product recommendations in post-purchase automation emails: cross-sells of the purchased products, products with the same tag, or products from the same category

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -388,6 +388,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockValidator::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Coupons\EmailContextBuilder::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Link::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\LinksToShortcodesConvertor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUrl::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/CategoryPurchaseFollowUpPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/CategoryPurchaseFollowUpPattern.php
@@ -7,13 +7,14 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor;
 
 /**
- * First purchase thank you email pattern.
+ * Follow-up email pattern for the "purchased in a category" automation.
  *
- * The product grid uses the order cross-sells collection: at send time it shows
- * cross-sells of the purchased products (or their related products as backup).
+ * The product grid uses the order same-category collection: at send time it
+ * shows other products from the categories of the purchased products, so the
+ * recommendations match what the customer already shops for.
  */
-class FirstPurchaseThankYouPattern extends Pattern {
-  protected $name = 'first-purchase-thank-you';
+class CategoryPurchaseFollowUpPattern extends Pattern {
+  protected $name = 'category-purchase-follow-up';
   protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $categories = ['purchase'];
@@ -27,15 +28,15 @@ class FirstPurchaseThankYouPattern extends Pattern {
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     return $this->buildContent($this->getProductPlaceholderColumns([
       'product-small-02.jpg',
-      'product-small-04.jpg',
-      'product-small-03.jpg',
+      'product-small-06.jpg',
       'product-small-01.jpg',
+      'product-small-04.jpg',
     ]));
   }
 
   public function get_email_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     return $this->buildContent($this->getRecommendedProductCollectionBlock(
-      OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS,
+      OrderProductCollectionProcessor::COLLECTION_ORDER_SAME_CATEGORY,
       'popularity'
     ));
   }
@@ -45,22 +46,12 @@ class FirstPurchaseThankYouPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
       <!-- wp:heading {"level":1} -->
-      <h1 class="wp-block-heading">' . __('Thank You for Your First Order', 'mailpoet') . '</h1>
+      <h1 class="wp-block-heading">' . __('Great choice! Here is more you might love', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
       <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
-      /* translators: %s is a placeholder for the shop name */
-      sprintf(__('We’re thrilled you chose %s. Your order is being processed, and we can’t wait for you to receive it.', 'mailpoet'), '<!--[woocommerce/store-name]-->') . '</p>
-      <!-- /wp:paragraph -->
-
-      <!-- wp:heading {"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}},"typography":{"fontSize":"24px"}}} -->
-      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('You might also like', 'mailpoet') . '</h2>
-      <!-- /wp:heading -->
-
-      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
-      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">
-      ' . __('While you wait, check out other items that pair perfectly with your order.', 'mailpoet') . '</p>
+      __('We picked a few more favorites from the same category as your order.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       ' . $productSection . '
@@ -83,6 +74,6 @@ class FirstPurchaseThankYouPattern extends Pattern {
 
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     /* translators: Name of a content pattern used as starting content of an email */
-    return __('First Purchase Thank You', 'mailpoet');
+    return __('Category Purchase Follow-Up', 'mailpoet');
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductPurchaseFollowUpPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductPurchaseFollowUpPattern.php
@@ -4,9 +4,14 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor;
 
 /**
  * Product purchase follow-up email pattern.
+ *
+ * The product grid uses the order cross-sells collection: at send time it shows
+ * cross-sells of the purchased products (or their related products as backup),
+ * so the recommendations match what the customer actually bought.
  */
 class ProductPurchaseFollowUpPattern extends Pattern {
   protected $name = 'product-purchase-follow-up';
@@ -30,13 +35,13 @@ class ProductPurchaseFollowUpPattern extends Pattern {
   }
 
   public function get_email_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    return $this->buildContent($this->getRecommendedProductCollectionBlock('best-sellers', 'popularity'));
+    return $this->buildContent($this->getRecommendedProductCollectionBlock(
+      OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS,
+      'popularity'
+    ));
   }
 
   private function buildContent(string $productSection): string {
-    $mainProductImage = esc_url($this->cdnAssetUrl->generateCdnUrl('email-editor/welcome-email.jpg'));
-    $mainProductAlt = esc_attr__('Product placeholder', 'mailpoet');
-
     return '
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
@@ -48,32 +53,8 @@ class ProductPurchaseFollowUpPattern extends Pattern {
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
       <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
-      __('Here are a few essentials that pair perfectly.', 'mailpoet') . '</p>
+      __('Here are a few essentials that pair perfectly with your purchase.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
-
-      <!-- wp:image {"sizeSlug":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <figure class="wp-block-image size-full" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"><img src="' . $mainProductImage . '" alt="' . $mainProductAlt . '"/></figure>
-      <!-- /wp:image -->
-
-      <!-- wp:heading {"textAlign":"center","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}},"typography":{"fontSize":"24px"}}} -->
-      <h2 class="wp-block-heading has-text-align-center" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:24px">' . __('Product name', 'mailpoet') . '</h2>
-      <!-- /wp:heading -->
-
-      <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <p class="has-text-align-center" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:14px">$99.90</p>
-      <!-- /wp:paragraph -->
-
-      <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-      <div class="wp-block-buttons">
-      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
-      <!-- /wp:button -->
-      </div>
-      <!-- /wp:buttons -->
-
-      <!-- wp:heading {"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}},"typography":{"fontSize":"24px"}}} -->
-      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('You might also like', 'mailpoet') . '</h2>
-      <!-- /wp:heading -->
 
       ' . $productSection . '
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/TagPurchaseFollowUpPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/TagPurchaseFollowUpPattern.php
@@ -7,13 +7,14 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor;
 
 /**
- * First purchase thank you email pattern.
+ * Follow-up email pattern for the "purchased a product with a tag" automation.
  *
- * The product grid uses the order cross-sells collection: at send time it shows
- * cross-sells of the purchased products (or their related products as backup).
+ * The product grid uses the order same-tag collection: at send time it shows
+ * other products sharing tags with the purchased products, so the
+ * recommendations stay within the product line the customer already chose.
  */
-class FirstPurchaseThankYouPattern extends Pattern {
-  protected $name = 'first-purchase-thank-you';
+class TagPurchaseFollowUpPattern extends Pattern {
+  protected $name = 'tag-purchase-follow-up';
   protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $categories = ['purchase'];
@@ -26,16 +27,16 @@ class FirstPurchaseThankYouPattern extends Pattern {
    */
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     return $this->buildContent($this->getProductPlaceholderColumns([
-      'product-small-02.jpg',
-      'product-small-04.jpg',
-      'product-small-03.jpg',
       'product-small-01.jpg',
+      'product-small-03.jpg',
+      'product-small-05.jpg',
+      'product-small-02.jpg',
     ]));
   }
 
   public function get_email_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     return $this->buildContent($this->getRecommendedProductCollectionBlock(
-      OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS,
+      OrderProductCollectionProcessor::COLLECTION_ORDER_SAME_TAG,
       'popularity'
     ));
   }
@@ -45,22 +46,12 @@ class FirstPurchaseThankYouPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
       <!-- wp:heading {"level":1} -->
-      <h1 class="wp-block-heading">' . __('Thank You for Your First Order', 'mailpoet') . '</h1>
+      <h1 class="wp-block-heading">' . __('You have great taste — there is more where that came from', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
       <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
-      /* translators: %s is a placeholder for the shop name */
-      sprintf(__('We’re thrilled you chose %s. Your order is being processed, and we can’t wait for you to receive it.', 'mailpoet'), '<!--[woocommerce/store-name]-->') . '</p>
-      <!-- /wp:paragraph -->
-
-      <!-- wp:heading {"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}},"typography":{"fontSize":"24px"}}} -->
-      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('You might also like', 'mailpoet') . '</h2>
-      <!-- /wp:heading -->
-
-      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
-      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">
-      ' . __('While you wait, check out other items that pair perfectly with your order.', 'mailpoet') . '</p>
+      __('We picked a few more favorites from the same collection as your order.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       ' . $productSection . '
@@ -83,6 +74,6 @@ class FirstPurchaseThankYouPattern extends Pattern {
 
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     /* translators: Name of a content pattern used as starting content of an email */
-    return __('First Purchase Thank You', 'mailpoet');
+    return __('Tagged Product Purchase Follow-Up', 'mailpoet');
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Pattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Pattern.php
@@ -72,14 +72,18 @@ abstract class Pattern extends Abstract_Pattern {
   /**
    * Get a product collection block for recommended products.
    *
-   * @param string $collection Collection slug (e.g., 'best-sellers', 'new-arrivals').
+   * @param string $collection WooCommerce collection slug (e.g., 'best-sellers', 'new-arrivals')
+   *   or a fully namespaced collection (e.g., OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS,
+   *   resolved per order at send time). The query authored here is the fallback when an
+   *   order-aware collection cannot be resolved.
    * @param string $orderBy Order by field (e.g., 'date', 'popularity').
    * @param int $perPage Number of products to show.
    * @param int $columns Number of columns in the grid.
    */
   protected function getRecommendedProductCollectionBlock(string $collection, string $orderBy = 'date', int $perPage = 4, int $columns = 2): string {
+    $collectionSlug = strpos($collection, '/') !== false ? $collection : 'woocommerce/product-collection/' . $collection;
     return '
-      <!-- wp:woocommerce/product-collection {"query":{"perPage":' . $perPage . ',"pages":1,"offset":0,"postType":"product","order":"desc","orderBy":"' . $orderBy . '","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false},"tagName":"div","displayLayout":{"type":"flex","columns":' . $columns . ',"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/' . $collection . '","hideControls":["inherit","attributes","keyword","order","default-order","featured","on-sale","stock-status","hand-picked","taxonomy","filterable","created","price-range"]} -->
+      <!-- wp:woocommerce/product-collection {"query":{"perPage":' . $perPage . ',"pages":1,"offset":0,"postType":"product","order":"desc","orderBy":"' . $orderBy . '","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false},"tagName":"div","displayLayout":{"type":"flex","columns":' . $columns . ',"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"' . $collectionSlug . '","hideControls":["inherit","attributes","keyword","order","default-order","featured","on-sale","stock-status","hand-picked","taxonomy","filterable","created","price-range"]} -->
       <div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
       <!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
       <!-- wp:woocommerce/product-sale-badge {"align":"right"} /-->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -6,6 +6,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartPat
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartReminderPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartWithDiscountPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AskForReviewPostPurchasePattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\CategoryPurchaseFollowUpPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EducationalCampaignPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EventInvitationPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\FirstPurchaseThankYouPattern;
@@ -16,6 +17,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\PostPurchaseThan
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\ProductPurchaseFollowUpPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\ProductRestockNotificationPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\SaleAnnouncementPattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\TagPurchaseFollowUpPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\WelcomeEmailPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\WelcomeWithDiscountEmailPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\WinBackCustomerPattern;
@@ -110,6 +112,8 @@ class PatternsController {
         new FirstPurchaseThankYouPattern($this->cdnAssetUrl),
         new PostPurchaseThankYouPattern($this->cdnAssetUrl),
         new ProductPurchaseFollowUpPattern($this->cdnAssetUrl),
+        new TagPurchaseFollowUpPattern($this->cdnAssetUrl),
+        new CategoryPurchaseFollowUpPattern($this->cdnAssetUrl),
         new AbandonedCartPattern($this->cdnAssetUrl),
         new AbandonedCartReminderPattern($this->cdnAssetUrl),
       ]);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/ProductCollection/OrderProductCollectionProcessor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/ProductCollection/OrderProductCollectionProcessor.php
@@ -1,0 +1,264 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection;
+
+/**
+ * Fills product collection blocks using one of the MailPoet order-aware
+ * collections with products derived from the order that triggered the email.
+ *
+ * The collection slug stored in the block's `collection` attribute is the
+ * marker — it is a declared block attribute, so it survives editing and
+ * re-saving the email in the block editor. The same slugs are registered in
+ * the editor (see assets/js/src/mailpoet-email-editor-integration/order-product-collections.ts)
+ * so merchants see what the block does.
+ *
+ * When a source yields no products, related products of the purchased items
+ * are used instead. When even those are missing, the block is left untouched
+ * and renders the generic store query authored in the pattern.
+ */
+class OrderProductCollectionProcessor {
+  public const COLLECTION_ORDER_CROSS_SELLS = 'mailpoet/product-collection/order-cross-sells';
+  public const COLLECTION_ORDER_SAME_TAG = 'mailpoet/product-collection/order-same-tag';
+  public const COLLECTION_ORDER_SAME_CATEGORY = 'mailpoet/product-collection/order-same-category';
+
+  public const ORDER_COLLECTIONS = [
+    self::COLLECTION_ORDER_CROSS_SELLS,
+    self::COLLECTION_ORDER_SAME_TAG,
+    self::COLLECTION_ORDER_SAME_CATEGORY,
+  ];
+
+  private const PRODUCT_COLLECTION_BLOCK = 'woocommerce/product-collection';
+  private const MAX_PRODUCTS = 24;
+  private const RELATED_PRODUCTS_PER_ITEM = 8;
+
+  /**
+   * Build a `woocommerce_email_blocks_renderer_parsed_blocks` filter bound to the
+   * order in the render context. Returns null when there is no order, leaving
+   * marked blocks to render their authored fallback query.
+   *
+   * @param array<string, mixed> $renderContext
+   */
+  public function createBlocksFilter(array $renderContext): ?callable {
+    $order = $renderContext['order'] ?? null;
+    if (!$order instanceof \WC_Order) {
+      return null;
+    }
+
+    return function (array $blocks) use ($order): array {
+      return $this->fillOrderCollections($blocks, $order);
+    };
+  }
+
+  /**
+   * Set hand-picked products on every product collection block using one of the
+   * order-aware collections, descending into inner blocks. Each collection is
+   * resolved at most once per call.
+   *
+   * @param array<array-key, mixed> $blocks
+   * @return array<array-key, mixed>
+   */
+  public function fillOrderCollections(array $blocks, \WC_Order $order): array {
+    $resolvedIds = [];
+    return $this->walkBlocks($blocks, $order, $resolvedIds);
+  }
+
+  /**
+   * Product IDs for an order-aware collection, excluding the purchased products
+   * themselves and products that are not displayable (unpublished, out of stock).
+   * Falls back to related products of the purchased items when the primary
+   * source yields nothing.
+   *
+   * @return int[]
+   */
+  public function resolveProductIds(string $collection, \WC_Order $order): array {
+    $purchasedProducts = $this->getPurchasedProducts($order);
+    if (!$purchasedProducts) {
+      return [];
+    }
+    $purchasedIds = array_keys($purchasedProducts);
+
+    switch ($collection) {
+      case self::COLLECTION_ORDER_CROSS_SELLS:
+        $ids = $this->getCrossSellIds($purchasedProducts);
+        break;
+      case self::COLLECTION_ORDER_SAME_TAG:
+        $ids = $this->getSameTermProductIds($purchasedProducts, 'product_tag_id');
+        break;
+      case self::COLLECTION_ORDER_SAME_CATEGORY:
+        $ids = $this->getSameTermProductIds($purchasedProducts, 'product_category_id');
+        break;
+      default:
+        return [];
+    }
+
+    $ids = $this->filterDisplayable($ids, $purchasedIds);
+    if (!$ids) {
+      $ids = $this->filterDisplayable($this->getRelatedIds($purchasedIds), $purchasedIds);
+    }
+
+    return array_slice($ids, 0, self::MAX_PRODUCTS);
+  }
+
+  /**
+   * @param array<array-key, mixed> $blocks
+   * @param array<string, int[]> $resolvedIds
+   * @return array<array-key, mixed>
+   */
+  private function walkBlocks(array $blocks, \WC_Order $order, array &$resolvedIds): array {
+    foreach ($blocks as $index => $block) {
+      if (!is_array($block)) {
+        continue;
+      }
+
+      $collection = $this->getOrderCollectionSlug($block);
+      if ($collection !== null) {
+        if (!array_key_exists($collection, $resolvedIds)) {
+          $resolvedIds[$collection] = $this->resolveProductIds($collection, $order);
+        }
+        if ($resolvedIds[$collection]) {
+          $block = $this->setHandPickedProducts($block, $resolvedIds[$collection]);
+        }
+      }
+
+      if (isset($block['innerBlocks']) && is_array($block['innerBlocks'])) {
+        $block['innerBlocks'] = $this->walkBlocks($block['innerBlocks'], $order, $resolvedIds);
+      }
+
+      $blocks[$index] = $block;
+    }
+
+    return $blocks;
+  }
+
+  /**
+   * @param array<array-key, mixed> $block
+   */
+  private function getOrderCollectionSlug(array $block): ?string {
+    if (($block['blockName'] ?? null) !== self::PRODUCT_COLLECTION_BLOCK) {
+      return null;
+    }
+
+    $attrs = $block['attrs'] ?? null;
+    $collection = is_array($attrs) ? ($attrs['collection'] ?? null) : null;
+    return is_string($collection) && in_array($collection, self::ORDER_COLLECTIONS, true) ? $collection : null;
+  }
+
+  /**
+   * @param array<array-key, mixed> $block
+   * @param int[] $productIds
+   * @return array<array-key, mixed>
+   */
+  private function setHandPickedProducts(array $block, array $productIds): array {
+    $attrs = is_array($block['attrs'] ?? null) ? $block['attrs'] : [];
+    $query = is_array($attrs['query'] ?? null) ? $attrs['query'] : [];
+    $query['woocommerceHandPickedProducts'] = $productIds;
+    $attrs['query'] = $query;
+    $block['attrs'] = $attrs;
+    return $block;
+  }
+
+  /**
+   * Purchased products keyed by product ID. Uses the parent product for
+   * variations because cross-sells and taxonomy terms live on the parent.
+   *
+   * @return array<int, \WC_Product>
+   */
+  private function getPurchasedProducts(\WC_Order $order): array {
+    $products = [];
+    foreach ($order->get_items() as $item) {
+      if (!$item instanceof \WC_Order_Item_Product) {
+        continue;
+      }
+      $productId = $item->get_product_id();
+      if (!$productId || isset($products[$productId])) {
+        continue;
+      }
+      $product = wc_get_product($productId);
+      if ($product instanceof \WC_Product) {
+        $products[$productId] = $product;
+      }
+    }
+    return $products;
+  }
+
+  /**
+   * @param array<int, \WC_Product> $purchasedProducts
+   * @return int[]
+   */
+  private function getCrossSellIds(array $purchasedProducts): array {
+    $ids = [];
+    foreach ($purchasedProducts as $product) {
+      foreach ($product->get_cross_sell_ids() as $crossSellId) {
+        $ids[] = (int)$crossSellId;
+      }
+    }
+    return $ids;
+  }
+
+  /**
+   * Products sharing taxonomy terms with the purchased products.
+   *
+   * @param array<int, \WC_Product> $purchasedProducts
+   * @param string $termQueryArg WC_Product_Query taxonomy argument ('product_tag_id' or 'product_category_id').
+   * @return int[]
+   */
+  private function getSameTermProductIds(array $purchasedProducts, string $termQueryArg): array {
+    $termIds = [];
+    foreach ($purchasedProducts as $product) {
+      $productTermIds = $termQueryArg === 'product_tag_id' ? $product->get_tag_ids() : $product->get_category_ids();
+      foreach ($productTermIds as $termId) {
+        $termIds[] = (int)$termId;
+      }
+    }
+    $termIds = array_values(array_unique($termIds));
+    if (!$termIds) {
+      return [];
+    }
+
+    // Purchased products are not excluded here (the exclude/post__not_in query
+    // parameter scales poorly); filterDisplayable() removes them afterwards.
+    $ids = wc_get_products([
+      'status' => 'publish',
+      'limit' => self::MAX_PRODUCTS + count($purchasedProducts),
+      'orderby' => 'date',
+      'order' => 'DESC',
+      $termQueryArg => $termIds,
+      'return' => 'ids',
+    ]);
+    return is_array($ids) ? array_map('intval', $ids) : [];
+  }
+
+  /**
+   * @param int[] $purchasedIds
+   * @return int[]
+   */
+  private function getRelatedIds(array $purchasedIds): array {
+    $ids = [];
+    foreach ($purchasedIds as $purchasedId) {
+      foreach (wc_get_related_products($purchasedId, self::RELATED_PRODUCTS_PER_ITEM) as $relatedId) {
+        $ids[] = (int)$relatedId;
+      }
+    }
+    return $ids;
+  }
+
+  /**
+   * Deduplicates, removes purchased products, and keeps only products a
+   * customer can still see and buy.
+   *
+   * @param int[] $ids
+   * @param int[] $excludeIds
+   * @return int[]
+   */
+  private function filterDisplayable(array $ids, array $excludeIds): array {
+    $ids = array_values(array_unique(array_map('intval', $ids)));
+    $ids = array_values(array_diff($ids, $excludeIds));
+
+    return array_values(array_filter($ids, function (int $id): bool {
+      $product = wc_get_product($id);
+      return $product instanceof \WC_Product
+        && $product->get_status() === 'publish'
+        && $product->get_stock_status() !== 'outofstock';
+    }));
+  }
+}

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -9,6 +9,7 @@ use MailPoet\Config\Env;
 use MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockFailureTranslator;
 use MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockGenerationFailureCollector;
 use MailPoet\EmailEditor\Integrations\MailPoet\Coupons\EmailContextBuilder;
+use MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Logging\LoggerFactory;
@@ -57,6 +58,8 @@ class Renderer {
 
   private CouponBlockFailureTranslator $couponBlockFailureTranslator;
 
+  private OrderProductCollectionProcessor $orderProductCollectionProcessor;
+
   public function __construct(
     BodyRenderer $bodyRenderer,
     Preprocessor $preprocessor,
@@ -68,7 +71,8 @@ class Renderer {
     CapabilitiesManager $capabilitiesManager,
     CouponBlockGenerationFailureCollector $couponBlockFailureCollector,
     EmailContextBuilder $emailContextBuilder,
-    CouponBlockFailureTranslator $couponBlockFailureTranslator
+    CouponBlockFailureTranslator $couponBlockFailureTranslator,
+    OrderProductCollectionProcessor $orderProductCollectionProcessor
   ) {
     $this->bodyRenderer = $bodyRenderer;
     $this->guntenbergRenderer = Email_Editor_Container::container()->get(GuntenbergRenderer::class);
@@ -82,6 +86,7 @@ class Renderer {
     $this->couponBlockFailureCollector = $couponBlockFailureCollector;
     $this->emailContextBuilder = $emailContextBuilder;
     $this->couponBlockFailureTranslator = $couponBlockFailureTranslator;
+    $this->orderProductCollectionProcessor = $orderProductCollectionProcessor;
   }
 
   public function render(NewsletterEntity $newsletter, ?SendingQueueEntity $sendingQueue = null, $type = false) {
@@ -107,6 +112,11 @@ class Renderer {
       };
       $this->wp->addFilter('woocommerce_email_editor_rendering_email_context', $filterCallback);
 
+      $orderProductsFilter = $this->orderProductCollectionProcessor->createBlocksFilter($renderContext);
+      if ($orderProductsFilter) {
+        $this->wp->addFilter('woocommerce_email_blocks_renderer_parsed_blocks', $orderProductsFilter);
+      }
+
       try {
         $renderedNewsletter = $this->guntenbergRenderer->render($wpPost, $subject, $newsletter->getPreheader(), $language, $metaRobots);
         if ($this->couponBlockFailureCollector->hasFailures()) {
@@ -122,6 +132,9 @@ class Renderer {
         }
       } finally {
         $this->wp->removeFilter('woocommerce_email_editor_rendering_email_context', $filterCallback);
+        if ($orderProductsFilter) {
+          $this->wp->removeFilter('woocommerce_email_blocks_renderer_parsed_blocks', $orderProductsFilter);
+        }
         $this->couponBlockFailureCollector->clear();
       }
     } else {

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -110,14 +110,14 @@ class Renderer {
       $filterCallback = function (array $context) use ($renderContext): array {
         return array_merge($context, $renderContext);
       };
-      $this->wp->addFilter('woocommerce_email_editor_rendering_email_context', $filterCallback);
-
-      $orderProductsFilter = $this->orderProductCollectionProcessor->createBlocksFilter($renderContext);
-      if ($orderProductsFilter) {
-        $this->wp->addFilter('woocommerce_email_blocks_renderer_parsed_blocks', $orderProductsFilter);
-      }
+      $orderProductsFilter = null;
 
       try {
+        $this->wp->addFilter('woocommerce_email_editor_rendering_email_context', $filterCallback);
+        $orderProductsFilter = $this->orderProductCollectionProcessor->createBlocksFilter($renderContext);
+        if ($orderProductsFilter) {
+          $this->wp->addFilter('woocommerce_email_blocks_renderer_parsed_blocks', $orderProductsFilter);
+        }
         $renderedNewsletter = $this->guntenbergRenderer->render($wpPost, $subject, $newsletter->getPreheader(), $language, $metaRobots);
         if ($this->couponBlockFailureCollector->hasFailures()) {
           throw NewsletterProcessingException::create()

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -43,6 +43,8 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/first-purchase-thank-you', $patternNames);
     $this->assertContains('mailpoet/post-purchase-thank-you', $patternNames);
     $this->assertContains('mailpoet/product-purchase-follow-up', $patternNames);
+    $this->assertContains('mailpoet/tag-purchase-follow-up', $patternNames);
+    $this->assertContains('mailpoet/category-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
@@ -53,7 +55,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(17, $blockPatterns);
+    $this->assertCount(19, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
@@ -130,6 +132,8 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/first-purchase-thank-you', $patternNames);
     $this->assertContains('mailpoet/post-purchase-thank-you', $patternNames);
     $this->assertContains('mailpoet/product-purchase-follow-up', $patternNames);
+    $this->assertContains('mailpoet/tag-purchase-follow-up', $patternNames);
+    $this->assertContains('mailpoet/category-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
@@ -140,7 +144,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count (all patterns except 3 coupon patterns)
-    $this->assertCount(14, $blockPatterns);
+    $this->assertCount(16, $blockPatterns);
   }
 
   /**
@@ -270,6 +274,8 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/first-purchase-thank-you', $patternNames);
     $this->assertNotContains('mailpoet/post-purchase-thank-you', $patternNames);
     $this->assertNotContains('mailpoet/product-purchase-follow-up', $patternNames);
+    $this->assertNotContains('mailpoet/tag-purchase-follow-up', $patternNames);
+    $this->assertNotContains('mailpoet/category-purchase-follow-up', $patternNames);
     $this->assertNotContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertNotContains('mailpoet/win-back-customer', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-content', $patternNames);
@@ -336,6 +342,8 @@ class PatternsControllerTest extends \MailPoetTest {
       'mailpoet/first-purchase-thank-you',
       'mailpoet/post-purchase-thank-you',
       'mailpoet/product-purchase-follow-up',
+      'mailpoet/tag-purchase-follow-up',
+      'mailpoet/category-purchase-follow-up',
       'mailpoet/win-back-customer',
       'mailpoet/abandoned-cart-content',
       'mailpoet/abandoned-cart-reminder-content',

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/ProductCollection/OrderProductCollectionProcessorTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/ProductCollection/OrderProductCollectionProcessorTest.php
@@ -1,0 +1,288 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\EmailEditor\Integrations\MailPoet\ProductCollection;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController;
+use MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor;
+use MailPoet\Util\CdnAssetUrl;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+use MailPoet\WP\Functions as WPFunctions;
+
+/**
+ * @group woo
+ */
+class OrderProductCollectionProcessorTest extends \MailPoetTest {
+  /** @var OrderProductCollectionProcessor */
+  private $processor;
+
+  /** @var int[] */
+  private $productIds = [];
+
+  /** @var int[] */
+  private $orderIds = [];
+
+  public function _before(): void {
+    parent::_before();
+    $this->processor = new OrderProductCollectionProcessor();
+  }
+
+  public function _after(): void {
+    foreach ($this->orderIds as $orderId) {
+      $order = wc_get_order($orderId);
+      if ($order instanceof \WC_Order) {
+        $order->delete(true);
+      }
+    }
+    foreach ($this->productIds as $productId) {
+      $product = wc_get_product($productId);
+      if ($product instanceof \WC_Product) {
+        $product->delete(true);
+      }
+    }
+    $this->orderIds = [];
+    $this->productIds = [];
+    parent::_after();
+  }
+
+  public function testCrossSellsCollectionExcludesPurchasedProducts(): void {
+    $crossSell = $this->createProduct('Cross-sell');
+    $alsoPurchased = $this->createProduct('Also purchased');
+    $purchased = $this->createProduct('Purchased', ['crossSellIds' => [$crossSell->get_id(), $alsoPurchased->get_id()]]);
+    $order = $this->createOrder([$purchased, $alsoPurchased]);
+
+    $ids = $this->processor->resolveProductIds(OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS, $order);
+
+    $this->assertSame([$crossSell->get_id()], $ids);
+  }
+
+  public function testCrossSellsCollectionExcludesOutOfStockProducts(): void {
+    $outOfStock = $this->createProduct('Out of stock', ['stockStatus' => 'outofstock']);
+    $inStock = $this->createProduct('In stock');
+    $purchased = $this->createProduct('Purchased', ['crossSellIds' => [$outOfStock->get_id(), $inStock->get_id()]]);
+    $order = $this->createOrder([$purchased]);
+
+    $ids = $this->processor->resolveProductIds(OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS, $order);
+
+    $this->assertSame([$inStock->get_id()], $ids);
+  }
+
+  public function testCrossSellsCollectionFallsBackToRelatedProducts(): void {
+    $categoryId = $this->createTerm('Fallback category', 'product_cat');
+    $purchased = $this->createProduct('Purchased', ['categoryIds' => [$categoryId]]);
+    $related = $this->createProduct('Related', ['categoryIds' => [$categoryId]]);
+    $order = $this->createOrder([$purchased]);
+
+    $ids = $this->processor->resolveProductIds(OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS, $order);
+
+    $this->assertSame([$related->get_id()], $ids);
+  }
+
+  public function testSameTagCollectionFindsProductsSharingTags(): void {
+    $tagId = $this->createTerm('Shared tag', 'product_tag');
+    $purchased = $this->createProduct('Purchased', ['tagIds' => [$tagId]]);
+    $sameTagA = $this->createProduct('Same tag A', ['tagIds' => [$tagId]]);
+    $sameTagB = $this->createProduct('Same tag B', ['tagIds' => [$tagId]]);
+    $this->createProduct('Unrelated');
+    $order = $this->createOrder([$purchased]);
+
+    $ids = $this->processor->resolveProductIds(OrderProductCollectionProcessor::COLLECTION_ORDER_SAME_TAG, $order);
+
+    sort($ids);
+    $expected = [$sameTagA->get_id(), $sameTagB->get_id()];
+    sort($expected);
+    $this->assertSame($expected, $ids);
+  }
+
+  public function testSameCategoryCollectionFindsProductsSharingCategories(): void {
+    $categoryId = $this->createTerm('Shared category', 'product_cat');
+    $purchased = $this->createProduct('Purchased', ['categoryIds' => [$categoryId]]);
+    $sameCategory = $this->createProduct('Same category', ['categoryIds' => [$categoryId]]);
+    $this->createProduct('Unrelated');
+    $order = $this->createOrder([$purchased]);
+
+    $ids = $this->processor->resolveProductIds(OrderProductCollectionProcessor::COLLECTION_ORDER_SAME_CATEGORY, $order);
+
+    $this->assertSame([$sameCategory->get_id()], $ids);
+  }
+
+  public function testResolveReturnsNothingWhenThereAreNoRecommendableProducts(): void {
+    // The purchased product gets its own category: products saved without one
+    // fall into the store default category, which products created by other
+    // tests may share, making the related-products fallback non-empty.
+    $purchased = $this->createProduct('Purchased', ['categoryIds' => [$this->createTerm('Lonely category', 'product_cat')]]);
+    $this->createProduct('Stray uncategorized');
+    $order = $this->createOrder([$purchased]);
+
+    foreach (OrderProductCollectionProcessor::ORDER_COLLECTIONS as $collection) {
+      $this->assertSame([], $this->processor->resolveProductIds($collection, $order));
+    }
+  }
+
+  public function testBlocksFilterFillsOnlyMarkedCollectionBlocks(): void {
+    $crossSell = $this->createProduct('Cross-sell');
+    $purchased = $this->createProduct('Purchased', ['crossSellIds' => [$crossSell->get_id()]]);
+    $order = $this->createOrder([$purchased]);
+
+    $content = $this->getPatternContent('product-purchase-follow-up');
+    $this->assertStringContainsString(OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS, $content);
+
+    $bestSellersBlock = '<!-- wp:woocommerce/product-collection {"query":{"woocommerceHandPickedProducts":[]},"collection":"woocommerce/product-collection/best-sellers"} --><div class="wp-block-woocommerce-product-collection"></div><!-- /wp:woocommerce/product-collection -->';
+
+    $filter = $this->processor->createBlocksFilter(['order' => $order]);
+    $this->assertIsCallable($filter);
+    $blocks = $filter(parse_blocks($content . $bestSellersBlock));
+
+    $collectionBlocks = $this->findBlocks($blocks, 'woocommerce/product-collection');
+    $this->assertCount(2, $collectionBlocks);
+
+    // The order-aware collection receives the order's cross-sell products.
+    $marked = $this->blockWithCollection($collectionBlocks, OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS);
+    $this->assertSame([$crossSell->get_id()], $this->handPicked($marked));
+    // The best-sellers block stays a generic store collection, untouched by the order.
+    $bestSellers = $this->blockWithCollection($collectionBlocks, 'woocommerce/product-collection/best-sellers');
+    $this->assertSame([], $this->handPicked($bestSellers));
+  }
+
+  public function testBlocksFilterLeavesMarkedBlockUntouchedWhenNothingResolves(): void {
+    // Own category for the same reason as in testResolveReturnsNothingWhenThereAreNoRecommendableProducts.
+    $purchased = $this->createProduct('Purchased', ['categoryIds' => [$this->createTerm('Lonely category', 'product_cat')]]);
+    $this->createProduct('Stray uncategorized');
+    $order = $this->createOrder([$purchased]);
+
+    $content = $this->getPatternContent('product-purchase-follow-up');
+    $filter = $this->processor->createBlocksFilter(['order' => $order]);
+    $this->assertIsCallable($filter);
+    $blocks = $filter(parse_blocks($content));
+
+    $collectionBlocks = $this->findBlocks($blocks, 'woocommerce/product-collection');
+    $marked = $this->blockWithCollection($collectionBlocks, OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS);
+    // The authored fallback query renders generic store products instead.
+    $this->assertSame([], $this->handPicked($marked));
+  }
+
+  public function testTagAndCategoryPatternsUseTheirOrderAwareCollections(): void {
+    $this->assertStringContainsString(
+      OrderProductCollectionProcessor::COLLECTION_ORDER_SAME_TAG,
+      $this->getPatternContent('tag-purchase-follow-up')
+    );
+    $this->assertStringContainsString(
+      OrderProductCollectionProcessor::COLLECTION_ORDER_SAME_CATEGORY,
+      $this->getPatternContent('category-purchase-follow-up')
+    );
+    $this->assertStringContainsString(
+      OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS,
+      $this->getPatternContent('first-purchase-thank-you')
+    );
+  }
+
+  /**
+   * @param array{crossSellIds?: int[], categoryIds?: int[], tagIds?: int[], stockStatus?: string} $args
+   */
+  private function createProduct(string $name, array $args = []): \WC_Product {
+    $product = new \WC_Product_Simple();
+    $product->set_name($name);
+    $product->set_regular_price('10');
+    $product->set_status('publish');
+    if (isset($args['crossSellIds'])) {
+      $product->set_cross_sell_ids($args['crossSellIds']);
+    }
+    if (isset($args['categoryIds'])) {
+      $product->set_category_ids($args['categoryIds']);
+    }
+    if (isset($args['tagIds'])) {
+      $product->set_tag_ids($args['tagIds']);
+    }
+    if (isset($args['stockStatus'])) {
+      $product->set_stock_status($args['stockStatus']);
+    }
+    $product->save();
+    $this->productIds[] = $product->get_id();
+    return $product;
+  }
+
+  private function createTerm(string $name, string $taxonomy): int {
+    $term = wp_insert_term($name . ' ' . uniqid(), $taxonomy);
+    $this->assertIsArray($term);
+    return (int)$term['term_id'];
+  }
+
+  /**
+   * @param \WC_Product[] $products
+   */
+  private function createOrder(array $products): \WC_Order {
+    $order = wc_create_order();
+    $this->assertInstanceOf(\WC_Order::class, $order);
+    foreach ($products as $product) {
+      $order->add_product($product);
+    }
+    $order->save();
+    $this->orderIds[] = $order->get_id();
+    return $order;
+  }
+
+  private function getPatternContent(string $patternName): string {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
+
+    $patternsController = new PatternsController(
+      $this->diContainer->get(CdnAssetUrl::class),
+      $this->diContainer->get(WPFunctions::class),
+      $wooCommerceHelper
+    );
+
+    $content = $patternsController->getPatternContent($patternName);
+    $this->assertIsString($content);
+    return $content;
+  }
+
+  /**
+   * @param array<array-key, mixed> $blocks
+   * @return array<int, array<array-key, mixed>>
+   */
+  private function findBlocks(array $blocks, string $blockName): array {
+    $found = [];
+    foreach ($blocks as $block) {
+      if (!is_array($block)) {
+        continue;
+      }
+      if (($block['blockName'] ?? null) === $blockName) {
+        $found[] = $block;
+      }
+      $inner = $block['innerBlocks'] ?? null;
+      if (is_array($inner)) {
+        $found = array_merge($found, $this->findBlocks($inner, $blockName));
+      }
+    }
+    return $found;
+  }
+
+  /**
+   * @param array<array-key, mixed> $block
+   * @return array<array-key, mixed>
+   */
+  private function handPicked(array $block): array {
+    $attrs = $block['attrs'] ?? null;
+    $this->assertIsArray($attrs);
+    $query = $attrs['query'] ?? null;
+    $this->assertIsArray($query);
+    $picked = $query['woocommerceHandPickedProducts'] ?? null;
+    $this->assertIsArray($picked);
+    return $picked;
+  }
+
+  /**
+   * @param array<int, array<array-key, mixed>> $blocks
+   * @return array<array-key, mixed>
+   */
+  private function blockWithCollection(array $blocks, string $collection): array {
+    foreach ($blocks as $block) {
+      $attrs = $block['attrs'] ?? null;
+      if (is_array($attrs) && ($attrs['collection'] ?? null) === $collection) {
+        return $block;
+      }
+    }
+    $this->fail(sprintf('No product collection block using the "%s" collection was found.', $collection));
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -76,7 +76,8 @@ class RendererTest extends \MailPoetTest {
       $this->capabilitiesManager,
       $this->diContainer->get(CouponBlockGenerationFailureCollector::class),
       $this->diContainer->get(EmailContextBuilder::class),
-      $this->diContainer->get(CouponBlockFailureTranslator::class)
+      $this->diContainer->get(CouponBlockFailureTranslator::class),
+      $this->diContainer->get(\MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor::class)
     );
     $this->columnRenderer = new ColumnRenderer();
     $this->dOMParser = new pQuery();
@@ -651,7 +652,8 @@ class RendererTest extends \MailPoetTest {
       $capabilitiesManager,
       $this->diContainer->get(CouponBlockGenerationFailureCollector::class),
       $this->diContainer->get(EmailContextBuilder::class),
-      $this->diContainer->get(CouponBlockFailureTranslator::class)
+      $this->diContainer->get(CouponBlockFailureTranslator::class),
+      $this->diContainer->get(\MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor::class)
     );
     $body = json_decode(Fixtures::get('newsletter_body_template'), true);
     $this->assertIsArray($body);
@@ -674,7 +676,8 @@ class RendererTest extends \MailPoetTest {
       $capabilitiesManager,
       $this->diContainer->get(CouponBlockGenerationFailureCollector::class),
       $this->diContainer->get(EmailContextBuilder::class),
-      $this->diContainer->get(CouponBlockFailureTranslator::class)
+      $this->diContainer->get(CouponBlockFailureTranslator::class),
+      $this->diContainer->get(\MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor::class)
     );
 
     $body = json_decode(Fixtures::get('newsletter_body_template'), true);
@@ -865,7 +868,8 @@ class RendererTest extends \MailPoetTest {
       $this->capabilitiesManager,
       $this->diContainer->get(CouponBlockGenerationFailureCollector::class),
       $this->diContainer->get(EmailContextBuilder::class),
-      $this->diContainer->get(CouponBlockFailureTranslator::class)
+      $this->diContainer->get(CouponBlockFailureTranslator::class),
+      $this->diContainer->get(\MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor::class)
     );
   }
 

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -381,7 +381,8 @@ class RendererTest extends \MailPoetTest {
       $this->diContainer->get(CapabilitiesManager::class),
       $this->diContainer->get(\MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockGenerationFailureCollector::class),
       $this->diContainer->get(\MailPoet\EmailEditor\Integrations\MailPoet\Coupons\EmailContextBuilder::class),
-      $this->diContainer->get(\MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockFailureTranslator::class)
+      $this->diContainer->get(\MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockFailureTranslator::class),
+      $this->diContainer->get(\MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor::class)
     );
   }
 

--- a/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/ProductCollection/OrderProductCollectionProcessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/ProductCollection/OrderProductCollectionProcessorTest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace unit\EmailEditor\Integrations\MailPoet\ProductCollection;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor;
+
+class OrderProductCollectionProcessorTest extends \MailPoetUnitTest {
+  /** @var OrderProductCollectionProcessor */
+  private $processor;
+
+  public function _before(): void {
+    parent::_before();
+    $this->processor = new OrderProductCollectionProcessor();
+  }
+
+  public function testCreateBlocksFilterReturnsNullWithoutAnOrder(): void {
+    $this->assertNull($this->processor->createBlocksFilter([]));
+    $this->assertNull($this->processor->createBlocksFilter(['order' => null]));
+    $this->assertNull($this->processor->createBlocksFilter(['order' => new \stdClass()]));
+  }
+}


### PR DESCRIPTION
## Description

Product collection blocks in automation emails can now show products based on the order that triggered the automation. Three new collections:

- `order-cross-sells` — cross-sells of the purchased products (Product Purchase Follow-Up, First Purchase Thank You patterns)
- `order-same-tag` — products sharing the order's tags (new Tagged Product Purchase Follow-Up pattern)
- `order-same-category` — products from the order's categories (new Category Purchase Follow-Up pattern)

At send time `OrderProductCollectionProcessor` fills the marked blocks, excluding purchased and out-of-stock products, with fallback to related products and then to the authored generic query. In the editor the collections show a title, description, and a notice that products are picked per order.

## Code review notes

- The block's `collection` attribute is the marker because it's declared in the block schema — a custom attribute would be stripped when a merchant re-saves the email in the editor.
- `__experimentalRegisterProductCollection` is an experimental WC API; registration polls for the registry and degrades gracefully (unlabeled block, send-time behavior unaffected).
- Possible follow-up: upstream order context into `get_product_references_for_collection()` (woocommerce/email-editor) so core cross-sells/related collections become order-aware.

## QA notes

1. Give a product cross-sells, a tag, and a category; add other products sharing them.
2. Create an order-triggered automation and insert the Product Purchase Follow-Up (or tag/category) pattern into its email — note the preview notice on the product grid.
3. Buy the product: the email grid shows the cross-sells (or same-tag/same-category products), never the purchased product itself, and never renders empty.

## Linked PRs

- #6816 builds on this PR — merge this one first.

## Linked tickets

- [STOMAIL-8155](https://linear.app/a8c/issue/STOMAIL-8155/add-order-aware-product-recommendations-to-automation-emails)

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8155-add-order-aware-product-recommendations-to-automation-emails)

_The latest successful build from `stomail-8155-add-order-aware-product-recommendations-to-automation-emails` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Issues found: 2 categories

- Security: multiple occurrences of risky functions/patterns (exec/system/`exec()` calls, use of base64_decode, references to eval-like patterns in docs).  
- Suggestion: many TODO/FIXME comments throughout the codebase indicating incomplete work or planned improvements.

No Bug or Performance issues identified from the quick scan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->