### PR TITLE
Remove unused wordpress/vips/worker from common.js

### DIFF
--- a/mailpoet/changelog/2026-06-10-14-51-03-improved-reduce-javascript-size-in-the-admin-area.md
+++ b/mailpoet/changelog/2026-06-10-14-51-03-improved-reduce-javascript-size-in-the-admin-area.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Reduce JavaScript size in the admin area

--- a/mailpoet/views/form/editor.html
+++ b/mailpoet/views/form/editor.html
@@ -9,6 +9,8 @@
 
 <script>
   <% autoescape 'js' %>
+  // Disable Gutenberg's opt-in VIPS upload path before the form editor bundle runs.
+  window.__clientSideMediaProcessing = false;
   var mailpoet_form_data = <%= form|wp_json_encode %>;
   var mailpoet_form_exports = <%= form_exports|wp_json_encode %>;
   var mailpoet_form_segments = <%= segments|wp_json_encode %>;

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -270,6 +270,9 @@ const adminConfig = {
   },
   plugins: [
     ...baseConfig.plugins,
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^@wordpress\/vips\/worker$/,
+    }),
 
     new WebpackCopyPlugin({
       patterns: [


### PR DESCRIPTION
## Description

MailPoet's admin build was emitting the optional `@wordpress/vips/worker` code through Gutenberg's media upload package, even though the form editor does not enable Gutenberg client-side media processing.

This removes that unused worker from the admin build and explicitly keeps client-side media processing disabled in the form editor.

#### Before
common.js raw 18.2MB
zip size: 14.7MB

#### After
common.js raw 4.4MB
zip size: 10.1MB

### Next steps
We can still look into splitting the common.js into chunks. I think it contains a lot of code for automations and form editor that bundle WordPress packages that are not needed on most pages.

## Code review notes

The `window.__clientSideMediaProcessing` flag is set to `false` in the form editor as a defensive guard. If another script enables it later, Gutenberg could try to use the ignored VIPS worker path.

## QA notes

Please manually check image blocks for regressions:

- Form editor: add/select/replace image blocks (we can upload/insert and resize image - no crop/rotate)
- Email editor: add/select/replace image blocks (crop/rotate/edit image flows still work where the editor exposes 

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8154

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:js-build-tuning)

_The latest successful build from `js-build-tuning` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->