### PR TITLE
Fix form editor inserter close button

### DIFF
--- a/mailpoet/assets/js/src/form-editor/components/inserter.tsx
+++ b/mailpoet/assets/js/src/form-editor/components/inserter.tsx
@@ -1,4 +1,4 @@
-import { useRef } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { close } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
@@ -15,11 +15,15 @@ export function Inserter({ setIsInserterOpened }: Props): JSX.Element {
     [],
   );
   const libraryRef = useRef(null);
+  const closeInserter = useCallback(
+    (): void => setIsInserterOpened(false),
+    [setIsInserterOpened],
+  );
 
   return (
     <div className="editor-inserter-sidebar">
       <div className="editor-inserter-sidebar__header">
-        <Button icon={close} onClick={(): void => setIsInserterOpened(false)} />
+        <Button icon={close} onClick={closeInserter} />
       </div>
       <div className="editor-inserter-sidebar__content">
         <Library
@@ -27,6 +31,7 @@ export function Inserter({ setIsInserterOpened }: Props): JSX.Element {
           showInserterHelpPanel={false}
           rootClientId={insertPoint.rootClientId ?? undefined}
           __experimentalInsertionIndex={insertPoint.insertionIndex ?? undefined}
+          onClose={closeInserter}
           ref={libraryRef}
         />
       </div>

--- a/mailpoet/changelog/2026-06-10-15-19-02-fixed-form-editor-block-inserter-close-button-not-closin.md
+++ b/mailpoet/changelog/2026-06-10-15-19-02-fixed-form-editor-block-inserter-close-button-not-closin.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Form editor block inserter close button not closing the panel


### PR DESCRIPTION
## Description

Fixes the form editor block inserter close button by passing MailPoet's close handler to Gutenberg's inserter library.

<img width="863" height="553" alt="Screenshot 2026-06-10 at 13 34 24" src="https://github.com/user-attachments/assets/bcb0f580-6019-4181-bab4-e250ce294649" />


## Code review notes

_N/A_

## QA notes

- Browser verified: open the form editor, open the block inserter, click "Close Block Inserter", confirm the panel closes without an `onClose` console error.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8158

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/form-editor-close-inserter)

_The latest successful build from `fix/form-editor-close-inserter` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
1 issue found:
- Bug: Form editor block inserter close button threw "onClose is not a function" error when clicked, caused by missing close handler callback passed to Gutenberg's inserter library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->