### PR TITLE
Register MailPoet fields in WooCommerce order attribution

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -21,6 +21,7 @@ use MailPoet\Subscription\Manage;
 use MailPoet\Subscription\Registration;
 use MailPoet\WooCommerce\Helper as WooHelper;
 use MailPoet\WooCommerce\Integrations\AutomateWooHooks;
+use MailPoet\WooCommerce\OrderAttributionFields;
 use MailPoet\WooCommerce\Subscription;
 use MailPoet\WooCommerce\WooSystemInfoController;
 use MailPoet\WP\Functions as WPFunctions;
@@ -111,6 +112,9 @@ class Hooks {
   /** @var AdminUserSubscription */
   private $adminUserSubscription;
 
+  /** @var OrderAttributionFields */
+  private $orderAttributionFields;
+
   private CouponBlockGenerator $couponBlockGenerator;
 
   public function __construct(
@@ -137,6 +141,7 @@ class Hooks {
     CronTrigger $cronTrigger,
     WooHelper $wooHelper,
     AdminUserSubscription $adminUserSubscription,
+    OrderAttributionFields $orderAttributionFields,
     CouponBlockGenerator $couponBlockGenerator
   ) {
     $this->subscriptionForm = $subscriptionForm;
@@ -162,6 +167,7 @@ class Hooks {
     $this->cronTrigger = $cronTrigger;
     $this->wooHelper = $wooHelper;
     $this->adminUserSubscription = $adminUserSubscription;
+    $this->orderAttributionFields = $orderAttributionFields;
     $this->couponBlockGenerator = $couponBlockGenerator;
   }
 
@@ -191,6 +197,8 @@ class Hooks {
 
   public function initEarlyHooks() {
     $this->setupMailer();
+    // Must run before the WooCommerce plugin file loads, see OrderAttributionFields::setup()
+    $this->orderAttributionFields->setup();
   }
 
   public function setupSubscriptionEvents() {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -692,6 +692,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // WooCommerce
     $container->autowire(\MailPoet\WooCommerce\Helper::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Integrations\AutomateWooHooks::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\OrderAttributionFields::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Settings::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\SubscriberEngagement::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Subscription::class)->setPublic(true);

--- a/mailpoet/lib/WooCommerce/OrderAttributionFields.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionFields.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use MailPoet\WP\Functions as WPFunctions;
+
+class OrderAttributionFields {
+  const FIELD_CLICK_ID = 'mailpoet_click_id';
+  const FIELD_NEWSLETTER_ID = 'mailpoet_newsletter_id';
+  const FIELD_QUEUE_ID = 'mailpoet_queue_id';
+  const FIELD_SUBSCRIBER_ID = 'mailpoet_subscriber_id';
+
+  const FIELD_NAMES = [
+    self::FIELD_CLICK_ID,
+    self::FIELD_NEWSLETTER_ID,
+    self::FIELD_QUEUE_ID,
+    self::FIELD_SUBSCRIBER_ID,
+  ];
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var Helper */
+  private $wooHelper;
+
+  public function __construct(
+    WPFunctions $wp,
+    Helper $wooHelper
+  ) {
+    $this->wp = $wp;
+    $this->wooHelper = $wooHelper;
+  }
+
+  /**
+   * WooCommerce applies the filter while its plugin file is being loaded,
+   * so this must run before WooCommerce loads (MailPoet loads first
+   * because WordPress loads active plugins in alphabetical order).
+   */
+  public function setup(): void {
+    $this->wp->addFilter(
+      'wc_order_attribution_tracking_fields',
+      [$this, 'registerTrackingFields']
+    );
+  }
+
+  /**
+   * @param mixed $fields
+   * @return mixed
+   */
+  public function registerTrackingFields($fields) {
+    if (!is_array($fields) || !$this->wooHelper->isWooCommerceActive()) {
+      return $fields;
+    }
+    foreach (self::FIELD_NAMES as $fieldName) {
+      // The value is a sourcebuster.js accessor path. An empty path resolves to null
+      // client-side, so the fields stay empty placeholders until MailPoet writes
+      // values server-side via the woocommerce_order_save_attribution_data action.
+      $fields[$fieldName] = '';
+    }
+    return $fields;
+  }
+}

--- a/mailpoet/tasks/phpstan/custom-stubs.php
+++ b/mailpoet/tasks/phpstan/custom-stubs.php
@@ -311,6 +311,18 @@ namespace Automattic\WooCommerce\Internal\Features {
   }
 }
 
+// Stub for the order attribution controller, which is internal and not included in php-stubs/woocommerce-stubs
+namespace Automattic\WooCommerce\Internal\Orders {
+
+  if (!class_exists(\Automattic\WooCommerce\Internal\Orders\OrderAttributionController::class)) {
+    class OrderAttributionController {
+      public function get_field_names(): array {
+        return [];
+      }
+    }
+  }
+}
+
 // Temporary stubs for marketing channels
 // I have no idea why PhpStorm is complaining, but the woocommerce-stubs library has the latest updates
 namespace Automattic\WooCommerce\Admin\Marketing {

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionFieldsTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionFieldsTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use Automattic\WooCommerce\Internal\Orders\OrderAttributionController;
+
+/**
+ * @group woo
+ */
+class OrderAttributionFieldsTest extends \MailPoetTest {
+  public function testItRegistersTheFilterDuringPluginBootstrap(): void {
+    $orderAttributionFields = $this->diContainer->get(OrderAttributionFields::class);
+    verify(has_filter(
+      'wc_order_attribution_tracking_fields',
+      [$orderAttributionFields, 'registerTrackingFields']
+    ))->notEmpty();
+  }
+
+  public function testWooCommerceAttributionKnowsMailPoetFields(): void {
+    foreach (OrderAttributionFields::FIELD_NAMES as $fieldName) {
+      verify($this->getWooAttributionFieldNames())->arrayContains($fieldName);
+    }
+  }
+
+  public function testWooCommerceStandardFieldsAreUnchanged(): void {
+    $fieldNames = $this->getWooAttributionFieldNames();
+    $standardFields = [
+      'source_type',
+      'referrer',
+      'utm_campaign',
+      'utm_source',
+      'utm_medium',
+      'utm_source_platform',
+    ];
+    foreach ($standardFields as $fieldName) {
+      verify($fieldNames)->arrayContains($fieldName);
+    }
+  }
+
+  /**
+   * Reads the field names cached by WooCommerce's attribution controller when
+   * WooCommerce loaded. Both the classic checkout hidden inputs and the Block
+   * checkout Store API schema are built from these names, so they prove the
+   * filter was registered early enough (before the WooCommerce plugin file
+   * loaded and applied it).
+   */
+  private function getWooAttributionFieldNames(): array {
+    return wc_get_container()->get(OrderAttributionController::class)->get_field_names();
+  }
+}

--- a/mailpoet/tests/unit/WooCommerce/OrderAttributionFieldsTest.php
+++ b/mailpoet/tests/unit/WooCommerce/OrderAttributionFieldsTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use Codeception\Stub;
+use Codeception\Stub\Expected;
+use MailPoet\WP\Functions as WPFunctions;
+
+class OrderAttributionFieldsTest extends \MailPoetUnitTest {
+  private const WOO_DEFAULT_FIELDS = [
+    'source_type' => 'current.typ',
+    'referrer' => 'current_add.rf',
+    'utm_campaign' => 'current.cmp',
+    'utm_source' => 'current.src',
+    'utm_medium' => 'current.mdm',
+  ];
+
+  public function testItRegistersTheTrackingFieldsFilter(): void {
+    $wp = Stub::make(WPFunctions::class, [
+      'addFilter' => Expected::once(function ($tag, $callback) {
+        verify($tag)->equals('wc_order_attribution_tracking_fields');
+        verify($callback)->notEmpty();
+      }),
+    ], $this);
+    $orderAttributionFields = new OrderAttributionFields($wp, Stub::make(Helper::class));
+
+    $orderAttributionFields->setup();
+  }
+
+  public function testItAddsMailPoetFieldsAndKeepsWooFieldsUnchanged(): void {
+    $orderAttributionFields = $this->createOrderAttributionFields(true);
+
+    $fields = (array)$orderAttributionFields->registerTrackingFields(self::WOO_DEFAULT_FIELDS);
+
+    foreach (OrderAttributionFields::FIELD_NAMES as $fieldName) {
+      verify($fields)->arrayHasKey($fieldName);
+      verify($fields[$fieldName])->equals('');
+    }
+    foreach (self::WOO_DEFAULT_FIELDS as $fieldName => $accessor) {
+      verify($fields[$fieldName])->equals($accessor);
+    }
+    verify($fields)->arrayCount(count(self::WOO_DEFAULT_FIELDS) + count(OrderAttributionFields::FIELD_NAMES));
+  }
+
+  public function testItDoesNotAddFieldsWhenWooCommerceIsNotActive(): void {
+    $orderAttributionFields = $this->createOrderAttributionFields(false);
+
+    $fields = $orderAttributionFields->registerTrackingFields(self::WOO_DEFAULT_FIELDS);
+
+    verify($fields)->equals(self::WOO_DEFAULT_FIELDS);
+  }
+
+  public function testItReturnsNonArrayValuesUnchanged(): void {
+    $orderAttributionFields = $this->createOrderAttributionFields(true);
+
+    verify($orderAttributionFields->registerTrackingFields(null))->null();
+    verify($orderAttributionFields->registerTrackingFields('invalid'))->equals('invalid');
+  }
+
+  private function createOrderAttributionFields(bool $isWooCommerceActive): OrderAttributionFields {
+    $wooHelper = Stub::make(Helper::class, [
+      'isWooCommerceActive' => $isWooCommerceActive,
+    ], $this);
+    return new OrderAttributionFields(Stub::make(WPFunctions::class), $wooHelper);
+  }
+}


### PR DESCRIPTION
## Description

Registers the MailPoet-specific fields (`mailpoet_click_id`, `mailpoet_newsletter_id`, `mailpoet_queue_id`, `mailpoet_subscriber_id`) in WooCommerce order attribution via the `wc_order_attribution_tracking_fields` filter, so WooCommerce persists them as `_wc_order_attribution_mailpoet_*` order meta.

Registration only — the fields stay empty placeholders until MailPoet writes values server-side (STOMAIL-7485). Standard Woo attribution fields are not touched. No changelog entry since there is no user-facing change yet.

## Code review notes

- WooCommerce applies the filter **while its plugin file is loading** (its DI container instantiates the attribution controller in the `WooCommerce` constructor), so the registration runs in `Hooks::initEarlyHooks()` at MailPoet plugin load time — `plugins_loaded` would be too late. This works because WordPress loads active plugins alphabetically (`mailpoet` < `woocommerce`). Known edge case: WooCommerce network-activated + MailPoet site-activated on multisite reverses the order; tracked for the STOMAIL-8144 compat matrix.
- The integration test reads the field names cached by Woo's real attribution controller, which proves the early-registration timing end-to-end (both the classic checkout hidden inputs and the Block Store API schema are built from those names).
- Woo's internal `OrderAttributionController` is not in `php-stubs/woocommerce-stubs`, hence the custom PHPStan stub (same approach as the existing `DataSynchronizer` stub).

## QA notes

With WooCommerce active, open the classic checkout page and verify the hidden inputs include `wc_order_attribution_mailpoet_*` fields (empty values). On Block checkout, the Store API checkout schema (`woocommerce/order-attribution` extension namespace) accepts the same field names. With WooCommerce disabled, nothing is registered.

<img width="643" height="348" alt="Screenshot 2026-06-10 at 21 34 52" src="https://github.com/user-attachments/assets/d334812e-2d6d-4262-9617-feb27e69b986" />

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7487](https://linear.app/a8c/issue/STOMAIL-7487/register-mailpoet-fields-in-woocommerce-order-attribution)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-7487-register-mailpoet-fields-in-woo-order-attribution)

_The latest successful build from `add/stomail-7487-register-mailpoet-fields-in-woo-order-attribution` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

The PR implementation is well-structured with proper defensive coding, complete test coverage, and correct integration into the DI container and initialization sequence. The code properly:

- Registers the WooCommerce filter with type checking and conditional WooCommerce active verification
- Integrates the filter registration into early hook initialization before WooCommerce loads
- Uses dependency injection with proper type hints
- Includes both unit and integration tests verifying filter registration and field persistence
- Follows existing code patterns and conventions

The only known limitation (alphabetical plugin loading assumption) is already documented in the PR notes as a tracked edge case (STOMAIL-8144).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->