### PR TITLE
Write MailPoet attribution onto Woo orders server-side

### DIFF
--- a/mailpoet/changelog/2026-06-10-20-22-07-added-email-campaign-attribution-on-woocommerce-orders.md
+++ b/mailpoet/changelog/2026-06-10-20-22-07-added-email-campaign-attribution-on-woocommerce-orders.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Email campaign attribution on WooCommerce orders

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -175,6 +175,7 @@ class Hooks {
     $this->setupWPUsers();
     $this->setupWooCommerceUsers();
     $this->setupWooCommercePurchases();
+    $this->setupWooCommerceOrderAttribution();
     $this->setupWooCommerceSubscriberEngagement();
     $this->setupWooCommerceTracking();
     $this->setupListing();
@@ -528,6 +529,34 @@ class Hooks {
       [$this->hooksWooCommerce, 'trackRefund'],
       10,
       1
+    );
+  }
+
+  public function setupWooCommerceOrderAttribution() {
+    // After Woo's own priority-10 handler so the resolved values overwrite
+    // the empty placeholders Woo persists from the checkout form
+    $this->wp->addAction(
+      'woocommerce_order_save_attribution_data',
+      [$this->hooksWooCommerce, 'writeOrderAttribution'],
+      20
+    );
+    // Admin and REST orders; gated inside to stay out of storefront checkout
+    $this->wp->addAction(
+      'woocommerce_new_order',
+      [$this->hooksWooCommerce, 'writeOrderAttributionForNewOrder'],
+      20
+    );
+    $this->wp->addAction(
+      'woocommerce_order_status_changed',
+      [$this->hooksWooCommerce, 'writeOrderAttribution'],
+      10,
+      1
+    );
+    // After WC_Meta_Box_Order_Data::save (priority 40) so the billing email is saved
+    $this->wp->addAction(
+      'woocommerce_process_shop_order_meta',
+      [$this->hooksWooCommerce, 'writeOrderAttribution'],
+      50
     );
   }
 

--- a/mailpoet/lib/Config/HooksWooCommerce.php
+++ b/mailpoet/lib/Config/HooksWooCommerce.php
@@ -10,6 +10,7 @@ use MailPoet\Statistics\Track\WooCommercePurchases;
 use MailPoet\Subscription\Registration;
 use MailPoet\WooCommerce\MailPoetTask;
 use MailPoet\WooCommerce\MultichannelMarketing\MPMarketingChannelController;
+use MailPoet\WooCommerce\OrderAttributionWriter;
 use MailPoet\WooCommerce\Settings as WooCommerceSettings;
 use MailPoet\WooCommerce\SubscriberEngagement;
 use MailPoet\WooCommerce\Subscription as WooCommerceSubscription;
@@ -43,6 +44,9 @@ class HooksWooCommerce {
   /** @var MPMarketingChannelController */
   private $marketingChannelController;
 
+  /** @var OrderAttributionWriter */
+  private $orderAttributionWriter;
+
   public function __construct(
     WooCommerceSubscription $woocommerceSubscription,
     WooCommerceSegment $woocommerceSegment,
@@ -52,7 +56,8 @@ class HooksWooCommerce {
     LoggerFactory $loggerFactory,
     Tracker $tracker,
     SubscriberEngagement $subscriberEngagement,
-    MPMarketingChannelController $marketingChannelController
+    MPMarketingChannelController $marketingChannelController,
+    OrderAttributionWriter $orderAttributionWriter
   ) {
     $this->woocommerceSubscription = $woocommerceSubscription;
     $this->woocommerceSegment = $woocommerceSegment;
@@ -63,6 +68,7 @@ class HooksWooCommerce {
     $this->tracker = $tracker;
     $this->subscriberEngagement = $subscriberEngagement;
     $this->marketingChannelController = $marketingChannelController;
+    $this->orderAttributionWriter = $orderAttributionWriter;
   }
 
   public function extendWooCommerceCheckoutForm() {
@@ -126,6 +132,22 @@ class HooksWooCommerce {
       $this->woocommercePurchases->trackPurchase($id, $useCookies);
     } catch (\Throwable $e) {
       $this->logError($e, 'WooCommerce Purchases');
+    }
+  }
+
+  public function writeOrderAttribution($order) {
+    try {
+      $this->orderAttributionWriter->writeForOrder($order);
+    } catch (\Throwable $e) {
+      $this->logError($e, 'WooCommerce Order Attribution');
+    }
+  }
+
+  public function writeOrderAttributionForNewOrder($order) {
+    try {
+      $this->orderAttributionWriter->writeForNewOrder($order);
+    } catch (\Throwable $e) {
+      $this->logError($e, 'WooCommerce Order Attribution');
     }
   }
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -693,6 +693,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\WooCommerce\Helper::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Integrations\AutomateWooHooks::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\OrderAttributionFields::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\OrderAttributionWriter::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Settings::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\SubscriberEngagement::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Subscription::class)->setPublic(true);

--- a/mailpoet/lib/WooCommerce/OrderAttributionWriter.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionWriter.php
@@ -1,0 +1,275 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Settings\TrackingConfig;
+use MailPoet\Statistics\StatisticsClicksRepository;
+use MailPoet\Statistics\Track\Clicks;
+use MailPoet\Statistics\Track\WooCommercePurchases;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Util\Cookies;
+use MailPoet\WP\Functions as WPFunctions;
+use WC_Order;
+
+class OrderAttributionWriter {
+  const WRITES_STARTED_AT_OPTION = 'mailpoet_woo_attribution_writes_started_at';
+
+  // The meta key names are pinned by the migration contract (STOMAIL-8135), so Woo's
+  // filterable wc_order_attribution_tracking_field_prefix is intentionally not applied.
+  const META_PREFIX = '_wc_order_attribution_';
+
+  // 'typein' is Woo's source type for direct traffic. A clear non-MailPoet source
+  // (organic, referral, non-MailPoet utm, admin, mobile_app) is never overwritten.
+  const OVERWRITABLE_SOURCE_TYPES = ['', 'typein', 'unknown'];
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var Helper */
+  private $wooHelper;
+
+  /** @var TrackingConfig */
+  private $trackingConfig;
+
+  /** @var StatisticsClicksRepository */
+  private $statisticsClicksRepository;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var Cookies */
+  private $cookies;
+
+  public function __construct(
+    WPFunctions $wp,
+    Helper $wooHelper,
+    TrackingConfig $trackingConfig,
+    StatisticsClicksRepository $statisticsClicksRepository,
+    SubscribersRepository $subscribersRepository,
+    Cookies $cookies
+  ) {
+    $this->wp = $wp;
+    $this->wooHelper = $wooHelper;
+    $this->trackingConfig = $trackingConfig;
+    $this->statisticsClicksRepository = $statisticsClicksRepository;
+    $this->subscribersRepository = $subscribersRepository;
+    $this->cookies = $cookies;
+  }
+
+  /**
+   * @param int|WC_Order $order
+   */
+  public function writeForOrder($order): void {
+    if (!$this->isWritePathActive()) {
+      return;
+    }
+    if (!$order instanceof WC_Order) {
+      $order = $this->wooHelper->wcGetOrder($order);
+    }
+    if (!$order instanceof WC_Order) {
+      return;
+    }
+    $this->markWritesStarted();
+
+    $click = $this->resolveCanonicalClick($order);
+    if (!$click) {
+      $this->removeEmptyPlaceholders($order);
+      $order->save_meta_data();
+      return;
+    }
+    $this->writeMailPoetFields($order, $click);
+    $this->writeStandardSourceFields($order, $click);
+    $order->save_meta_data();
+  }
+
+  /**
+   * woocommerce_new_order also fires during storefront checkout, before WooCommerce
+   * captures its attribution data. Writing MailPoet meta at that point would make
+   * Woo's has_attribution() check skip its own capture, so this path handles only
+   * admin and (non-Store-API) REST requests; checkout orders are covered by the
+   * woocommerce_order_save_attribution_data and order-status-changed paths.
+   *
+   * @param int|WC_Order $order
+   */
+  public function writeForNewOrder($order): void {
+    if (!$this->isAdminOrRestApiRequest()) {
+      return;
+    }
+    $this->writeForOrder($order);
+  }
+
+  private function isWritePathActive(): bool {
+    return $this->wooHelper->isWooCommerceActive()
+      && $this->isWooAttributionAvailable()
+      && $this->trackingConfig->isEmailTrackingEnabled();
+  }
+
+  private function isWooAttributionAvailable(): bool {
+    return class_exists(FeaturesUtil::class) && FeaturesUtil::feature_is_enabled('order_attribution');
+  }
+
+  private function isAdminOrRestApiRequest(): bool {
+    if ($this->wp->isAdmin()) {
+      return true;
+    }
+    $wc = $this->wooHelper->WC();
+    if (!$wc instanceof \WooCommerce) {
+      return false;
+    }
+    return $wc->is_rest_api_request() && !$wc->is_store_api_request();
+  }
+
+  /**
+   * The historical read boundary defined by the migration contract (STOMAIL-8135):
+   * persisted once when the write path first activates and never moved.
+   */
+  private function markWritesStarted(): void {
+    if ($this->wp->getOption(self::WRITES_STARTED_AT_OPTION)) {
+      return;
+    }
+    $this->wp->addOption(self::WRITES_STARTED_AT_OPTION, gmdate('Y-m-d H:i:s'));
+  }
+
+  /**
+   * Last click wins (STOMAIL-8135): the most recent eligible click before order
+   * creation, across billing-email-matched and cookie-matched candidates. The
+   * candidate set mirrors WooCommercePurchases::trackPurchase; the legacy engine
+   * is intentionally left untouched while both run in parallel for reconciliation.
+   */
+  private function resolveCanonicalClick(WC_Order $order): ?StatisticsClickEntity {
+    $to = $order->get_date_created();
+    if (is_null($to)) {
+      return null;
+    }
+    $from = clone $to;
+    $from->modify(-WooCommercePurchases::USE_CLICKS_SINCE_DAYS_AGO . ' days');
+
+    $candidates = $this->getClicks($order->get_billing_email(), $from, $to);
+    if ($this->trackingConfig->isCookieTrackingEnabled()) {
+      $cookieEmail = $this->getSubscriberEmailFromCookie();
+      if ($cookieEmail && $cookieEmail !== $order->get_billing_email()) {
+        $candidates = array_merge($candidates, $this->getClicks($cookieEmail, $from, $to));
+      }
+    }
+
+    if (!$candidates) {
+      return null;
+    }
+    $latest = array_shift($candidates);
+    foreach ($candidates as $click) {
+      if ($this->isMoreRecent($click, $latest)) {
+        $latest = $click;
+      }
+    }
+    return $latest;
+  }
+
+  private function isMoreRecent(StatisticsClickEntity $click, StatisticsClickEntity $other): bool {
+    $clickUpdatedAt = $click->getUpdatedAt();
+    $otherUpdatedAt = $other->getUpdatedAt();
+    if ($clickUpdatedAt->getTimestamp() === $otherUpdatedAt->getTimestamp()) {
+      return (int)$click->getId() > (int)$other->getId();
+    }
+    return $clickUpdatedAt > $otherUpdatedAt;
+  }
+
+  /**
+   * @return StatisticsClickEntity[]
+   */
+  private function getClicks(?string $email, \DateTimeInterface $from, \DateTimeInterface $to): array {
+    if (!$email) {
+      return [];
+    }
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => $email]);
+    if (!$subscriber instanceof SubscriberEntity) {
+      return [];
+    }
+    return $this->statisticsClicksRepository->findLatestPerNewsletterBySubscriber($subscriber, $from, $to);
+  }
+
+  private function getSubscriberEmailFromCookie(): ?string {
+    $cookieData = $this->cookies->get(Clicks::REVENUE_TRACKING_COOKIE_NAME);
+    if (!$cookieData || !isset($cookieData['statistics_clicks'])) {
+      return null;
+    }
+    try {
+      $click = $this->statisticsClicksRepository->findOneById($cookieData['statistics_clicks']);
+    } catch (\Exception $e) {
+      return null;
+    }
+    if (!$click instanceof StatisticsClickEntity) {
+      return null;
+    }
+    $subscriber = $click->getSubscriber();
+    return $subscriber instanceof SubscriberEntity ? $subscriber->getEmail() : null;
+  }
+
+  private function writeMailPoetFields(WC_Order $order, StatisticsClickEntity $click): void {
+    $newsletter = $click->getNewsletter();
+    $queue = $click->getQueue();
+    $subscriber = $click->getSubscriber();
+    $values = [
+      OrderAttributionFields::FIELD_CLICK_ID => (string)$click->getId(),
+      OrderAttributionFields::FIELD_NEWSLETTER_ID => $newsletter ? (string)$newsletter->getId() : '',
+      OrderAttributionFields::FIELD_QUEUE_ID => $queue ? (string)$queue->getId() : '',
+      OrderAttributionFields::FIELD_SUBSCRIBER_ID => $subscriber ? (string)$subscriber->getId() : '',
+    ];
+    foreach ($values as $fieldName => $value) {
+      if ($value === '') {
+        $this->removeEmptyPlaceholder($order, $fieldName);
+        continue;
+      }
+      $order->update_meta_data(self::META_PREFIX . $fieldName, $value);
+    }
+  }
+
+  private function writeStandardSourceFields(WC_Order $order, StatisticsClickEntity $click): void {
+    $sourceType = $this->getMetaString($order, self::META_PREFIX . 'source_type');
+    $utmSource = $this->getMetaString($order, self::META_PREFIX . 'utm_source');
+    $isOverwritable = in_array($sourceType, self::OVERWRITABLE_SOURCE_TYPES, true) || $utmSource === 'mailpoet';
+    if (!$isOverwritable) {
+      return;
+    }
+    $values = [
+      'source_type' => 'utm',
+      'utm_source' => 'mailpoet',
+      'utm_medium' => 'email',
+      'utm_source_platform' => 'mailpoet',
+    ];
+    $newsletter = $click->getNewsletter();
+    if ($newsletter) {
+      $subject = (string)$newsletter->getSubject();
+      $values['utm_campaign'] = $subject !== '' ? $subject : 'newsletter-' . $newsletter->getId();
+    }
+    foreach ($values as $fieldName => $value) {
+      $order->update_meta_data(self::META_PREFIX . $fieldName, $this->wp->sanitizeTextField($value));
+    }
+  }
+
+  /**
+   * WooCommerce persists the registered MailPoet fields as empty strings on checkout
+   * orders (the placeholders from STOMAIL-7487). When no attribution is resolved,
+   * the empty placeholders are removed so "no eligible click" leaves no MailPoet
+   * meta behind. Non-empty values are never removed.
+   */
+  private function removeEmptyPlaceholders(WC_Order $order): void {
+    foreach (OrderAttributionFields::FIELD_NAMES as $fieldName) {
+      $this->removeEmptyPlaceholder($order, $fieldName);
+    }
+  }
+
+  private function removeEmptyPlaceholder(WC_Order $order, string $fieldName): void {
+    $metaKey = self::META_PREFIX . $fieldName;
+    if ($order->meta_exists($metaKey) && $this->getMetaString($order, $metaKey) === '') {
+      $order->delete_meta_data($metaKey);
+    }
+  }
+
+  private function getMetaString(WC_Order $order, string $metaKey): string {
+    $value = $order->get_meta($metaKey);
+    return is_scalar($value) ? (string)$value : '';
+  }
+}

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionWriterTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionWriterTest.php
@@ -1,0 +1,348 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use Codeception\Stub;
+use DateTime;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\TrackingConfig;
+use MailPoet\Statistics\StatisticsClicksRepository;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Util\Cookies;
+use MailPoet\WP\Functions as WPFunctions;
+use WC_Order;
+
+/**
+ * @group woo
+ */
+class OrderAttributionWriterTest extends \MailPoetTest {
+  private const WOO_ATTRIBUTION_FEATURE_OPTION = 'woocommerce_feature_order_attribution_enabled';
+
+  /** @var SubscriberEntity */
+  private $subscriber;
+
+  /** @var NewsletterEntity */
+  private $newsletter;
+
+  /** @var SendingQueueEntity */
+  private $queue;
+
+  /** @var NewsletterLinkEntity */
+  private $link;
+
+  /** @var OrderAttributionWriter */
+  private $writer;
+
+  /** @var SettingsController */
+  private $settings;
+
+  public function _before() {
+    parent::_before();
+    delete_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
+    unset($_COOKIE['mailpoet_revenue_tracking']);
+    $this->settings = SettingsController::getInstance();
+    $this->settings->set('tracking.level', TrackingConfig::LEVEL_FULL);
+    $this->subscriber = $this->createSubscriber('attribution@example.com');
+    $this->newsletter = $this->createNewsletter('First Campaign');
+    $this->queue = $this->createQueue($this->newsletter, $this->subscriber);
+    $this->link = $this->createLink($this->newsletter, $this->queue);
+    $this->writer = $this->diContainer->get(OrderAttributionWriter::class);
+  }
+
+  public function testItWritesAttributionMetaForEligibleOrder(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+
+    $this->writer->writeForOrder($order->get_id());
+
+    $order = $this->reloadOrder($order);
+    verify($order->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$click->getId());
+    verify($order->get_meta('_wc_order_attribution_mailpoet_newsletter_id'))->equals((string)$this->newsletter->getId());
+    verify($order->get_meta('_wc_order_attribution_mailpoet_queue_id'))->equals((string)$this->queue->getId());
+    verify($order->get_meta('_wc_order_attribution_mailpoet_subscriber_id'))->equals((string)$this->subscriber->getId());
+    verify($order->get_meta('_wc_order_attribution_source_type'))->equals('utm');
+    verify($order->get_meta('_wc_order_attribution_utm_source'))->equals('mailpoet');
+    verify($order->get_meta('_wc_order_attribution_utm_medium'))->equals('email');
+    verify($order->get_meta('_wc_order_attribution_utm_source_platform'))->equals('mailpoet');
+    verify($order->get_meta('_wc_order_attribution_utm_campaign'))->equals('First Campaign');
+    verify(get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION))->notEmpty();
+  }
+
+  public function testLastClickWinsAcrossEmailAndCookieCandidates(): void {
+    $this->createClick($this->link, $this->subscriber, 5);
+
+    $cookieSubscriber = $this->createSubscriber('cookie@example.com');
+    $cookieNewsletter = $this->createNewsletter('Cookie Campaign');
+    $cookieQueue = $this->createQueue($cookieNewsletter, $cookieSubscriber);
+    $cookieLink = $this->createLink($cookieNewsletter, $cookieQueue);
+    $cookieClick = $this->createClick($cookieLink, $cookieSubscriber, 1);
+    $this->entityManager->flush();
+
+    $_COOKIE['mailpoet_revenue_tracking'] = (string)json_encode([
+      'statistics_clicks' => $cookieClick->getId(),
+      'created_at' => time(),
+    ]);
+
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->writer->writeForOrder($order->get_id());
+
+    $order = $this->reloadOrder($order);
+    verify($order->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$cookieClick->getId());
+    verify($order->get_meta('_wc_order_attribution_mailpoet_newsletter_id'))->equals((string)$cookieNewsletter->getId());
+    verify($order->get_meta('_wc_order_attribution_utm_campaign'))->equals('Cookie Campaign');
+  }
+
+  public function testLastClickWinsAcrossNewslettersForTheSameSubscriber(): void {
+    $this->createClick($this->link, $this->subscriber, 3);
+
+    $newerNewsletter = $this->createNewsletter('Newer Campaign');
+    $newerQueue = $this->createQueue($newerNewsletter, $this->subscriber);
+    $newerLink = $this->createLink($newerNewsletter, $newerQueue);
+    $newerClick = $this->createClick($newerLink, $this->subscriber, 1);
+    $this->entityManager->flush();
+
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->writer->writeForOrder($order->get_id());
+
+    $order = $this->reloadOrder($order);
+    verify($order->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$newerClick->getId());
+    verify($order->get_meta('_wc_order_attribution_mailpoet_newsletter_id'))->equals((string)$newerNewsletter->getId());
+  }
+
+  public function testItPreservesExistingNonMailPoetSource(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $order->update_meta_data('_wc_order_attribution_source_type', 'referral');
+    $order->update_meta_data('_wc_order_attribution_utm_source', 'google');
+    $order->save_meta_data();
+
+    $this->writer->writeForOrder($order->get_id());
+
+    $order = $this->reloadOrder($order);
+    verify($order->get_meta('_wc_order_attribution_source_type'))->equals('referral');
+    verify($order->get_meta('_wc_order_attribution_utm_source'))->equals('google');
+    verify($order->meta_exists('_wc_order_attribution_utm_medium'))->false();
+    verify($order->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$click->getId());
+  }
+
+  public function testItIsIdempotent(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+
+    $this->writer->writeForOrder($order->get_id());
+    $writesStartedAt = get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
+    $this->writer->writeForOrder($order->get_id());
+
+    $order = $this->reloadOrder($order);
+    verify($this->getMetaValues($order, '_wc_order_attribution_mailpoet_click_id'))->equals([(string)$click->getId()]);
+    verify($this->getMetaValues($order, '_wc_order_attribution_utm_source'))->equals(['mailpoet']);
+    verify(get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION))->equals($writesStartedAt);
+  }
+
+  public function testItWritesNothingWhenTrackingIsDisabled(): void {
+    $this->settings->set('tracking.level', TrackingConfig::LEVEL_BASIC);
+    $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+
+    $this->writer->writeForOrder($order->get_id());
+
+    $order = $this->reloadOrder($order);
+    verify($order->meta_exists('_wc_order_attribution_mailpoet_click_id'))->false();
+    verify($order->meta_exists('_wc_order_attribution_utm_source'))->false();
+    verify(get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION))->false();
+  }
+
+  public function testItWritesNothingWhenWooAttributionIsDisabled(): void {
+    $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+
+    update_option(self::WOO_ATTRIBUTION_FEATURE_OPTION, 'no');
+    try {
+      $this->writer->writeForOrder($order->get_id());
+    } finally {
+      update_option(self::WOO_ATTRIBUTION_FEATURE_OPTION, 'yes');
+    }
+
+    $order = $this->reloadOrder($order);
+    verify($order->meta_exists('_wc_order_attribution_mailpoet_click_id'))->false();
+    verify(get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION))->false();
+  }
+
+  public function testItRemovesEmptyPlaceholdersWhenNoClickResolves(): void {
+    $order = $this->createOrder('no-clicks@example.com');
+    foreach (OrderAttributionFields::FIELD_NAMES as $fieldName) {
+      $order->update_meta_data('_wc_order_attribution_' . $fieldName, '');
+    }
+    $order->save_meta_data();
+
+    $this->writer->writeForOrder($order->get_id());
+
+    $order = $this->reloadOrder($order);
+    foreach (OrderAttributionFields::FIELD_NAMES as $fieldName) {
+      verify($order->meta_exists('_wc_order_attribution_' . $fieldName))->false();
+    }
+    verify($order->meta_exists('_wc_order_attribution_utm_source'))->false();
+  }
+
+  public function testItWritesViaWooAttributionDataAction(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+
+    // simulate the params of a classic checkout submission: Woo's own priority-10
+    // handler persists the MailPoet fields as empty placeholders, which the
+    // MailPoet handler then overwrites with the resolved values
+    $params = array_fill_keys([
+      'source_type',
+      'referrer',
+      'utm_campaign',
+      'utm_source',
+      'utm_medium',
+      'utm_content',
+      'utm_id',
+      'utm_term',
+      'utm_source_platform',
+      'utm_creative_format',
+      'utm_marketing_tactic',
+      'session_entry',
+      'session_start_time',
+      'session_pages',
+      'session_count',
+      'user_agent',
+    ], '(none)');
+    foreach (OrderAttributionFields::FIELD_NAMES as $fieldName) {
+      $params[$fieldName] = '';
+    }
+
+    do_action('woocommerce_order_save_attribution_data', $order, $params);
+
+    $order = $this->reloadOrder($order);
+    verify($order->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$click->getId());
+    verify($this->getMetaValues($order, '_wc_order_attribution_mailpoet_click_id'))->equals([(string)$click->getId()]);
+  }
+
+  public function testItWritesWhenOrderStatusChanges(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+
+    $order->set_status('processing');
+    $order->save();
+
+    $order = $this->reloadOrder($order);
+    verify($order->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$click->getId());
+  }
+
+  public function testNewOrderPathRunsOnlyInAdminOrRestContext(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+
+    // neither admin nor REST here, so the new-order path must not write
+    $this->writer->writeForNewOrder($order->get_id());
+    $reloaded = $this->reloadOrder($order);
+    verify($reloaded->meta_exists('_wc_order_attribution_mailpoet_click_id'))->false();
+
+    $adminWriter = new OrderAttributionWriter(
+      Stub::make(WPFunctions::class, ['isAdmin' => true]),
+      $this->diContainer->get(Helper::class),
+      $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(StatisticsClicksRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
+      new Cookies()
+    );
+    $adminWriter->writeForNewOrder($order->get_id());
+    $reloaded = $this->reloadOrder($order);
+    verify($reloaded->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$click->getId());
+  }
+
+  private function createOrder(string $billingEmail): WC_Order {
+    $order = wc_create_order();
+    $this->assertInstanceOf(WC_Order::class, $order);
+    $order->set_billing_email($billingEmail);
+    $order->set_total('15');
+    $order->save();
+    return $order;
+  }
+
+  private function reloadOrder(WC_Order $order): WC_Order {
+    $reloaded = wc_get_order($order->get_id());
+    $this->assertInstanceOf(WC_Order::class, $reloaded);
+    return $reloaded;
+  }
+
+  /**
+   * @return string[]
+   */
+  private function getMetaValues(WC_Order $order, string $metaKey): array {
+    $values = [];
+    foreach ($order->get_meta_data() as $meta) {
+      $data = $meta->get_data();
+      if ($data['key'] === $metaKey) {
+        $values[] = $data['value'];
+      }
+    }
+    return $values;
+  }
+
+  private function createNewsletter(string $subject): NewsletterEntity {
+    $newsletter = new NewsletterEntity();
+    $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
+    $newsletter->setSubject($subject);
+    $this->entityManager->persist($newsletter);
+    return $newsletter;
+  }
+
+  private function createQueue(NewsletterEntity $newsletter, SubscriberEntity $subscriber): SendingQueueEntity {
+    $task = new ScheduledTaskEntity();
+    $this->entityManager->persist($task);
+    $queue = new SendingQueueEntity();
+    $queue->setNewsletter($newsletter);
+    $queue->setTask($task);
+    $this->entityManager->persist($queue);
+    $sendingTaskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber, 1);
+    $this->entityManager->persist($sendingTaskSubscriber);
+    return $queue;
+  }
+
+  private function createSubscriber(string $email): SubscriberEntity {
+    $subscriber = new SubscriberEntity();
+    $subscriber->setEmail($email);
+    $subscriber->setFirstName('First');
+    $subscriber->setLastName('Last');
+    $this->entityManager->persist($subscriber);
+    return $subscriber;
+  }
+
+  private function createLink(NewsletterEntity $newsletter, SendingQueueEntity $queue): NewsletterLinkEntity {
+    $link = new NewsletterLinkEntity($newsletter, $queue, 'url', 'hash');
+    $this->entityManager->persist($link);
+    return $link;
+  }
+
+  private function createClick(NewsletterLinkEntity $link, SubscriberEntity $subscriber, int $createdDaysAgo = 5): StatisticsClickEntity {
+    $newsletter = $link->getNewsletter();
+    $queue = $link->getQueue();
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
+    $click = new StatisticsClickEntity($newsletter, $queue, $subscriber, $link, 1);
+    $this->entityManager->persist($click);
+    $timestamp = new DateTime("-$createdDaysAgo days");
+    $click->setCreatedAt($timestamp);
+    $click->setUpdatedAt($timestamp);
+    return $click;
+  }
+}


### PR DESCRIPTION
## Description

Writes MailPoet's server-side-resolved email attribution onto WooCommerce orders as `_wc_order_attribution_mailpoet_*` meta, making Woo order meta the system of record for attribution data. Resolution follows the ratified contract (STOMAIL-8135): last click wins across billing-email and cookie candidates within 14 days. Standard Woo source fields (`utm_source=mailpoet` etc.) are set only when the existing source is empty/direct/unknown or already MailPoet. MailPoet reports are unchanged; both attribution engines run in parallel until reconciliation (STOMAIL-8136).

## Code review notes

- The `woocommerce_new_order` path is gated to admin/REST contexts on purpose: Woo's `has_attribution()` checks **all registered fields, including ours**, so writing MailPoet meta during storefront checkout before Woo's capture would make Woo skip its own attribution entirely. Checkout orders are handled on `woocommerce_order_save_attribution_data` at priority 20, after Woo's handler.
- The click-candidate logic intentionally duplicates (rather than refactors) `WooCommercePurchases::trackPurchase` helpers — the legacy engine must stay untouched while both run in parallel for reconciliation.
- `utm_campaign` uses the newsletter subject (marketer-recognizable in Woo Analytics). Subjects are editable, which can split a campaign key — open to switching to the newsletter ID.
- The optional `wc_order_attribution_origin_label` relabel from the ticket is left as a follow-up.

## QA notes

On a store with Woo order attribution enabled and MailPoet tracking at full level: click a tracked newsletter link, place an order with the subscriber's email, and check the order's attribution meta (Order edit → order attribution / metadata) — `mailpoet_*` fields carry the click/newsletter/queue/subscriber IDs and origin shows `Source: mailpoet`. Orders from other sources (e.g. organic) keep their original source. Covered by 11 `@group woo` integration tests.

## Linked PRs

#6832

## Linked tickets

[STOMAIL-7485](https://linear.app/a8c/issue/STOMAIL-7485/write-mailpoet-attribution-onto-woo-orders-server-side)

## After-merge notes

First activation persists the `mailpoet_woo_attribution_writes_started_at` option — the historical read boundary consumed by STOMAIL-8138.

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-7485-write-mailpoet-attribution-onto-woo-orders)

_The latest successful build from `add/stomail-7485-write-mailpoet-attribution-onto-woo-orders` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->