### PR TITLE
Index subscribers created_at for fast Created on sort

### DIFF
--- a/mailpoet/changelog/2026-06-09-06-35-49-improved-speed-up-sorting-the-subscribers-list-by-subscript.md
+++ b/mailpoet/changelog/2026-06-09-06-35-49-improved-speed-up-sorting-the-subscribers-list-by-subscript.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Speed up sorting the subscribers list by subscription date on large lists

--- a/mailpoet/lib/Migrations/Db/Migration_20260609_120000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260609_120000_Db.php
@@ -9,13 +9,28 @@ class Migration_20260609_120000_Db extends DbMigration {
   public function run(): void {
     $subscribersTable = $this->getTableName(SubscriberEntity::class);
 
-    // Index created_at so the subscribers listing can sort by "Created on"
-    // without a filesort. InnoDB appends the primary key to secondary indexes,
-    // so this single-column index covers `ORDER BY created_at, id` as well.
-    if (!$this->indexExists($subscribersTable, 'created_at')) {
+    // Index (deleted_at, created_at) so the subscribers listing's default view
+    // (non-trashed, newest first) reads its rows straight from the index:
+    // `deleted_at IS NULL` pins the first column, so entries come out ordered
+    // by created_at — and by id within ties, since InnoDB appends the primary
+    // key to secondary indexes. Without it the query has no usable index at
+    // all (every other index leads with another column) and degrades to a
+    // full-table scan plus a filesort of every non-trashed subscriber.
+    //
+    // A single-column created_at index would serve the same query slightly
+    // worse (it scans trashed rows too), but the important difference shows
+    // under `deleted_at IS NULL` filtering: a single-column index is then
+    // fully bound, which qualifies it as a rowid-ordered scan that the
+    // optimizer can combine into an index-merge intersect with other
+    // status/deleted_at indexes — a plan that materializes and filesorts
+    // millions of rows on large sites. With created_at as an unbound second
+    // column, this index never qualifies, so that plan cannot be built from
+    // it. The deleted_at prefix also covers Trash counts
+    // (`deleted_at IS NOT NULL`) as an index-only range scan.
+    if (!$this->indexExists($subscribersTable, 'deleted_at_created')) {
       $this->connection->executeQuery(
         "ALTER TABLE `{$subscribersTable}`
-          ADD INDEX `created_at` (`created_at`)"
+          ADD INDEX `deleted_at_created` (`deleted_at`, `created_at`)"
       );
     }
   }

--- a/mailpoet/lib/Migrations/Db/Migration_20260609_120000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260609_120000_Db.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20260609_120000_Db extends DbMigration {
+  public function run(): void {
+    $subscribersTable = $this->getTableName(SubscriberEntity::class);
+
+    // Index created_at so the subscribers listing can sort by "Created on"
+    // without a filesort. InnoDB appends the primary key to secondary indexes,
+    // so this single-column index covers `ORDER BY created_at, id` as well.
+    if (!$this->indexExists($subscribersTable, 'created_at')) {
+      $this->connection->executeQuery(
+        "ALTER TABLE `{$subscribersTable}`
+          ADD INDEX `created_at` (`created_at`)"
+      );
+    }
+  }
+}

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -792,7 +792,9 @@ class SubscriberListingRepository extends ListingRepository {
       // Deterministic tiebreaker so pagination stays stable when the sorted
       // column has duplicate values. created_at has per-second granularity, so
       // large or imported lists tie often; pairing it with id also matches the
-      // (created_at, id) shape of the index, keeping the sort index-backed.
+      // deleted_at_created index (deleted_at, created_at + implicit id), which
+      // serves the default listing with the WHERE pinning deleted_at, keeping
+      // the sort index-backed.
       $queryBuilder->addOrderBy('s.id', $sortOrder);
     }
   }

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -975,6 +975,11 @@ class SubscriberListingRepository extends ListingRepository {
       ->from($subscribersTable);
     $subscribersIdsQuery = $this->applyConstraintsForDynamicSegment($subscribersIdsQuery, $definition, $segment);
     $subscribersIdsQuery->orderBy($this->getDynamicSegmentSortColumn($sortBy, $subscribersTable), $sortOrder);
+    if ($sortBy !== 'id') {
+      // The page boundary is cut here, so this query needs the same id
+      // tiebreaker as applySorting() for pagination to stay stable.
+      $subscribersIdsQuery->addOrderBy($this->getDynamicSegmentSortColumn('id', $subscribersTable), $sortOrder);
+    }
     $subscribersIdsQuery->setFirstResult($definition->getOffset());
     $subscribersIdsQuery->setMaxResults($definition->getLimit());
 

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -788,6 +788,13 @@ class SubscriberListingRepository extends ListingRepository {
       $sortBy = self::DEFAULT_SORT_BY;
     }
     $queryBuilder->addOrderBy("s.$sortBy", $sortOrder);
+    if ($sortBy !== 'id') {
+      // Deterministic tiebreaker so pagination stays stable when the sorted
+      // column has duplicate values. created_at has per-second granularity, so
+      // large or imported lists tie often; pairing it with id also matches the
+      // (created_at, id) shape of the index, keeping the sort index-backed.
+      $queryBuilder->addOrderBy('s.id', $sortOrder);
+    }
   }
 
   public function getGroups(ListingDefinition $definition): array {

--- a/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
@@ -199,6 +199,35 @@ class SubscriberListingRepositoryTest extends \MailPoetTest {
     $this->listingData['sort_by'] = '';
   }
 
+  public function testItSortsByCreatedAtWithIdTiebreaker() {
+    // First-inserted (lowest id) but the newest created_at.
+    $newestSameSecond = $this->createSubscriberEntity();
+    $newestSameSecond->setCreatedAt(new \DateTimeImmutable('2020-01-01 00:00:00'));
+
+    // Second-inserted (higher id) sharing the newest created_at second.
+    $newestHigherId = $this->createSubscriberEntity();
+    $newestHigherId->setCreatedAt(new \DateTimeImmutable('2020-01-01 00:00:00'));
+
+    // Third-inserted (highest id) but the oldest created_at.
+    $oldest = $this->createSubscriberEntity();
+    $oldest->setCreatedAt(new \DateTimeImmutable('2010-01-01 00:00:00'));
+
+    $this->entityManager->flush();
+
+    $this->listingData['sort_by'] = 'created_at';
+    $this->listingData['sort_order'] = 'desc';
+    $data = $this->repository->getData($this->getListingDefinition());
+    $this->listingData['sort_by'] = '';
+    $this->listingData['sort_order'] = '';
+
+    verify(count($data))->equals(3);
+    // Real created_at order: the oldest date sorts last despite its highest id.
+    // Within the tied newest second, id desc breaks the tie deterministically.
+    verify($data[0]->getEmail())->equals($newestHigherId->getEmail());
+    verify($data[1]->getEmail())->equals($newestSameSecond->getEmail());
+    verify($data[2]->getEmail())->equals($oldest->getEmail());
+  }
+
   public function testLoadSubscribersInDynamicSegment() {
     $wpUserEmail = 'user-role-test1@example.com';
     $this->tester->deleteWordPressUser($wpUserEmail);


### PR DESCRIPTION
## Description
This PR adds an index on `created_at` for the `mailpoet_subscribers`. The issue we are facing: `order by created_at` is the default ordering we use on the subscriber pages. But there is no index on that column.

I was playing with the idea to just map `order_by=createdAt` to `id`. Usually this would be a nice way around the issue without creating another index. But, when you import a list, you can import when the subscriber signed up and that means that id and created_at are not necessarily in line with each other.

So I decided to add an index instead.

## Linked tickets

STOMAIL-8156

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8156-scale-subscriptions-page-for-1m-subscribers-and-2-lists)

_The latest successful build from `stomail-8156-scale-subscriptions-page-for-1m-subscribers-and-2-lists` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

The PR correctly implements database optimization and pagination stability improvements:

1. Migration - Adds a composite index `deleted_at_created` on (deleted_at, created_at) with an idempotent existence check and parameterized table name usage. The composite index is the intended design to support WHERE deleted_at IS NULL plus ORDER BY created_at efficiently and to avoid index-merge / filesort plans on large tables.

2. Tie-breaker logic - applySorting() and dynamic-segment ID-subquery ordering add a deterministic secondary sort on id (using the same sort direction) when the primary sort is not id, ensuring stable pagination when created_at values tie.

3. Test validation - New integration test verifies sorting by created_at descending uses id as a tiebreaker for determinism.

All changes follow project patterns; no Bug, Security, Performance, or Suggestion issues were identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->