### PR TITLE
Restore bulk "select all on all pages" for subscribers

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -479,11 +479,12 @@
   margin: 4px 0 0;
 }
 
-// Center the confirm/apply button in the bulk-action modals and give it room
-// to breathe below the message text.
+// Right-align the confirm/apply button in the bulk-action modals (matching the
+// usual WordPress/WooCommerce modal footer placement) with room to breathe
+// below the message text.
 .mailpoet-subscribers-bulk-confirm-actions {
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
   margin-top: 20px;
 }
 

--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -456,3 +456,16 @@
     grid-template-columns: 1fr;
   }
 }
+
+.mailpoet-subscribers-select-all-banner {
+  background: #f0f6fc;
+  border: 1px solid #c3c4c7;
+  border-radius: 2px;
+  margin-bottom: 8px;
+  padding: 8px 12px;
+  text-align: center;
+
+  .mailpoet-subscribers-select-all-caveat {
+    margin: 4px 0 0;
+  }
+}

--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -464,6 +464,15 @@
   margin-bottom: 8px;
   padding: 8px 12px;
   text-align: center;
+
+  // The WordPress `button-link` aligns differently from adjacent inline text,
+  // which left the link sitting below the sentence. Match the surrounding
+  // text metrics and baseline so they read as one line.
+  .button-link {
+    font-size: inherit;
+    line-height: inherit;
+    vertical-align: baseline;
+  }
 }
 
 .mailpoet-subscribers-select-all-caveat {

--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -458,21 +458,32 @@
 }
 
 .mailpoet-subscribers-select-all-banner {
-  background: #f0f6fc;
-  border: 1px solid #c3c4c7;
+  // Derive from the active WP admin color scheme so the banner reads correctly
+  // on every profile colour (Light, Coffee, Sunrise, …) rather than a fixed
+  // blue that clashes with darker themes.
+  background: color-mix(
+    in srgb,
+    rgb(var(--wp-admin-theme-color--rgb)) 4%,
+    #fff
+  );
+  border: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
   border-radius: 2px;
   margin-bottom: 8px;
   padding: 8px 12px;
   text-align: center;
 
-  // The WordPress `button-link` aligns differently from adjacent inline text,
-  // which left the link sitting below the sentence. Match the surrounding
-  // text metrics and baseline so they read as one line.
-  .button-link {
+  // The link button aligns differently from adjacent inline text, which left
+  // the link sitting below the sentence. Match the surrounding text metrics and
+  // baseline so they read as one line.
+  .components-button.is-link {
     font-size: inherit;
     line-height: inherit;
     vertical-align: baseline;
   }
+}
+
+.mailpoet-subscribers-select-all-warning {
+  margin: 0 0 12px;
 }
 
 .mailpoet-subscribers-select-all-caveat {

--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -488,6 +488,22 @@
   margin-top: 20px;
 }
 
+// Filled red confirm button for the permanent-delete bulk action. MailPoet's
+// Button has no filled-destructive variant, so recolor the primary button
+// rather than fall back to the lighter red text-link `destructive` variant.
+.mailpoet-button.mailpoet-subscribers-confirm-destructive.button-primary {
+  background: $color-destructive;
+  border-color: $color-destructive;
+
+  &:hover,
+  &:focus,
+  &:active {
+    background: $color-destructive-hover;
+    border-color: $color-destructive-hover;
+    color: #fff;
+  }
+}
+
 // List/tag picker modal: let the dropdown span the modal width (matching the
 // modal's own horizontal padding) and add space before the caveat text.
 .mailpoet-subscribers-picker-modal {

--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -486,3 +486,16 @@
   justify-content: center;
   margin-top: 20px;
 }
+
+// List/tag picker modal: let the dropdown span the modal width (matching the
+// modal's own horizontal padding) and add space before the caveat text.
+.mailpoet-subscribers-picker-modal {
+  .mailpoet-form-select {
+    margin-bottom: 16px;
+    width: 100%;
+  }
+
+  .select2-container {
+    width: 100% !important;
+  }
+}

--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -464,8 +464,8 @@
   margin-bottom: 8px;
   padding: 8px 12px;
   text-align: center;
+}
 
-  .mailpoet-subscribers-select-all-caveat {
-    margin: 4px 0 0;
-  }
+.mailpoet-subscribers-select-all-caveat {
+  margin: 4px 0 0;
 }

--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -478,3 +478,11 @@
 .mailpoet-subscribers-select-all-caveat {
   margin: 4px 0 0;
 }
+
+// Center the confirm/apply button in the bulk-action modals and give it room
+// to breathe below the message text.
+.mailpoet-subscribers-bulk-confirm-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+}

--- a/mailpoet/assets/js/src/subscribers/api.ts
+++ b/mailpoet/assets/js/src/subscribers/api.ts
@@ -7,6 +7,10 @@ import {
   type RestApiError,
 } from 'common/dataviews';
 import type { EngagementScoreType } from './engagement-score-badge-type';
+import {
+  type SubscriberBulkActionScope,
+  buildBulkActionPayload,
+} from './bulk-action-payload';
 
 declare global {
   interface Window {
@@ -72,12 +76,7 @@ export type SubscriberBulkAction =
   | 'addTag'
   | 'removeTag';
 
-export type SubscriberBulkActionScope = {
-  group: string;
-  filter: Record<string, string>;
-  search: string;
-  selection: number[];
-};
+export type { SubscriberBulkActionScope } from './bulk-action-payload';
 
 export type SubscriberBulkActionResult = {
   action: SubscriberBulkAction;
@@ -115,14 +114,10 @@ export function bulkAction(
   scope: SubscriberBulkActionScope,
   extra: Record<string, unknown> = {},
 ): Promise<{ data: SubscriberBulkActionResult }> {
-  return restPost<{ data: SubscriberBulkActionResult }>(BULK_ACTION_PATH, {
-    action,
-    selection: scope.selection,
-    group: scope.group,
-    search: scope.search,
-    filter: scope.filter,
-    ...extra,
-  });
+  return restPost<{ data: SubscriberBulkActionResult }>(
+    BULK_ACTION_PATH,
+    buildBulkActionPayload(action, scope, extra),
+  );
 }
 
 export async function sendConfirmationEmail(id: number): Promise<void> {

--- a/mailpoet/assets/js/src/subscribers/bulk-action-payload.ts
+++ b/mailpoet/assets/js/src/subscribers/bulk-action-payload.ts
@@ -1,0 +1,24 @@
+export type SubscriberBulkActionScope = {
+  group: string;
+  filter: Record<string, string>;
+  search: string;
+  selection: number[];
+  selectAll?: boolean;
+};
+
+export function buildBulkActionPayload(
+  action: string,
+  scope: SubscriberBulkActionScope,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const selectAll = Boolean(scope.selectAll);
+  return {
+    action,
+    selection: selectAll ? [] : scope.selection,
+    select_all: selectAll,
+    group: scope.group,
+    search: scope.search,
+    filter: scope.filter,
+    ...extra,
+  };
+}

--- a/mailpoet/assets/js/src/subscribers/filter-sync.ts
+++ b/mailpoet/assets/js/src/subscribers/filter-sync.ts
@@ -1,0 +1,42 @@
+type FilterOptions =
+  | Record<string, { value: string | number }[]>
+  | undefined
+  | null;
+
+// Returns a copy of `filter` with any value that is no longer a selectable
+// option removed, or `null` when nothing changed. A filter is only pruned once
+// its options have loaded (a non-empty option list), so a valid filter is never
+// cleared before the first listing response arrives.
+//
+// This keeps the filter dropdowns in sync with the query: the backend drops a
+// list/tag from the options once it has no subscribers in the current group
+// (e.g. after select-all + Move to trash empties the filtered list), which would
+// otherwise leave the dropdown showing "All Lists" while the query stays
+// filtered — "No items found" with a stale value.
+export function pruneUnavailableFilters(
+  filter: Record<string, string>,
+  filters: FilterOptions,
+): Record<string, string> | null {
+  if (!filters) {
+    return null;
+  }
+  const next = { ...filter };
+  let changed = false;
+  Object.entries(filter).forEach(([name, value]) => {
+    if (!value) {
+      return;
+    }
+    const options = filters[name];
+    if (!Array.isArray(options) || options.length === 0) {
+      return;
+    }
+    const isSelectable = options.some(
+      (option) => String(option.value) === String(value),
+    );
+    if (!isSelectable) {
+      delete next[name];
+      changed = true;
+    }
+  });
+  return changed ? next : null;
+}

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -528,11 +528,13 @@ function BulkResendConfirmationEmailsModal({
 function PickerModal({
   title,
   config,
+  caveat,
   onApply,
   onClose,
 }: {
   title: string;
   config: PickerConfig;
+  caveat?: JSX.Element | null;
   onApply: (value: number) => void;
   onClose: () => void;
 }) {
@@ -575,15 +577,17 @@ function PickerModal({
           setValue(Number.isFinite(next) ? next : 0);
         }}
       />
-      <span className="mailpoet-gap-half" />
-      <Button
-        onClick={handleApply}
-        dimension="small"
-        variant="secondary"
-        isDisabled={!value}
-      >
-        {__('Apply', 'mailpoet')}
-      </Button>
+      {caveat}
+      <div className="mailpoet-subscribers-bulk-confirm-actions">
+        <Button
+          onClick={handleApply}
+          dimension="small"
+          variant="secondary"
+          isDisabled={!value}
+        >
+          {__('Apply', 'mailpoet')}
+        </Button>
+      </div>
     </Modal>
   );
 }
@@ -1310,15 +1314,16 @@ function SubscriberList() {
             ).replace('%s', formatCount(count))}
           </p>
           {largeOpCaveat}
-          <span className="mailpoet-gap-half" />
-          <Button
-            onClick={() => handlePendingActionSubmit()}
-            dimension="small"
-            variant="secondary"
-            automationId="bulk-select-all-confirm"
-          >
-            {__('Apply', 'mailpoet')}
-          </Button>
+          <div className="mailpoet-subscribers-bulk-confirm-actions">
+            <Button
+              onClick={() => handlePendingActionSubmit()}
+              dimension="small"
+              variant="secondary"
+              automationId="bulk-select-all-confirm"
+            >
+              {__('Apply', 'mailpoet')}
+            </Button>
+          </div>
         </Modal>
       );
     }
@@ -1337,15 +1342,16 @@ function SubscriberList() {
             ).replace('%s', formatCount(count))}
           </p>
           {largeOpCaveat}
-          <span className="mailpoet-gap-half" />
-          <Button
-            onClick={() => handlePendingActionSubmit()}
-            dimension="small"
-            variant="secondary"
-            automationId="bulk-unsubscribe-confirm"
-          >
-            {__('Apply', 'mailpoet')}
-          </Button>
+          <div className="mailpoet-subscribers-bulk-confirm-actions">
+            <Button
+              onClick={() => handlePendingActionSubmit()}
+              dimension="small"
+              variant="secondary"
+              automationId="bulk-unsubscribe-confirm"
+            >
+              {__('Apply', 'mailpoet')}
+            </Button>
+          </div>
         </Modal>
       );
     }
@@ -1368,6 +1374,7 @@ function SubscriberList() {
       <PickerModal
         title={modalTitle(action)}
         config={config}
+        caveat={largeOpCaveat}
         onApply={(value) =>
           handlePendingActionSubmit(
             config.kind === 'segment'

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -585,7 +585,7 @@ function PickerModal({
       />
       {caveat}
       <div className="mailpoet-subscribers-bulk-confirm-actions">
-        <Button onClick={handleApply} variant="secondary" isDisabled={!value}>
+        <Button onClick={handleApply} isDisabled={!value}>
           {__('Apply', 'mailpoet')}
         </Button>
       </div>
@@ -1318,7 +1318,7 @@ function SubscriberList() {
           <div className="mailpoet-subscribers-bulk-confirm-actions">
             <Button
               onClick={() => handlePendingActionSubmit()}
-              variant="secondary"
+              variant={action === 'delete' ? 'destructive' : undefined}
               automationId="bulk-select-all-confirm"
             >
               {__('Apply', 'mailpoet')}
@@ -1345,7 +1345,6 @@ function SubscriberList() {
           <div className="mailpoet-subscribers-bulk-confirm-actions">
             <Button
               onClick={() => handlePendingActionSubmit()}
-              variant="secondary"
               automationId="bulk-unsubscribe-confirm"
             >
               {__('Apply', 'mailpoet')}

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -549,6 +549,14 @@ function PickerModal({
       endpoint: config.endpoint,
       filter: config.filter,
       forceSelect2: true,
+      // A placeholder forces Select2 to render a blank leading option and
+      // preselect nothing, so the Apply button's disabled-until-chosen state
+      // reads as intentional rather than broken — and a select-all bulk action
+      // can't be applied to the first list/tag by an accidental click.
+      placeholder:
+        config.kind === 'segment'
+          ? __('Select a list...', 'mailpoet')
+          : __('Select a tag...', 'mailpoet'),
     }),
     [config],
   );

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -72,8 +72,9 @@ type PendingModalAction =
 
 type PendingAction = {
   action: SubscriberBulkAction;
-  targets: Subscriber[];
   selectAll: boolean;
+  scope: SubscriberBulkActionScope;
+  count: number;
 } | null;
 
 const SELECT_ALL_GENERIC_CONFIRM_ACTIONS: SubscriberBulkAction[] = [
@@ -896,9 +897,21 @@ function SubscriberList() {
   const openPendingAction = useCallback(
     (action: SubscriberBulkAction, targets: Subscriber[]): void => {
       triggerElementRef.current = document.activeElement as HTMLElement | null;
-      setPendingAction({ action, targets, selectAll });
+      const selectedIds = targets.map((subscriber) => Number(subscriber.id));
+      setPendingAction({
+        action,
+        selectAll,
+        count: selectAll ? meta.count : targets.length,
+        scope: {
+          group,
+          filter: { ...filter },
+          search: view.search || '',
+          selection: selectAll ? [] : selectedIds,
+          ...(selectAll ? { selectAll: true } : {}),
+        },
+      });
     },
-    [selectAll],
+    [filter, group, meta.count, selectAll, view.search],
   );
 
   const handleSelectionChange = useCallback((next: string[]): void => {
@@ -1044,16 +1057,16 @@ function SubscriberList() {
     async (extra: Record<string, unknown> = {}): Promise<void> => {
       if (!pendingAction || pendingActionInFlightRef.current) return;
       pendingActionInFlightRef.current = true;
-      const { action, targets } = pendingAction;
+      const { action, scope } = pendingAction;
       try {
-        await handleBulkAction(action, targets, extra);
+        await runBulkAction(action, scope, extra);
       } finally {
         pendingActionInFlightRef.current = false;
         setPendingAction(null);
         window.setTimeout(restoreTriggerFocus);
       }
     },
-    [handleBulkAction, pendingAction, restoreTriggerFocus],
+    [pendingAction, restoreTriggerFocus, runBulkAction],
   );
 
   const handleSendConfirmationEmail = useCallback(
@@ -1308,8 +1321,7 @@ function SubscriberList() {
 
   const renderPendingActionModal = (): JSX.Element | null => {
     if (!pendingAction) return null;
-    const { action, targets, selectAll: pendingSelectAll } = pendingAction;
-    const count = pendingSelectAll ? meta.count : targets.length;
+    const { action, count, selectAll: pendingSelectAll } = pendingAction;
     const largeOpCaveat =
       pendingSelectAll && shouldWarnLargeOperation(count) ? (
         <Notice

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -531,12 +531,16 @@ function PickerModal({
   title,
   config,
   caveat,
+  selectionNotice,
+  requireChoice,
   onApply,
   onClose,
 }: {
   title: string;
   config: PickerConfig;
   caveat?: JSX.Element | null;
+  selectionNotice?: JSX.Element | null;
+  requireChoice?: boolean;
   onApply: (value: number) => void;
   onClose: () => void;
 }) {
@@ -544,7 +548,7 @@ function PickerModal({
   // a controlled component by reading values out of its `onValueChange` callback
   // — no jQuery DOM lookups leak into this file.
   const [value, setValue] = useState<number>(() =>
-    getInitialPickerValue(config),
+    requireChoice ? 0 : getInitialPickerValue(config),
   );
   const fieldConfig = useMemo(
     () => ({
@@ -578,6 +582,7 @@ function PickerModal({
       contentClassName="mailpoet-subscribers-picker-modal"
     >
       {caveat}
+      {selectionNotice}
       <Selection
         field={fieldConfig}
         width="100%"
@@ -1420,11 +1425,21 @@ function SubscriberList() {
       return null;
     }
     const config = PICKERS[action];
+    const selectAllScopeNotice = pendingSelectAll ? (
+      <p>
+        {__(
+          'This action will be applied to all %s subscribers matching the current view.',
+          'mailpoet',
+        ).replace('%s', formatCount(count))}
+      </p>
+    ) : null;
     return (
       <PickerModal
         title={modalTitle(action)}
         config={config}
         caveat={largeOpCaveat}
+        selectionNotice={selectAllScopeNotice}
+        requireChoice={pendingSelectAll}
         onApply={(value) =>
           handlePendingActionSubmit(
             config.kind === 'segment'

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -576,6 +576,7 @@ function PickerModal({
       isDismissible
       contentClassName="mailpoet-subscribers-picker-modal"
     >
+      {caveat}
       <Selection
         field={fieldConfig}
         width="100%"
@@ -584,7 +585,6 @@ function PickerModal({
           setValue(Number.isFinite(next) ? next : 0);
         }}
       />
-      {caveat}
       <div className="mailpoet-subscribers-bulk-confirm-actions">
         <Button onClick={handleApply} isDisabled={!value}>
           {__('Apply', 'mailpoet')}
@@ -1312,12 +1312,16 @@ function SubscriberList() {
     const count = pendingSelectAll ? meta.count : targets.length;
     const largeOpCaveat =
       pendingSelectAll && shouldWarnLargeOperation(count) ? (
-        <p className="mailpoet-subscribers-select-all-caveat">
+        <Notice
+          status="warning"
+          isDismissible={false}
+          className="mailpoet-subscribers-select-all-warning"
+        >
           {__(
             'Large operations may take a while and could time out on very large lists.',
             'mailpoet',
           )}
-        </p>
+        </Notice>
       ) : null;
     // Select-all permanent delete keeps WordPress users and WooCommerce
     // customers (SubscribersRepository::bulkDelete only deletes rows with no
@@ -1339,13 +1343,13 @@ function SubscriberList() {
           onRequestClose={closePendingAction}
           isDismissible
         >
+          {largeOpCaveat}
           <p>
             {__(
               'This action will be applied to all %s subscribers matching the current view.',
               'mailpoet',
             ).replace('%s', formatCount(count))}
           </p>
-          {largeOpCaveat}
           {deleteSkipCaveat}
           <div className="mailpoet-subscribers-bulk-confirm-actions">
             <Button
@@ -1371,13 +1375,13 @@ function SubscriberList() {
           onRequestClose={closePendingAction}
           isDismissible
         >
+          {largeOpCaveat}
           <p>
             {__(
               'This action will unsubscribe %s subscribers from all lists. This action cannot be undone. Are you sure, you want to continue?',
               'mailpoet',
             ).replace('%s', formatCount(count))}
           </p>
-          {largeOpCaveat}
           <div className="mailpoet-subscribers-bulk-confirm-actions">
             <Button
               onClick={() => handlePendingActionSubmit()}

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -887,17 +887,15 @@ function SubscriberList() {
 
   const handleViewChange = useCallback(
     (nextView: View): void => {
-      const scopeChanged =
-        nextView.search !== view.search ||
-        nextView.sort?.field !== view.sort?.field ||
-        nextView.sort?.direction !== view.sort?.direction;
-      if (scopeChanged) {
-        setSelectAll(false);
-      }
+      // DataViews can't keep row checkboxes ticked across pages, so "select all
+      // matching" would leave the banner claiming everything is selected while
+      // the new page shows empty checkboxes. Drop the intent on any view change
+      // (page, per-page, search, sort) so the banner never contradicts the rows.
+      setSelectAll(false);
       setSelection([]);
       setView(nextView);
     },
-    [setView, view],
+    [setView],
   );
   const persistedViewChange = usePersistedDataViewsPreference(
     'subscribers',

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -38,6 +38,8 @@ import { GlobalContext, type GlobalContextValue } from 'context';
 import { SubscribersHeading } from './heading';
 import { getSubscriberFields } from './fields';
 import { getInitialPickerValue, type PickerConfig } from './picker-value';
+import { SelectAllBanner } from './select-all-banner';
+import { selectAllBannerState, shouldWarnLargeOperation } from './select-all';
 import {
   bulkAction,
   getSubscribers,
@@ -68,9 +70,17 @@ type PendingModalAction =
   | 'removeTag';
 
 type PendingAction = {
-  action: PendingModalAction;
+  action: SubscriberBulkAction;
   targets: Subscriber[];
+  selectAll: boolean;
 } | null;
+
+const SELECT_ALL_GENERIC_CONFIRM_ACTIONS: SubscriberBulkAction[] = [
+  'trash',
+  'restore',
+  'delete',
+  'removeFromAllLists',
+];
 
 const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
 const bulkConfirmationResendLimit =
@@ -261,6 +271,12 @@ const PICKERS: Record<
     endpoint: 'tags',
   },
 };
+
+function isPickerAction(
+  action: SubscriberBulkAction,
+): action is keyof typeof PICKERS {
+  return action in PICKERS;
+}
 
 function modalTitle(action: PendingModalAction): string {
   const titles = {
@@ -680,6 +696,7 @@ function SubscriberList() {
     hashState.filter ?? {},
   );
   const [selection, setSelection] = useState<string[]>([]);
+  const [selectAll, setSelectAll] = useState<boolean>(false);
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
   const triggerElementRef = useRef<HTMLElement | null>(null);
   // Synchronous guard that blocks re-entrancy while a confirmation-modal action
@@ -760,6 +777,7 @@ function SubscriberList() {
       setGroup((current) => next.group ?? current);
       setFilter(next.filter ?? {});
       setSelection([]);
+      setSelectAll(false);
       clearLoadError();
       // Fill hash segments the URL omits from the preference-merged defaults
       // (not the in-memory view) so back/forward resolves a URL exactly like
@@ -817,6 +835,7 @@ function SubscriberList() {
     ) {
       setGroup('all');
       setSelection([]);
+      setSelectAll(false);
       setView((currentView) => ({ ...currentView, page: 1 }));
     }
   }, [
@@ -843,19 +862,34 @@ function SubscriberList() {
   }, [restoreTriggerFocus]);
 
   const openPendingAction = useCallback(
-    (action: PendingModalAction, targets: Subscriber[]): void => {
+    (action: SubscriberBulkAction, targets: Subscriber[]): void => {
       triggerElementRef.current = document.activeElement as HTMLElement | null;
-      setPendingAction({ action, targets });
+      setPendingAction({ action, targets, selectAll });
     },
-    [],
+    [selectAll],
   );
 
+  const handleSelectionChange = useCallback((next: string[]): void => {
+    // A manual checkbox change means the user is hand-picking rows, so the
+    // "all matching" intent no longer applies. Programmatic page changes go
+    // through handleViewChange (which clears selection itself), not this path.
+    setSelectAll(false);
+    setSelection(next);
+  }, []);
+
   const handleViewChange = useCallback(
-    (nextView: View) => {
+    (nextView: View): void => {
+      const scopeChanged =
+        nextView.search !== view.search ||
+        nextView.sort?.field !== view.sort?.field ||
+        nextView.sort?.direction !== view.sort?.direction;
+      if (scopeChanged) {
+        setSelectAll(false);
+      }
       setSelection([]);
       setView(nextView);
     },
-    [setView],
+    [setView, view],
   );
   const persistedViewChange = usePersistedDataViewsPreference(
     'subscribers',
@@ -906,6 +940,7 @@ function SubscriberList() {
         const response = await bulkAction(action, scope, extra);
         const result = response.data;
         setSelection([]);
+        setSelectAll(false);
         if (action === 'resendConfirmationEmails') {
           showBulkResendConfirmationNotice(result);
         } else {
@@ -925,6 +960,20 @@ function SubscriberList() {
       targets: Subscriber[],
       extra: Record<string, unknown> = {},
     ): Promise<void> => {
+      if (selectAll) {
+        await runBulkAction(
+          action,
+          {
+            group,
+            filter,
+            search: view.search || '',
+            selection: [],
+            selectAll: true,
+          },
+          extra,
+        );
+        return;
+      }
       if (targets.length === 0) return;
       const selectedIds = targets.map((subscriber) => Number(subscriber.id));
       await runBulkAction(
@@ -938,7 +987,7 @@ function SubscriberList() {
         extra,
       );
     },
-    [filter, group, runBulkAction, view.search],
+    [filter, group, runBulkAction, selectAll, view.search],
   );
 
   // "Empty Trash" is the only listing-scoped destructive call we make with no
@@ -955,6 +1004,7 @@ function SubscriberList() {
         filter,
         search: view.search || '',
         selection: [],
+        selectAll: true,
       },
       {},
     );
@@ -1047,6 +1097,10 @@ function SubscriberList() {
         supportsBulk: true,
         isEligible: () => group !== 'trash',
         callback: (targets) => {
+          if (selectAll) {
+            openPendingAction('trash', targets);
+            return;
+          }
           void handleBulkAction('trash', targets);
         },
       },
@@ -1056,6 +1110,10 @@ function SubscriberList() {
         supportsBulk: true,
         isEligible: () => group === 'trash',
         callback: (targets) => {
+          if (selectAll) {
+            openPendingAction('restore', targets);
+            return;
+          }
           void handleBulkAction('restore', targets);
         },
       },
@@ -1066,6 +1124,10 @@ function SubscriberList() {
         isDestructive: true,
         isEligible: (item) => group === 'trash' && isItemDeletable(item),
         callback: (targets) => {
+          if (selectAll) {
+            openPendingAction('delete', targets);
+            return;
+          }
           void handleBulkAction('delete', targets.filter(isItemDeletable));
         },
       },
@@ -1100,6 +1162,10 @@ function SubscriberList() {
         supportsBulk: true,
         isEligible: () => group !== 'trash',
         callback: (targets) => {
+          if (selectAll) {
+            openPendingAction('removeFromAllLists', targets);
+            return;
+          }
           void handleBulkAction('removeFromAllLists', targets);
         },
       },
@@ -1146,6 +1212,7 @@ function SubscriberList() {
       handleSendConfirmationEmail,
       navigate,
       openPendingAction,
+      selectAll,
     ],
   );
 
@@ -1153,6 +1220,7 @@ function SubscriberList() {
     if (nextGroup === group) return;
     setGroup(nextGroup);
     setSelection([]);
+    setSelectAll(false);
     clearLoadError();
     setView((currentView) => ({ ...currentView, page: 1 }));
   };
@@ -1168,12 +1236,14 @@ function SubscriberList() {
       return nextFilter;
     });
     setSelection([]);
+    setSelectAll(false);
     setView((currentView) => ({ ...currentView, page: 1 }));
   };
 
   const handleCheckTrash = (): void => {
     setGroup('trash');
     setSelection([]);
+    setSelectAll(false);
     clearLoadError();
     setView((currentView) => ({ ...currentView, page: 1 }));
   };
@@ -1196,9 +1266,56 @@ function SubscriberList() {
     [meta],
   );
 
+  const isPageFullySelected =
+    items.length > 0 && selection.length === items.length;
+  const bannerMode = selectAllBannerState({
+    pageItemCount: items.length,
+    totalCount: meta.count,
+    totalPages: meta.pages,
+    isPageFullySelected,
+    isSelectAll: selectAll,
+  });
+
   const renderPendingActionModal = (): JSX.Element | null => {
     if (!pendingAction) return null;
-    const { action, targets } = pendingAction;
+    const { action, targets, selectAll: pendingSelectAll } = pendingAction;
+    const count = pendingSelectAll ? meta.count : targets.length;
+    const largeOpCaveat =
+      pendingSelectAll && shouldWarnLargeOperation(count) ? (
+        <p className="mailpoet-subscribers-select-all-caveat">
+          {__(
+            'Large operations may take a while and could time out on very large lists.',
+            'mailpoet',
+          )}
+        </p>
+      ) : null;
+
+    if (SELECT_ALL_GENERIC_CONFIRM_ACTIONS.includes(action)) {
+      return (
+        <Modal
+          title={__('Confirm bulk action', 'mailpoet')}
+          onRequestClose={closePendingAction}
+          isDismissible
+        >
+          <p>
+            {__(
+              'This action will be applied to all %s subscribers matching the current view.',
+              'mailpoet',
+            ).replace('%s', formatCount(count))}
+          </p>
+          {largeOpCaveat}
+          <span className="mailpoet-gap-half" />
+          <Button
+            onClick={() => handlePendingActionSubmit()}
+            dimension="small"
+            variant="secondary"
+            automationId="bulk-select-all-confirm"
+          >
+            {__('Apply', 'mailpoet')}
+          </Button>
+        </Modal>
+      );
+    }
 
     if (action === 'unsubscribe') {
       return (
@@ -1211,8 +1328,9 @@ function SubscriberList() {
             {__(
               'This action will unsubscribe %s subscribers from all lists. This action cannot be undone. Are you sure, you want to continue?',
               'mailpoet',
-            ).replace('%s', formatCount(targets.length))}
+            ).replace('%s', formatCount(count))}
           </p>
+          {largeOpCaveat}
           <span className="mailpoet-gap-half" />
           <Button
             onClick={() => handlePendingActionSubmit()}
@@ -1231,11 +1349,14 @@ function SubscriberList() {
         <BulkResendConfirmationEmailsModal
           submitModal={() => handlePendingActionSubmit()}
           closeModal={closePendingAction}
-          count={targets.length}
+          count={count}
         />
       );
     }
 
+    if (!isPickerAction(action)) {
+      return null;
+    }
     const config = PICKERS[action];
     return (
       <PickerModal
@@ -1301,6 +1422,17 @@ function SubscriberList() {
         </div>
       </div>
 
+      <SelectAllBanner
+        mode={bannerMode}
+        totalCount={meta.count}
+        pageItemCount={items.length}
+        onSelectAll={() => setSelectAll(true)}
+        onClear={() => {
+          setSelectAll(false);
+          setSelection([]);
+        }}
+      />
+
       <div
         className="mailpoet-dataviews mailpoet-subscribers-dataviews"
         data-automation-id="subscribers_listing"
@@ -1315,7 +1447,7 @@ function SubscriberList() {
           defaultLayouts={{ table: {} }}
           getItemId={(item) => String(item.id)}
           selection={selection}
-          onChangeSelection={setSelection}
+          onChangeSelection={handleSelectionChange}
           isLoading={isLoading}
           empty={
             <EmptyContent

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -1318,7 +1318,11 @@ function SubscriberList() {
           <div className="mailpoet-subscribers-bulk-confirm-actions">
             <Button
               onClick={() => handlePendingActionSubmit()}
-              variant={action === 'delete' ? 'destructive' : undefined}
+              className={
+                action === 'delete'
+                  ? 'mailpoet-subscribers-confirm-destructive'
+                  : undefined
+              }
               automationId="bulk-select-all-confirm"
             >
               {__('Apply', 'mailpoet')}

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -785,12 +785,19 @@ function SubscriberList() {
   // select-all + Move to trash emptied the filtered list, so the backend
   // dropped it from the options), the dropdown would show "All Lists" while the
   // query stayed filtered — "No items found" with a stale hash. Clear the
-  // orphaned filter so a valid list shows automatically.
+  // orphaned filter so a valid list shows automatically. Treat it like any
+  // other filter change: drop the selection/select-all intent and reset to the
+  // first page so no hidden selection survives the scope change.
   useEffect(() => {
-    setFilter(
-      (current) => pruneUnavailableFilters(current, filters) ?? current,
-    );
-  }, [filters]);
+    const pruned = pruneUnavailableFilters(filter, filters);
+    if (!pruned) {
+      return;
+    }
+    setFilter(pruned);
+    setSelection([]);
+    setSelectAll(false);
+    setView((currentView) => ({ ...currentView, page: 1 }));
+  }, [filter, filters, setView]);
 
   // DataViews has no built-in URL state, so back/forward inside the listing
   // is wired manually. Browser navigation fires `hashchange`; programmatic
@@ -1312,6 +1319,18 @@ function SubscriberList() {
           )}
         </p>
       ) : null;
+    // Select-all permanent delete keeps WordPress users and WooCommerce
+    // customers (SubscribersRepository::bulkDelete only deletes rows with no
+    // linked WP/Woo account), so the count above can overstate what is removed.
+    const deleteSkipCaveat =
+      pendingSelectAll && action === 'delete' ? (
+        <p className="mailpoet-subscribers-select-all-caveat">
+          {__(
+            'WordPress users and WooCommerce customers are kept and will not be permanently deleted.',
+            'mailpoet',
+          )}
+        </p>
+      ) : null;
 
     if (SELECT_ALL_GENERIC_CONFIRM_ACTIONS.includes(action)) {
       return (
@@ -1327,6 +1346,7 @@ function SubscriberList() {
             ).replace('%s', formatCount(count))}
           </p>
           {largeOpCaveat}
+          {deleteSkipCaveat}
           <div className="mailpoet-subscribers-bulk-confirm-actions">
             <Button
               onClick={() => handlePendingActionSubmit()}

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -40,6 +40,7 @@ import { getSubscriberFields } from './fields';
 import { getInitialPickerValue, type PickerConfig } from './picker-value';
 import { SelectAllBanner } from './select-all-banner';
 import { selectAllBannerState, shouldWarnLargeOperation } from './select-all';
+import { pruneUnavailableFilters } from './filter-sync';
 import {
   bulkAction,
   getSubscribers,
@@ -779,6 +780,17 @@ function SubscriberList() {
   useEffect(() => {
     updateHash(group, view, filter, getPreferredView());
   }, [filter, group, view, getPreferredView]);
+
+  // When the active list/tag filter is no longer a selectable option (e.g.
+  // select-all + Move to trash emptied the filtered list, so the backend
+  // dropped it from the options), the dropdown would show "All Lists" while the
+  // query stayed filtered — "No items found" with a stale hash. Clear the
+  // orphaned filter so a valid list shows automatically.
+  useEffect(() => {
+    setFilter(
+      (current) => pruneUnavailableFilters(current, filters) ?? current,
+    );
+  }, [filters]);
 
   // DataViews has no built-in URL state, so back/forward inside the listing
   // is wired manually. Browser navigation fires `hashchange`; programmatic

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -569,9 +569,15 @@ function PickerModal({
   };
 
   return (
-    <Modal title={title} onRequestClose={onClose} isDismissible>
+    <Modal
+      title={title}
+      onRequestClose={onClose}
+      isDismissible
+      contentClassName="mailpoet-subscribers-picker-modal"
+    >
       <Selection
         field={fieldConfig}
+        width="100%"
         onValueChange={(event: { target: { value: string | number } }) => {
           const next = Number(event.target.value);
           setValue(Number.isFinite(next) ? next : 0);
@@ -579,12 +585,7 @@ function PickerModal({
       />
       {caveat}
       <div className="mailpoet-subscribers-bulk-confirm-actions">
-        <Button
-          onClick={handleApply}
-          dimension="small"
-          variant="secondary"
-          isDisabled={!value}
-        >
+        <Button onClick={handleApply} variant="secondary" isDisabled={!value}>
           {__('Apply', 'mailpoet')}
         </Button>
       </div>
@@ -1317,7 +1318,6 @@ function SubscriberList() {
           <div className="mailpoet-subscribers-bulk-confirm-actions">
             <Button
               onClick={() => handlePendingActionSubmit()}
-              dimension="small"
               variant="secondary"
               automationId="bulk-select-all-confirm"
             >
@@ -1345,7 +1345,6 @@ function SubscriberList() {
           <div className="mailpoet-subscribers-bulk-confirm-actions">
             <Button
               onClick={() => handlePendingActionSubmit()}
-              dimension="small"
               variant="secondary"
               automationId="bulk-unsubscribe-confirm"
             >

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -1318,7 +1318,7 @@ function SubscriberList() {
           className="mailpoet-subscribers-select-all-warning"
         >
           {__(
-            'Large operations may take a while and could time out on very large lists.',
+            'Large operations may take a while and could time out on very large lists!',
             'mailpoet',
           )}
         </Notice>

--- a/mailpoet/assets/js/src/subscribers/select-all-banner.tsx
+++ b/mailpoet/assets/js/src/subscribers/select-all-banner.tsx
@@ -1,0 +1,77 @@
+import { __ } from '@wordpress/i18n';
+import { SelectAllBannerMode } from './select-all';
+
+type Props = {
+  mode: SelectAllBannerMode;
+  totalCount: number;
+  pageItemCount: number;
+  onSelectAll: () => void;
+  onClear: () => void;
+};
+
+function formatCount(value: number): string {
+  return value.toLocaleString();
+}
+
+export function SelectAllBanner({
+  mode,
+  totalCount,
+  pageItemCount,
+  onSelectAll,
+  onClear,
+}: Props): JSX.Element | null {
+  if (mode === 'hidden') {
+    return null;
+  }
+
+  if (mode === 'active') {
+    return (
+      <div
+        className="mailpoet-subscribers-select-all-banner"
+        data-automation-id="subscribers_select_all_banner"
+      >
+        <span>
+          {__(
+            'All %s subscribers matching this view are selected.',
+            'mailpoet',
+          ).replace('%s', formatCount(totalCount))}
+        </span>{' '}
+        <button
+          type="button"
+          className="button button-link"
+          data-automation-id="subscribers_select_all_clear"
+          onClick={onClear}
+        >
+          {__('Clear selection', 'mailpoet')}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="mailpoet-subscribers-select-all-banner"
+      data-automation-id="subscribers_select_all_banner"
+    >
+      <span>
+        {__(
+          'All %s subscribers on this page are selected.',
+          'mailpoet',
+        ).replace('%s', formatCount(pageItemCount))}
+      </span>{' '}
+      <button
+        type="button"
+        className="button button-link"
+        data-automation-id="subscribers_select_all_offer"
+        onClick={onSelectAll}
+      >
+        {__('Select all %s subscribers matching this view', 'mailpoet').replace(
+          '%s',
+          formatCount(totalCount),
+        )}
+      </button>
+    </div>
+  );
+}
+
+SelectAllBanner.displayName = 'SelectAllBanner';

--- a/mailpoet/assets/js/src/subscribers/select-all-banner.tsx
+++ b/mailpoet/assets/js/src/subscribers/select-all-banner.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { SelectAllBannerMode } from './select-all';
 
@@ -36,14 +37,13 @@ export function SelectAllBanner({
             'mailpoet',
           ).replace('%s', formatCount(totalCount))}
         </span>{' '}
-        <button
-          type="button"
-          className="button button-link"
+        <Button
+          variant="link"
           data-automation-id="subscribers_select_all_clear"
           onClick={onClear}
         >
           {__('Clear selection', 'mailpoet')}
-        </button>
+        </Button>
       </div>
     );
   }
@@ -59,9 +59,8 @@ export function SelectAllBanner({
           'mailpoet',
         ).replace('%s', formatCount(pageItemCount))}
       </span>{' '}
-      <button
-        type="button"
-        className="button button-link"
+      <Button
+        variant="link"
         data-automation-id="subscribers_select_all_offer"
         onClick={onSelectAll}
       >
@@ -69,7 +68,7 @@ export function SelectAllBanner({
           '%s',
           formatCount(totalCount),
         )}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/mailpoet/assets/js/src/subscribers/select-all.ts
+++ b/mailpoet/assets/js/src/subscribers/select-all.ts
@@ -1,0 +1,36 @@
+export const SELECT_ALL_WARNING_THRESHOLD = 10000;
+
+export type SelectAllBannerMode = 'hidden' | 'offer' | 'active';
+
+export function selectAllBannerState(params: {
+  pageItemCount: number;
+  totalCount: number;
+  totalPages: number;
+  isPageFullySelected: boolean;
+  isSelectAll: boolean;
+}): SelectAllBannerMode {
+  const {
+    pageItemCount,
+    totalCount,
+    totalPages,
+    isPageFullySelected,
+    isSelectAll,
+  } = params;
+  if (totalCount <= 0 || totalPages <= 1) {
+    return 'hidden';
+  }
+  if (isSelectAll) {
+    return 'active';
+  }
+  if (isPageFullySelected && pageItemCount > 0) {
+    return 'offer';
+  }
+  return 'hidden';
+}
+
+export function shouldWarnLargeOperation(
+  count: number,
+  threshold: number = SELECT_ALL_WARNING_THRESHOLD,
+): boolean {
+  return count > threshold;
+}

--- a/mailpoet/changelog/2026-06-11-01-40-29-added-restore-selecting-all-subscribers-across-every-pag.md
+++ b/mailpoet/changelog/2026-06-11-01-40-29-added-restore-selecting-all-subscribers-across-every-pag.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Restore selecting all subscribers across every page for bulk actions

--- a/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
+++ b/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
@@ -19,6 +19,32 @@ use MailPoet\WP\Functions as WPFunctions;
 class SubscribersBulkActionEndpoint extends Endpoint {
   public const ACTION_RESEND_CONFIRMATION_EMAILS = 'resendConfirmationEmails';
 
+  private const VALID_SELECT_ALL_GROUPS = [
+    'all',
+    SubscriberEntity::STATUS_SUBSCRIBED,
+    SubscriberEntity::STATUS_UNCONFIRMED,
+    SubscriberEntity::STATUS_UNSUBSCRIBED,
+    SubscriberEntity::STATUS_INACTIVE,
+    SubscriberEntity::STATUS_BOUNCED,
+    'trash',
+  ];
+
+  private const TRASH_ONLY_ACTIONS = [
+    BulkActionController::ACTION_DELETE,
+    BulkActionController::ACTION_RESTORE,
+  ];
+
+  private const NON_TRASH_ACTIONS = [
+    BulkActionController::ACTION_TRASH,
+    BulkActionController::ACTION_UNSUBSCRIBE,
+    BulkActionController::ACTION_MOVE_TO_LIST,
+    BulkActionController::ACTION_ADD_TO_LIST,
+    BulkActionController::ACTION_REMOVE_FROM_LIST,
+    BulkActionController::ACTION_REMOVE_FROM_ALL_LISTS,
+    BulkActionController::ACTION_ADD_TAG,
+    BulkActionController::ACTION_REMOVE_TAG,
+  ];
+
   /** @var ListingHandler */
   private $listingHandler;
 
@@ -65,6 +91,9 @@ class SubscribersBulkActionEndpoint extends Endpoint {
         400,
         'mailpoet_subscribers_no_selection'
       );
+    }
+    if ($selectAll) {
+      $this->validateSelectAllScope($action, $definition);
     }
 
     $data = [];
@@ -183,6 +212,33 @@ class SubscribersBulkActionEndpoint extends Endpoint {
       'selection' => is_array($selection) ? $this->toIntList($selection) : [],
       'params' => [],
     ]);
+  }
+
+  private function validateSelectAllScope(string $action, ListingDefinition $definition): void {
+    $group = $definition->getGroup();
+    if (!is_string($group) || !in_array($group, self::VALID_SELECT_ALL_GROUPS, true)) {
+      throw new ApiException(
+        __('Select all requires a valid subscriber view.', 'mailpoet'),
+        400,
+        'mailpoet_subscribers_invalid_select_all_group'
+      );
+    }
+
+    if (in_array($action, self::TRASH_ONLY_ACTIONS, true) && $group !== 'trash') {
+      throw new ApiException(
+        __('This bulk action can only be applied from the Trash view.', 'mailpoet'),
+        400,
+        'mailpoet_subscribers_invalid_select_all_scope'
+      );
+    }
+
+    if (in_array($action, self::NON_TRASH_ACTIONS, true) && $group === 'trash') {
+      throw new ApiException(
+        __('This bulk action cannot be applied from the Trash view.', 'mailpoet'),
+        400,
+        'mailpoet_subscribers_invalid_select_all_scope'
+      );
+    }
   }
 
   /**

--- a/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
+++ b/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
@@ -56,6 +56,17 @@ class SubscribersBulkActionEndpoint extends Endpoint {
       return $this->handleResendConfirmation($request, $definition);
     }
 
+    $selectAll = $request->getParam('select_all') === true;
+    $selectionParam = $request->getParam('selection');
+    $hasSelection = is_array($selectionParam) && $selectionParam !== [];
+    if (!$hasSelection && !$selectAll) {
+      throw new ApiException(
+        __('No subscribers selected.', 'mailpoet'),
+        400,
+        'mailpoet_subscribers_no_selection'
+      );
+    }
+
     $data = [];
     $segmentIdParam = $request->getParam('segment_id');
     if (is_numeric($segmentIdParam)) {
@@ -88,6 +99,7 @@ class SubscribersBulkActionEndpoint extends Endpoint {
     return [
       'action' => Builder::string()->required(),
       'selection' => Builder::array(Builder::integer()),
+      'select_all' => Builder::boolean(),
       'group' => Builder::string(),
       'search' => Builder::string(),
       'filter' => Builder::object(),

--- a/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
+++ b/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
@@ -198,6 +198,7 @@ class SubscribersBulkActionEndpoint extends Endpoint {
   private function buildDefinition(Request $request): ListingDefinition {
     $filter = $request->getParam('filter');
     $selection = $request->getParam('selection');
+    $selectAll = $request->getParam('select_all') === true;
     $searchParam = $request->getParam('search');
     $groupParam = $request->getParam('group');
 
@@ -209,7 +210,7 @@ class SubscribersBulkActionEndpoint extends Endpoint {
       'search' => is_string($searchParam) ? $searchParam : null,
       'group' => is_string($groupParam) ? $groupParam : null,
       'filter' => is_array($filter) ? $filter : [],
-      'selection' => is_array($selection) ? $this->toIntList($selection) : [],
+      'selection' => !$selectAll && is_array($selection) ? $this->toIntList($selection) : [],
       'params' => [],
     ]);
   }

--- a/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
+++ b/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
@@ -130,6 +130,19 @@ class SubscribersBulkActionEndpoint extends Endpoint {
         'mailpoet_subscribers_confirmation_disabled'
       );
     }
+    $selectAll = $request->getParam('select_all') === true;
+    $selection = $request->getParam('selection');
+    $hasSelection = is_array($selection) && $selection !== [];
+    // Resend runs before the main guard, so apply the same explicit-intent
+    // rule here: without a selection and without select_all, an omitted
+    // listing selection would otherwise target every matching subscriber.
+    if (!$hasSelection && !$selectAll) {
+      throw new ApiException(
+        __('No subscribers selected.', 'mailpoet'),
+        400,
+        'mailpoet_subscribers_no_selection'
+      );
+    }
     // BulkConfirmationEmailResender::queue() inspects $requestData['listing']
     // to detect whether the caller provided an explicit selection (so that
     // empty selection at the listing scope can target every matching
@@ -139,8 +152,6 @@ class SubscribersBulkActionEndpoint extends Endpoint {
       'search' => $request->getParam('search'),
       'filter' => $request->getParam('filter'),
     ];
-    $selectAll = $request->getParam('select_all') === true;
-    $selection = $request->getParam('selection');
     if (!$selectAll && is_array($selection)) {
       $listing['selection'] = $this->toIntList($selection);
     }

--- a/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
+++ b/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
@@ -139,8 +139,9 @@ class SubscribersBulkActionEndpoint extends Endpoint {
       'search' => $request->getParam('search'),
       'filter' => $request->getParam('filter'),
     ];
+    $selectAll = $request->getParam('select_all') === true;
     $selection = $request->getParam('selection');
-    if (is_array($selection)) {
+    if (!$selectAll && is_array($selection)) {
       $listing['selection'] = $this->toIntList($selection);
     }
     $queueResult = $this->bulkConfirmationEmailResender->queue($definition, ['listing' => $listing]);

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -175,6 +175,11 @@ class SubscribersRepository extends Repository {
       return 0;
     }
 
+    $ids = $this->findPermanentlyDeletableIds($ids);
+    if (empty($ids)) {
+      return 0;
+    }
+
     $count = 0;
     $this->entityManager->transactional(function (EntityManager $entityManager) use ($ids, &$count) {
       // Delete subscriber segments
@@ -213,6 +218,29 @@ class SubscribersRepository extends Repository {
     $this->changesNotifier->subscribersDeleted($ids);
     $this->invalidateTotalSubscribersCache();
     return $count;
+  }
+
+  /**
+   * @param int[] $ids
+   * @return int[]
+   */
+  private function findPermanentlyDeletableIds(array $ids): array {
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $deletableIds = $this->entityManager->getConnection()->executeQuery(
+      "SELECT `id`
+       FROM $subscriberTable
+       WHERE `id` IN (:ids)
+       AND `is_woocommerce_user` = false
+       AND `wp_user_id` IS NULL",
+      ['ids' => $ids],
+      ['ids' => ArrayParameterType::INTEGER]
+    )->fetchFirstColumn();
+
+    $ids = [];
+    foreach ($deletableIds as $id) {
+      $ids[] = $this->toInt($id);
+    }
+    return $ids;
   }
 
   public function sendPublicConfirmationEmailWithCap(

--- a/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
@@ -192,6 +192,39 @@ class SubscribersEndpointsTest extends Test {
     $this->assertInstanceOf(SubscriberEntity::class, $this->subscribersRepository->findOneById($subscriberId));
   }
 
+  public function testBulkDeleteWithSelectAllIgnoresSubmittedSelection(): void {
+    $live = (new SubscriberFactory())
+      ->withEmail('rest-select-all-delete-selection-live-' . uniqid() . '@example.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $trashed = (new SubscriberFactory())
+      ->withEmail('rest-select-all-delete-selection-trash-' . uniqid() . '@example.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->withDeletedAt(new \DateTimeImmutable())
+      ->create();
+    $liveId = (int)$live->getId();
+    $trashedId = (int)$trashed->getId();
+
+    $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
+      'action' => 'delete',
+      'group' => 'trash',
+      'selection' => [$liveId],
+      'select_all' => true,
+    ]]);
+
+    $this->assertIsArray($response);
+    $payload = $response['data'];
+    $this->assertIsArray($payload);
+    $this->assertSame('delete', $payload['action']);
+    $this->assertGreaterThanOrEqual(1, $payload['count']);
+    $this->entityManager->clear();
+
+    $liveSubscriber = $this->subscribersRepository->findOneById($liveId);
+    $this->assertInstanceOf(SubscriberEntity::class, $liveSubscriber);
+    $this->assertNull($liveSubscriber->getDeletedAt());
+    $this->assertNull($this->subscribersRepository->findOneById($trashedId));
+  }
+
   public function testBulkTrashWithSelectAllIsRejectedFromTrash(): void {
     $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
       'action' => 'trash',

--- a/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
@@ -209,6 +209,37 @@ class SubscribersEndpointsTest extends Test {
     $this->assertSame(400, $errorData['status']);
   }
 
+  public function testBulkResendConfirmationWithSelectAllQueuesAllMatching(): void {
+    $settings = $this->diContainer->get(SettingsController::class);
+    $settings->set('signup_confirmation.enabled', true);
+
+    $suffix = uniqid();
+    (new SubscriberFactory())
+      ->withEmail("rest-resend-select-all-1-{$suffix}@example.com")
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->create();
+    (new SubscriberFactory())
+      ->withEmail("rest-resend-select-all-2-{$suffix}@example.com")
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->create();
+
+    $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
+      'action' => 'resendConfirmationEmails',
+      'group' => 'unconfirmed',
+      'selection' => [],
+      'select_all' => true,
+    ]]);
+
+    $this->assertIsArray($response);
+    $payload = $response['data'];
+    $this->assertIsArray($payload);
+    $this->assertSame('resendConfirmationEmails', $payload['action']);
+    $queue = $payload['queue'];
+    $this->assertIsArray($queue);
+    $this->assertArrayHasKey('queued_count', $queue);
+    $this->assertGreaterThanOrEqual(2, $queue['queued_count']);
+  }
+
   public function testResendConfirmationReturnsDisabledErrorWhenSignupConfirmationIsOff(): void {
     $subscriber = (new SubscriberFactory())
       ->withEmail('rest-resend-confirmation-disabled-' . uniqid() . '@example.com')

--- a/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
@@ -112,6 +112,75 @@ class SubscribersEndpointsTest extends Test {
     $this->assertNotNull($subscriber->getDeletedAt());
   }
 
+  public function testBulkActionWithEmptySelectionAndNoSelectAllReturnsError(): void {
+    $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
+      'action' => 'trash',
+      'group' => 'all',
+      'selection' => [],
+    ]]);
+
+    $this->assertIsArray($response);
+    $this->assertSame('mailpoet_subscribers_no_selection', $response['code']);
+    $errorData = $response['data'];
+    $this->assertIsArray($errorData);
+    $this->assertSame(400, $errorData['status']);
+  }
+
+  public function testBulkActionWithSelectAllTrashesAllMatchingInGroup(): void {
+    $suffix = uniqid();
+    $first = (new SubscriberFactory())
+      ->withEmail("rest-select-all-1-{$suffix}@example.com")
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $second = (new SubscriberFactory())
+      ->withEmail("rest-select-all-2-{$suffix}@example.com")
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+
+    $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
+      'action' => 'trash',
+      'group' => 'subscribed',
+      'selection' => [],
+      'select_all' => true,
+    ]]);
+
+    $this->assertIsArray($response);
+    $payload = $response['data'];
+    $this->assertIsArray($payload);
+    $this->assertSame('trash', $payload['action']);
+    $this->assertGreaterThanOrEqual(2, $payload['count']);
+
+    $this->subscribersRepository->refresh($first);
+    $this->subscribersRepository->refresh($second);
+    $this->assertNotNull($first->getDeletedAt());
+    $this->assertNotNull($second->getDeletedAt());
+  }
+
+  public function testBulkActionWithExplicitSelectionIgnoresSelectAllFlagWhenAbsent(): void {
+    $kept = (new SubscriberFactory())
+      ->withEmail('rest-explicit-keep-' . uniqid() . '@example.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $trashed = (new SubscriberFactory())
+      ->withEmail('rest-explicit-trash-' . uniqid() . '@example.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+
+    $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
+      'action' => 'trash',
+      'group' => 'all',
+      'selection' => [(int)$trashed->getId()],
+    ]]);
+
+    $this->assertIsArray($response);
+    $payload = $response['data'];
+    $this->assertIsArray($payload);
+    $this->assertSame(1, $payload['count']);
+
+    $this->subscribersRepository->refresh($kept);
+    $this->assertNull($kept->getDeletedAt());
+  }
+
   public function testBulkActionWithUnknownActionReturnsError(): void {
     $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
       'action' => 'pretend-this-is-real',

--- a/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
@@ -240,6 +240,23 @@ class SubscribersEndpointsTest extends Test {
     $this->assertGreaterThanOrEqual(2, $queue['queued_count']);
   }
 
+  public function testBulkResendConfirmationWithoutSelectionOrSelectAllReturnsError(): void {
+    $settings = $this->diContainer->get(SettingsController::class);
+    $settings->set('signup_confirmation.enabled', true);
+
+    $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
+      'action' => 'resendConfirmationEmails',
+      'group' => 'unconfirmed',
+      'selection' => [],
+    ]]);
+
+    $this->assertIsArray($response);
+    $this->assertSame('mailpoet_subscribers_no_selection', $response['code']);
+    $errorData = $response['data'];
+    $this->assertIsArray($errorData);
+    $this->assertSame(400, $errorData['status']);
+  }
+
   public function testResendConfirmationReturnsDisabledErrorWhenSignupConfirmationIsOff(): void {
     $subscriber = (new SubscriberFactory())
       ->withEmail('rest-resend-confirmation-disabled-' . uniqid() . '@example.com')

--- a/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
@@ -156,6 +156,57 @@ class SubscribersEndpointsTest extends Test {
     $this->assertNotNull($second->getDeletedAt());
   }
 
+  public function testBulkActionWithSelectAllRequiresValidGroup(): void {
+    $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
+      'action' => 'trash',
+      'selection' => [],
+      'select_all' => true,
+    ]]);
+
+    $this->assertIsArray($response);
+    $this->assertSame('mailpoet_subscribers_invalid_select_all_group', $response['code']);
+    $errorData = $response['data'];
+    $this->assertIsArray($errorData);
+    $this->assertSame(400, $errorData['status']);
+  }
+
+  public function testBulkDeleteWithSelectAllIsRejectedOutsideTrash(): void {
+    $subscriber = (new SubscriberFactory())
+      ->withEmail('rest-select-all-delete-live-' . uniqid() . '@example.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $subscriberId = (int)$subscriber->getId();
+
+    $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
+      'action' => 'delete',
+      'group' => 'all',
+      'selection' => [],
+      'select_all' => true,
+    ]]);
+
+    $this->assertIsArray($response);
+    $this->assertSame('mailpoet_subscribers_invalid_select_all_scope', $response['code']);
+    $errorData = $response['data'];
+    $this->assertIsArray($errorData);
+    $this->assertSame(400, $errorData['status']);
+    $this->assertInstanceOf(SubscriberEntity::class, $this->subscribersRepository->findOneById($subscriberId));
+  }
+
+  public function testBulkTrashWithSelectAllIsRejectedFromTrash(): void {
+    $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
+      'action' => 'trash',
+      'group' => 'trash',
+      'selection' => [],
+      'select_all' => true,
+    ]]);
+
+    $this->assertIsArray($response);
+    $this->assertSame('mailpoet_subscribers_invalid_select_all_scope', $response['code']);
+    $errorData = $response['data'];
+    $this->assertIsArray($errorData);
+    $this->assertSame(400, $errorData['status']);
+  }
+
   public function testBulkActionWithExplicitSelectionIgnoresSelectAllFlagWhenAbsent(): void {
     $kept = (new SubscriberFactory())
       ->withEmail('rest-explicit-keep-' . uniqid() . '@example.com')

--- a/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
@@ -369,28 +369,42 @@ class SubscribersRepositoryTest extends \MailPoetTest {
 
   public function testItDoesntRemovePermanentlyWordpressSubscriber(): void {
     $subscriber = $this->createSubscriber('wpsubscriber@delete.com');
+    $segment = $this->segmentRepository->createOrUpdate('WP subscriber delete guard');
+    $this->createSubscriberSegment($segment, $subscriber);
     $subscriber->setWpUserId(1);
     $this->repository->flush();
     $this->entityManager->clear();
     $subscriberId = $subscriber->getId();
+    $segmentId = $segment->getId();
 
     $count = $this->repository->bulkDelete([$subscriber->getId()]);
 
     verify($count)->equals(0);
     verify($this->repository->findOneById($subscriberId))->notNull();
+    verify($this->subscriberSegmentRepository->findOneBy([
+      'subscriber' => $subscriberId,
+      'segment' => $segmentId,
+    ]))->notNull();
   }
 
   public function testItDoesntRemovePermanentlyWoocommerceSubscriber(): void {
     $subscriber = $this->createSubscriber('wcsubscriber@delete.com');
+    $segment = $this->segmentRepository->createOrUpdate('WC subscriber delete guard');
+    $this->createSubscriberSegment($segment, $subscriber);
     $subscriber->setIsWoocommerceUser(true);
     $this->repository->flush();
     $this->entityManager->clear();
     $subscriberId = $subscriber->getId();
+    $segmentId = $segment->getId();
 
     $count = $this->repository->bulkDelete([$subscriberId]);
 
     verify($count)->equals(0);
     verify($this->repository->findOneById($subscriberId))->notNull();
+    verify($this->subscriberSegmentRepository->findOneBy([
+      'subscriber' => $subscriberId,
+      'segment' => $segmentId,
+    ]))->notNull();
   }
 
   public function testItGetsMaxSubscriberId(): void {

--- a/mailpoet/tests/javascript/subscribers/bulk-action-payload.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/bulk-action-payload.spec.ts
@@ -1,0 +1,38 @@
+import { buildBulkActionPayload } from '../../../assets/js/src/subscribers/bulk-action-payload';
+
+describe('Subscribers bulk-action payload', () => {
+  const scope = {
+    group: 'all',
+    filter: {},
+    search: '',
+    selection: [1, 2, 3],
+  };
+
+  it('sends the explicit selection when selectAll is falsy', () => {
+    const payload = buildBulkActionPayload('trash', scope);
+    expect(payload.select_all).to.equal(false);
+    expect(payload.selection).to.deep.equal([1, 2, 3]);
+    expect(payload.action).to.equal('trash');
+  });
+
+  it('clears the selection and sets select_all when selectAll is true', () => {
+    const payload = buildBulkActionPayload('trash', {
+      ...scope,
+      selectAll: true,
+    });
+    expect(payload.select_all).to.equal(true);
+    expect(payload.selection).to.deep.equal([]);
+  });
+
+  it('merges extra params and forwards scope fields', () => {
+    const payload = buildBulkActionPayload(
+      'moveToList',
+      { ...scope, group: 'subscribed', search: 'foo', selectAll: true },
+      { segment_id: 5 },
+    );
+    expect(payload.segment_id).to.equal(5);
+    expect(payload.select_all).to.equal(true);
+    expect(payload.group).to.equal('subscribed');
+    expect(payload.search).to.equal('foo');
+  });
+});

--- a/mailpoet/tests/javascript/subscribers/filter-sync.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/filter-sync.spec.ts
@@ -1,0 +1,35 @@
+import { pruneUnavailableFilters } from '../../../assets/js/src/subscribers/filter-sync';
+
+describe('Subscribers filter sync', () => {
+  const filters = {
+    segment: [{ value: '' }, { value: 4 }, { value: 'mailpoet_without_list' }],
+    tag: [{ value: '' }, { value: 7 }],
+  };
+
+  it('returns null when every active filter is still selectable', () => {
+    expect(pruneUnavailableFilters({ segment: '4' }, filters)).to.equal(null);
+  });
+
+  it('removes a filter whose value is no longer an option', () => {
+    expect(pruneUnavailableFilters({ segment: '9' }, filters)).to.deep.equal(
+      {},
+    );
+  });
+
+  it('keeps still-valid filters while removing invalid ones', () => {
+    expect(
+      pruneUnavailableFilters({ segment: '9', tag: '7' }, filters),
+    ).to.deep.equal({ tag: '7' });
+  });
+
+  it('does not prune before options have loaded', () => {
+    expect(pruneUnavailableFilters({ segment: '4' }, null)).to.equal(null);
+    expect(pruneUnavailableFilters({ segment: '4' }, { segment: [] })).to.equal(
+      null,
+    );
+  });
+
+  it('ignores empty filter values', () => {
+    expect(pruneUnavailableFilters({ segment: '' }, filters)).to.equal(null);
+  });
+});

--- a/mailpoet/tests/javascript/subscribers/select-all.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/select-all.spec.ts
@@ -1,0 +1,72 @@
+import {
+  SELECT_ALL_WARNING_THRESHOLD,
+  selectAllBannerState,
+  shouldWarnLargeOperation,
+} from '../../../assets/js/src/subscribers/select-all';
+
+describe('Subscribers select-all helpers', () => {
+  describe('selectAllBannerState', () => {
+    const base = {
+      pageItemCount: 25,
+      totalCount: 47312,
+      totalPages: 1893,
+      isPageFullySelected: false,
+      isSelectAll: false,
+    };
+
+    it('is hidden when there is one page or fewer', () => {
+      expect(
+        selectAllBannerState({
+          ...base,
+          totalPages: 1,
+          isPageFullySelected: true,
+        }),
+      ).to.equal('hidden');
+    });
+
+    it('is hidden when nothing matches', () => {
+      expect(
+        selectAllBannerState({
+          ...base,
+          totalCount: 0,
+          isPageFullySelected: true,
+        }),
+      ).to.equal('hidden');
+    });
+
+    it('offers select-all when the current page is fully selected', () => {
+      expect(
+        selectAllBannerState({ ...base, isPageFullySelected: true }),
+      ).to.equal('offer');
+    });
+
+    it('is hidden when the page is not fully selected and select-all is off', () => {
+      expect(selectAllBannerState(base)).to.equal('hidden');
+    });
+
+    it('is active whenever select-all is on, regardless of page selection', () => {
+      expect(
+        selectAllBannerState({
+          ...base,
+          isPageFullySelected: false,
+          isSelectAll: true,
+        }),
+      ).to.equal('active');
+    });
+  });
+
+  describe('shouldWarnLargeOperation', () => {
+    it('warns above the threshold', () => {
+      expect(
+        shouldWarnLargeOperation(SELECT_ALL_WARNING_THRESHOLD + 1),
+      ).to.equal(true);
+    });
+
+    it('does not warn at or below the threshold', () => {
+      expect(shouldWarnLargeOperation(SELECT_ALL_WARNING_THRESHOLD)).to.equal(
+        false,
+      );
+      expect(shouldWarnLargeOperation(10)).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Restores the "Select all X subscribers on all pages" bulk-select capability that was lost when the Subscribers page migrated to `@wordpress/dataviews` (DataViews only selects the current page and has no cross-page "select all" — see [Gutenberg #71269](https://github.com/WordPress/gutenberg/issues/71269)).

When the current page is fully selected and there is more than one page of matches, a Gmail-style banner offers **"Select all N subscribers matching this view."** Activating it:

- Sends `select_all: true` with an empty `selection`; the backend resolves every subscriber matching the current group/filter/search scope and applies the action.
- Clears when you change page, per-page, search, sort, or filter, or hand-pick rows — so the banner never claims everything is selected while a new page shows empty checkboxes (DataViews can't keep checkboxes ticked across pages).
- Routes **every** select-all action through a confirmation that shows the full matching count, plus a performance caveat above 10,000.

Backend: adds an explicit `select_all` flag and an empty-selection guard to the bulk-action endpoint, and makes the resend-confirmation path honour it. The picker modal (Move/Add/Remove list, Add/Remove tag) now opens with a placeholder so nothing is preselected.

## Code review notes

- The endpoint **already** acted on every matching subscriber when `selection` was empty, with no explicit intent — an unguarded footgun. This PR makes "all matching" deliberate via `select_all` and rejects an empty selection that lacks the flag (`SubscribersBulkActionEndpoint`).
- `selectAll` is tracked as **intent**, never a client-side list of IDs, so it works around the DataViews cross-page selection bug without ever materialising thousands of IDs in the browser.
- No backend batching: bulk actions run as a single `IN (:ids)` query — same scaling characteristics as the pre-DataViews "select all on all pages". Genuinely huge destructive ops (100k+) remain a known follow-up (e.g. chunking / a dedicated list-cleaning flow).
- The picker uses a placeholder (no preselection) specifically so a select-all bulk action can't be applied to whatever list/tag happened to be first by an accidental click.

## QA notes

- On a list spanning >1 page: tick the page checkbox → banner offers "Select all N"; activate it → banner shows "All N matching selected"; run **Move to trash** → confirmation shows the full count → all matching are trashed.
- From **Trash**, **Restore** and **Empty Trash** still work.
- **Move to list… / Add tag…** open with a placeholder; **Apply** enables only after a choice.
- Changing group/filter/search clears the selection.
- Resend confirmation emails under select-all targets all matching unconfirmed (regression-tested).

Automated coverage: `SubscribersEndpointsTest` (select_all acts on all matching, empty-selection guard, explicit selection unaffected, resend-under-select-all) and JS specs for the payload builder and banner-state/warning helpers. Verified manually against ~100 seeded subscribers.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8112](https://linear.app/a8c/issue/STOMAIL-8112/restore-bulk-select-across-pages-for-subscribers)

## After-merge notes

_N/A_

## Screenshots or screencast
<img width="1233" height="500" alt="select-all-1" src="https://github.com/user-attachments/assets/2a7bebf3-372f-43b1-ac4e-2bfa53e60c8b" />

<img width="1237" height="455" alt="select-all-2" src="https://github.com/user-attachments/assets/2d99040b-4bbd-41cc-8e94-2016233f26d5" />


## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8112-restore-bulk-select-across-pages-for-subscribers)

_The latest successful build from `add/stomail-8112-restore-bulk-select-across-pages-for-subscribers` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Found 1 issue:
- Performance: 1 — cross-page “select all” still uses `IN(:ids)` with no backend batching; may be slow for very large result sets despite the UI warning at 10,000.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->