### PR TITLE
Add dual-run reconciliation for MailPoet and Woo attribution

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -558,6 +558,20 @@ class Hooks {
       [$this->hooksWooCommerce, 'writeOrderAttribution'],
       50
     );
+    // Reconciliation (STOMAIL-8136) must run after both the legacy purchase
+    // tracker and the attribution writer (priority 10 on the same hooks)
+    $this->wp->addAction(
+      'woocommerce_order_status_changed',
+      [$this->hooksWooCommerce, 'reconcileOrderAttribution'],
+      20,
+      1
+    );
+    $this->wp->addAction(
+      'woocommerce_order_refunded',
+      [$this->hooksWooCommerce, 'reconcileOrderAttributionOnRefund'],
+      20,
+      1
+    );
   }
 
   public function setupWooCommerceSubscriberEngagement() {

--- a/mailpoet/lib/Config/HooksWooCommerce.php
+++ b/mailpoet/lib/Config/HooksWooCommerce.php
@@ -10,6 +10,7 @@ use MailPoet\Statistics\Track\WooCommercePurchases;
 use MailPoet\Subscription\Registration;
 use MailPoet\WooCommerce\MailPoetTask;
 use MailPoet\WooCommerce\MultichannelMarketing\MPMarketingChannelController;
+use MailPoet\WooCommerce\OrderAttributionReconciler;
 use MailPoet\WooCommerce\OrderAttributionWriter;
 use MailPoet\WooCommerce\Settings as WooCommerceSettings;
 use MailPoet\WooCommerce\SubscriberEngagement;
@@ -47,6 +48,9 @@ class HooksWooCommerce {
   /** @var OrderAttributionWriter */
   private $orderAttributionWriter;
 
+  /** @var OrderAttributionReconciler */
+  private $orderAttributionReconciler;
+
   public function __construct(
     WooCommerceSubscription $woocommerceSubscription,
     WooCommerceSegment $woocommerceSegment,
@@ -57,7 +61,8 @@ class HooksWooCommerce {
     Tracker $tracker,
     SubscriberEngagement $subscriberEngagement,
     MPMarketingChannelController $marketingChannelController,
-    OrderAttributionWriter $orderAttributionWriter
+    OrderAttributionWriter $orderAttributionWriter,
+    OrderAttributionReconciler $orderAttributionReconciler
   ) {
     $this->woocommerceSubscription = $woocommerceSubscription;
     $this->woocommerceSegment = $woocommerceSegment;
@@ -69,6 +74,7 @@ class HooksWooCommerce {
     $this->subscriberEngagement = $subscriberEngagement;
     $this->marketingChannelController = $marketingChannelController;
     $this->orderAttributionWriter = $orderAttributionWriter;
+    $this->orderAttributionReconciler = $orderAttributionReconciler;
   }
 
   public function extendWooCommerceCheckoutForm() {
@@ -148,6 +154,22 @@ class HooksWooCommerce {
       $this->orderAttributionWriter->writeForNewOrder($order);
     } catch (\Throwable $e) {
       $this->logError($e, 'WooCommerce Order Attribution');
+    }
+  }
+
+  public function reconcileOrderAttribution($order) {
+    try {
+      $this->orderAttributionReconciler->reconcileForOrder($order, OrderAttributionReconciler::TRIGGER_STATUS_CHANGED);
+    } catch (\Throwable $e) {
+      $this->logError($e, 'WooCommerce Order Attribution Reconciliation');
+    }
+  }
+
+  public function reconcileOrderAttributionOnRefund($order) {
+    try {
+      $this->orderAttributionReconciler->reconcileForOrder($order, OrderAttributionReconciler::TRIGGER_REFUND);
+    } catch (\Throwable $e) {
+      $this->logError($e, 'WooCommerce Order Attribution Reconciliation');
     }
   }
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -693,6 +693,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\WooCommerce\Helper::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Integrations\AutomateWooHooks::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\OrderAttributionFields::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\OrderAttributionReconciler::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\OrderAttributionWriter::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Settings::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\SubscriberEngagement::class)->setPublic(true);

--- a/mailpoet/lib/WooCommerce/OrderAttributionReconciler.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionReconciler.php
@@ -1,0 +1,357 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
+use MailPoet\Settings\TrackingConfig;
+use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
+use MailPoet\WP\Functions as WPFunctions;
+use WC_Order;
+
+/**
+ * Dual-run reconciliation for the Woo attribution migration (STOMAIL-8136).
+ *
+ * Compares MailPoet's legacy purchase attribution (statistics_woocommerce_purchases
+ * rows) with the MailPoet attribution stored on the Woo order by OrderAttributionWriter
+ * and records a structured result as order meta. The record feeds the rollout gate
+ * ratified in STOMAIL-8135 (decision 8); it never changes reported revenue.
+ */
+class OrderAttributionReconciler {
+  const RECONCILIATION_META_KEY = '_mailpoet_attribution_reconciliation';
+  const RECORD_VERSION = 1;
+
+  const OUTCOME_MATCH = 'match';
+  const OUTCOME_DIVERGED = 'diverged';
+
+  const CLASSIFICATION_INTENTIONAL = 'intentional';
+  const CLASSIFICATION_UNEXPLAINED = 'unexplained';
+
+  const REASON_MATCHED = 'matched';
+  const REASON_NO_CLICK_CANDIDATE = 'no_click_candidate';
+  // Intentional divergences per the STOMAIL-8135 contract.
+  const REASON_LAST_CLICK_COLLAPSE = 'last_click_collapse';
+  const REASON_FOREIGN_SOURCE_PRESERVED = 'foreign_source_preserved';
+  // Unexplained unless proven otherwise.
+  const REASON_CANONICAL_CLICK_MISMATCH = 'canonical_click_mismatch';
+  const REASON_WOO_ATTRIBUTION_DISABLED = 'woo_attribution_disabled';
+  const REASON_TRACKING_DISABLED = 'tracking_disabled';
+  const REASON_WOO_ATTRIBUTION_MISSING = 'woo_attribution_missing';
+  const REASON_LEGACY_ATTRIBUTION_MISSING = 'legacy_attribution_missing';
+
+  const TRIGGER_STATUS_CHANGED = 'status_changed';
+  const TRIGGER_REFUND = 'refund';
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var Helper */
+  private $wooHelper;
+
+  /** @var TrackingConfig */
+  private $trackingConfig;
+
+  /** @var StatisticsWooCommercePurchasesRepository */
+  private $purchasesRepository;
+
+  public function __construct(
+    WPFunctions $wp,
+    Helper $wooHelper,
+    TrackingConfig $trackingConfig,
+    StatisticsWooCommercePurchasesRepository $purchasesRepository
+  ) {
+    $this->wp = $wp;
+    $this->wooHelper = $wooHelper;
+    $this->trackingConfig = $trackingConfig;
+    $this->purchasesRepository = $purchasesRepository;
+  }
+
+  /**
+   * Runs on woocommerce_order_status_changed/woocommerce_order_refunded after both
+   * the legacy purchase tracker and the attribution writer (priority 10), so both
+   * attribution results are available and the legacy rows are synced to the live
+   * order status.
+   *
+   * @param int|WC_Order $order
+   */
+  public function reconcileForOrder($order, string $trigger = self::TRIGGER_STATUS_CHANGED): void {
+    if (!$this->wooHelper->isWooCommerceActive()) {
+      return;
+    }
+    if (!$order instanceof WC_Order) {
+      $order = $this->wooHelper->wcGetOrder($order);
+    }
+    if (!$order instanceof WC_Order) {
+      return;
+    }
+    if (!$this->isAfterWritesStartedBoundary($order)) {
+      return;
+    }
+
+    $purchases = $this->getPurchasesWithClicks($order);
+    $wooClickId = $this->getWooClickId($order);
+    $trackingEnabled = $this->trackingConfig->isEmailTrackingEnabled();
+
+    // Neither system attributed the order and the writer cannot run: there is
+    // no migration signal to record, so avoid stamping every order with meta.
+    if (!$purchases && $wooClickId === null && !$trackingEnabled) {
+      return;
+    }
+
+    $record = $this->buildRecord($order, $purchases, $wooClickId, $trackingEnabled, $trigger);
+    $order->update_meta_data(self::RECONCILIATION_META_KEY, (string)$this->wp->wpJsonEncode($record));
+    $order->save_meta_data();
+  }
+
+  /**
+   * Orders created before the writer first activated have no Woo-stored attribution
+   * by design (STOMAIL-8135, decision 6) and must not be counted as divergences.
+   */
+  private function isAfterWritesStartedBoundary(WC_Order $order): bool {
+    $boundary = $this->wp->getOption(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
+    $createdAt = $order->get_date_created();
+    if (!is_string($boundary) || $boundary === '' || is_null($createdAt)) {
+      return false;
+    }
+    try {
+      $boundaryDate = new \DateTimeImmutable($boundary, new \DateTimeZone('UTC'));
+    } catch (\Exception $e) {
+      return false;
+    }
+    return $createdAt->getTimestamp() >= $boundaryDate->getTimestamp();
+  }
+
+  /**
+   * @return StatisticsWooCommercePurchaseEntity[]
+   */
+  private function getPurchasesWithClicks(WC_Order $order): array {
+    $purchases = $this->purchasesRepository->findBy(['orderId' => $order->get_id()]);
+    return array_values(array_filter($purchases, function(StatisticsWooCommercePurchaseEntity $purchase): bool {
+      return !is_null($purchase->getClick());
+    }));
+  }
+
+  private function getWooClickId(WC_Order $order): ?int {
+    $value = $order->get_meta(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_CLICK_ID);
+    if (!is_scalar($value) || (string)$value === '') {
+      return null;
+    }
+    return (int)$value;
+  }
+
+  /**
+   * @param StatisticsWooCommercePurchaseEntity[] $purchases
+   * @return array<string, mixed>
+   */
+  private function buildRecord(
+    WC_Order $order,
+    array $purchases,
+    ?int $wooClickId,
+    bool $trackingEnabled,
+    string $trigger
+  ): array {
+    $legacyClickIds = $this->getLegacyClickIds($purchases);
+    $lastClickPurchase = $this->getLastClickPurchase($purchases);
+    $lastClick = $lastClickPurchase ? $lastClickPurchase->getClick() : null;
+    $legacyLastClickId = $lastClick ? (int)$lastClick->getId() : null;
+    $foreignSourcePreserved = $this->isForeignSourcePreserved($order, $wooClickId);
+
+    [$outcome, $reason, $classification] = $this->resolveOutcome(
+      $legacyClickIds,
+      $legacyLastClickId,
+      $wooClickId,
+      $trackingEnabled,
+      $foreignSourcePreserved
+    );
+
+    $purchaseStates = $this->wooHelper->getPurchaseStates();
+    $createdAt = $order->get_date_created();
+
+    return [
+      'version' => self::RECORD_VERSION,
+      'trigger' => $trigger,
+      'outcome' => $outcome,
+      'reason' => $reason,
+      'classification' => $classification,
+      'legacy_click_ids' => $legacyClickIds,
+      'legacy_min_click_id' => $legacyClickIds ? min($legacyClickIds) : null,
+      'legacy_last_click_id' => $legacyLastClickId,
+      'woo_click_id' => $wooClickId,
+      'legacy_revenue' => $this->getLegacyDedupedRevenue($purchases, $purchaseStates),
+      'legacy_revenue_per_newsletter' => $this->getLegacyPerNewsletterRevenue($purchases, $purchaseStates),
+      'woo_revenue' => $this->getWooRevenue($order, $wooClickId, $purchaseStates),
+      'currency' => $order->get_currency(),
+      'order_status' => $order->get_status(),
+      'foreign_source_preserved' => $foreignSourcePreserved,
+      'order_created_at' => $createdAt ? gmdate('Y-m-d H:i:s', $createdAt->getTimestamp()) : null,
+      'reconciled_at' => gmdate('Y-m-d H:i:s'),
+    ];
+  }
+
+  /**
+   * @param int[] $legacyClickIds
+   * @return array{0: string, 1: string, 2: string|null}
+   */
+  private function resolveOutcome(
+    array $legacyClickIds,
+    ?int $legacyLastClickId,
+    ?int $wooClickId,
+    bool $trackingEnabled,
+    bool $foreignSourcePreserved
+  ): array {
+    if (!$legacyClickIds && $wooClickId === null) {
+      $reason = $trackingEnabled ? self::REASON_NO_CLICK_CANDIDATE : self::REASON_TRACKING_DISABLED;
+      return [self::OUTCOME_MATCH, $reason, null];
+    }
+
+    if ($legacyClickIds && $wooClickId === null) {
+      if (!$this->isWooAttributionAvailable()) {
+        return [self::OUTCOME_DIVERGED, self::REASON_WOO_ATTRIBUTION_DISABLED, self::CLASSIFICATION_UNEXPLAINED];
+      }
+      if (!$trackingEnabled) {
+        return [self::OUTCOME_DIVERGED, self::REASON_TRACKING_DISABLED, self::CLASSIFICATION_UNEXPLAINED];
+      }
+      return [self::OUTCOME_DIVERGED, self::REASON_WOO_ATTRIBUTION_MISSING, self::CLASSIFICATION_UNEXPLAINED];
+    }
+
+    if (!$legacyClickIds) {
+      return [self::OUTCOME_DIVERGED, self::REASON_LEGACY_ATTRIBUTION_MISSING, self::CLASSIFICATION_UNEXPLAINED];
+    }
+
+    if ($wooClickId !== $legacyLastClickId) {
+      return [self::OUTCOME_DIVERGED, self::REASON_CANONICAL_CLICK_MISMATCH, self::CLASSIFICATION_UNEXPLAINED];
+    }
+
+    if (count($legacyClickIds) > 1) {
+      return [self::OUTCOME_DIVERGED, self::REASON_LAST_CLICK_COLLAPSE, self::CLASSIFICATION_INTENTIONAL];
+    }
+
+    if ($foreignSourcePreserved) {
+      return [self::OUTCOME_DIVERGED, self::REASON_FOREIGN_SOURCE_PRESERVED, self::CLASSIFICATION_INTENTIONAL];
+    }
+
+    return [self::OUTCOME_MATCH, self::REASON_MATCHED, null];
+  }
+
+  /**
+   * @param StatisticsWooCommercePurchaseEntity[] $purchases
+   * @return int[]
+   */
+  private function getLegacyClickIds(array $purchases): array {
+    $clickIds = [];
+    foreach ($purchases as $purchase) {
+      $click = $purchase->getClick();
+      if ($click) {
+        $clickIds[] = (int)$click->getId();
+      }
+    }
+    sort($clickIds);
+    return $clickIds;
+  }
+
+  /**
+   * Mirrors OrderAttributionWriter::isMoreRecent so the legacy last-click candidate
+   * is computed with the same tie-breaking as the writer's canonical click.
+   *
+   * @param StatisticsWooCommercePurchaseEntity[] $purchases
+   */
+  private function getLastClickPurchase(array $purchases): ?StatisticsWooCommercePurchaseEntity {
+    $latest = null;
+    foreach ($purchases as $purchase) {
+      if (is_null($latest) || $this->isMoreRecent($purchase, $latest)) {
+        $latest = $purchase;
+      }
+    }
+    return $latest;
+  }
+
+  private function isMoreRecent(
+    StatisticsWooCommercePurchaseEntity $purchase,
+    StatisticsWooCommercePurchaseEntity $other
+  ): bool {
+    $click = $purchase->getClick();
+    $otherClick = $other->getClick();
+    if (is_null($click) || is_null($otherClick)) {
+      return !is_null($click);
+    }
+    $clickUpdatedAt = $click->getUpdatedAt();
+    $otherUpdatedAt = $otherClick->getUpdatedAt();
+    if ($clickUpdatedAt->getTimestamp() === $otherUpdatedAt->getTimestamp()) {
+      return (int)$click->getId() > (int)$otherClick->getId();
+    }
+    return $clickUpdatedAt > $otherUpdatedAt;
+  }
+
+  /**
+   * Today's campaign-revenue dedup counts each order once via its MIN(click_id) row
+   * (StatisticsWooCommercePurchasesRepository::getRevenuesByCampaigns).
+   *
+   * @param StatisticsWooCommercePurchaseEntity[] $purchases
+   * @param string[] $purchaseStates
+   */
+  private function getLegacyDedupedRevenue(array $purchases, array $purchaseStates): float {
+    $minClickPurchase = null;
+    $minClickId = null;
+    foreach ($purchases as $purchase) {
+      $click = $purchase->getClick();
+      if (is_null($click)) {
+        continue;
+      }
+      if (is_null($minClickId) || (int)$click->getId() < $minClickId) {
+        $minClickId = (int)$click->getId();
+        $minClickPurchase = $purchase;
+      }
+    }
+    if (is_null($minClickPurchase) || !in_array($minClickPurchase->getStatus(), $purchaseStates, true)) {
+      return 0.0;
+    }
+    return $minClickPurchase->getOrderPriceTotal();
+  }
+
+  /**
+   * Today's per-newsletter crediting counts the order total once per credited
+   * newsletter row.
+   *
+   * @param StatisticsWooCommercePurchaseEntity[] $purchases
+   * @param string[] $purchaseStates
+   */
+  private function getLegacyPerNewsletterRevenue(array $purchases, array $purchaseStates): float {
+    $revenue = 0.0;
+    foreach ($purchases as $purchase) {
+      if (in_array($purchase->getStatus(), $purchaseStates, true)) {
+        $revenue += $purchase->getOrderPriceTotal();
+      }
+    }
+    return $revenue;
+  }
+
+  /**
+   * The Woo-backed read model (STOMAIL-8138) credits the live refund-aware order
+   * value once to the canonical click when the order is in a purchase state.
+   *
+   * @param string[] $purchaseStates
+   */
+  private function getWooRevenue(WC_Order $order, ?int $wooClickId, array $purchaseStates): float {
+    if ($wooClickId === null || !in_array($order->get_status(), $purchaseStates, true)) {
+      return 0.0;
+    }
+    return (float)$order->get_remaining_refund_amount();
+  }
+
+  private function isForeignSourcePreserved(WC_Order $order, ?int $wooClickId): bool {
+    if ($wooClickId === null) {
+      return false;
+    }
+    $sourceType = $order->get_meta(OrderAttributionWriter::META_PREFIX . 'source_type');
+    $utmSource = $order->get_meta(OrderAttributionWriter::META_PREFIX . 'utm_source');
+    $sourceType = is_scalar($sourceType) ? (string)$sourceType : '';
+    $utmSource = is_scalar($utmSource) ? (string)$utmSource : '';
+    $isOverwritable = in_array($sourceType, OrderAttributionWriter::OVERWRITABLE_SOURCE_TYPES, true)
+      || $utmSource === 'mailpoet';
+    return !$isOverwritable;
+  }
+
+  private function isWooAttributionAvailable(): bool {
+    return class_exists(FeaturesUtil::class) && FeaturesUtil::feature_is_enabled('order_attribution');
+  }
+}

--- a/mailpoet/lib/WooCommerce/OrderAttributionReconciler.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionReconciler.php
@@ -99,7 +99,13 @@ class OrderAttributionReconciler {
     }
 
     $record = $this->buildRecord($order, $purchases, $wooClickId, $trackingEnabled, $trigger);
-    $order->update_meta_data(self::RECONCILIATION_META_KEY, (string)$this->wp->wpJsonEncode($record));
+    $encoded = $this->wp->wpJsonEncode($record);
+    if (!is_string($encoded) || $encoded === '') {
+      // Leave the order without a record so the next status change retries,
+      // rather than persisting an empty blob that reads as a corrupt record.
+      return;
+    }
+    $order->update_meta_data(self::RECONCILIATION_META_KEY, $encoded);
     $order->save_meta_data();
   }
 

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionReconcilerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionReconcilerTest.php
@@ -1,0 +1,376 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use DateTime;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\TrackingConfig;
+use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
+use WC_Order;
+
+/**
+ * @group woo
+ */
+class OrderAttributionReconcilerTest extends \MailPoetTest {
+  private const WOO_ATTRIBUTION_FEATURE_OPTION = 'woocommerce_feature_order_attribution_enabled';
+
+  /** @var SubscriberEntity */
+  private $subscriber;
+
+  /** @var NewsletterEntity */
+  private $newsletter;
+
+  /** @var SendingQueueEntity */
+  private $queue;
+
+  /** @var NewsletterLinkEntity */
+  private $link;
+
+  /** @var OrderAttributionReconciler */
+  private $reconciler;
+
+  /** @var SettingsController */
+  private $settings;
+
+  public function _before() {
+    parent::_before();
+    unset($_COOKIE['mailpoet_revenue_tracking']);
+    // The boundary must predate the orders created in the tests; the writer only
+    // persists it during the order-save hooks, which run after order creation.
+    update_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION, gmdate('Y-m-d H:i:s', time() - DAY_IN_SECONDS));
+    $this->settings = SettingsController::getInstance();
+    $this->settings->set('tracking.level', TrackingConfig::LEVEL_FULL);
+    $this->subscriber = $this->createSubscriber('reconciliation@example.com');
+    $this->newsletter = $this->createNewsletter('First Campaign');
+    $this->queue = $this->createQueue($this->newsletter, $this->subscriber);
+    $this->link = $this->createLink($this->newsletter, $this->queue);
+    $this->reconciler = $this->diContainer->get(OrderAttributionReconciler::class);
+  }
+
+  public function testItRecordsMatchedAttributionViaStatusChangeHook(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+
+    $this->completeOrder($order);
+
+    $record = $this->getRecord($this->reloadOrder($order));
+    verify($record['outcome'])->equals(OrderAttributionReconciler::OUTCOME_MATCH);
+    verify($record['reason'])->equals(OrderAttributionReconciler::REASON_MATCHED);
+    verify($record['classification'])->null();
+    verify($record['trigger'])->equals(OrderAttributionReconciler::TRIGGER_STATUS_CHANGED);
+    verify($record['legacy_click_ids'])->equals([$click->getId()]);
+    verify($record['legacy_last_click_id'])->equals($click->getId());
+    verify($record['woo_click_id'])->equals($click->getId());
+    verify($record['legacy_revenue'])->equals(15.0);
+    verify($record['legacy_revenue_per_newsletter'])->equals(15.0);
+    verify($record['woo_revenue'])->equals(15.0);
+    verify($record['order_status'])->equals('completed');
+    verify($record['foreign_source_preserved'])->false();
+  }
+
+  public function testItRecordsLastClickCollapseForMultipleNewsletters(): void {
+    $olderClick = $this->createClick($this->link, $this->subscriber, 5);
+
+    $newerNewsletter = $this->createNewsletter('Newer Campaign');
+    $newerQueue = $this->createQueue($newerNewsletter, $this->subscriber);
+    $newerLink = $this->createLink($newerNewsletter, $newerQueue);
+    $newerClick = $this->createClick($newerLink, $this->subscriber, 1);
+    $this->entityManager->flush();
+
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->completeOrder($order);
+
+    $record = $this->getRecord($this->reloadOrder($order));
+    verify($record['outcome'])->equals(OrderAttributionReconciler::OUTCOME_DIVERGED);
+    verify($record['reason'])->equals(OrderAttributionReconciler::REASON_LAST_CLICK_COLLAPSE);
+    verify($record['classification'])->equals(OrderAttributionReconciler::CLASSIFICATION_INTENTIONAL);
+    verify($record['legacy_click_ids'])->equals([$olderClick->getId(), $newerClick->getId()]);
+    verify($record['legacy_min_click_id'])->equals($olderClick->getId());
+    verify($record['legacy_last_click_id'])->equals($newerClick->getId());
+    verify($record['woo_click_id'])->equals($newerClick->getId());
+    verify($record['legacy_revenue'])->equals(15.0);
+    verify($record['legacy_revenue_per_newsletter'])->equals(30.0);
+    verify($record['woo_revenue'])->equals(15.0);
+  }
+
+  public function testItRecordsPreservedForeignSourceAsIntentional(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $order->update_meta_data('_wc_order_attribution_source_type', 'referral');
+    $order->update_meta_data('_wc_order_attribution_utm_source', 'google');
+    $order->save_meta_data();
+
+    $this->completeOrder($order);
+
+    $record = $this->getRecord($this->reloadOrder($order));
+    verify($record['outcome'])->equals(OrderAttributionReconciler::OUTCOME_DIVERGED);
+    verify($record['reason'])->equals(OrderAttributionReconciler::REASON_FOREIGN_SOURCE_PRESERVED);
+    verify($record['classification'])->equals(OrderAttributionReconciler::CLASSIFICATION_INTENTIONAL);
+    verify($record['foreign_source_preserved'])->true();
+    verify($record['woo_click_id'])->equals($click->getId());
+    verify($record['legacy_revenue'])->equals(15.0);
+    verify($record['woo_revenue'])->equals(15.0);
+  }
+
+  public function testItRecordsMissingWooAttribution(): void {
+    $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->completeOrder($order);
+
+    $order = $this->reloadOrder($order);
+    $order->delete_meta_data('_wc_order_attribution_mailpoet_click_id');
+    $order->save_meta_data();
+
+    $this->reconciler->reconcileForOrder($order->get_id());
+
+    $record = $this->getRecord($this->reloadOrder($order));
+    verify($record['outcome'])->equals(OrderAttributionReconciler::OUTCOME_DIVERGED);
+    verify($record['reason'])->equals(OrderAttributionReconciler::REASON_WOO_ATTRIBUTION_MISSING);
+    verify($record['classification'])->equals(OrderAttributionReconciler::CLASSIFICATION_UNEXPLAINED);
+    verify($record['woo_click_id'])->null();
+    verify($record['legacy_revenue'])->equals(15.0);
+    verify($record['woo_revenue'])->equals(0.0);
+  }
+
+  public function testItRecordsMissingLegacyAttribution(): void {
+    $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->completeOrder($order);
+
+    $purchasesRepository = $this->diContainer->get(StatisticsWooCommercePurchasesRepository::class);
+    foreach ($purchasesRepository->findBy(['orderId' => $order->get_id()]) as $purchase) {
+      $this->entityManager->remove($purchase);
+    }
+    $this->entityManager->flush();
+
+    $this->reconciler->reconcileForOrder($order->get_id());
+
+    $record = $this->getRecord($this->reloadOrder($order));
+    verify($record['outcome'])->equals(OrderAttributionReconciler::OUTCOME_DIVERGED);
+    verify($record['reason'])->equals(OrderAttributionReconciler::REASON_LEGACY_ATTRIBUTION_MISSING);
+    verify($record['classification'])->equals(OrderAttributionReconciler::CLASSIFICATION_UNEXPLAINED);
+    verify($record['legacy_click_ids'])->equals([]);
+    verify($record['legacy_revenue'])->equals(0.0);
+    verify($record['woo_revenue'])->equals(15.0);
+  }
+
+  public function testItRecordsCanonicalClickMismatch(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->completeOrder($order);
+
+    $order = $this->reloadOrder($order);
+    $order->update_meta_data('_wc_order_attribution_mailpoet_click_id', (string)((int)$click->getId() + 999));
+    $order->save_meta_data();
+
+    $this->reconciler->reconcileForOrder($order->get_id());
+
+    $record = $this->getRecord($this->reloadOrder($order));
+    verify($record['outcome'])->equals(OrderAttributionReconciler::OUTCOME_DIVERGED);
+    verify($record['reason'])->equals(OrderAttributionReconciler::REASON_CANONICAL_CLICK_MISMATCH);
+    verify($record['classification'])->equals(OrderAttributionReconciler::CLASSIFICATION_UNEXPLAINED);
+  }
+
+  public function testItRecordsTrackingDisabledWhenLegacyRowsExist(): void {
+    $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+
+    $this->settings->set('tracking.level', TrackingConfig::LEVEL_BASIC);
+    $this->completeOrder($order);
+
+    $record = $this->getRecord($this->reloadOrder($order));
+    verify($record['outcome'])->equals(OrderAttributionReconciler::OUTCOME_DIVERGED);
+    verify($record['reason'])->equals(OrderAttributionReconciler::REASON_TRACKING_DISABLED);
+    verify($record['classification'])->equals(OrderAttributionReconciler::CLASSIFICATION_UNEXPLAINED);
+    verify($record['woo_click_id'])->null();
+  }
+
+  public function testItRecordsWooAttributionDisabled(): void {
+    $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+
+    update_option(self::WOO_ATTRIBUTION_FEATURE_OPTION, 'no');
+    try {
+      $this->completeOrder($order);
+    } finally {
+      update_option(self::WOO_ATTRIBUTION_FEATURE_OPTION, 'yes');
+    }
+
+    $record = $this->getRecord($this->reloadOrder($order));
+    verify($record['outcome'])->equals(OrderAttributionReconciler::OUTCOME_DIVERGED);
+    verify($record['reason'])->equals(OrderAttributionReconciler::REASON_WOO_ATTRIBUTION_DISABLED);
+    verify($record['classification'])->equals(OrderAttributionReconciler::CLASSIFICATION_UNEXPLAINED);
+  }
+
+  public function testItRecordsNoClickCandidateWhenBothSidesAreEmpty(): void {
+    $order = $this->createOrder('no-clicks@example.com');
+    $this->completeOrder($order);
+
+    $record = $this->getRecord($this->reloadOrder($order));
+    verify($record['outcome'])->equals(OrderAttributionReconciler::OUTCOME_MATCH);
+    verify($record['reason'])->equals(OrderAttributionReconciler::REASON_NO_CLICK_CANDIDATE);
+    verify($record['classification'])->null();
+    verify($record['legacy_click_ids'])->equals([]);
+    verify($record['woo_click_id'])->null();
+  }
+
+  public function testItSkipsOrdersWithoutAttributionWhenTrackingIsDisabled(): void {
+    $this->settings->set('tracking.level', TrackingConfig::LEVEL_BASIC);
+    $order = $this->createOrder('no-clicks@example.com');
+    $this->completeOrder($order);
+
+    $order = $this->reloadOrder($order);
+    verify($order->meta_exists(OrderAttributionReconciler::RECONCILIATION_META_KEY))->false();
+  }
+
+  public function testItSkipsOrdersCreatedBeforeWritesStartedBoundary(): void {
+    $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+
+    update_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION, gmdate('Y-m-d H:i:s', time() + HOUR_IN_SECONDS));
+    $this->reconciler->reconcileForOrder($order->get_id());
+    $reloaded = $this->reloadOrder($order);
+    verify($reloaded->meta_exists(OrderAttributionReconciler::RECONCILIATION_META_KEY))->false();
+
+    delete_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
+    $this->reconciler->reconcileForOrder($order->get_id());
+    $reloaded = $this->reloadOrder($order);
+    verify($reloaded->meta_exists(OrderAttributionReconciler::RECONCILIATION_META_KEY))->false();
+  }
+
+  public function testItUpdatesRevenueOnRefund(): void {
+    $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->completeOrder($order);
+
+    $refund = wc_create_refund([
+      'order_id' => $order->get_id(),
+      'amount' => 5,
+    ]);
+    $this->assertNotInstanceOf(\WP_Error::class, $refund);
+
+    $record = $this->getRecord($this->reloadOrder($order));
+    verify($record['trigger'])->equals(OrderAttributionReconciler::TRIGGER_REFUND);
+    verify($record['outcome'])->equals(OrderAttributionReconciler::OUTCOME_MATCH);
+    verify($record['legacy_revenue'])->equals(10.0);
+    verify($record['woo_revenue'])->equals(10.0);
+  }
+
+  public function testRecordCanBeRebuiltFromDirectCall(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->completeOrder($order);
+
+    $this->reconciler->reconcileForOrder($this->reloadOrder($order));
+
+    $record = $this->getRecord($this->reloadOrder($order));
+    verify($record['version'])->equals(OrderAttributionReconciler::RECORD_VERSION);
+    verify($record['woo_click_id'])->equals($click->getId());
+    verify($record['currency'])->equals(get_woocommerce_currency());
+    verify($record['order_created_at'])->notEmpty();
+    verify($record['reconciled_at'])->notEmpty();
+  }
+
+  private function createOrder(string $billingEmail): WC_Order {
+    $order = wc_create_order();
+    $this->assertInstanceOf(WC_Order::class, $order);
+    $order->set_billing_email($billingEmail);
+    $order->set_total('15');
+    $order->save();
+    return $order;
+  }
+
+  /**
+   * Drives the production pipeline on woocommerce_order_status_changed: the legacy
+   * purchase tracker and the attribution writer (priority 10), then the reconciler
+   * (priority 20).
+   */
+  private function completeOrder(WC_Order $order): void {
+    $order->set_status('completed');
+    $order->save();
+  }
+
+  private function reloadOrder(WC_Order $order): WC_Order {
+    $reloaded = wc_get_order($order->get_id());
+    $this->assertInstanceOf(WC_Order::class, $reloaded);
+    return $reloaded;
+  }
+
+  /**
+   * @return mixed[]
+   */
+  private function getRecord(WC_Order $order): array {
+    $meta = $order->get_meta(OrderAttributionReconciler::RECONCILIATION_META_KEY);
+    $this->assertIsString($meta);
+    $this->assertNotSame('', $meta, 'Expected a reconciliation record on the order');
+    $record = json_decode($meta, true);
+    $this->assertIsArray($record);
+    return $record;
+  }
+
+  private function createNewsletter(string $subject): NewsletterEntity {
+    $newsletter = new NewsletterEntity();
+    $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
+    $newsletter->setSubject($subject);
+    $this->entityManager->persist($newsletter);
+    return $newsletter;
+  }
+
+  private function createQueue(NewsletterEntity $newsletter, SubscriberEntity $subscriber): SendingQueueEntity {
+    $task = new ScheduledTaskEntity();
+    $this->entityManager->persist($task);
+    $queue = new SendingQueueEntity();
+    $queue->setNewsletter($newsletter);
+    $queue->setTask($task);
+    $this->entityManager->persist($queue);
+    $sendingTaskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber, 1);
+    $this->entityManager->persist($sendingTaskSubscriber);
+    return $queue;
+  }
+
+  private function createSubscriber(string $email): SubscriberEntity {
+    $subscriber = new SubscriberEntity();
+    $subscriber->setEmail($email);
+    $subscriber->setFirstName('First');
+    $subscriber->setLastName('Last');
+    $this->entityManager->persist($subscriber);
+    return $subscriber;
+  }
+
+  private function createLink(NewsletterEntity $newsletter, SendingQueueEntity $queue): NewsletterLinkEntity {
+    $link = new NewsletterLinkEntity($newsletter, $queue, 'url', 'hash');
+    $this->entityManager->persist($link);
+    return $link;
+  }
+
+  private function createClick(NewsletterLinkEntity $link, SubscriberEntity $subscriber, int $createdDaysAgo = 5): StatisticsClickEntity {
+    $newsletter = $link->getNewsletter();
+    $queue = $link->getQueue();
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
+    $click = new StatisticsClickEntity($newsletter, $queue, $subscriber, $link, 1);
+    $this->entityManager->persist($click);
+    $timestamp = new DateTime("-$createdDaysAgo days");
+    $click->setCreatedAt($timestamp);
+    $click->setUpdatedAt($timestamp);
+    return $click;
+  }
+}


### PR DESCRIPTION
## Description

Runs MailPoet's legacy purchase attribution and the Woo-stored MailPoet attribution in parallel and records a structured comparison as order meta (`_mailpoet_attribution_reconciliation`): outcome, reason code classified intentional vs unexplained, legacy MIN/last click IDs vs Woo click ID, and the revenue each read model would report. The records feed the STOMAIL-8135 rollout gate (`>98%` match, `<3%` revenue divergence, intentional diffs excluded). Reported revenue is unchanged; no UI changes.

## Code review notes

- Reconciliation hooks `woocommerce_order_status_changed` / `woocommerce_order_refunded` at priority 20 so it runs after both the legacy tracker and `OrderAttributionWriter` (priority 10) — the legacy rows are synced to the live order status at that point.
- Revenue fields intentionally mirror existing semantics: `legacy_revenue` reproduces the `MIN(click_id)` dedup from `getRevenuesByCampaigns`, `woo_revenue` the planned STOMAIL-8138 read model (refund-aware, purchase states only).
- Orders created before the `writes_started_at` boundary are skipped per contract decision 6, so they don't count as divergences.
- Reason codes reflect settings at reconciliation time, not at checkout — acceptable since reconciliation runs immediately after the writers.

## QA notes

Covered by integration tests that drive the real hook pipeline (status change → tracker → writer → reconciler), including refunds. Dev-facing only: inspect the `_mailpoet_attribution_reconciliation` order meta after changing an attributed order's status.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8136](https://linear.app/a8c/issue/STOMAIL-8136/add-dual-run-reconciliation-for-mailpoet-and-woo-attribution)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`) — not applicable, no user-facing change
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)