### PR TITLE
Show Woo Segments only when Woo is active

### DIFF
--- a/mailpoet/changelog/2026-06-11-08-27-15-improved-performance-when-woocommerce-is-inactive-by-hiding.md
+++ b/mailpoet/changelog/2026-06-11-08-27-15-improved-performance-when-woocommerce-is-inactive-by-hiding.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Performance when WooCommerce is inactive by hiding the WooCommerce Customers list instead of running a slow database check

--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -93,13 +93,7 @@ class WooCommerce {
   }
 
   public function shouldShowWooCommerceSegment(): bool {
-    $isWoocommerceActive = $this->woocommerceHelper->isWooCommerceActive();
-    $woocommerceUserExists = $this->subscribersRepository->woocommerceUserExists();
-
-    if (!$isWoocommerceActive && !$woocommerceUserExists) {
-      return false;
-    }
-    return true;
+    return $this->woocommerceHelper->isWooCommerceActive();
   }
 
   public function synchronizeRegisteredCustomer(int $wpUserId, ?string $currentFilter = null): bool {

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -724,23 +724,6 @@ class SubscribersRepository extends Repository {
     return $count;
   }
 
-  public function woocommerceUserExists(): bool {
-    $subscribers = $this->entityManager
-      ->createQueryBuilder()
-      ->select('s')
-      ->from(SubscriberEntity::class, 's')
-      ->join('s.subscriberSegments', 'ss')
-      ->join('ss.segment', 'segment')
-      ->where('segment.type = :segmentType')
-      ->setParameter('segmentType', SegmentEntity::TYPE_WC_USERS)
-      ->andWhere('s.isWoocommerceUser = true')
-      ->getQuery()
-      ->setMaxResults(1)
-      ->execute();
-
-    return is_array($subscribers) && count($subscribers) > 0;
-  }
-
    /**
    * @return int - number of processed ids
    */


### PR DESCRIPTION
## Description
We stop querying whether there are Woo subscribers when Woo is not active. This is a performance improvement. The query was originally introduced in https://github.com/mailpoet/mailpoet/pull/2219 and the query was pointed out as risky. In my opinion, this query covers an edge case we do not need to cover.

RSM-4315

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:rsm-4315-avoid-unconditional-32-second-woocommerce-segment-query)

_The latest successful build from `rsm-4315-avoid-unconditional-32-second-woocommerce-segment-query` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->