### PR TITLE
Speed up the subscribers list Trash tab count on large lists

### DIFF
--- a/mailpoet/changelog/2026-06-09-10-20-38-improved-speed-up-the-subscribers-list-trash-tab-count-on-l.md
+++ b/mailpoet/changelog/2026-06-09-10-20-38-improved-speed-up-the-subscribers-list-trash-tab-count-on-l.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Speed up the subscribers list Trash tab count on large lists

--- a/mailpoet/lib/Migrations/Db/Migration_20260609_130000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260609_130000_Db.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20260609_130000_Db extends DbMigration {
+  public function run(): void {
+    $subscribersTable = $this->getTableName(SubscriberEntity::class);
+
+    // Index deleted_at so the Trash tab count (`deleted_at IS NOT NULL`) can seek
+    // instead of scanning the whole table. Trash is sparse, so without an index a
+    // `LIMIT`-capped count never reaches its cap and reads every row; with it, the
+    // range scan touches only the few trashed rows — fast even alongside a search.
+    if (!$this->indexExists($subscribersTable, 'deleted_at')) {
+      $this->connection->executeQuery(
+        "ALTER TABLE `{$subscribersTable}`
+          ADD INDEX `deleted_at` (`deleted_at`)"
+      );
+    }
+  }
+}


### PR DESCRIPTION
In a lot of queries, we use `where deleted_at IS NULL` or `IS NOT NULL` to separate subscribers that are in trash vs. those that are not. This PR proposes to index `deleted_at` to optimize those queries.

Example:
```
# Time: 260611  9:07:42
# User@Host: wpuser57773[wpuser57773] @ localhost []
# Thread_id: 4524  Schema: wp1744149  QC_hit: No
# Query_time: 29.390117  Lock_time: 0.000118  Rows_sent: 1  Rows_examined: 5000000
# Rows_affected: 0  Bytes_sent: 63
SET timestamp=1781168862;
SELECT COUNT(*) FROM wp_mailpoet_subscriber_segment ss INNER JOIN wp_mailpoet_subscribers s ON s.id = ss.subscriber_id WHERE (ss.segment_id = '5') AND (s.deleted_at IS NOT NULL);
```

```
MariaDB [wp1744149]> explain SELECT COUNT(*) FROM wp_mailpoet_subscriber_segment ss INNER JOIN wp_mailpoet_subscribers s ON s.id = ss.subscriber_id WHERE (ss.segment_id = '5') AND (s.deleted_at IS NOT NULL);
+------+-------------+-------+--------+--------------------------------------------------+--------------------+---------+----------------------------+---------+-------------+
| id   | select_type | table | type   | possible_keys                                    | key                | key_len | ref                        | rows    | Extra       |
+------+-------------+-------+--------+--------------------------------------------------+--------------------+---------+----------------------------+---------+-------------+
|    1 | SIMPLE      | ss    | ref    | subscriber_segment,segment_id,idx_segment_status | idx_segment_status | 4       | const                      | 2491800 | Using index |
|    1 | SIMPLE      | s     | eq_ref | PRIMARY                                          | PRIMARY            | 4       | wp1744149.ss.subscriber_id | 1       | Using where |
+------+-------------+-------+--------+--------------------------------------------------+--------------------+---------+----------------------------+---------+-------------+
2 rows in set (0.018 sec)

MariaDB [wp1744149]>     ALTER TABLE `wp_mailpoet_subscribers` ADD INDEX `deleted_at` (`deleted_at`);
Query OK, 0 rows affected (46.655 sec)
Records: 0  Duplicates: 0  Warnings: 0

MariaDB [wp1744149]> explain SELECT COUNT(*) FROM wp_mailpoet_subscriber_segment ss INNER JOIN wp_mailpoet_subscribers s ON s.id = ss.subscriber_id WHERE (ss.segment_id = '5') AND (s.deleted_at IS NOT NULL);
+------+-------------+-------+--------+--------------------------------------------------+--------------------+---------+----------------------+------+--------------------------+
| id   | select_type | table | type   | possible_keys                                    | key                | key_len | ref                  | rows | Extra                    |
+------+-------------+-------+--------+--------------------------------------------------+--------------------+---------+----------------------+------+--------------------------+
|    1 | SIMPLE      | s     | range  | PRIMARY,deleted_at                               | deleted_at         | 5       | NULL                 | 1    | Using where; Using index |
|    1 | SIMPLE      | ss    | eq_ref | subscriber_segment,segment_id,idx_segment_status | subscriber_segment | 8       | wp1744149.s.id,const | 1    | Using index              |
+------+-------------+-------+--------+--------------------------------------------------+--------------------+---------+----------------------+------+--------------------------+
2 rows in set (0.024 sec)

MariaDB [wp1744149]> SELECT COUNT(*) FROM wp_mailpoet_subscriber_segment ss INNER JOIN wp_mailpoet_subscribers s ON s.id = ss.subscriber_id WHERE (ss.segment_id = '5') AND (s.deleted_at IS NOT NULL);
+----------+
| COUNT(*) |
+----------+
|        0 |
+----------+
1 row in set (0.018 sec)
```

stomail-8156

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8156-scale-subscriptions-page-for-1m-subscribers-and-2-lists-trash)

_The latest successful build from `stomail-8156-scale-subscriptions-page-for-1m-subscribers-and-2-lists-trash` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The migration code properly implements database index creation with appropriate safeguards: it checks for index existence before adding it (idempotent), uses the framework's table name resolution method, and properly escapes identifiers. The implementation is clean, well-documented, and follows migration best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->