### PR TITLE
Preserve form math formatting

### DIFF
--- a/mailpoet/changelog/2026-06-11-11-39-43-fixed-preserve-math-formatting-in-subscription-forms.md
+++ b/mailpoet/changelog/2026-06-11-11-39-43-fixed-preserve-math-formatting-in-subscription-forms.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Preserve math formatting in subscription forms

--- a/mailpoet/lib/Form/FormHtmlSanitizer.php
+++ b/mailpoet/lib/Form/FormHtmlSanitizer.php
@@ -37,6 +37,47 @@ class FormHtmlSanitizer {
       'data-font' => true,
       'class' => true,
     ],
+    'math' => [
+      'data-latex' => true,
+      'display' => true,
+    ],
+    'semantics' => [],
+    'annotation' => [
+      'encoding' => true,
+    ],
+    'mrow' => [],
+    'mi' => [],
+    'mn' => [],
+    'mo' => [
+      'movablelimits' => true,
+    ],
+    'mtext' => [],
+    'mspace' => [
+      'height' => true,
+      'width' => true,
+    ],
+    'mfrac' => [
+      'linethickness' => true,
+    ],
+    'msqrt' => [],
+    'mroot' => [],
+    'msub' => [],
+    'msup' => [],
+    'msubsup' => [],
+    'munder' => [],
+    'mover' => [],
+    'munderover' => [],
+    'mtable' => [
+      'columnalign' => true,
+      'rowspacing' => true,
+      'columnspacing' => true,
+    ],
+    'mtr' => [],
+    'mtd' => [
+      'columnalign' => true,
+      'rowalign' => true,
+      'style' => true,
+    ],
     'mark' => [
       'style' => true,
       'class' => true,

--- a/mailpoet/tests/integration/Form/FormHtmlSanitizerTest.php
+++ b/mailpoet/tests/integration/Form/FormHtmlSanitizerTest.php
@@ -25,6 +25,25 @@ class FormHtmlSanitizerTest extends \MailPoetTest {
     verify($this->sanitizer->sanitize('<img class="wp-image-55" style="width: 150px;height: 1px" src="http://test.com/logo-1.jpg" alt="alt text">'))->equals('<img class="wp-image-55" style="width: 150px;height: 1px" src="http://test.com/logo-1.jpg" alt="alt text">');
   }
 
+  public function testItKeepsMathFormatting() {
+    $input = implode('', [
+      '<span contenteditable="false" data-rich-text-bogus="true" data-rich-text-format-boundary="true">',
+      '<math data-latex="x^2">',
+      '<semantics><msup><mi>x</mi><mn>2</mn></msup><annotation encoding="application/x-tex">x^2</annotation></semantics>',
+      '</math>',
+      '</span>',
+    ]);
+    $expected = implode('', [
+      '<span>',
+      '<math data-latex="x^2">',
+      '<semantics><msup><mi>x</mi><mn>2</mn></msup><annotation encoding="application/x-tex">x^2</annotation></semantics>',
+      '</math>',
+      '</span>',
+    ]);
+
+    verify($this->sanitizer->sanitize($input))->equals($expected);
+  }
+
   public function testItRemovesUnwantedHtml() {
     verify($this->sanitizer->sanitize('<script>'))->equals('');
     verify($this->sanitizer->sanitize('<span>Hello<img src="http://nonsense" onerror="alert(1)"/></span>'))->equals('<span>Hello<img src="http://nonsense" /></span>');


### PR DESCRIPTION
## Description

Math rich-text formatting was available in the form editor, but saving a form stripped the MathML markup. This allows the MathML tags and attributes generated by the WordPress math format to pass through the form HTML sanitizer, and they are saved properly.

<img width="432" height="320" alt="Screenshot 2026-06-10 at 13 35 42" src="https://github.com/user-attachments/assets/253a7586-3d03-4be6-87d8-05d874a993d5" />


## Code review notes

The editor-only span attributes (`contenteditable` and `data-rich-text-*`) are still stripped; the sanitizer keeps the wrapper span and MathML only.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/math-formatting-form-editor)

_The latest successful build from `fix/math-formatting-form-editor` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->