### PR TITLE
Persist DataViews layout preferences in listings

### DIFF
--- a/mailpoet/assets/css/src/mailpoet-dataviews.scss
+++ b/mailpoet/assets/css/src/mailpoet-dataviews.scss
@@ -43,6 +43,16 @@
   padding: 8px;
 }
 
+// Right-aligned group inside a listing toolbar. Holds the DataViews filters
+// toggle and view-config (preferences) buttons so they sit at the toolbar's
+// right edge while search and legacy filters stay on the left.
+.mailpoet-dataviews__toolbar-end {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
 .mailpoet-segments-dataviews .mailpoet-listing-actions {
   display: flex;
   gap: 8px;

--- a/mailpoet/assets/css/src/mailpoet-tags.scss
+++ b/mailpoet/assets/css/src/mailpoet-tags.scss
@@ -9,7 +9,3 @@
     min-height: 200px;
   }
 }
-
-.mailpoet-tags-dataviews__toolbar {
-  padding: 8px;
-}

--- a/mailpoet/assets/js/src/automation/listing/index.tsx
+++ b/mailpoet/assets/js/src/automation/listing/index.tsx
@@ -13,7 +13,10 @@ import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { getDataViewsPreference } from 'common/dataviews';
+import {
+  getDataViewsPreference,
+  usePersistedDataViewsPreference,
+} from 'common/dataviews';
 import { storeName } from './store/constants';
 import type { AutomationItem } from './store/types';
 import { AutomationStatus } from './automation';
@@ -291,19 +294,29 @@ export function AutomationListing(): JSX.Element {
   useEffect(() => {
     const nextSearch = new URLSearchParams(location.search);
     const nextGroup = getGroupFromSearch(nextSearch);
+    // Resolve omitted URL params against the current preference-merged
+    // defaults so browser navigation restores the view the URL was written
+    // against.
+    const currentDefaultView = getDataViewsPreference(
+      'automation',
+      DEFAULT_VIEW,
+      automationFields,
+    );
     let selectionShouldBeCleared = false;
     if (nextGroup !== latestGroupRef.current) {
       setGroup(nextGroup);
       selectionShouldBeCleared = true;
     }
-    if (!viewMatchesSearch(latestViewRef.current, nextSearch, defaultView)) {
-      setView(getViewFromSearch(nextSearch, defaultView));
+    if (
+      !viewMatchesSearch(latestViewRef.current, nextSearch, currentDefaultView)
+    ) {
+      setView(getViewFromSearch(nextSearch, currentDefaultView));
       selectionShouldBeCleared = true;
     }
     if (selectionShouldBeCleared) {
       setSelection([]);
     }
-  }, [defaultView, location.search]);
+  }, [location.search]);
 
   const updateUrlSearchString = useCallback(
     (nextGroup: Group, nextView: View) => {
@@ -315,7 +328,13 @@ export function AutomationListing(): JSX.Element {
       } else {
         newSearch.delete('paged');
       }
-      if ((nextView.perPage ?? DEFAULT_PER_PAGE) !== DEFAULT_PER_PAGE) {
+      // Compare against the preference-merged default, resolved at write time
+      // (not the hardcoded one, not a mount-time snapshot), so reloading a
+      // URL without `per_page` resolves to the same view it was written from.
+      const defaultPerPage =
+        getDataViewsPreference('automation', DEFAULT_VIEW, automationFields)
+          .perPage ?? DEFAULT_PER_PAGE;
+      if ((nextView.perPage ?? defaultPerPage) !== defaultPerPage) {
         newSearch.set('per_page', String(nextView.perPage));
       } else {
         newSearch.delete('per_page');
@@ -351,6 +370,11 @@ export function AutomationListing(): JSX.Element {
       updateUrlSearchString(group, nextView);
     },
     [group, updateUrlSearchString],
+  );
+  const persistedViewChange = usePersistedDataViewsPreference(
+    'automation',
+    view,
+    handleViewChange,
   );
 
   const handleTabSelect = (tabName: string): void => {
@@ -615,7 +639,7 @@ export function AutomationListing(): JSX.Element {
               data={data}
               fields={automationFields}
               view={view}
-              onChangeView={handleViewChange}
+              onChangeView={persistedViewChange}
               actions={actions}
               paginationInfo={paginationInfo}
               defaultLayouts={{ table: {} }}
@@ -631,6 +655,9 @@ export function AutomationListing(): JSX.Element {
                 <DataViews.Search
                   label={__('Search automations', 'mailpoet')}
                 />
+                <div className="mailpoet-dataviews__toolbar-end">
+                  <DataViews.ViewConfig />
+                </div>
               </div>
               <DataViews.Layout />
               <DataViews.Footer />

--- a/mailpoet/assets/js/src/automation/listing/index.tsx
+++ b/mailpoet/assets/js/src/automation/listing/index.tsx
@@ -13,6 +13,7 @@ import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { getDataViewsPreference } from 'common/dataviews';
 import { storeName } from './store/constants';
 import type { AutomationItem } from './store/types';
 import { AutomationStatus } from './automation';
@@ -72,23 +73,30 @@ function getGroupFromSearch(search: URLSearchParams): Group {
   return groupNames.includes(status as Group) ? (status as Group) : 'all';
 }
 
-function getViewFromSearch(search: URLSearchParams): View {
+function getViewFromSearch(
+  search: URLSearchParams,
+  defaultView = DEFAULT_VIEW,
+): View {
   const order = search.get('order');
   const orderby = search.get('orderby');
   return {
-    ...DEFAULT_VIEW,
-    page: parsePositiveInt(search.get('paged')) ?? DEFAULT_VIEW.page,
-    perPage: parsePositiveInt(search.get('per_page')) ?? DEFAULT_VIEW.perPage,
+    ...defaultView,
+    page: parsePositiveInt(search.get('paged')) ?? defaultView.page,
+    perPage: parsePositiveInt(search.get('per_page')) ?? defaultView.perPage,
     search: search.get('search') ?? undefined,
     sort:
       orderby && (order === 'asc' || order === 'desc')
         ? { field: orderby, direction: order }
-        : undefined,
+        : defaultView.sort,
   };
 }
 
-function viewMatchesSearch(view: View, search: URLSearchParams): boolean {
-  const searchView = getViewFromSearch(search);
+function viewMatchesSearch(
+  view: View,
+  search: URLSearchParams,
+  defaultView = DEFAULT_VIEW,
+): boolean {
+  const searchView = getViewFromSearch(search, defaultView);
   return (
     (view.page ?? 1) === (searchView.page ?? 1) &&
     (view.perPage ?? DEFAULT_PER_PAGE) ===
@@ -240,11 +248,15 @@ export function AutomationListingHeader(): JSX.Element {
 export function AutomationListing(): JSX.Element {
   const navigate = useNavigate();
   const location = useLocation();
+  const defaultView = useMemo(
+    () => getDataViewsPreference('automation', DEFAULT_VIEW, automationFields),
+    [],
+  );
   const [group, setGroup] = useState<Group>(() =>
     getGroupFromSearch(new URLSearchParams(location.search)),
   );
   const [view, setView] = useState<View>(() =>
-    getViewFromSearch(new URLSearchParams(location.search)),
+    getViewFromSearch(new URLSearchParams(location.search), defaultView),
   );
   const [selection, setSelection] = useState<string[]>([]);
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
@@ -284,14 +296,14 @@ export function AutomationListing(): JSX.Element {
       setGroup(nextGroup);
       selectionShouldBeCleared = true;
     }
-    if (!viewMatchesSearch(latestViewRef.current, nextSearch)) {
-      setView(getViewFromSearch(nextSearch));
+    if (!viewMatchesSearch(latestViewRef.current, nextSearch, defaultView)) {
+      setView(getViewFromSearch(nextSearch, defaultView));
       selectionShouldBeCleared = true;
     }
     if (selectionShouldBeCleared) {
       setSelection([]);
     }
-  }, [location.search]);
+  }, [defaultView, location.search]);
 
   const updateUrlSearchString = useCallback(
     (nextGroup: Group, nextView: View) => {

--- a/mailpoet/assets/js/src/common/dataviews/index.ts
+++ b/mailpoet/assets/js/src/common/dataviews/index.ts
@@ -1,6 +1,10 @@
 export { useDataViewsQuery } from './use-dataviews-query';
 export type { LoadListing } from './use-dataviews-query';
 export {
+  getDataViewsPreference,
+  getDataViewsPreferenceKey,
+} from './preferences';
+export {
   buildRestApiPath,
   configureRestApi,
   createRestListingLoader,

--- a/mailpoet/assets/js/src/common/dataviews/index.ts
+++ b/mailpoet/assets/js/src/common/dataviews/index.ts
@@ -1,8 +1,10 @@
-export { useDataViewsQuery } from './use-dataviews-query';
-export type { LoadListing } from './use-dataviews-query';
+export { useDataViewsQuery, type LoadListing } from './use-dataviews-query';
 export {
   getDataViewsPreference,
   getDataViewsPreferenceKey,
+  getPersistedDataViewsPreference,
+  persistDataViewsPreference,
+  usePersistedDataViewsPreference,
 } from './preferences';
 export {
   buildRestApiPath,

--- a/mailpoet/assets/js/src/common/dataviews/preferences.ts
+++ b/mailpoet/assets/js/src/common/dataviews/preferences.ts
@@ -1,6 +1,20 @@
 import type { Field, View } from '@wordpress/dataviews';
+import { dispatch, select } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { useCallback, useRef } from 'react';
 
 import { getPreloadedPreference } from '../preferences';
+
+// Read the live store first so preferences persisted during the session are
+// reflected; fall back to the server-preloaded snapshot for reads that happen
+// before the store is initialized.
+function readPreference(scope: string, name: string): unknown {
+  const fromStore: unknown = select(preferencesStore).get(scope, name);
+  if (fromStore !== undefined) {
+    return fromStore;
+  }
+  return getPreloadedPreference<unknown>(scope, name);
+}
 
 const VIEW_PREFERENCES_SCOPE = 'core/views';
 const MAX_PER_PAGE = 100;
@@ -8,6 +22,7 @@ const MAX_PER_PAGE = 100;
 type DataViewsField = Pick<Field<unknown>, 'id'>;
 
 type PersistedView = Partial<View> & Record<string, unknown>;
+type OnChangeView = (view: View) => void;
 
 export function getDataViewsPreferenceKey(
   name: string,
@@ -102,7 +117,7 @@ export function getDataViewsPreference<T>(
   defaultView: View,
   fields?: readonly Field<T>[],
 ): View {
-  const preference = getPreloadedPreference<unknown>(
+  const preference = readPreference(
     VIEW_PREFERENCES_SCOPE,
     getDataViewsPreferenceKey(name),
   );
@@ -182,4 +197,86 @@ export function getDataViewsPreference<T>(
   }
 
   return view;
+}
+
+export function getPersistedDataViewsPreference(view: View): Partial<View> {
+  const preference: Partial<View> = {
+    type: view.type,
+  };
+
+  if (view.perPage) {
+    preference.perPage = view.perPage;
+  }
+  if (view.sort) {
+    preference.sort = view.sort;
+  }
+  if (Array.isArray(view.fields)) {
+    preference.fields = view.fields;
+  }
+  if (isRecord(view.layout)) {
+    preference.layout = view.layout;
+  }
+  if (view.titleField) {
+    preference.titleField = view.titleField;
+  }
+  if (view.descriptionField) {
+    preference.descriptionField = view.descriptionField;
+  }
+  if (view.mediaField) {
+    preference.mediaField = view.mediaField;
+  }
+  if (typeof view.showTitle === 'boolean') {
+    preference.showTitle = view.showTitle;
+  }
+  if (typeof view.showDescription === 'boolean') {
+    preference.showDescription = view.showDescription;
+  }
+  if (typeof view.showMedia === 'boolean') {
+    preference.showMedia = view.showMedia;
+  }
+
+  return preference;
+}
+
+export function persistDataViewsPreference(
+  name: string,
+  view: View,
+  slug = 'default',
+): void {
+  void dispatch(preferencesStore).set(
+    VIEW_PREFERENCES_SCOPE,
+    getDataViewsPreferenceKey(name, slug),
+    getPersistedDataViewsPreference(view),
+  );
+}
+
+export function isSameDataViewsPreference(view: View, nextView: View): boolean {
+  return (
+    JSON.stringify(getPersistedDataViewsPreference(view)) ===
+    JSON.stringify(getPersistedDataViewsPreference(nextView))
+  );
+}
+
+export function usePersistedDataViewsPreference(
+  name: string,
+  view: View,
+  onChangeView: OnChangeView,
+  slug = 'default',
+): OnChangeView {
+  const viewRef = useRef(view);
+  viewRef.current = view;
+  return useCallback(
+    (nextView: View) => {
+      // DataViews fires spurious `onChangeView` calls (e.g. its search box
+      // syncs an undefined `view.search` to '' on mount). Persisting then
+      // would freeze the current defaults as a user preference, overriding
+      // later server-driven defaults (per-page, tracking-dependent columns).
+      // Persist only when a persisted-view property actually changed.
+      if (!isSameDataViewsPreference(viewRef.current, nextView)) {
+        persistDataViewsPreference(name, nextView, slug);
+      }
+      onChangeView(nextView);
+    },
+    [name, onChangeView, slug],
+  );
 }

--- a/mailpoet/assets/js/src/common/dataviews/preferences.ts
+++ b/mailpoet/assets/js/src/common/dataviews/preferences.ts
@@ -1,0 +1,185 @@
+import type { Field, View } from '@wordpress/dataviews';
+
+import { getPreloadedPreference } from '../preferences';
+
+const VIEW_PREFERENCES_SCOPE = 'core/views';
+const MAX_PER_PAGE = 100;
+
+type DataViewsField = Pick<Field<unknown>, 'id'>;
+
+type PersistedView = Partial<View> & Record<string, unknown>;
+
+export function getDataViewsPreferenceKey(
+  name: string,
+  slug = 'default',
+): string {
+  return `dataviews-mailpoet-${name}-${slug}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getAvailableFieldIds(
+  fields?: readonly DataViewsField[],
+): Set<string> | undefined {
+  return fields ? new Set(fields.map((field) => field.id)) : undefined;
+}
+
+function isAllowedField(
+  field: unknown,
+  availableFieldIds?: Set<string>,
+): field is string {
+  return (
+    typeof field === 'string' &&
+    (!availableFieldIds || availableFieldIds.has(field))
+  );
+}
+
+function getPreferredFields(
+  fields: unknown,
+  availableFieldIds?: Set<string>,
+): string[] | undefined {
+  if (!Array.isArray(fields)) {
+    return undefined;
+  }
+  const preferredFields = fields.filter((field) =>
+    isAllowedField(field, availableFieldIds),
+  );
+  if (fields.length > 0 && preferredFields.length === 0) {
+    return undefined;
+  }
+  return preferredFields;
+}
+
+function getPreferredPerPage(perPage: unknown): number | undefined {
+  if (
+    typeof perPage !== 'number' ||
+    !Number.isInteger(perPage) ||
+    perPage < 1
+  ) {
+    return undefined;
+  }
+  return Math.min(perPage, MAX_PER_PAGE);
+}
+
+function getPreferredSort(
+  sort: unknown,
+  availableFieldIds?: Set<string>,
+): View['sort'] | undefined {
+  if (!isRecord(sort)) {
+    return undefined;
+  }
+  if (
+    !isAllowedField(sort.field, availableFieldIds) ||
+    (sort.direction !== 'asc' && sort.direction !== 'desc')
+  ) {
+    return undefined;
+  }
+  return { field: sort.field, direction: sort.direction };
+}
+
+function getBooleanPreference(
+  preference: PersistedView,
+  key: 'showTitle' | 'showDescription' | 'showMedia',
+): boolean | undefined {
+  return typeof preference[key] === 'boolean' ? preference[key] : undefined;
+}
+
+function getFieldPreference(
+  preference: PersistedView,
+  key: 'titleField' | 'descriptionField' | 'mediaField',
+  availableFieldIds?: Set<string>,
+): string | undefined {
+  if (isAllowedField(preference[key], availableFieldIds)) {
+    return preference[key];
+  }
+  return undefined;
+}
+
+export function getDataViewsPreference<T>(
+  name: string,
+  defaultView: View,
+  fields?: readonly Field<T>[],
+): View {
+  const preference = getPreloadedPreference<unknown>(
+    VIEW_PREFERENCES_SCOPE,
+    getDataViewsPreferenceKey(name),
+  );
+  if (!isRecord(preference)) {
+    return defaultView;
+  }
+
+  const availableFieldIds = getAvailableFieldIds(fields);
+  const persistedView = preference as PersistedView;
+  const view: View = { ...defaultView };
+
+  const preferredPerPage = getPreferredPerPage(persistedView.perPage);
+  if (preferredPerPage) {
+    view.perPage = preferredPerPage;
+  }
+
+  const preferredSort = getPreferredSort(persistedView.sort, availableFieldIds);
+  if (preferredSort) {
+    view.sort = preferredSort;
+  }
+
+  const preferredFields = getPreferredFields(
+    persistedView.fields,
+    availableFieldIds,
+  );
+  if (preferredFields) {
+    view.fields = preferredFields;
+  }
+
+  if (isRecord(persistedView.layout)) {
+    view.layout = persistedView.layout;
+  }
+
+  const titleField = getFieldPreference(
+    persistedView,
+    'titleField',
+    availableFieldIds,
+  );
+  if (titleField) {
+    view.titleField = titleField;
+  }
+
+  const descriptionField = getFieldPreference(
+    persistedView,
+    'descriptionField',
+    availableFieldIds,
+  );
+  if (descriptionField) {
+    view.descriptionField = descriptionField;
+  }
+
+  const mediaField = getFieldPreference(
+    persistedView,
+    'mediaField',
+    availableFieldIds,
+  );
+  if (mediaField) {
+    view.mediaField = mediaField;
+  }
+
+  const showTitle = getBooleanPreference(persistedView, 'showTitle');
+  if (showTitle !== undefined) {
+    view.showTitle = showTitle;
+  }
+
+  const showDescription = getBooleanPreference(
+    persistedView,
+    'showDescription',
+  );
+  if (showDescription !== undefined) {
+    view.showDescription = showDescription;
+  }
+
+  const showMedia = getBooleanPreference(persistedView, 'showMedia');
+  if (showMedia !== undefined) {
+    view.showMedia = showMedia;
+  }
+
+  return view;
+}

--- a/mailpoet/assets/js/src/common/preferences/index.ts
+++ b/mailpoet/assets/js/src/common/preferences/index.ts
@@ -1,0 +1,93 @@
+import { dispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+type PreferencesData = Record<string, Record<string, unknown>>;
+
+const EMPTY_PREFERENCES: PreferencesData = {};
+const LEGACY_PERSISTENCE_LAYER_FACTORY = '__unstableCreatePersistenceLayer';
+
+let isInitialized = false;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function getPreloadedPreferencesData(): PreferencesData {
+  if (typeof window === 'undefined') {
+    return EMPTY_PREFERENCES;
+  }
+  const preloadedData = window.mailpoet_preferences_data?.preloadedData;
+  return isRecord(preloadedData)
+    ? (preloadedData as PreferencesData)
+    : EMPTY_PREFERENCES;
+}
+
+export function getPreloadedPreference<T>(
+  scope: string,
+  name: string,
+): T | undefined {
+  const scopedPreferences = getPreloadedPreferencesData()[scope];
+  if (!isRecord(scopedPreferences)) {
+    return undefined;
+  }
+
+  return scopedPreferences[name] as T | undefined;
+}
+
+function createPersistenceLayer():
+  | MailPoetPreferencesPersistenceLayer
+  | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  const preferencesData = window.mailpoet_preferences_data;
+  const preferencesPersistence = window.wp?.preferencesPersistence;
+  if (!preferencesData || !preferencesPersistence) {
+    return undefined;
+  }
+
+  // Feature-detect and guard both factories: `create` is the stable API, the
+  // `__unstable*` one only exists on older WordPress versions and may change
+  // shape. On failure, degrade gracefully — preferences still work within the
+  // session from the preloaded data, they just don't persist across reloads.
+  if (typeof preferencesPersistence.create === 'function') {
+    try {
+      return preferencesPersistence.create({
+        preloadedData: getPreloadedPreferencesData(),
+        localStorageRestoreKey: `WP_PREFERENCES_USER_${preferencesData.currentUserId}`,
+      });
+    } catch {
+      return undefined;
+    }
+  }
+
+  const createLegacyPersistenceLayer =
+    preferencesPersistence[LEGACY_PERSISTENCE_LAYER_FACTORY];
+  if (typeof createLegacyPersistenceLayer === 'function') {
+    try {
+      return createLegacyPersistenceLayer(
+        getPreloadedPreferencesData(),
+        preferencesData.currentUserId,
+      );
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}
+
+export function initializeMailPoetPreferences(): void {
+  if (isInitialized) {
+    return;
+  }
+  isInitialized = true;
+
+  const persistenceLayer = createPersistenceLayer();
+  if (!persistenceLayer) {
+    return;
+  }
+
+  void dispatch(preferencesStore).setPersistenceLayer(persistenceLayer);
+}

--- a/mailpoet/assets/js/src/common/preferences/initialize.ts
+++ b/mailpoet/assets/js/src/common/preferences/initialize.ts
@@ -1,0 +1,3 @@
+import { initializeMailPoetPreferences } from './index';
+
+initializeMailPoetPreferences();

--- a/mailpoet/assets/js/src/common/translations/i18n.tsx
+++ b/mailpoet/assets/js/src/common/translations/i18n.tsx
@@ -1,13 +1,4 @@
-import { getLocaleData, setLocaleData } from '@wordpress/i18n';
-
-declare global {
-  interface Window {
-    wp: {
-      i18n: { getLocaleData: typeof getLocaleData };
-      date: Record<string, unknown>;
-    };
-  }
-}
+import { setLocaleData } from '@wordpress/i18n';
 
 // We are using "@wordpress/i18n" from our bundle while WordPress initializes
 // translation data on the core one — we need to pass the data to our code.

--- a/mailpoet/assets/js/src/forms/list.tsx
+++ b/mailpoet/assets/js/src/forms/list.tsx
@@ -6,7 +6,11 @@ import { DataViews, View, Action } from '@wordpress/dataviews';
 import { MailPoet } from 'mailpoet';
 import { Button } from 'common';
 import { withNpsPoll } from 'nps-poll.jsx';
-import { useDataViewsQuery, type ListingQueryParams } from 'common/dataviews';
+import {
+  getDataViewsPreference,
+  useDataViewsQuery,
+  type ListingQueryParams,
+} from 'common/dataviews';
 import { FormsHeading, onAddNewForm } from './heading';
 import { listFields } from './fields';
 import {
@@ -76,6 +80,9 @@ function FormListComponent(): JSX.Element {
   const [selection, setSelection] = useState<string[]>([]);
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
+  const [initialView] = useState<View>(() =>
+    getDataViewsPreference('forms', DEFAULT_VIEW, listFields),
+  );
 
   const load = useCallback(
     (params: ListingQueryParams) => getForms({ ...params, group }),
@@ -93,7 +100,7 @@ function FormListComponent(): JSX.Element {
     clearError: clearLoadError,
     refresh,
   } = useDataViewsQuery<FormListingItem>({
-    initialView: DEFAULT_VIEW,
+    initialView,
     load,
   });
 

--- a/mailpoet/assets/js/src/forms/list.tsx
+++ b/mailpoet/assets/js/src/forms/list.tsx
@@ -8,6 +8,7 @@ import { Button } from 'common';
 import { withNpsPoll } from 'nps-poll.jsx';
 import {
   getDataViewsPreference,
+  usePersistedDataViewsPreference,
   useDataViewsQuery,
   type ListingQueryParams,
 } from 'common/dataviews';
@@ -97,12 +98,18 @@ function FormListComponent(): JSX.Element {
     groups,
     isLoading,
     error: loadError,
+    onChangeView,
     clearError: clearLoadError,
     refresh,
   } = useDataViewsQuery<FormListingItem>({
     initialView,
     load,
   });
+  const handleViewChange = usePersistedDataViewsPreference(
+    'forms',
+    view,
+    onChangeView,
+  );
 
   // Surface broken-settings forms via the global notice system so admins
   // know to repair them. Each form is warned about at most once per page
@@ -339,7 +346,7 @@ function FormListComponent(): JSX.Element {
               data={items}
               fields={listFields}
               view={view}
-              onChangeView={setView}
+              onChangeView={handleViewChange}
               actions={actions}
               paginationInfo={paginationInfo}
               defaultLayouts={{ table: {} }}
@@ -362,6 +369,9 @@ function FormListComponent(): JSX.Element {
             >
               <div className="mailpoet-forms-dataviews__toolbar">
                 <DataViews.Search label={__('Search forms', 'mailpoet')} />
+                <div className="mailpoet-dataviews__toolbar-end">
+                  <DataViews.ViewConfig />
+                </div>
               </div>
               <DataViews.Layout />
               <DataViews.Footer />

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -115,8 +115,36 @@ type NumberCapability = BaseCapability & {
 type Capability = BooleanCapability | NumberCapability;
 type Capabilities = Record<string, Capability>;
 
+type MailPoetPreferencesData = {
+  currentUserId: number;
+  preloadedData?: Record<string, Record<string, unknown>>;
+};
+
+type MailPoetPreferencesPersistenceLayer = {
+  get: () => Promise<Record<string, Record<string, unknown>>>;
+  set: (value: Record<string, Record<string, unknown>>) => void;
+};
+
+type MailPoetPreferencesPersistence = {
+  create?: (options: {
+    preloadedData?: Record<string, Record<string, unknown>>;
+    localStorageRestoreKey?: string;
+  }) => MailPoetPreferencesPersistenceLayer;
+  __unstableCreatePersistenceLayer?: (
+    preloadedData?: Record<string, Record<string, unknown>>,
+    currentUserId?: number,
+  ) => MailPoetPreferencesPersistenceLayer;
+};
+
+type MailPoetWpGlobal = {
+  i18n: { getLocaleData: typeof import('@wordpress/i18n').getLocaleData };
+  date: Record<string, unknown>;
+  preferencesPersistence?: MailPoetPreferencesPersistence;
+};
+
 interface Window {
   ajaxurl: string;
+  wp: MailPoetWpGlobal;
   mailpoet_wp_locale: string;
   mailpoet_token: string;
   mailpoet_feature_flags: string;
@@ -145,6 +173,7 @@ interface Window {
   mailpoet_time_format: string;
   mailpoet_date_format: string;
   mailpoet_listing_per_page: string;
+  mailpoet_preferences_data?: MailPoetPreferencesData;
   mailpoet_signup_confirmation_enabled: boolean;
   mailpoet_bulk_confirmation_resend_limit: number;
   mailpoet_3rd_party_libs_enabled: string;

--- a/mailpoet/assets/js/src/logs/fields.tsx
+++ b/mailpoet/assets/js/src/logs/fields.tsx
@@ -118,3 +118,12 @@ export function getLogFields(
     },
   ];
 }
+
+const EMPTY_EXPANDED_LOG_IDS = new Set<number>();
+const NOOP_TOGGLE = (): void => undefined;
+
+// Stable field definitions for callers that only need the field schema (e.g.
+// DataViews preference validation), without per-row expand/collapse state.
+export function getLogFieldDefinitions(): Field<LogListingItem>[] {
+  return getLogFields(EMPTY_EXPANDED_LOG_IDS, NOOP_TOGGLE);
+}

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -4,7 +4,11 @@ import { DataViews, View } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 
 import { Button } from 'common';
-import { useDataViewsQuery, type ListingQueryParams } from 'common/dataviews';
+import {
+  getDataViewsPreference,
+  useDataViewsQuery,
+  type ListingQueryParams,
+} from 'common/dataviews';
 import { Datepicker } from '../common/datepicker/datepicker';
 import { buildLogsRequestParams, getLogs, type LogListingItem } from './api';
 import { getLogFields } from './fields';
@@ -35,13 +39,22 @@ function buildInitialView(defaultFrom: string): {
   view: View;
   dateFilters: DateFilters;
 } {
-  const state = parseLogsUrlState(window.location.href, defaultFrom);
+  const currentUrl = window.location.href;
+  const state = parseLogsUrlState(currentUrl, defaultFrom);
+  const searchParams = new URL(currentUrl).searchParams;
+  const hasPerPageUrlState =
+    searchParams.has('per_page') || searchParams.has('limit');
+  const preferredView = getDataViewsPreference(
+    'logs',
+    DEFAULT_VIEW,
+    getLogFields(new Set(), () => undefined),
+  );
 
   return {
     view: {
-      ...DEFAULT_VIEW,
+      ...preferredView,
       page: state.page,
-      perPage: state.perPage,
+      perPage: hasPerPageUrlState ? state.perPage : preferredView.perPage,
       search: state.search,
     },
     dateFilters: state.dateFilters,

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -6,12 +6,13 @@ import { __ } from '@wordpress/i18n';
 import { Button } from 'common';
 import {
   getDataViewsPreference,
+  usePersistedDataViewsPreference,
   useDataViewsQuery,
   type ListingQueryParams,
 } from 'common/dataviews';
 import { Datepicker } from '../common/datepicker/datepicker';
 import { buildLogsRequestParams, getLogs, type LogListingItem } from './api';
-import { getLogFields } from './fields';
+import { getLogFieldDefinitions, getLogFields } from './fields';
 import {
   buildLogsUrl,
   dateFromString,
@@ -47,7 +48,7 @@ function buildInitialView(defaultFrom: string): {
   const preferredView = getDataViewsPreference(
     'logs',
     DEFAULT_VIEW,
-    getLogFields(new Set(), () => undefined),
+    getLogFieldDefinitions(),
   );
 
   return {
@@ -124,6 +125,11 @@ export function List({ defaultFrom }: Props): JSX.Element {
       });
     },
     [setView, view],
+  );
+  const persistedViewChange = usePersistedDataViewsPreference(
+    'logs',
+    view,
+    updateView,
   );
 
   useEffect(() => {
@@ -204,7 +210,7 @@ export function List({ defaultFrom }: Props): JSX.Element {
         data={items}
         fields={fields}
         view={view}
-        onChangeView={updateView}
+        onChangeView={persistedViewChange}
         paginationInfo={paginationInfo}
         defaultLayouts={{ table: {} }}
         getItemId={(item) => String(item.id)}
@@ -277,6 +283,9 @@ export function List({ defaultFrom }: Props): JSX.Element {
             >
               {__('Clear', 'mailpoet')}
             </Button>
+          </div>
+          <div className="mailpoet-dataviews__toolbar-end">
+            <DataViews.ViewConfig />
           </div>
           {dateRangeError && (
             <div

--- a/mailpoet/assets/js/src/newsletters/listings/newsletters-listing.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/newsletters-listing.tsx
@@ -22,6 +22,7 @@ import { MailPoet } from 'mailpoet';
 import { MailerError } from 'notices/mailer-error';
 import {
   getDataViewsPreference,
+  usePersistedDataViewsPreference,
   useDataViewsQuery,
   type ListingGroup,
   type ListingQueryParams,
@@ -226,24 +227,25 @@ export function NewslettersListing({
     log: NewsletterMailerLog;
   }>({ method: null, log: { status: '' } });
 
+  const [defaultViewBase] = useState<View>(() => ({
+    type: 'table',
+    perPage: listingPerPage,
+    page: 1,
+    sort: defaultSort,
+    fields: defaultFields,
+    // `fields` always leads with the subject/name column; that is the row
+    // title. `defaultFields` lists only the *other* visible columns, so the
+    // title renders once and is never duplicated as a regular column.
+    titleField: fields[0]?.id,
+    showTitle: true,
+  }));
+  const getPreferredView = useCallback(
+    () =>
+      getDataViewsPreference(`newsletters-${type}`, defaultViewBase, fields),
+    [defaultViewBase, fields, type],
+  );
   const [initialView] = useState<View>(() => {
-    const defaultView: View = {
-      type: 'table',
-      perPage: listingPerPage,
-      page: 1,
-      sort: defaultSort,
-      fields: defaultFields,
-      // `fields` always leads with the subject/name column; that is the row
-      // title. `defaultFields` lists only the *other* visible columns, so the
-      // title renders once and is never duplicated as a regular column.
-      titleField: fields[0]?.id,
-      showTitle: true,
-    };
-    const preferredView = getDataViewsPreference(
-      `newsletters-${type}`,
-      defaultView,
-      fields,
-    );
+    const preferredView = getPreferredView();
     return {
       ...preferredView,
       perPage: hashState.perPage ?? preferredView.perPage,
@@ -324,15 +326,27 @@ export function NewslettersListing({
   }, [refresh, selection.length]);
 
   useEffect(() => {
+    // Compare against the preference-merged defaults, resolved at write time
+    // (not the hardcoded ones, not a mount-time snapshot), so reloading a URL
+    // without explicit params resolves to the same view it was written from.
+    const preferredView = getPreferredView();
     const hash = buildHash(baseUrl, group, view, filter, {
-      sort: defaultSort.field,
-      order: defaultSort.direction,
-      perPage: listingPerPage,
+      sort: preferredView.sort?.field ?? defaultSort.field,
+      order: preferredView.sort?.direction ?? defaultSort.direction,
+      perPage: preferredView.perPage ?? listingPerPage,
     });
     if (window.location.hash !== hash) {
       window.history.replaceState(null, '', hash);
     }
-  }, [baseUrl, defaultSort.direction, defaultSort.field, filter, group, view]);
+  }, [
+    baseUrl,
+    defaultSort.direction,
+    defaultSort.field,
+    filter,
+    getPreferredView,
+    group,
+    view,
+  ]);
 
   useEffect(() => {
     const applyHash = (): void => {
@@ -343,15 +357,21 @@ export function NewslettersListing({
       setFilter(next.filter ?? {});
       setSelection([]);
       clearLoadError();
+      // Fill hash segments the URL omits from the preference-merged defaults
+      // (not the in-memory view) so back/forward resolves a URL exactly like
+      // reopening it.
+      const preferredView = getPreferredView();
       setView((currentView) => ({
         ...currentView,
         page: next.page ?? 1,
-        perPage: next.perPage ?? currentView.perPage,
+        perPage: next.perPage ?? preferredView.perPage,
         search: next.search ?? '',
         sort: {
-          field: next.orderby ?? currentView.sort?.field ?? defaultSort.field,
+          field: next.orderby ?? preferredView.sort?.field ?? defaultSort.field,
           direction:
-            next.order ?? currentView.sort?.direction ?? defaultSort.direction,
+            next.order ??
+            preferredView.sort?.direction ??
+            defaultSort.direction,
         },
       }));
     };
@@ -362,6 +382,7 @@ export function NewslettersListing({
     clearLoadError,
     defaultSort.direction,
     defaultSort.field,
+    getPreferredView,
     setView,
     supportedGroups,
   ]);
@@ -436,6 +457,11 @@ export function NewslettersListing({
       onChangeView(nextView);
     },
     [onChangeView],
+  );
+  const persistedViewChange = usePersistedDataViewsPreference(
+    `newsletters-${type}`,
+    view,
+    handleViewChange,
   );
 
   const handleSelectionChange = useCallback(
@@ -685,7 +711,7 @@ export function NewslettersListing({
           data={items}
           fields={fields}
           view={view}
-          onChangeView={handleViewChange}
+          onChangeView={persistedViewChange}
           actions={actions}
           paginationInfo={paginationInfo}
           defaultLayouts={{ table: {} }}
@@ -742,6 +768,9 @@ export function NewslettersListing({
                 )}
               </div>
             )}
+            <div className="mailpoet-dataviews__toolbar-end">
+              <DataViews.ViewConfig />
+            </div>
           </div>
           <DataViews.Layout />
           <DataViews.Footer />

--- a/mailpoet/assets/js/src/newsletters/listings/newsletters-listing.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/newsletters-listing.tsx
@@ -21,6 +21,7 @@ import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import { MailerError } from 'notices/mailer-error';
 import {
+  getDataViewsPreference,
   useDataViewsQuery,
   type ListingGroup,
   type ListingQueryParams,
@@ -225,22 +226,39 @@ export function NewslettersListing({
     log: NewsletterMailerLog;
   }>({ method: null, log: { status: '' } });
 
-  const [initialView] = useState<View>(() => ({
-    type: 'table',
-    perPage: hashState.perPage ?? listingPerPage,
-    page: hashState.page ?? 1,
-    search: hashState.search,
-    sort: {
-      field: hashState.orderby ?? defaultSort.field,
-      direction: hashState.order ?? defaultSort.direction,
-    },
-    fields: defaultFields,
-    // `fields` always leads with the subject/name column; that is the row
-    // title. `defaultFields` lists only the *other* visible columns, so the
-    // title renders once and is never duplicated as a regular column.
-    titleField: fields[0]?.id,
-    showTitle: true,
-  }));
+  const [initialView] = useState<View>(() => {
+    const defaultView: View = {
+      type: 'table',
+      perPage: listingPerPage,
+      page: 1,
+      sort: defaultSort,
+      fields: defaultFields,
+      // `fields` always leads with the subject/name column; that is the row
+      // title. `defaultFields` lists only the *other* visible columns, so the
+      // title renders once and is never duplicated as a regular column.
+      titleField: fields[0]?.id,
+      showTitle: true,
+    };
+    const preferredView = getDataViewsPreference(
+      `newsletters-${type}`,
+      defaultView,
+      fields,
+    );
+    return {
+      ...preferredView,
+      perPage: hashState.perPage ?? preferredView.perPage,
+      page: hashState.page ?? 1,
+      search: hashState.search,
+      sort: {
+        field:
+          hashState.orderby ?? preferredView.sort?.field ?? defaultSort.field,
+        direction:
+          hashState.order ??
+          preferredView.sort?.direction ??
+          defaultSort.direction,
+      },
+    };
+  });
 
   const load = useCallback(
     (params: ListingQueryParams, signal?: AbortSignal) => {

--- a/mailpoet/assets/js/src/newsletters/sending-status/sending-status.tsx
+++ b/mailpoet/assets/js/src/newsletters/sending-status/sending-status.tsx
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
 
 import { MailPoet } from 'mailpoet';
 import {
+  getDataViewsPreference,
   useDataViewsQuery,
   type ListingGroup,
   type ListingQueryParams,
@@ -152,20 +153,37 @@ export function SendingStatus() {
     [baseUrl],
   );
   const [group, setGroup] = useState<string>(hashState.group ?? 'all');
+  const fields = useMemo(() => buildFields(), []);
 
-  const [initialView] = useState<View>(() => ({
-    type: 'table',
-    perPage: hashState.perPage ?? listingPerPage,
-    page: hashState.page ?? 1,
-    search: hashState.search,
-    sort: {
-      field: hashState.orderby ?? DEFAULT_SORT.field,
-      direction: hashState.order ?? DEFAULT_SORT.direction,
-    },
-    fields: ['failed', 'error'],
-    titleField: 'subscriberId',
-    showTitle: true,
-  }));
+  const [initialView] = useState<View>(() => {
+    const preferredView = getDataViewsPreference(
+      'sending-status',
+      {
+        type: 'table',
+        perPage: listingPerPage,
+        page: 1,
+        sort: DEFAULT_SORT,
+        fields: ['failed', 'error'],
+        titleField: 'subscriberId',
+        showTitle: true,
+      },
+      fields,
+    );
+    return {
+      ...preferredView,
+      perPage: hashState.perPage ?? preferredView.perPage,
+      page: hashState.page ?? 1,
+      search: hashState.search,
+      sort: {
+        field:
+          hashState.orderby ?? preferredView.sort?.field ?? DEFAULT_SORT.field,
+        direction:
+          hashState.order ??
+          preferredView.sort?.direction ??
+          DEFAULT_SORT.direction,
+      },
+    };
+  });
 
   const load = useCallback(
     async (queryParams: ListingQueryParams, signal?: AbortSignal) => {
@@ -279,8 +297,6 @@ export function SendingStatus() {
     },
     [newsletterId, refresh],
   );
-
-  const fields = useMemo(() => buildFields(), []);
 
   const actions = useMemo<Action<SendingStatusItem>[]>(
     () => [

--- a/mailpoet/assets/js/src/newsletters/sending-status/sending-status.tsx
+++ b/mailpoet/assets/js/src/newsletters/sending-status/sending-status.tsx
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import {
   getDataViewsPreference,
+  usePersistedDataViewsPreference,
   useDataViewsQuery,
   type ListingGroup,
   type ListingQueryParams,
@@ -155,20 +156,25 @@ export function SendingStatus() {
   const [group, setGroup] = useState<string>(hashState.group ?? 'all');
   const fields = useMemo(() => buildFields(), []);
 
+  const getPreferredView = useCallback(
+    () =>
+      getDataViewsPreference(
+        'sending-status',
+        {
+          type: 'table',
+          perPage: listingPerPage,
+          page: 1,
+          sort: DEFAULT_SORT,
+          fields: ['failed', 'error'],
+          titleField: 'subscriberId',
+          showTitle: true,
+        },
+        fields,
+      ),
+    [fields],
+  );
   const [initialView] = useState<View>(() => {
-    const preferredView = getDataViewsPreference(
-      'sending-status',
-      {
-        type: 'table',
-        perPage: listingPerPage,
-        page: 1,
-        sort: DEFAULT_SORT,
-        fields: ['failed', 'error'],
-        titleField: 'subscriberId',
-        showTitle: true,
-      },
-      fields,
-    );
+    const preferredView = getPreferredView();
     return {
       ...preferredView,
       perPage: hashState.perPage ?? preferredView.perPage,
@@ -220,23 +226,32 @@ export function SendingStatus() {
     clearError,
     refresh,
   } = useDataViewsQuery<SendingStatusItem>({ initialView, load });
+  const persistedViewChange = usePersistedDataViewsPreference(
+    'sending-status',
+    view,
+    onChangeView,
+  );
 
   useEffect(() => {
+    // Compare against the preference-merged defaults, resolved at write time
+    // (not the hardcoded ones, not a mount-time snapshot), so reloading a URL
+    // without explicit params resolves to the same view it was written from.
+    const preferredView = getPreferredView();
     const hash = buildHash(
       baseUrl,
       group,
       view,
       {},
       {
-        sort: DEFAULT_SORT.field,
-        order: DEFAULT_SORT.direction,
-        perPage: listingPerPage,
+        sort: preferredView.sort?.field ?? DEFAULT_SORT.field,
+        order: preferredView.sort?.direction ?? DEFAULT_SORT.direction,
+        perPage: preferredView.perPage ?? listingPerPage,
       },
     );
     if (window.location.hash !== hash) {
       window.history.replaceState(null, '', hash);
     }
-  }, [baseUrl, group, view]);
+  }, [baseUrl, getPreferredView, group, view]);
 
   useEffect(() => {
     const applyHash = (): void => {
@@ -245,21 +260,28 @@ export function SendingStatus() {
       ]);
       setGroup(next.group ?? 'all');
       clearError();
+      // Fill hash segments the URL omits from the preference-merged defaults
+      // (not the in-memory view) so back/forward resolves a URL exactly like
+      // reopening it.
+      const preferredView = getPreferredView();
       setView((currentView) => ({
         ...currentView,
         page: next.page ?? 1,
-        perPage: next.perPage ?? currentView.perPage,
+        perPage: next.perPage ?? preferredView.perPage,
         search: next.search ?? '',
         sort: {
-          field: next.orderby ?? currentView.sort?.field ?? DEFAULT_SORT.field,
+          field:
+            next.orderby ?? preferredView.sort?.field ?? DEFAULT_SORT.field,
           direction:
-            next.order ?? currentView.sort?.direction ?? DEFAULT_SORT.direction,
+            next.order ??
+            preferredView.sort?.direction ??
+            DEFAULT_SORT.direction,
         },
       }));
     };
     window.addEventListener('hashchange', applyHash);
     return () => window.removeEventListener('hashchange', applyHash);
-  }, [baseUrl, clearError, setView]);
+  }, [baseUrl, clearError, getPreferredView, setView]);
 
   // Auto-refresh on the WP heartbeat tick.
   useEffect(() => {
@@ -412,7 +434,7 @@ export function SendingStatus() {
           data={items}
           fields={fields}
           view={view}
-          onChangeView={onChangeView}
+          onChangeView={persistedViewChange}
           actions={actions}
           paginationInfo={paginationInfo}
           defaultLayouts={{ table: {} }}
@@ -422,6 +444,9 @@ export function SendingStatus() {
         >
           <div className="mailpoet-dataviews__toolbar">
             <DataViews.Search label={__('Search', 'mailpoet')} />
+            <div className="mailpoet-dataviews__toolbar-end">
+              <DataViews.ViewConfig />
+            </div>
           </div>
           <DataViews.Layout />
           <DataViews.Footer />

--- a/mailpoet/assets/js/src/segments/dynamic/list.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list.tsx
@@ -7,7 +7,11 @@ import {
 } from '@wordpress/components';
 import { DataViews, View, Action } from '@wordpress/dataviews';
 import { escapeHTML } from '@wordpress/escape-html';
-import { useDataViewsQuery, type ListingQueryParams } from 'common/dataviews';
+import {
+  getDataViewsPreference,
+  useDataViewsQuery,
+  type ListingQueryParams,
+} from 'common/dataviews';
 import { Notices } from './list/notices';
 import { getSegmentsQuery, updateSegmentsQuery } from './list/query';
 import * as ROUTES from '../routes';
@@ -41,9 +45,12 @@ const DEFAULT_VIEW_BASE: View = {
   showTitle: true,
 };
 
-function viewFromQuery(query: ReturnType<typeof getSegmentsQuery>): View {
+function viewFromQuery(
+  query: ReturnType<typeof getSegmentsQuery>,
+  defaultView = DEFAULT_VIEW_BASE,
+): View {
   return {
-    ...DEFAULT_VIEW_BASE,
+    ...defaultView,
     perPage: query.limit,
     page: Math.floor(query.offset / query.limit) + 1,
     search: query.search,
@@ -196,6 +203,15 @@ function confirmCopy(pendingAction: PendingAction): {
 
 export function DynamicSegmentList(): JSX.Element {
   const [initialQuery] = useState(() => getSegmentsQuery());
+  const defaultView = useMemo(
+    () =>
+      getDataViewsPreference(
+        'dynamic-segments',
+        DEFAULT_VIEW_BASE,
+        dynamicSegmentFields,
+      ),
+    [],
+  );
   const [group, setGroup] = useState<Group>(initialQuery.group as Group);
   const [selection, setSelection] = useState<string[]>([]);
   const [globalError, setGlobalError] = useState<string | null>(null);
@@ -204,7 +220,7 @@ export function DynamicSegmentList(): JSX.Element {
   const legacyOffsetRef = useRef<number | null>(
     usesNonPageAlignedOffset(initialQuery) ? initialQuery.offset : null,
   );
-  const latestViewRef = useRef<View>(viewFromQuery(initialQuery));
+  const latestViewRef = useRef<View>(viewFromQuery(initialQuery, defaultView));
   const latestGroupRef = useRef<Group>(initialQuery.group as Group);
 
   const load = useCallback(
@@ -223,7 +239,7 @@ export function DynamicSegmentList(): JSX.Element {
     clearError: clearLoadError,
     refresh,
   } = useDataViewsQuery<DynamicSegmentListingItem>({
-    initialView: viewFromQuery(initialQuery),
+    initialView: viewFromQuery(initialQuery, defaultView),
     load,
     extraParams: (currentView) => {
       if (
@@ -285,7 +301,7 @@ export function DynamicSegmentList(): JSX.Element {
         setView((currentView) =>
           viewMatchesQuery(currentView, nextQuery)
             ? currentView
-            : viewFromQuery(nextQuery),
+            : viewFromQuery(nextQuery, defaultView),
         );
       }
       setSelection([]);
@@ -296,7 +312,7 @@ export function DynamicSegmentList(): JSX.Element {
 
     window.addEventListener('hashchange', applyHashState);
     return () => window.removeEventListener('hashchange', applyHashState);
-  }, [clearLoadError, setView]);
+  }, [clearLoadError, defaultView, setView]);
 
   const handleViewChange = (nextView: View): void => {
     legacyOffsetRef.current = null;

--- a/mailpoet/assets/js/src/segments/dynamic/list.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list.tsx
@@ -9,6 +9,7 @@ import { DataViews, View, Action } from '@wordpress/dataviews';
 import { escapeHTML } from '@wordpress/escape-html';
 import {
   getDataViewsPreference,
+  usePersistedDataViewsPreference,
   useDataViewsQuery,
   type ListingQueryParams,
 } from 'common/dataviews';
@@ -44,6 +45,19 @@ const DEFAULT_VIEW_BASE: View = {
   titleField: 'name',
   showTitle: true,
 };
+
+// The hash omits values that equal the query defaults, so the persisted
+// view preference must be part of the defaults — otherwise an empty hash
+// would always reset sort and per-page back to the hardcoded values.
+function queryDefaultsFromView(
+  view: View,
+): Partial<ReturnType<typeof getSegmentsQuery>> {
+  return {
+    limit: view.perPage ?? 25,
+    sort_by: view.sort?.field ?? 'updated_at',
+    sort_order: view.sort?.direction ?? 'desc',
+  };
+}
 
 function viewFromQuery(
   query: ReturnType<typeof getSegmentsQuery>,
@@ -202,7 +216,19 @@ function confirmCopy(pendingAction: PendingAction): {
 }
 
 export function DynamicSegmentList(): JSX.Element {
-  const [initialQuery] = useState(() => getSegmentsQuery());
+  // Resolved at call time (not mount time) so query defaults reflect
+  // preferences persisted during the session.
+  const getQueryDefaults = useCallback(
+    () =>
+      queryDefaultsFromView(
+        getDataViewsPreference(
+          'dynamic-segments',
+          DEFAULT_VIEW_BASE,
+          dynamicSegmentFields,
+        ),
+      ),
+    [],
+  );
   const defaultView = useMemo(
     () =>
       getDataViewsPreference(
@@ -211,6 +237,9 @@ export function DynamicSegmentList(): JSX.Element {
         dynamicSegmentFields,
       ),
     [],
+  );
+  const [initialQuery] = useState(() =>
+    getSegmentsQuery(window.location.hash, getQueryDefaults()),
   );
   const [group, setGroup] = useState<Group>(initialQuery.group as Group);
   const [selection, setSelection] = useState<string[]>([]);
@@ -236,6 +265,7 @@ export function DynamicSegmentList(): JSX.Element {
     groups,
     isLoading,
     error: loadError,
+    onChangeView,
     clearError: clearLoadError,
     refresh,
   } = useDataViewsQuery<DynamicSegmentListingItem>({
@@ -277,19 +307,25 @@ export function DynamicSegmentList(): JSX.Element {
     ) {
       return;
     }
-    updateSegmentsQuery({
-      group,
-      limit: view.perPage ?? 25,
-      offset: ((view.page ?? 1) - 1) * (view.perPage ?? 25),
-      search: view.search ?? '',
-      sort_by: view.sort?.field ?? 'updated_at',
-      sort_order: view.sort?.direction ?? 'desc',
-    });
-  }, [group, initialQuery, view]);
+    updateSegmentsQuery(
+      {
+        group,
+        limit: view.perPage ?? 25,
+        offset: ((view.page ?? 1) - 1) * (view.perPage ?? 25),
+        search: view.search ?? '',
+        sort_by: view.sort?.field ?? 'updated_at',
+        sort_order: view.sort?.direction ?? 'desc',
+      },
+      getQueryDefaults(),
+    );
+  }, [getQueryDefaults, group, initialQuery, view]);
 
   useEffect(() => {
     const applyHashState = (): void => {
-      const nextQuery = getSegmentsQuery();
+      const nextQuery = getSegmentsQuery(
+        window.location.hash,
+        getQueryDefaults(),
+      );
       const nextGroup = nextQuery.group as Group;
       legacyOffsetRef.current = usesNonPageAlignedOffset(nextQuery)
         ? nextQuery.offset
@@ -298,10 +334,13 @@ export function DynamicSegmentList(): JSX.Element {
         setGroup(nextGroup);
       }
       if (!viewMatchesQuery(latestViewRef.current, nextQuery)) {
+        // Rebuild from the current view, not the default one, so state the
+        // hash doesn't encode (active DataViews filters, column choices)
+        // survives browser navigation.
         setView((currentView) =>
           viewMatchesQuery(currentView, nextQuery)
             ? currentView
-            : viewFromQuery(nextQuery, defaultView),
+            : viewFromQuery(nextQuery, currentView),
         );
       }
       setSelection([]);
@@ -312,12 +351,20 @@ export function DynamicSegmentList(): JSX.Element {
 
     window.addEventListener('hashchange', applyHashState);
     return () => window.removeEventListener('hashchange', applyHashState);
-  }, [clearLoadError, defaultView, setView]);
+  }, [clearLoadError, getQueryDefaults, setView]);
 
-  const handleViewChange = (nextView: View): void => {
-    legacyOffsetRef.current = null;
-    setView(nextView);
-  };
+  const handleViewChange = useCallback(
+    (nextView: View): void => {
+      legacyOffsetRef.current = null;
+      onChangeView(nextView);
+    },
+    [onChangeView],
+  );
+  const persistedViewChange = usePersistedDataViewsPreference(
+    'dynamic-segments',
+    view,
+    handleViewChange,
+  );
 
   const handleBulkAction = useCallback(
     async (
@@ -549,7 +596,7 @@ export function DynamicSegmentList(): JSX.Element {
               data={items}
               fields={dynamicSegmentFields}
               view={view}
-              onChangeView={handleViewChange}
+              onChangeView={persistedViewChange}
               actions={actions}
               paginationInfo={paginationInfo}
               defaultLayouts={{ table: {} }}
@@ -561,6 +608,9 @@ export function DynamicSegmentList(): JSX.Element {
             >
               <div className="mailpoet-segments-dataviews__toolbar">
                 <DataViews.Search label={__('Search', 'mailpoet')} />
+                <div className="mailpoet-dataviews__toolbar-end">
+                  <DataViews.ViewConfig />
+                </div>
               </div>
               <DataViews.Layout />
               <DataViews.Footer />

--- a/mailpoet/assets/js/src/segments/dynamic/list/query.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/list/query.ts
@@ -23,8 +23,11 @@ function parseQuery(path: string): Partial<Query> {
     .reduce((map, [k, v]) => ({ ...map, [k]: v }), {});
 }
 
-export function getSegmentsQuery(path: string = window.location.hash): Query {
-  return { ...defaultQuery, ...parseQuery(path) };
+export function getSegmentsQuery(
+  path: string = window.location.hash,
+  defaults: Partial<Query> = {},
+): Query {
+  return { ...defaultQuery, ...defaults, ...parseQuery(path) };
 }
 
 export function useSegmentsQuery(): Query {
@@ -32,12 +35,16 @@ export function useSegmentsQuery(): Query {
   return useMemo(() => getSegmentsQuery(location.pathname), [location]);
 }
 
-export function updateSegmentsQuery(query: Partial<Query>): void {
+export function updateSegmentsQuery(
+  query: Partial<Query>,
+  defaults: Partial<Query> = {},
+): void {
+  const effectiveDefaults = { ...defaultQuery, ...defaults };
   const queryEntries = Object.entries({
     ...parseQuery(window.location.hash),
     ...query,
   })
-    .filter(([key, value]) => value !== defaultQuery[key])
+    .filter(([key, value]) => value !== effectiveDefaults[key])
     .sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
 
   const hash = queryEntries.reduce(

--- a/mailpoet/assets/js/src/segments/static/fields.ts
+++ b/mailpoet/assets/js/src/segments/static/fields.ts
@@ -26,6 +26,23 @@ function dateTime(value: string | null): JSX.Element {
   );
 }
 
+const engagementScoreFields: Field<SegmentListingItem>[] = MailPoet
+  .trackingConfig.emailTrackingEnabled
+  ? [
+      {
+        id: 'average_engagement_score',
+        label: MailPoet.I18n.t('listScore'),
+        enableSorting: true,
+        enableGlobalSearch: false,
+        render: ({ item }) =>
+          createElement(ListingsEngagementScore, {
+            id: Number(item.id),
+            engagementScore: item.average_engagement_score,
+          }),
+      },
+    ]
+  : [];
+
 export const segmentFields: Field<SegmentListingItem>[] = [
   {
     id: 'name',
@@ -81,21 +98,21 @@ export const segmentFields: Field<SegmentListingItem>[] = [
     enableSorting: false,
     enableGlobalSearch: false,
   },
-  ...(MailPoet.trackingConfig.emailTrackingEnabled
-    ? [
-        {
-          id: 'average_engagement_score',
-          label: MailPoet.I18n.t('listScore'),
-          enableSorting: true,
-          enableGlobalSearch: false,
-          render: ({ item }) =>
-            createElement(ListingsEngagementScore, {
-              id: Number(item.id),
-              engagementScore: item.average_engagement_score,
-            }),
-        },
-      ]
-    : []),
+  {
+    id: 'type',
+    label: __('Type', 'mailpoet'),
+    elements: [
+      { value: 'default', label: __('List', 'mailpoet') },
+      { value: 'wp_users', label: __('WordPress users', 'mailpoet') },
+      {
+        value: 'woocommerce_users',
+        label: __('WooCommerce customers', 'mailpoet'),
+      },
+    ],
+    enableSorting: false,
+    enableGlobalSearch: false,
+  },
+  ...engagementScoreFields,
   {
     id: 'subscribed',
     label: MailPoet.I18n.t('subscribed'),

--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -11,6 +11,7 @@ import { MailPoet } from 'mailpoet';
 import { HideScreenOptions } from 'common/hide-screen-options/hide-screen-options';
 import {
   getDataViewsPreference,
+  usePersistedDataViewsPreference,
   useDataViewsQuery,
   type ListingQueryParams,
 } from 'common/dataviews';
@@ -103,25 +104,30 @@ function parseHash(): Partial<{
     }, {});
 }
 
-function updateHash(group: Group, view: View): void {
+// `defaults` is the preference-merged view the listing falls back to when the
+// URL omits a param. Comparing against it (not the hardcoded site defaults)
+// keeps the URL round-trip lossless: reloading a URL without explicit params
+// resolves to the same view the URL was written from.
+function updateHash(group: Group, view: View, defaults: View): void {
   const entries: Array<[string, string | number | undefined]> = [
     ['group', group],
     ['page', view.page && view.page !== 1 ? view.page : undefined],
     [
       'limit',
-      view.perPage && view.perPage !== listingPerPage
+      view.perPage && view.perPage !== (defaults.perPage ?? listingPerPage)
         ? view.perPage
         : undefined,
     ],
     [
       'sort_by',
-      view.sort?.field && view.sort.field !== 'name'
+      view.sort?.field && view.sort.field !== (defaults.sort?.field ?? 'name')
         ? view.sort.field
         : undefined,
     ],
     [
       'sort_order',
-      view.sort?.direction && view.sort.direction !== 'asc'
+      view.sort?.direction &&
+      view.sort.direction !== (defaults.sort?.direction ?? 'asc')
         ? view.sort.direction
         : undefined,
     ],
@@ -257,22 +263,18 @@ function SegmentListComponent(): JSX.Element {
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
-  const [initialView] = useState<View>(() => {
-    const preferredView = getDataViewsPreference(
-      'static-segments',
-      DEFAULT_VIEW,
-      segmentFields,
-    );
-    return {
-      ...preferredView,
-      page: hashState.page ?? preferredView.page,
-      perPage: hashState.perPage ?? preferredView.perPage,
-      sort: {
-        field: hashState.orderby ?? preferredView.sort?.field ?? 'name',
-        direction: hashState.order ?? preferredView.sort?.direction ?? 'asc',
-      },
-    };
-  });
+  const [preferredView] = useState<View>(() =>
+    getDataViewsPreference('static-segments', DEFAULT_VIEW, segmentFields),
+  );
+  const [initialView] = useState<View>(() => ({
+    ...preferredView,
+    page: hashState.page ?? preferredView.page,
+    perPage: hashState.perPage ?? preferredView.perPage,
+    sort: {
+      field: hashState.orderby ?? preferredView.sort?.field ?? 'name',
+      direction: hashState.order ?? preferredView.sort?.direction ?? 'asc',
+    },
+  }));
 
   const load = useCallback(
     (params: ListingQueryParams) => getSegments({ ...params, group }),
@@ -287,15 +289,27 @@ function SegmentListComponent(): JSX.Element {
     groups,
     isLoading,
     error: loadError,
+    onChangeView,
     clearError: clearLoadError,
     refresh,
   } = useDataViewsQuery<SegmentListingItem>({
     initialView,
     load,
   });
+  const handleViewChange = usePersistedDataViewsPreference(
+    'static-segments',
+    view,
+    onChangeView,
+  );
 
   useEffect(() => {
-    updateHash(group, view);
+    // Resolve the defaults at write time (not mount time) so preferences
+    // persisted during the session are reflected.
+    updateHash(
+      group,
+      view,
+      getDataViewsPreference('static-segments', DEFAULT_VIEW, segmentFields),
+    );
   }, [group, view]);
 
   const handleBulkAction = useCallback(
@@ -612,7 +626,7 @@ function SegmentListComponent(): JSX.Element {
               data={items}
               fields={segmentFields}
               view={view}
-              onChangeView={setView}
+              onChangeView={handleViewChange}
               actions={actions}
               paginationInfo={paginationInfo}
               defaultLayouts={{ table: {} }}
@@ -624,6 +638,9 @@ function SegmentListComponent(): JSX.Element {
             >
               <div className="mailpoet-segments-dataviews__toolbar">
                 <DataViews.Search label={__('Search', 'mailpoet')} />
+                <div className="mailpoet-dataviews__toolbar-end">
+                  <DataViews.ViewConfig />
+                </div>
               </div>
               {group === 'trash' && (groupCounts.trash ?? 0) > 0 && (
                 <div className="mailpoet-segments-dataviews__toolbar">

--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -9,7 +9,11 @@ import { escapeHTML } from '@wordpress/escape-html';
 import { DataViews, View, Action } from '@wordpress/dataviews';
 import { MailPoet } from 'mailpoet';
 import { HideScreenOptions } from 'common/hide-screen-options/hide-screen-options';
-import { useDataViewsQuery, type ListingQueryParams } from 'common/dataviews';
+import {
+  getDataViewsPreference,
+  useDataViewsQuery,
+  type ListingQueryParams,
+} from 'common/dataviews';
 import { ListHeading } from 'segments/static/heading';
 import {
   bulkAction,
@@ -253,15 +257,22 @@ function SegmentListComponent(): JSX.Element {
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
-  const [initialView] = useState<View>(() => ({
-    ...DEFAULT_VIEW,
-    page: hashState.page ?? DEFAULT_VIEW.page,
-    perPage: hashState.perPage ?? DEFAULT_VIEW.perPage,
-    sort: {
-      field: hashState.orderby ?? DEFAULT_VIEW.sort?.field ?? 'name',
-      direction: hashState.order ?? DEFAULT_VIEW.sort?.direction ?? 'asc',
-    },
-  }));
+  const [initialView] = useState<View>(() => {
+    const preferredView = getDataViewsPreference(
+      'static-segments',
+      DEFAULT_VIEW,
+      segmentFields,
+    );
+    return {
+      ...preferredView,
+      page: hashState.page ?? preferredView.page,
+      perPage: hashState.perPage ?? preferredView.perPage,
+      sort: {
+        field: hashState.orderby ?? preferredView.sort?.field ?? 'name',
+        direction: hashState.order ?? preferredView.sort?.direction ?? 'asc',
+      },
+    };
+  });
 
   const load = useCallback(
     (params: ListingQueryParams) => getSegments({ ...params, group }),

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
@@ -5,10 +5,11 @@ import { DataViews, View, Action } from '@wordpress/dataviews';
 import { BackButton, PageHeader } from 'common/page-header';
 import { TopBarWithBoundary } from 'common/top-bar/top-bar';
 import {
+  getDataViewsPreference,
   type LoadListing,
+  usePersistedDataViewsPreference,
   useDataViewsQuery,
-} from 'common/dataviews/use-dataviews-query';
-import { getDataViewsPreference } from 'common/dataviews';
+} from 'common/dataviews';
 import type { ListingGroup } from 'common/dataviews/types';
 import { CustomFieldsForm } from './custom-fields-form';
 import { listFields } from './fields';
@@ -136,12 +137,18 @@ export function CustomFieldsPage() {
     groups,
     isLoading,
     error: loadError,
+    onChangeView,
     refresh,
     clearError: clearLoadError,
   } = useDataViewsQuery<CustomField>({
     initialView,
     load,
   });
+  const handleViewChange = usePersistedDataViewsPreference(
+    'custom-fields',
+    view,
+    onChangeView,
+  );
 
   const handleBulkAction = useCallback(
     async (
@@ -416,7 +423,7 @@ export function CustomFieldsPage() {
               data={items}
               fields={listFields}
               view={view}
-              onChangeView={setView}
+              onChangeView={handleViewChange}
               actions={actions}
               paginationInfo={paginationInfo}
               defaultLayouts={{ table: {} }}
@@ -430,6 +437,9 @@ export function CustomFieldsPage() {
                 <DataViews.Search
                   label={__('Search custom fields', 'mailpoet')}
                 />
+                <div className="mailpoet-dataviews__toolbar-end">
+                  <DataViews.ViewConfig />
+                </div>
               </div>
               {group === 'trash' && (groupCounts.trash ?? 0) > 0 && (
                 <div className="mailpoet-custom-fields-dataviews__toolbar">

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
@@ -8,6 +8,7 @@ import {
   type LoadListing,
   useDataViewsQuery,
 } from 'common/dataviews/use-dataviews-query';
+import { getDataViewsPreference } from 'common/dataviews';
 import type { ListingGroup } from 'common/dataviews/types';
 import { CustomFieldsForm } from './custom-fields-form';
 import { listFields } from './fields';
@@ -104,6 +105,9 @@ export function CustomFieldsPage() {
   const [selection, setSelection] = useState<string[]>([]);
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
+  const [initialView] = useState<View>(() =>
+    getDataViewsPreference('custom-fields', DEFAULT_VIEW, listFields),
+  );
 
   const load = useCallback<LoadListing<CustomField>>(
     async (params) => {
@@ -135,7 +139,7 @@ export function CustomFieldsPage() {
     refresh,
     clearError: clearLoadError,
   } = useDataViewsQuery<CustomField>({
-    initialView: DEFAULT_VIEW,
+    initialView,
     load,
   });
 

--- a/mailpoet/assets/js/src/subscribers/fields.tsx
+++ b/mailpoet/assets/js/src/subscribers/fields.tsx
@@ -61,6 +61,31 @@ function dateTime(value: string | null): JSX.Element | null {
 export function getSubscriberFields(
   getBackUrl: () => string,
 ): Field<Subscriber>[] {
+  const statisticsFields: Field<Subscriber>[] = mailpoetTrackingEnabled
+    ? [
+        {
+          id: 'statistics',
+          label: __('Score', 'mailpoet'),
+          enableSorting: false,
+          enableGlobalSearch: false,
+          render: ({ item }) => (
+            <div className="mailpoet-listing-stats">
+              <Link
+                to={`/stats/${String(item.id)}`}
+                state={{ backUrl: getBackUrl() }}
+              >
+                <ListingsEngagementScore
+                  id={Number(item.id)}
+                  engagementScore={item.engagement_score}
+                  engagementScoreType={item.engagement_score_type}
+                />
+              </Link>
+            </div>
+          ),
+        },
+      ]
+    : [];
+
   return [
     {
       id: 'email',
@@ -114,30 +139,7 @@ export function getSubscriberFields(
         />
       ),
     },
-    ...(mailpoetTrackingEnabled
-      ? [
-          {
-            id: 'statistics',
-            label: __('Score', 'mailpoet'),
-            enableSorting: false,
-            enableGlobalSearch: false,
-            render: ({ item }) => (
-              <div className="mailpoet-listing-stats">
-                <Link
-                  to={`/stats/${String(item.id)}`}
-                  state={{ backUrl: getBackUrl() }}
-                >
-                  <ListingsEngagementScore
-                    id={Number(item.id)}
-                    engagementScore={item.engagement_score}
-                    engagementScoreType={item.engagement_score_type}
-                  />
-                </Link>
-              </div>
-            ),
-          },
-        ]
-      : []),
+    ...statisticsFields,
     {
       id: 'last_subscribed_at',
       label: __('Subscribed on', 'mailpoet'),

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -23,7 +23,11 @@ import { useNavigate } from 'react-router-dom';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
 import { Button } from 'common';
-import { useDataViewsQuery, type ListingQueryParams } from 'common/dataviews';
+import {
+  getDataViewsPreference,
+  useDataViewsQuery,
+  type ListingQueryParams,
+} from 'common/dataviews';
 import type { ListingFilters, ListingGroup } from 'common/dataviews/types';
 import { Select } from 'common/form/select/select';
 import { MailPoet } from 'mailpoet';
@@ -687,16 +691,23 @@ function SubscriberList() {
   // double-click on Apply / Resend emails / Unsubscribe must not fan out into
   // two bulk-action requests.
   const pendingActionInFlightRef = useRef(false);
-  const [initialView] = useState<View>(() => ({
-    ...DEFAULT_VIEW,
-    page: hashState.page ?? DEFAULT_VIEW.page,
-    perPage: hashState.perPage ?? DEFAULT_VIEW.perPage,
-    search: hashState.search,
-    sort: {
-      field: hashState.orderby ?? DEFAULT_VIEW.sort?.field ?? 'created_at',
-      direction: hashState.order ?? DEFAULT_VIEW.sort?.direction ?? 'desc',
-    },
-  }));
+  const [initialView] = useState<View>(() => {
+    const preferredView = getDataViewsPreference(
+      'subscribers',
+      DEFAULT_VIEW,
+      getSubscriberFields(() => ''),
+    );
+    return {
+      ...preferredView,
+      page: hashState.page ?? preferredView.page,
+      perPage: hashState.perPage ?? preferredView.perPage,
+      search: hashState.search,
+      sort: {
+        field: hashState.orderby ?? preferredView.sort?.field ?? 'created_at',
+        direction: hashState.order ?? preferredView.sort?.direction ?? 'desc',
+      },
+    };
+  });
 
   const load = useCallback(
     (params: ListingQueryParams, signal?: AbortSignal) =>

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -17,7 +17,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type SetStateAction,
 } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -25,6 +24,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { Button } from 'common';
 import {
   getDataViewsPreference,
+  usePersistedDataViewsPreference,
   useDataViewsQuery,
   type ListingQueryParams,
 } from 'common/dataviews';
@@ -165,10 +165,15 @@ function parseHash(): Partial<{
     }, {});
 }
 
+// `defaults` is the preference-merged view the listing falls back to when the
+// URL omits a param. Comparing against it (not the hardcoded site defaults)
+// keeps the URL round-trip lossless: reloading a URL without explicit params
+// resolves to the same view the URL was written from.
 function getListingPath(
   group: Group,
   view: View,
   filter: Record<string, string>,
+  defaults: View,
 ): string {
   const filterValue = new URLSearchParams(filter).toString();
   const entries: Array<[string, string | number | undefined]> = [
@@ -178,19 +183,21 @@ function getListingPath(
     ['page', view.page && view.page !== 1 ? view.page : undefined],
     [
       'limit',
-      view.perPage && view.perPage !== listingPerPage
+      view.perPage && view.perPage !== (defaults.perPage ?? listingPerPage)
         ? view.perPage
         : undefined,
     ],
     [
       'sort_by',
-      view.sort?.field && view.sort.field !== 'created_at'
+      view.sort?.field &&
+      view.sort.field !== (defaults.sort?.field ?? 'created_at')
         ? view.sort.field
         : undefined,
     ],
     [
       'sort_order',
-      view.sort?.direction && view.sort.direction !== 'desc'
+      view.sort?.direction &&
+      view.sort.direction !== (defaults.sort?.direction ?? 'desc')
         ? view.sort.direction
         : undefined,
     ],
@@ -206,8 +213,9 @@ function updateHash(
   group: Group,
   view: View,
   filter: Record<string, string>,
+  defaults: View,
 ): void {
-  const path = getListingPath(group, view, filter);
+  const path = getListingPath(group, view, filter, defaults);
   const hash = `#${path}`;
   if (window.location.hash !== hash) {
     window.history.replaceState(null, '', hash);
@@ -691,23 +699,23 @@ function SubscriberList() {
   // double-click on Apply / Resend emails / Unsubscribe must not fan out into
   // two bulk-action requests.
   const pendingActionInFlightRef = useRef(false);
-  const [initialView] = useState<View>(() => {
-    const preferredView = getDataViewsPreference(
+  const [preferredView] = useState<View>(() =>
+    getDataViewsPreference(
       'subscribers',
       DEFAULT_VIEW,
       getSubscriberFields(() => ''),
-    );
-    return {
-      ...preferredView,
-      page: hashState.page ?? preferredView.page,
-      perPage: hashState.perPage ?? preferredView.perPage,
-      search: hashState.search,
-      sort: {
-        field: hashState.orderby ?? preferredView.sort?.field ?? 'created_at',
-        direction: hashState.order ?? preferredView.sort?.direction ?? 'desc',
-      },
-    };
-  });
+    ),
+  );
+  const [initialView] = useState<View>(() => ({
+    ...preferredView,
+    page: hashState.page ?? preferredView.page,
+    perPage: hashState.perPage ?? preferredView.perPage,
+    search: hashState.search,
+    sort: {
+      field: hashState.orderby ?? preferredView.sort?.field ?? 'created_at',
+      direction: hashState.order ?? preferredView.sort?.direction ?? 'desc',
+    },
+  }));
 
   const load = useCallback(
     (params: ListingQueryParams, signal?: AbortSignal) =>
@@ -738,9 +746,21 @@ function SubscriberList() {
     load,
   });
 
+  // Resolve the URL defaults at write time (not mount time) so preferences
+  // persisted during the session are reflected.
+  const getPreferredView = useCallback(
+    () =>
+      getDataViewsPreference(
+        'subscribers',
+        DEFAULT_VIEW,
+        getSubscriberFields(() => ''),
+      ),
+    [],
+  );
+
   useEffect(() => {
-    updateHash(group, view, filter);
-  }, [filter, group, view]);
+    updateHash(group, view, filter, getPreferredView());
+  }, [filter, group, view, getPreferredView]);
 
   // DataViews has no built-in URL state, so back/forward inside the listing
   // is wired manually. Browser navigation fires `hashchange`; programmatic
@@ -753,24 +773,28 @@ function SubscriberList() {
       setFilter(next.filter ?? {});
       setSelection([]);
       clearLoadError();
+      // Fill hash segments the URL omits from the preference-merged defaults
+      // (not the in-memory view) so back/forward resolves a URL exactly like
+      // reopening it.
+      const preferredDefaults = getPreferredView();
       setView((currentView) => ({
         ...currentView,
         page: next.page ?? 1,
-        perPage: next.perPage ?? currentView.perPage,
+        perPage: next.perPage ?? preferredDefaults.perPage,
         search: next.search ?? '',
         sort: {
-          field: next.orderby ?? currentView.sort?.field ?? 'created_at',
-          direction: next.order ?? currentView.sort?.direction ?? 'desc',
+          field: next.orderby ?? preferredDefaults.sort?.field ?? 'created_at',
+          direction: next.order ?? preferredDefaults.sort?.direction ?? 'desc',
         },
       }));
     };
     window.addEventListener('hashchange', applyHash);
     return () => window.removeEventListener('hashchange', applyHash);
-  }, [clearLoadError, setView]);
+  }, [clearLoadError, getPreferredView, setView]);
 
   const backUrl = useMemo(
-    () => getListingPath(group, view, filter),
-    [filter, group, view],
+    () => getListingPath(group, view, filter, getPreferredView()),
+    [filter, group, view, getPreferredView],
   );
   const backUrlRef = useRef(backUrl);
   backUrlRef.current = backUrl;
@@ -839,11 +863,16 @@ function SubscriberList() {
   );
 
   const handleViewChange = useCallback(
-    (nextView: SetStateAction<View>) => {
+    (nextView: View) => {
       setSelection([]);
       setView(nextView);
     },
     [setView],
+  );
+  const persistedViewChange = usePersistedDataViewsPreference(
+    'subscribers',
+    view,
+    handleViewChange,
   );
 
   const handleApiError = useCallback(
@@ -1292,7 +1321,7 @@ function SubscriberList() {
           data={items}
           fields={fields}
           view={view}
-          onChangeView={handleViewChange}
+          onChangeView={persistedViewChange}
           actions={actions}
           paginationInfo={paginationInfo}
           defaultLayouts={{ table: {} }}
@@ -1319,6 +1348,9 @@ function SubscriberList() {
                 void handleEmptyTrash();
               }}
             />
+            <div className="mailpoet-dataviews__toolbar-end">
+              <DataViews.ViewConfig />
+            </div>
           </div>
           <DataViews.Layout />
           <DataViews.Footer />

--- a/mailpoet/assets/js/src/subscribers/tags/tags-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/tags/tags-page.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
 import { DataViews, View, Action } from '@wordpress/dataviews';
+import { getDataViewsPreference } from 'common/dataviews';
 import { BackButton, PageHeader } from 'common/page-header';
 import { TopBarWithBoundary } from 'common/top-bar/top-bar';
 import { listFields } from './fields';
@@ -30,7 +31,9 @@ const DEFAULT_VIEW: View = {
 };
 
 export function TagsPage() {
-  const [view, setView] = useState<View>(DEFAULT_VIEW);
+  const [view, setView] = useState<View>(() =>
+    getDataViewsPreference('tags', DEFAULT_VIEW, listFields),
+  );
   const [items, setItems] = useState<Tag[]>([]);
   const [meta, setMeta] = useState<TagListMeta>({ count: 0, pages: 0 });
   const [isLoading, setIsLoading] = useState(false);

--- a/mailpoet/assets/js/src/subscribers/tags/tags-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/tags/tags-page.tsx
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
 import { DataViews, View, Action } from '@wordpress/dataviews';
-import { getDataViewsPreference } from 'common/dataviews';
+import {
+  getDataViewsPreference,
+  usePersistedDataViewsPreference,
+} from 'common/dataviews';
 import { BackButton, PageHeader } from 'common/page-header';
 import { TopBarWithBoundary } from 'common/top-bar/top-bar';
 import { listFields } from './fields';
@@ -30,6 +33,16 @@ const DEFAULT_VIEW: View = {
   showTitle: true,
 };
 
+function resetPageWhenQueryChanges(currentView: View, nextView: View): View {
+  const searchChanged = (nextView.search ?? '') !== (currentView.search ?? '');
+  const perPageChanged = nextView.perPage !== currentView.perPage;
+
+  return {
+    ...nextView,
+    page: searchChanged || perPageChanged ? 1 : nextView.page,
+  };
+}
+
 export function TagsPage() {
   const [view, setView] = useState<View>(() =>
     getDataViewsPreference('tags', DEFAULT_VIEW, listFields),
@@ -42,6 +55,14 @@ export function TagsPage() {
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
   const latestRequestIdRef = useRef(0);
+  const updateView = useCallback((nextView: View): void => {
+    setView((currentView) => resetPageWhenQueryChanges(currentView, nextView));
+  }, []);
+  const handleViewChange = usePersistedDataViewsPreference(
+    'tags',
+    view,
+    updateView,
+  );
 
   const loadTags = useCallback(async () => {
     const requestId = latestRequestIdRef.current + 1;
@@ -226,7 +247,7 @@ export function TagsPage() {
           data={items}
           fields={listFields}
           view={view}
-          onChangeView={setView}
+          onChangeView={handleViewChange}
           actions={actions}
           paginationInfo={paginationInfo}
           defaultLayouts={{ table: {} }}
@@ -236,8 +257,11 @@ export function TagsPage() {
           isLoading={isLoading}
           empty={<div>{__('No tags yet.', 'mailpoet')}</div>}
         >
-          <div className="mailpoet-tags-dataviews__toolbar">
+          <div className="mailpoet-dataviews__toolbar">
             <DataViews.Search label={__('Search tags', 'mailpoet')} />
+            <div className="mailpoet-dataviews__toolbar-end">
+              <DataViews.ViewConfig />
+            </div>
           </div>
           <DataViews.Layout />
           <DataViews.Footer />

--- a/mailpoet/assets/js/src/types/wordpress-modules.ts
+++ b/mailpoet/assets/js/src/types/wordpress-modules.ts
@@ -79,7 +79,7 @@ declare module '@wordpress/preferences' {
   export const store: { name: 'core/preferences' } & StoreDescriptor<{
     reducer: () => unknown;
     actions: {
-      set: (scope: string, name: string, value: any) => void;
+      set: (scope: string, name: string, value: any) => Promise<object>;
       setPersistenceLayer: (persistenceLayer: {
         get: () => Promise<Record<string, Record<string, any>>>;
         set: (value: Record<string, Record<string, any>>) => void;

--- a/mailpoet/assets/js/src/types/wordpress-modules.ts
+++ b/mailpoet/assets/js/src/types/wordpress-modules.ts
@@ -80,6 +80,10 @@ declare module '@wordpress/preferences' {
     reducer: () => unknown;
     actions: {
       set: (scope: string, name: string, value: any) => void;
+      setPersistenceLayer: (persistenceLayer: {
+        get: () => Promise<Record<string, Record<string, any>>>;
+        set: (value: Record<string, Record<string, any>>) => void;
+      }) => Promise<object>;
       toggle: (scope: string, name: string) => void;
     };
     selectors: {

--- a/mailpoet/assets/js/src/webpack-admin-index.tsx
+++ b/mailpoet/assets/js/src/webpack-admin-index.tsx
@@ -4,6 +4,7 @@
 // This is to avoid undefined import order & messy WebPack config.
 // Code can be gradually refactored to avoid side effects completely.
 
+import 'common/preferences/initialize';
 import 'homepage/homepage'; // side effect - renders ReactDOM to document
 import 'subscribers/subscribers.jsx'; // side effect - renders ReactDOM to document
 import 'newsletters/newsletters'; // side effect - renders ReactDOM to window

--- a/mailpoet/changelog/2026-06-10-21-36-59-added-per-user-listing-preferences-and-sorting-acros.md
+++ b/mailpoet/changelog/2026-06-10-21-36-59-added-per-user-listing-preferences-and-sorting-acros.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Per-user listing preferences and sorting across MailPoet list pages

--- a/mailpoet/changelog/2026-06-11-15-10-12-changed-replaced-the-per-page-screen-options-on-the-emails.md
+++ b/mailpoet/changelog/2026-06-11-15-10-12-changed-replaced-the-per-page-screen-options-on-the-emails.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+Replaced the per-page Screen Options on the Emails, Subscribers, and Lists pages with the DataViews view settings

--- a/mailpoet/lib/AdminPages/AssetsController.php
+++ b/mailpoet/lib/AdminPages/AssetsController.php
@@ -170,9 +170,28 @@ class AssetsController {
     $this->registerFooterScript(
       'mailpoet_admin',
       $this->getScriptUrl('admin.js'),
-      ['mailpoet_admin_vendor']
+      ['mailpoet_admin_vendor', 'wp-preferences-persistence']
     );
+    $this->wp->wpLocalizeScript('mailpoet_admin', 'mailpoet_preferences_data', [
+      'currentUserId' => $this->wp->getCurrentUserId(),
+      'preloadedData' => $this->getPersistedPreferences(),
+    ]);
     $this->wp->wpSetScriptTranslations('mailpoet_admin', 'mailpoet');
+  }
+
+  private function getPersistedPreferences(): \stdClass {
+    $currentUserId = $this->wp->getCurrentUserId();
+    if (!$currentUserId) {
+      return new \stdClass();
+    }
+
+    $preferences = $this->wp->getUserMeta(
+      $currentUserId,
+      $this->wp->getBlogPrefix() . 'persisted_preferences',
+      true
+    );
+
+    return is_array($preferences) ? (object)$preferences : new \stdClass();
   }
 
   private function getScriptUrl(string $name): string {

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -178,7 +178,6 @@ class Hooks {
     $this->setupWooCommerceOrderAttribution();
     $this->setupWooCommerceSubscriberEngagement();
     $this->setupWooCommerceTracking();
-    $this->setupListing();
     $this->setupSubscriptionEvents();
     $this->setupWooCommerceSubscriptionEvents();
     $this->setupAutomateWooSubscriptionEvents();
@@ -580,23 +579,6 @@ class Hooks {
       [$this->hooksWooCommerce, 'addTrackingData'],
       10
     );
-  }
-
-  public function setupListing() {
-    $this->wp->addFilter(
-      'set-screen-option',
-      [$this, 'setScreenOption'],
-      10,
-      3
-    );
-  }
-
-  public function setScreenOption($status, $option, $value) {
-    if (preg_match('/^mailpoet_(.*)_per_page$/', $option)) {
-      return $value;
-    } else {
-      return $status;
-    }
   }
 
   public function setupPostNotifications() {

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -242,7 +242,7 @@ class Menu {
     );
 
     // Emails page
-    $newslettersPage = $this->wp->addSubmenuPage(
+    $this->wp->addSubmenuPage(
       self::MAIN_PAGE_SLUG,
       $this->setPageTitle(__('Emails', 'mailpoet')),
       esc_html__('Emails', 'mailpoet'),
@@ -253,18 +253,6 @@ class Menu {
         'newsletters',
       ]
     );
-
-    // add limit per page to screen options
-    $this->wp->addAction('load-' . $newslettersPage, function() {
-      $this->wp->addScreenOption('per_page', [
-        'label' => _x(
-          'Number of newsletters per page',
-          'newsletters per page (screen options)',
-          'mailpoet'
-        ),
-        'option' => 'mailpoet_newsletters_per_page',
-      ]);
-    });
 
     // newsletter editor
     $this->wp->addSubmenuPage(

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -405,7 +405,7 @@ class Menu {
     );
 
     // Lists page
-    $listsPage = $this->wp->addSubmenuPage(
+    $this->wp->addSubmenuPage(
       self::MAIN_PAGE_SLUG,
       $this->setPageTitle(__('Lists', 'mailpoet')),
       esc_html__('Lists', 'mailpoet'),
@@ -416,21 +416,6 @@ class Menu {
         'lists',
       ]
     );
-
-    // add limit per page to screen options
-    // The lists page renders the StaticSegments listing, which reads its limit
-    // via PageLimit::getLimitPerPage('segments') -- so the screen option must
-    // write to the `mailpoet_segments_per_page` user meta.
-    $this->wp->addAction('load-' . $listsPage, function() {
-      $this->wp->addScreenOption('per_page', [
-        'label' => _x(
-          'Number of lists per page',
-          'lists per page (screen options)',
-          'mailpoet'
-        ),
-        'option' => 'mailpoet_segments_per_page',
-      ]);
-    });
 
     // Segments page
     $this->wp->addSubmenuPage(

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -316,7 +316,7 @@ class Menu {
     );
 
     // Subscribers page
-    $subscribersPage = $this->wp->addSubmenuPage(
+    $this->wp->addSubmenuPage(
       self::MAIN_PAGE_SLUG,
       $this->setPageTitle(__('Subscribers', 'mailpoet')),
       esc_html__('Subscribers', 'mailpoet'),
@@ -327,18 +327,6 @@ class Menu {
         'subscribers',
       ]
     );
-
-    // add limit per page to screen options
-    $this->wp->addAction('load-' . $subscribersPage, function() {
-      $this->wp->addScreenOption('per_page', [
-        'label' => _x(
-          'Number of subscribers per page',
-          'subscribers per page (screen options)',
-          'mailpoet'
-        ),
-        'option' => 'mailpoet_subscribers_per_page',
-      ]);
-    });
 
     // import
     $this->wp->addSubmenuPage(

--- a/mailpoet/lib/Form/Listing/FormListingRepository.php
+++ b/mailpoet/lib/Form/Listing/FormListingRepository.php
@@ -8,6 +8,11 @@ use MailPoet\Listing\ListingRepository;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 class FormListingRepository extends ListingRepository {
+  private const SORT_FIELDS = [
+    'name' => 'name',
+    'updatedAt' => 'updatedAt',
+  ];
+
   public function getGroups(ListingDefinition $definition): array {
     $queryBuilder = clone $this->queryBuilder;
     $this->applyFromClause($queryBuilder);
@@ -57,7 +62,9 @@ class FormListingRepository extends ListingRepository {
   }
 
   protected function applySorting(QueryBuilder $queryBuilder, string $sortBy, string $sortOrder) {
-    $queryBuilder->addOrderBy("f.$sortBy", $sortOrder);
+    $field = self::SORT_FIELDS[$sortBy] ?? 'updatedAt';
+    $queryBuilder->addOrderBy("f.$field", $sortOrder);
+    $queryBuilder->addOrderBy('f.id', 'asc');
   }
 
   protected function applySearch(QueryBuilder $queryBuilder, string $search, array $parameters = []) {

--- a/mailpoet/lib/Segments/SegmentListingRepository.php
+++ b/mailpoet/lib/Segments/SegmentListingRepository.php
@@ -11,11 +11,6 @@ use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 class SegmentListingRepository extends ListingRepository {
   const DEFAULT_SORT_BY = 'name';
-  private const TYPE_VALUES = [
-    SegmentEntity::TYPE_DEFAULT,
-    SegmentEntity::TYPE_WP_USERS,
-    SegmentEntity::TYPE_WC_USERS,
-  ];
 
   /** @var WooCommerce */
   private $wooCommerce;
@@ -52,13 +47,6 @@ class SegmentListingRepository extends ListingRepository {
   }
 
   protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
-    $types = $this->getFilterValues($filters, 'type', self::TYPE_VALUES);
-    if (!$types) {
-      return;
-    }
-    $queryBuilder
-      ->andWhere('s.type IN (:filterTypes)')
-      ->setParameter('filterTypes', $types);
   }
 
   protected function applyParameters(QueryBuilder $queryBuilder, array $parameters) {
@@ -76,23 +64,6 @@ class SegmentListingRepository extends ListingRepository {
       $sortBy = self::DEFAULT_SORT_BY;
     }
     $queryBuilder->addOrderBy("s.$sortBy", $sortOrder);
-  }
-
-  private function getFilterValues(array $filters, string $field, array $allowedValues): array {
-    $filter = $filters[$field] ?? null;
-    if (!is_array($filter)) {
-      return [];
-    }
-    $operator = isset($filter['operator']) && is_string($filter['operator']) ? $filter['operator'] : '';
-    if ($operator !== 'is' && $operator !== 'isAny') {
-      return [];
-    }
-    $value = $filter['value'] ?? null;
-    $values = is_array($value) ? $value : [$value];
-    return array_values(array_intersect(
-      array_map('strval', $values),
-      $allowedValues
-    ));
   }
 
   public function getGroups(ListingDefinition $definition): array {

--- a/mailpoet/lib/Segments/SegmentListingRepository.php
+++ b/mailpoet/lib/Segments/SegmentListingRepository.php
@@ -11,6 +11,11 @@ use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 class SegmentListingRepository extends ListingRepository {
   const DEFAULT_SORT_BY = 'name';
+  private const TYPE_VALUES = [
+    SegmentEntity::TYPE_DEFAULT,
+    SegmentEntity::TYPE_WP_USERS,
+    SegmentEntity::TYPE_WC_USERS,
+  ];
 
   /** @var WooCommerce */
   private $wooCommerce;
@@ -47,6 +52,13 @@ class SegmentListingRepository extends ListingRepository {
   }
 
   protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
+    $types = $this->getFilterValues($filters, 'type', self::TYPE_VALUES);
+    if (!$types) {
+      return;
+    }
+    $queryBuilder
+      ->andWhere('s.type IN (:filterTypes)')
+      ->setParameter('filterTypes', $types);
   }
 
   protected function applyParameters(QueryBuilder $queryBuilder, array $parameters) {
@@ -64,6 +76,23 @@ class SegmentListingRepository extends ListingRepository {
       $sortBy = self::DEFAULT_SORT_BY;
     }
     $queryBuilder->addOrderBy("s.$sortBy", $sortOrder);
+  }
+
+  private function getFilterValues(array $filters, string $field, array $allowedValues): array {
+    $filter = $filters[$field] ?? null;
+    if (!is_array($filter)) {
+      return [];
+    }
+    $operator = isset($filter['operator']) && is_string($filter['operator']) ? $filter['operator'] : '';
+    if ($operator !== 'is' && $operator !== 'isAny') {
+      return [];
+    }
+    $value = $filter['value'] ?? null;
+    $values = is_array($value) ? $value : [$value];
+    return array_values(array_intersect(
+      array_map('strval', $values),
+      $allowedValues
+    ));
   }
 
   public function getGroups(ListingDefinition $definition): array {

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -232,6 +232,15 @@ class Functions {
     return get_comment_meta($commentId, $key, $single);
   }
 
+  /**
+   * @param int|null $blogId
+   * @return string
+   */
+  public function getBlogPrefix($blogId = null) {
+    global $wpdb;
+    return $wpdb->get_blog_prefix($blogId);
+  }
+
   public function getCurrentScreen() {
     return get_current_screen();
   }

--- a/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -47,11 +47,9 @@ class ManageSegmentsCest {
     $i->seeNoJSErrors();
 
     $i->wantTo('Set pagination to 1 user per page and check if pagination is present');
-    $i->click('#show-settings-link');
-    $applyListingSettingsButton = '#screen-options-apply';
-    $i->waitForElementClickable($applyListingSettingsButton);
-    $i->fillField('#mailpoet_subscribers_per_page', '1');
-    $i->click($applyListingSettingsButton);
+    // The per-page setting moved from WP Screen Options to the DataViews view
+    // config; the listing also reads it from the URL, so drive it from there.
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-subscribers#/group[all]/filter[segment=' . $segment->getId() . ']/limit[1]');
     $i->reloadPage(); // to avoid flakyness we reload page manually
     $i->wantTo('Reorder subscribers by email and check if correct subscribes are present');
     // DataViews wraps sortable column labels in a button that opens a sort

--- a/mailpoet/tests/integration/Form/Listing/FormListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Form/Listing/FormListingRepositoryTest.php
@@ -70,6 +70,17 @@ class FormListingRepositoryTest extends \MailPoetTest {
     verify($forms[1]->getName())->same('Form 1');
   }
 
+  public function testItFallsBackForUnsupportedSort() {
+    $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition([
+      'sort_by' => 'status',
+      'sort_order' => 'asc',
+    ]));
+
+    verify($forms)->arrayCount(2);
+    verify($forms[0]->getName())->same('Form 1');
+    verify($forms[1]->getName())->same('Form 2');
+  }
+
   public function testItAppliesLimitAndOffset() {
     // first page
     $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition([

--- a/mailpoet/tests/javascript/common/dataviews/preferences.spec.ts
+++ b/mailpoet/tests/javascript/common/dataviews/preferences.spec.ts
@@ -1,0 +1,129 @@
+import type { Field, View } from '@wordpress/dataviews';
+
+import {
+  getDataViewsPreference,
+  getDataViewsPreferenceKey,
+} from '../../../../assets/js/src/common/dataviews/preferences';
+
+type TestItem = {
+  id: number;
+};
+
+const fields: Field<TestItem>[] = [
+  {
+    id: 'name',
+    label: 'Name',
+    enableSorting: true,
+  },
+  {
+    id: 'status',
+    label: 'Status',
+    enableSorting: true,
+  },
+  {
+    id: 'created_at',
+    label: 'Created',
+    enableSorting: true,
+  },
+];
+
+const defaultView: View = {
+  type: 'table',
+  perPage: 20,
+  page: 1,
+  sort: { field: 'name', direction: 'asc' },
+  fields: ['status'],
+  titleField: 'name',
+  showTitle: true,
+};
+
+function setPreferences(preference?: unknown): void {
+  const globals = global as typeof globalThis & {
+    window?: Window & typeof globalThis;
+  };
+  globals.window = {
+    mailpoet_preferences_data: {
+      currentUserId: 1,
+      preloadedData: preference
+        ? {
+            'core/views': {
+              [getDataViewsPreferenceKey('subscribers')]: preference,
+            },
+          }
+        : {},
+    },
+  } as unknown as Window & typeof globalThis;
+}
+
+describe('DataViews preferences', () => {
+  afterEach(() => {
+    const globals = global as typeof globalThis & {
+      window?: Window & typeof globalThis;
+    };
+    delete globals.window;
+  });
+
+  it('generates Gutenberg-compatible DataViews preference keys', () => {
+    expect(getDataViewsPreferenceKey('subscribers')).to.equal(
+      'dataviews-mailpoet-subscribers-default',
+    );
+  });
+
+  it('returns the default view when no preference is saved', () => {
+    setPreferences();
+
+    expect(getDataViewsPreference('subscribers', defaultView, fields)).to.equal(
+      defaultView,
+    );
+  });
+
+  it('loads sanitized view preferences', () => {
+    setPreferences({
+      type: 'table',
+      perPage: 250,
+      page: 9,
+      search: 'saved search',
+      sort: { field: 'created_at', direction: 'desc' },
+      fields: ['created_at', 'missing'],
+      titleField: 'name',
+      descriptionField: 'missing',
+      showTitle: false,
+      showDescription: true,
+      layout: { density: 'compact' },
+    });
+
+    expect(
+      getDataViewsPreference('subscribers', defaultView, fields),
+    ).to.deep.equal({
+      ...defaultView,
+      perPage: 100,
+      sort: { field: 'created_at', direction: 'desc' },
+      fields: ['created_at'],
+      titleField: 'name',
+      showTitle: false,
+      showDescription: true,
+      layout: { density: 'compact' },
+    });
+  });
+
+  it('ignores invalid stale fields and sort preferences', () => {
+    setPreferences({
+      type: 'grid',
+      perPage: 0,
+      sort: { field: 'missing', direction: 'desc' },
+      fields: ['missing'],
+    });
+
+    expect(
+      getDataViewsPreference('subscribers', defaultView, fields),
+    ).to.deep.equal(defaultView);
+  });
+
+  it('allows hiding every non-title field', () => {
+    setPreferences({ fields: [] });
+
+    expect(
+      getDataViewsPreference('subscribers', defaultView, fields).fields,
+    ).to.deep.equal([]);
+  });
+});

--- a/mailpoet/tests/javascript/common/dataviews/preferences.spec.ts
+++ b/mailpoet/tests/javascript/common/dataviews/preferences.spec.ts
@@ -3,6 +3,8 @@ import type { Field, View } from '@wordpress/dataviews';
 import {
   getDataViewsPreference,
   getDataViewsPreferenceKey,
+  getPersistedDataViewsPreference,
+  isSameDataViewsPreference,
 } from '../../../../assets/js/src/common/dataviews/preferences';
 
 type TestItem = {
@@ -125,5 +127,50 @@ describe('DataViews preferences', () => {
     expect(
       getDataViewsPreference('subscribers', defaultView, fields).fields,
     ).to.deep.equal([]);
+  });
+
+  it('persists only stable view preferences', () => {
+    expect(
+      getPersistedDataViewsPreference({
+        ...defaultView,
+        search: 'temporary search',
+        filters: [{ field: 'status', operator: 'isAny', value: ['active'] }],
+        page: 3,
+        perPage: 50,
+        showTitle: false,
+        showMedia: true,
+      }),
+    ).to.deep.equal({
+      type: 'table',
+      perPage: 50,
+      sort: { field: 'name', direction: 'asc' },
+      fields: ['status'],
+      titleField: 'name',
+      showTitle: false,
+      showMedia: true,
+    });
+  });
+
+  it('treats transient view changes as the same preference', () => {
+    expect(
+      isSameDataViewsPreference(defaultView, {
+        ...defaultView,
+        search: '',
+        page: 4,
+        filters: [{ field: 'status', operator: 'isAny', value: ['active'] }],
+      }),
+    ).to.equal(true);
+  });
+
+  it('detects changes to persisted view preferences', () => {
+    expect(
+      isSameDataViewsPreference(defaultView, {
+        ...defaultView,
+        fields: ['status', 'created_at'],
+      }),
+    ).to.equal(false);
+    expect(
+      isSameDataViewsPreference(defaultView, { ...defaultView, perPage: 50 }),
+    ).to.equal(false);
   });
 });

--- a/mailpoet/tests/javascript/segments/dynamic/list-query.spec.ts
+++ b/mailpoet/tests/javascript/segments/dynamic/list-query.spec.ts
@@ -1,0 +1,69 @@
+import {
+  getSegmentsQuery,
+  updateSegmentsQuery,
+} from '../../../../assets/js/src/segments/dynamic/list/query';
+
+describe('Dynamic segments list query', () => {
+  afterEach(() => {
+    const globals = global as typeof globalThis & {
+      window?: Window & typeof globalThis;
+    };
+    delete globals.window;
+  });
+
+  it('uses provided defaults when the hash has no explicit values', () => {
+    expect(
+      getSegmentsQuery('', { limit: 50, sort_by: 'name', sort_order: 'asc' }),
+    ).to.include({
+      offset: 0,
+      limit: 50,
+      search: '',
+      sort_by: 'name',
+      sort_order: 'asc',
+      group: 'all',
+    });
+  });
+
+  it('prefers explicit hash values over provided defaults', () => {
+    expect(
+      getSegmentsQuery('/segments/limit[25]/sort_by[updated_at]', {
+        limit: 50,
+        sort_by: 'name',
+      }),
+    ).to.include({ limit: 25, sort_by: 'updated_at' });
+  });
+
+  it('omits hash entries equal to provided defaults', () => {
+    const globals = global as typeof globalThis & {
+      window?: Window & typeof globalThis;
+    };
+    globals.window = {
+      location: { hash: '' },
+    } as unknown as Window & typeof globalThis;
+
+    updateSegmentsQuery(
+      { limit: 50, sort_by: 'name', sort_order: 'asc', offset: 0, search: '' },
+      { limit: 50, sort_by: 'name', sort_order: 'asc' },
+    );
+
+    expect(globals.window.location.hash).to.equal('/segments');
+  });
+
+  it('writes hash entries that differ from provided defaults', () => {
+    const globals = global as typeof globalThis & {
+      window?: Window & typeof globalThis;
+    };
+    globals.window = {
+      location: { hash: '' },
+    } as unknown as Window & typeof globalThis;
+
+    updateSegmentsQuery(
+      { limit: 25, sort_by: 'updated_at', offset: 0, search: '' },
+      { limit: 50, sort_by: 'name' },
+    );
+
+    expect(globals.window.location.hash).to.equal(
+      '/segments/limit[25]/sort_by[updated_at]',
+    );
+  });
+});


### PR DESCRIPTION
## Description

Persists DataViews layout preferences (visible columns, sorting, items per page) per listing using WordPress preferences, and adds DataViews list controls (search, filters, view configuration) to all listings. The preferences and filters toggle buttons are right-aligned in every listing toolbar, while search and legacy filters stay on the left.

## Code review notes

The right alignment is done via a shared `.mailpoet-dataviews__toolbar-end` class in `mailpoet-dataviews.scss`, which the premium stats listings also rely on (see linked premium PR).

## QA notes

On each listing (Emails, Subscribers, Lists, Segments, Forms, Tags, Custom fields, Logs, Automations): change visible columns/sorting/per-page via the gear button, reload, and verify the view is restored. Verify the gear (and filter toggle where present) sits on the right edge of the toolbar, with search and legacy filters on the left.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1091

## Linked tickets

[STOMAIL-8054](https://linear.app/mailpoet/issue/STOMAIL-8054)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8054-persist-dataviews-layout-preferences)

_The latest successful build from `stomail-8054-persist-dataviews-layout-preferences` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Issues Found: 4

### Bug (2)

1. **Unhandled Promise Rejection in Preference Persistence**
   - Location: mailpoet/assets/js/src/common/dataviews/preferences.ts (persistDataViewsPreference)
   - dispatch(preferencesStore).set(...) returns a Promise which is ignored via `void`. No error handling/logging if persistence fails.

2. **Incorrect Order of Operations in usePersistedDataViewsPreference**
   - Location: mailpoet/assets/js/src/common/dataviews/preferences.ts (usePersistedDataViewsPreference)
   - The hook persists preferences first and then calls onChangeView. If persistence fails (currently unobserved), UI state is updated despite failure, causing state/preference mismatch.

### Performance (1)

3. **Inefficient JSON Serialization for Equality Comparison**
   - Location: mailpoet/assets/js/src/common/dataviews/preferences.ts (isSameDataViewsPreference)
   - Uses JSON.stringify on every view change to compare persisted shapes; this occurs on a hot path and could be optimized (e.g., shallow checks before serialization).

### Suggestion (1)

4. **Missing Error Logging and Observability**
   - Locations: mailpoet/assets/js/src/common/dataviews/preferences.ts and mailpoet/assets/js/src/common/preferences/index.ts
   - Preference read/write flows lack logging or telemetry for persistence failures. Add error/warning logs or reporting to aid debugging and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->