### PR TITLE
Persist attribution write boundary on init

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -533,6 +533,13 @@ class Hooks {
   }
 
   public function setupWooCommerceOrderAttribution() {
+    // The reconciliation boundary must be persisted before any post-activation
+    // order exists, and on the init hook because this setup runs on
+    // plugins_loaded, where WooCommerce may not be loaded yet
+    $this->wp->addAction(
+      'init',
+      [$this->hooksWooCommerce, 'markAttributionWritesStarted']
+    );
     // After Woo's own priority-10 handler so the resolved values overwrite
     // the empty placeholders Woo persists from the checkout form
     $this->wp->addAction(

--- a/mailpoet/lib/Config/HooksWooCommerce.php
+++ b/mailpoet/lib/Config/HooksWooCommerce.php
@@ -141,6 +141,14 @@ class HooksWooCommerce {
     }
   }
 
+  public function markAttributionWritesStarted() {
+    try {
+      $this->orderAttributionWriter->markWritesStartedIfActive();
+    } catch (\Throwable $e) {
+      $this->logError($e, 'WooCommerce Order Attribution');
+    }
+  }
+
   public function writeOrderAttribution($order) {
     try {
       $this->orderAttributionWriter->writeForOrder($order);

--- a/mailpoet/lib/WooCommerce/OrderAttributionWriter.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionWriter.php
@@ -123,9 +123,21 @@ class OrderAttributionWriter {
   }
 
   /**
-   * The historical read boundary defined by the migration contract (STOMAIL-8135):
-   * persisted once when the write path first activates and never moved.
+   * Persists the historical read boundary defined by the migration contract
+   * (STOMAIL-8135): set once when the write path first activates and never
+   * moved. Runs on init so the boundary predates every post-activation order;
+   * if it were first persisted inside writeForOrder, the triggering order's
+   * date_created would fall before the boundary and the reconciler would skip
+   * the first post-activation orders.
    */
+  public function markWritesStartedIfActive(): void {
+    if (!$this->isWritePathActive()) {
+      return;
+    }
+    $this->markWritesStarted();
+  }
+
+  // Backstop for the order-save paths; normally already persisted on init.
   private function markWritesStarted(): void {
     if ($this->wp->getOption(self::WRITES_STARTED_AT_OPTION)) {
       return;

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionReconcilerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionReconcilerTest.php
@@ -42,11 +42,12 @@ class OrderAttributionReconcilerTest extends \MailPoetTest {
   public function _before() {
     parent::_before();
     unset($_COOKIE['mailpoet_revenue_tracking']);
-    // The boundary must predate the orders created in the tests; the writer only
-    // persists it during the order-save hooks, which run after order creation.
-    update_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION, gmdate('Y-m-d H:i:s', time() - DAY_IN_SECONDS));
     $this->settings = SettingsController::getInstance();
     $this->settings->set('tracking.level', TrackingConfig::LEVEL_FULL);
+    // Mirror production: the boundary is persisted on init, before any
+    // post-activation order exists, so even the first order is reconciled.
+    delete_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
+    $this->diContainer->get(OrderAttributionWriter::class)->markWritesStartedIfActive();
     $this->subscriber = $this->createSubscriber('reconciliation@example.com');
     $this->newsletter = $this->createNewsletter('First Campaign');
     $this->queue = $this->createQueue($this->newsletter, $this->subscriber);

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionWriterTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionWriterTest.php
@@ -150,6 +150,26 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     verify(get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION))->equals($writesStartedAt);
   }
 
+  public function testItMarksWritesStartedOnActivationAndNeverMovesIt(): void {
+    verify(get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION))->false();
+
+    $this->writer->markWritesStartedIfActive();
+
+    $writesStartedAt = get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
+    verify($writesStartedAt)->notEmpty();
+
+    $this->writer->markWritesStartedIfActive();
+    verify(get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION))->equals($writesStartedAt);
+  }
+
+  public function testItDoesNotMarkWritesStartedWhenTrackingIsDisabled(): void {
+    $this->settings->set('tracking.level', TrackingConfig::LEVEL_BASIC);
+
+    $this->writer->markWritesStartedIfActive();
+
+    verify(get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION))->false();
+  }
+
   public function testItWritesNothingWhenTrackingIsDisabled(): void {
     $this->settings->set('tracking.level', TrackingConfig::LEVEL_BASIC);
     $this->createClick($this->link, $this->subscriber);


### PR DESCRIPTION
## Description

Follow-up to #6837, which was merged before this fix could land on its branch.

The reconciliation write-start boundary (`mailpoet_woo_attribution_writes_started_at`) was first persisted inside `OrderAttributionWriter::writeForOrder()`, which runs from the order-save hooks. The triggering order's `date_created` therefore always predated the boundary by a few seconds, so `OrderAttributionReconciler::isAfterWritesStartedBoundary()` skipped the first post-activation order (and any other orders created just before the first write). Those orders silently got no reconciliation record, weakening the rollout-gate metrics from STOMAIL-8135 (decision 8). The reconciler test masked this by forcing the boundary to yesterday in `_before()`.

This change persists the boundary on the `init` hook when the write path is active, so it always predates every post-activation order. The lazy call in `writeForOrder()` remains as a backstop only.

## Code review notes

- The boundary marking is registered on `init` rather than called inline in `Hooks::setupWooCommerceOrderAttribution()` because that setup runs on `plugins_loaded`, where WooCommerce may not be loaded yet — `FeaturesUtil`/`WooCommerce` class checks inside `isWritePathActive()` would falsely report the write path inactive.
- The lazy backstop in `writeForOrder()` still stamps "now", so it retains the original flaw — but it can only initialize the boundary if the option is manually deleted on a live site. Backdating logic there (e.g. to the order's `date_created`) has its own risks (an old order's status change dragging the boundary weeks into the past), so it was left alone.
- `OrderAttributionReconcilerTest::_before()` now mirrors the production cold start (boundary persisted moments before the first order) instead of backdating it a day, so every reconciler test exercises the previously failing scenario.

## QA notes

On a site without the `mailpoet_woo_attribution_writes_started_at` option (fresh install or `wp option delete mailpoet_woo_attribution_writes_started_at`), with WooCommerce order attribution and MailPoet click tracking enabled: create and complete the very first order attributable to a newsletter click. The order should carry the `_mailpoet_attribution_reconciliation` meta. Before this fix, the first order after the option was (re)initialized had no reconciliation record.

## Linked PRs

- Follow-up to #6837 (accidentally merged before this fix)

## Linked tickets

- STOMAIL-8136

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8136-reconciliation-write-start-boundary)

_The latest successful build from `fix/stomail-8136-reconciliation-write-start-boundary` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

This PR properly addresses a timing initialization bug in the WooCommerce order attribution feature. The changes move the reconciliation write-start boundary initialization from the order-save hook to the WordPress init hook, ensuring the boundary predates all post-activation orders. The implementation includes appropriate safeguards (lazy initialization backstop in writeForOrder()), and tests have been updated to mirror production cold-start behavior, validating the fix for the previously failing scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->