### PR TITLE
Add review follow-up email patterns for automations

### DIFF
--- a/mailpoet/changelog/2026-06-03-15-20-15-added-review-follow-up-email-content-patterns-for-automa.md
+++ b/mailpoet/changelog/2026-06-03-15-20-15-added-review-follow-up-email-content-patterns-for-automa.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Pre-built email content for review follow-up and reviewer reward automation templates

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AskForReviewPostPurchasePattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AskForReviewPostPurchasePattern.php
@@ -25,12 +25,19 @@ class AskForReviewPostPurchasePattern extends Pattern {
     if ($variant === 'positive-follow-up') {
       $this->name = 'positive-review-follow-up';
       $this->categories = ['review'];
+    } elseif ($variant === 'negative-follow-up') {
+      $this->name = 'negative-review-follow-up';
+      $this->categories = ['review'];
     }
   }
 
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     if ($this->variant === 'positive-follow-up') {
       return $this->getPositiveFollowUpContent();
+    }
+
+    if ($this->variant === 'negative-follow-up') {
+      return $this->getNegativeFollowUpContent();
     }
 
     return '
@@ -99,9 +106,41 @@ class AskForReviewPostPurchasePattern extends Pattern {
     ';
   }
 
+  private function getNegativeFollowUpContent(): string {
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' . __('Sorry to hear that', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('Thank you for being honest in your review. We’re sorry your experience did not meet expectations.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('We’d like to understand what happened and see how we can make things right. Reply to this email and our team will help.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . __('We appreciate the chance to improve,', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     if ($this->variant === 'positive-follow-up') {
       return __('Positive review follow-up', 'mailpoet');
+    }
+
+    if ($this->variant === 'negative-follow-up') {
+      return __('Negative review follow-up', 'mailpoet');
     }
 
     return __('Ask for a product review', 'mailpoet');

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AskForReviewPostPurchasePattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AskForReviewPostPurchasePattern.php
@@ -28,6 +28,9 @@ class AskForReviewPostPurchasePattern extends Pattern {
     } elseif ($variant === 'negative-follow-up') {
       $this->name = 'negative-review-follow-up';
       $this->categories = ['review'];
+    } elseif ($variant === 'reward-positive') {
+      $this->name = 'reward-positive-reviewer';
+      $this->categories = ['review'];
     }
   }
 
@@ -38,6 +41,10 @@ class AskForReviewPostPurchasePattern extends Pattern {
 
     if ($this->variant === 'negative-follow-up') {
       return $this->getNegativeFollowUpContent();
+    }
+
+    if ($this->variant === 'reward-positive') {
+      return $this->getRewardPositiveContent();
     }
 
     return '
@@ -134,6 +141,46 @@ class AskForReviewPostPurchasePattern extends Pattern {
     ';
   }
 
+  private function getRewardPositiveContent(): string {
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' . __('Thanks for your review!', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('Thank you for taking the time to leave such a thoughtful review. We’re grateful for your support and happy to hear you enjoyed your purchase.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|20"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--20);font-size:16px">' . __('As a thank you, here’s a discount coupon for your next order:', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"20px","fontWeight":"700"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:20px;font-weight:700">[coupon code]</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
+      <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop again', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . __('See you soon,', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     if ($this->variant === 'positive-follow-up') {
       return __('Positive review follow-up', 'mailpoet');
@@ -141,6 +188,10 @@ class AskForReviewPostPurchasePattern extends Pattern {
 
     if ($this->variant === 'negative-follow-up') {
       return __('Negative review follow-up', 'mailpoet');
+    }
+
+    if ($this->variant === 'reward-positive') {
+      return __('Reward positive reviewer', 'mailpoet');
     }
 
     return __('Ask for a product review', 'mailpoet');

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AskForReviewPostPurchasePattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AskForReviewPostPurchasePattern.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+use MailPoet\Util\CdnAssetUrl;
 
 class AskForReviewPostPurchasePattern extends Pattern {
   protected $name = 'ask-for-review-post-purchase';
@@ -12,7 +13,26 @@ class AskForReviewPostPurchasePattern extends Pattern {
   protected $categories = ['purchase'];
   protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
+  /** @var string */
+  private $variant;
+
+  public function __construct(
+    CdnAssetUrl $cdnAssetUrl,
+    string $variant = 'ask'
+  ) {
+    parent::__construct($cdnAssetUrl);
+    $this->variant = $variant;
+    if ($variant === 'positive-follow-up') {
+      $this->name = 'positive-review-follow-up';
+      $this->categories = ['review'];
+    }
+  }
+
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->variant === 'positive-follow-up') {
+      return $this->getPositiveFollowUpContent();
+    }
+
     return '
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
@@ -51,7 +71,39 @@ class AskForReviewPostPurchasePattern extends Pattern {
     ';
   }
 
+  private function getPositiveFollowUpContent(): string {
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' . __('Thanks for your review!', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('Your review made our day. We’re thrilled you had a good experience and grateful that you took the time to share it.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('Reviews like yours help other shoppers choose with confidence. Thanks for being part of our community.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . __('With appreciation,', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->variant === 'positive-follow-up') {
+      return __('Positive review follow-up', 'mailpoet');
+    }
+
     return __('Ask for a product review', 'mailpoet');
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AskForReviewPostPurchasePattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AskForReviewPostPurchasePattern.php
@@ -157,9 +157,9 @@ class AskForReviewPostPurchasePattern extends Pattern {
       <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--20);font-size:16px">' . __('As a thank you, here’s a discount coupon for your next order:', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
-      <!-- wp:paragraph {"style":{"typography":{"fontSize":"20px","fontWeight":"700"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
-      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:20px;font-weight:700">[coupon code]</p>
-      <!-- /wp:paragraph -->
+      <!-- wp:woocommerce/coupon-code {"align":"left","source":"createNew","discountType":"percent","amount":10,"expiryDay":10} -->
+      <div class="wp-block-woocommerce-coupon-code alignleft"></div>
+      <!-- /wp:woocommerce/coupon-code -->
 
       <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
       <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -118,6 +118,7 @@ class PatternsController {
         new AbandonedCartReminderPattern($this->cdnAssetUrl),
         new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'positive-follow-up'),
         new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'negative-follow-up'),
+        new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'reward-positive'),
       ]);
 
       if ($this->wooCommerceHelper->wcSupportsOrderReviewUrl()) {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -116,6 +116,7 @@ class PatternsController {
         new CategoryPurchaseFollowUpPattern($this->cdnAssetUrl),
         new AbandonedCartPattern($this->cdnAssetUrl),
         new AbandonedCartReminderPattern($this->cdnAssetUrl),
+        new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'positive-follow-up'),
       ]);
 
       if ($this->wooCommerceHelper->wcSupportsOrderReviewUrl()) {
@@ -270,6 +271,11 @@ class PatternsController {
         'name' => 'abandoned-cart',
         'label' => _x('Abandoned cart', 'Block pattern category', 'mailpoet'),
         'description' => __('A collection of abandoned cart email layouts.', 'mailpoet'),
+      ];
+      $categories[] = [
+        'name' => 'review',
+        'label' => _x('Review', 'Block pattern category', 'mailpoet'),
+        'description' => __('A collection of review follow-up email layouts.', 'mailpoet'),
       ];
     }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -118,7 +118,6 @@ class PatternsController {
         new AbandonedCartReminderPattern($this->cdnAssetUrl),
         new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'positive-follow-up'),
         new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'negative-follow-up'),
-        new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'reward-positive'),
       ]);
 
       if ($this->wooCommerceHelper->wcSupportsOrderReviewUrl()) {
@@ -134,6 +133,7 @@ class PatternsController {
           new WelcomeWithDiscountEmailPattern($this->cdnAssetUrl),
           new WinBackCustomerPattern($this->cdnAssetUrl),
           new AbandonedCartWithDiscountPattern($this->cdnAssetUrl),
+          new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'reward-positive'),
         ]);
       }
     }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -117,6 +117,7 @@ class PatternsController {
         new AbandonedCartPattern($this->cdnAssetUrl),
         new AbandonedCartReminderPattern($this->cdnAssetUrl),
         new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'positive-follow-up'),
+        new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'negative-follow-up'),
       ]);
 
       if ($this->wooCommerceHelper->wcSupportsOrderReviewUrl()) {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -145,7 +145,6 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/positive-review-follow-up', $patternNames);
     $this->assertContains('mailpoet/negative-review-follow-up', $patternNames);
-    $this->assertContains('mailpoet/reward-positive-reviewer', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
 
@@ -153,9 +152,10 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/welcome-with-discount-email-content', $patternNames);
     $this->assertNotContains('mailpoet/win-back-customer', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
+    $this->assertNotContains('mailpoet/reward-positive-reviewer', $patternNames);
 
-    // Verify total count (all patterns except 3 coupon patterns)
-    $this->assertCount(19, $blockPatterns);
+    // Verify total count (all patterns except 4 coupon patterns)
+    $this->assertCount(18, $blockPatterns);
   }
 
   /**
@@ -181,6 +181,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/welcome-with-discount-email-content', $patternNames);
     $this->assertContains('mailpoet/win-back-customer', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
+    $this->assertContains('mailpoet/reward-positive-reviewer', $patternNames);
   }
 
   public function dataProviderForWooCommerceVersionsWithCouponSupport(): array {
@@ -295,7 +296,8 @@ class PatternsControllerTest extends \MailPoetTest {
 
     $this->assertIsString($content);
     $this->assertStringContainsString('Thanks for your review!', $content);
-    $this->assertStringContainsString('[coupon code]', $content);
+    $this->assertStringContainsString('wp:woocommerce/coupon-code', $content);
+    $this->assertStringContainsString('"source":"createNew"', $content);
     $this->assertStringContainsString('Shop again', $content);
   }
 

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -46,6 +46,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/tag-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/category-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
+    $this->assertContains('mailpoet/positive-review-follow-up', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
 
@@ -55,7 +56,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(19, $blockPatterns);
+    $this->assertCount(20, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
@@ -106,6 +107,11 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertIsArray($abandonedCartCategory);
     $this->assertEquals('abandoned-cart', $abandonedCartCategory['name']);
     $this->assertNotEmpty($abandonedCartCategory['label']);
+
+    $reviewCategory = $registry->get_registered('review');
+    $this->assertIsArray($reviewCategory);
+    $this->assertEquals('review', $reviewCategory['name']);
+    $this->assertNotEmpty($reviewCategory['label']);
   }
 
   public function testItDoesNotRegisterCouponPatternsWhenWooCommerceVersionIsBelowMinimum(): void {
@@ -135,6 +141,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/tag-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/category-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
+    $this->assertContains('mailpoet/positive-review-follow-up', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
 
@@ -144,7 +151,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count (all patterns except 3 coupon patterns)
-    $this->assertCount(16, $blockPatterns);
+    $this->assertCount(17, $blockPatterns);
   }
 
   /**
@@ -230,6 +237,25 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertStringContainsString('How was your experience?', $content);
   }
 
+  public function testPositiveReviewFollowUpPatternContainsReviewCopy(): void {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
+
+    $patterns = new PatternsController(
+      $this->diContainer->get(CdnAssetUrl::class),
+      $this->diContainer->get(WPFunctions::class),
+      $wooCommerceHelper
+    );
+
+    $content = $patterns->getPatternContent('positive-review-follow-up');
+
+    $this->assertIsString($content);
+    $this->assertStringContainsString('Thanks for your review!', $content);
+    $this->assertStringContainsString('Your review made our day.', $content);
+  }
+
   public function testItDoesNotRegisterAskForReviewPatternWhenOrderReviewUrlIsUnsupported(): void {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
@@ -277,6 +303,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/tag-purchase-follow-up', $patternNames);
     $this->assertNotContains('mailpoet/category-purchase-follow-up', $patternNames);
     $this->assertNotContains('mailpoet/ask-for-review-post-purchase', $patternNames);
+    $this->assertNotContains('mailpoet/positive-review-follow-up', $patternNames);
     $this->assertNotContains('mailpoet/win-back-customer', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
@@ -312,6 +339,9 @@ class PatternsControllerTest extends \MailPoetTest {
 
     $abandonedCartCategory = $registry->get_registered('abandoned-cart');
     $this->assertNull($abandonedCartCategory);
+
+    $reviewCategory = $registry->get_registered('review');
+    $this->assertNull($reviewCategory);
   }
 
   public function testItAddsEmailContentToRestResponseForSplitPatterns(): void {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -47,6 +47,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/category-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/positive-review-follow-up', $patternNames);
+    $this->assertContains('mailpoet/negative-review-follow-up', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
 
@@ -56,7 +57,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(20, $blockPatterns);
+    $this->assertCount(21, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
@@ -142,6 +143,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/category-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/positive-review-follow-up', $patternNames);
+    $this->assertContains('mailpoet/negative-review-follow-up', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
 
@@ -151,7 +153,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count (all patterns except 3 coupon patterns)
-    $this->assertCount(17, $blockPatterns);
+    $this->assertCount(18, $blockPatterns);
   }
 
   /**
@@ -256,6 +258,25 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertStringContainsString('Your review made our day.', $content);
   }
 
+  public function testNegativeReviewFollowUpPatternContainsReviewCopy(): void {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
+
+    $patterns = new PatternsController(
+      $this->diContainer->get(CdnAssetUrl::class),
+      $this->diContainer->get(WPFunctions::class),
+      $wooCommerceHelper
+    );
+
+    $content = $patterns->getPatternContent('negative-review-follow-up');
+
+    $this->assertIsString($content);
+    $this->assertStringContainsString('Sorry to hear that', $content);
+    $this->assertStringContainsString('We’d like to understand what happened', $content);
+  }
+
   public function testItDoesNotRegisterAskForReviewPatternWhenOrderReviewUrlIsUnsupported(): void {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
@@ -304,6 +325,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/category-purchase-follow-up', $patternNames);
     $this->assertNotContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertNotContains('mailpoet/positive-review-follow-up', $patternNames);
+    $this->assertNotContains('mailpoet/negative-review-follow-up', $patternNames);
     $this->assertNotContains('mailpoet/win-back-customer', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-reminder-content', $patternNames);

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -48,6 +48,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/positive-review-follow-up', $patternNames);
     $this->assertContains('mailpoet/negative-review-follow-up', $patternNames);
+    $this->assertContains('mailpoet/reward-positive-reviewer', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
 
@@ -57,7 +58,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(21, $blockPatterns);
+    $this->assertCount(22, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
@@ -144,6 +145,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/positive-review-follow-up', $patternNames);
     $this->assertContains('mailpoet/negative-review-follow-up', $patternNames);
+    $this->assertContains('mailpoet/reward-positive-reviewer', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
 
@@ -153,7 +155,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count (all patterns except 3 coupon patterns)
-    $this->assertCount(18, $blockPatterns);
+    $this->assertCount(19, $blockPatterns);
   }
 
   /**
@@ -277,6 +279,26 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertStringContainsString('We’d like to understand what happened', $content);
   }
 
+  public function testRewardPositiveReviewerPatternContainsCouponCopy(): void {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
+
+    $patterns = new PatternsController(
+      $this->diContainer->get(CdnAssetUrl::class),
+      $this->diContainer->get(WPFunctions::class),
+      $wooCommerceHelper
+    );
+
+    $content = $patterns->getPatternContent('reward-positive-reviewer');
+
+    $this->assertIsString($content);
+    $this->assertStringContainsString('Thanks for your review!', $content);
+    $this->assertStringContainsString('[coupon code]', $content);
+    $this->assertStringContainsString('Shop again', $content);
+  }
+
   public function testItDoesNotRegisterAskForReviewPatternWhenOrderReviewUrlIsUnsupported(): void {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
@@ -326,6 +348,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertNotContains('mailpoet/positive-review-follow-up', $patternNames);
     $this->assertNotContains('mailpoet/negative-review-follow-up', $patternNames);
+    $this->assertNotContains('mailpoet/reward-positive-reviewer', $patternNames);
     $this->assertNotContains('mailpoet/win-back-customer', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-reminder-content', $patternNames);


### PR DESCRIPTION
## Description

Adds block-editor email content patterns for the review follow-up automations: `positive-review-follow-up`, `negative-review-follow-up`, and `reward-positive-reviewer`. The reward pattern embeds the generated coupon block (10% off, 10-day expiry) and is registered only on WooCommerce 10.8.0+ where the block exists.

## Code review notes

The reward pattern is coupon-gated, so the premium `reward-positive-reviewers` template falls back to the `positive-review-follow-up` pattern on older WooCommerce — see the linked premium PR. The two PRs should be merged together.

## QA notes

With WooCommerce 10.8+, the three patterns appear in the email editor pattern library; with older WooCommerce the reward pattern is hidden.

## Linked PRs

- https://github.com/mailpoet/mailpoet-premium/pull/1092

## Linked tickets

[STOMAIL-8125](https://linear.app/a8c/issue/STOMAIL-8125/add-email-templates-for-review-follow-up-automations)

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->