### PR TITLE
Add Woo-backed revenue reporting

### DIFF
--- a/mailpoet/changelog/2026-06-12-10-26-12-improved-improve-woocommerce-revenue-reporting-with-order-a.md
+++ b/mailpoet/changelog/2026-06-12-10-26-12-improved-improve-woocommerce-revenue-reporting-with-order-a.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Improve WooCommerce revenue reporting with order attribution data

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -696,6 +696,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\WooCommerce\OrderAttributionFields::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\OrderAttributionPrivacy::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\OrderAttributionReconciler::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\OrderAttributionRevenueReader::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\OrderAttributionWriter::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\Settings::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\SubscriberEngagement::class)->setPublic(true);

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -7,12 +7,14 @@ use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 class FeaturesController {
   const FEATURE_BRAND_TEMPLATES = 'brand_templates';
   const FEATURE_SEND_BY_TIMEZONE = 'send_by_timezone';
+  const FEATURE_WOO_BACKED_REVENUE_REPORTING = 'woo_backed_revenue_reporting';
 
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::FEATURE_BRAND_TEMPLATES => false,
     self::FEATURE_SEND_BY_TIMEZONE => false,
+    self::FEATURE_WOO_BACKED_REVENUE_REPORTING => false,
   ];
 
   /** @var array|null */

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
@@ -17,6 +17,7 @@ use MailPoet\Entities\UserAgentEntity;
 use MailPoet\Newsletter\Sending\NewsletterReplayMetadata;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\WooCommerce\Helper as WCHelper;
+use MailPoet\WooCommerce\OrderAttributionRevenueReader;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\ORM\Query\Expr\Join;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
@@ -33,14 +34,19 @@ class NewsletterStatisticsRepository extends Repository {
   /** @var TrackingConfig */
   private $trackingConfig;
 
+  /** @var OrderAttributionRevenueReader */
+  private $orderAttributionRevenueReader;
+
   public function __construct(
     EntityManager $entityManager,
     WCHelper $wcHelper,
-    TrackingConfig $trackingConfig
+    TrackingConfig $trackingConfig,
+    OrderAttributionRevenueReader $orderAttributionRevenueReader
   ) {
     parent::__construct($entityManager);
     $this->wcHelper = $wcHelper;
     $this->trackingConfig = $trackingConfig;
+    $this->orderAttributionRevenueReader = $orderAttributionRevenueReader;
   }
 
   protected function getEntityClassName() {
@@ -278,9 +284,25 @@ class NewsletterStatisticsRepository extends Repository {
       return null;
     }
 
+    $newsletterIds = array_map(function(NewsletterEntity $newsletter): int {
+      return (int)$newsletter->getId();
+    }, $newsletters);
     $revenueStatus = $this->wcHelper->getPurchaseStates();
-
     $currency = $this->wcHelper->getWoocommerceCurrency();
+    $wooBackedRevenues = $this->orderAttributionRevenueReader->getNewsletterRevenues($newsletterIds, $from, $to);
+    if (is_array($wooBackedRevenues)) {
+      $revenues = [];
+      foreach ($wooBackedRevenues as $newsletterId => $result) {
+        $revenues[(int)$newsletterId] = new WooCommerceRevenue(
+          $currency,
+          (float)$result['total'],
+          (int)$result['count'],
+          $this->wcHelper
+        );
+      }
+      return $revenues;
+    }
+
     $query = $this->entityManager
       ->createQueryBuilder()
       ->select('IDENTITY(stats.newsletter) AS id, SUM(stats.orderPriceTotal) AS total, COUNT(stats.id) AS cnt')

--- a/mailpoet/lib/Subscribers/Statistics/SubscriberStatisticsRepository.php
+++ b/mailpoet/lib/Subscribers/Statistics/SubscriberStatisticsRepository.php
@@ -12,6 +12,7 @@ use MailPoet\Entities\UserAgentEntity;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\WooCommerce\Helper as WCHelper;
+use MailPoet\WooCommerce\OrderAttributionRevenueReader;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
@@ -35,14 +36,19 @@ class SubscriberStatisticsRepository extends Repository {
   /** @var TrackingConfig */
   private $trackingConfig;
 
+  /** @var OrderAttributionRevenueReader */
+  private $orderAttributionRevenueReader;
+
   public function __construct(
     EntityManager $entityManager,
     WCHelper $wcHelper,
-    TrackingConfig $trackingConfig
+    TrackingConfig $trackingConfig,
+    OrderAttributionRevenueReader $orderAttributionRevenueReader
   ) {
     parent::__construct($entityManager);
     $this->wcHelper = $wcHelper;
     $this->trackingConfig = $trackingConfig;
+    $this->orderAttributionRevenueReader = $orderAttributionRevenueReader;
   }
 
   protected function getEntityClassName() {
@@ -195,6 +201,16 @@ class SubscriberStatisticsRepository extends Repository {
 
     $revenueStatus = $this->wcHelper->getPurchaseStates();
     $currency = $this->wcHelper->getWoocommerceCurrency();
+    $wooBackedRevenue = $this->orderAttributionRevenueReader->getSubscriberRevenue((int)$subscriber->getId(), $startTime);
+    if (is_array($wooBackedRevenue)) {
+      return new WooCommerceRevenue(
+        $currency,
+        (float)$wooBackedRevenue['total'],
+        (int)$wooBackedRevenue['count'],
+        $this->wcHelper
+      );
+    }
+
     $queryBuilder = $this->entityManager->createQueryBuilder()
       ->select('stats.orderPriceTotal')
       ->from(StatisticsWooCommercePurchaseEntity::class, 'stats')

--- a/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
@@ -392,6 +392,11 @@ class OrderAttributionRevenueReader {
     $dateParams = [];
     $dateSql = $this->getDateRangeSql('swp.created_at', $from, $to, true, $excludeTo, $dateParams);
     $excludeParams = [];
+    // COMPLETE_FOR_SUBSCRIBER (not _NEWSLETTER as the revenue path uses) is intentional:
+    // the Woo order-row path (getWooNewsletterOrderRows) requires a subscriber and skips
+    // rows without subscriber meta, so the legacy fallback must only exclude orders that
+    // are complete down to the subscriber. Excluding on _NEWSLETTER would drop
+    // click+newsletter-but-no-subscriber orders from both paths and undercount the list.
     $excludeSql = $excludeCompleteWooAttribution ? $this->getCompleteWooAttributionExclusionSql(self::COMPLETE_FOR_SUBSCRIBER, 'swp.order_id', $excludeParams) : '';
     $newsletterPlaceholders = implode(',', array_fill(0, count($newsletterIds), '%d'));
     $orderTable = $this->getOrderTable();

--- a/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
@@ -9,6 +9,7 @@ use WC_Order;
 
 /**
  * @phpstan-type OrderRow array{created_at: string, newsletter_id: int, order_id: int, total: float, subscriber_id: int, first_name:string, last_name:string, email:string, subject:string, status:string}
+ * @phpstan-type AttributionRow array{order_id: int, date_created_gmt: string, newsletter_id: string, subscriber_id: string|null, queue_id: string|null}
  */
 class OrderAttributionRevenueReader {
   const COMPLETE_FOR_NEWSLETTER = 'newsletter';
@@ -267,7 +268,7 @@ class OrderAttributionRevenueReader {
       return [];
     }
 
-    $rows = $this->getWooAttributedOrders($from, $to, $newsletterIds, null);
+    $rows = $this->excludeReplayAttributionRows($this->getWooAttributedOrders($from, $to, $newsletterIds, null));
     $result = [];
     foreach ($rows as $row) {
       $order = $this->wooHelper->wcGetOrder((int)$row['order_id']);
@@ -458,7 +459,7 @@ class OrderAttributionRevenueReader {
       return [];
     }
 
-    $attributionRows = $this->getWooAttributedOrders($from, $to, $newsletterIds, null);
+    $attributionRows = $this->excludeReplayAttributionRows($this->getWooAttributedOrders($from, $to, $newsletterIds, null));
     if (!$attributionRows) {
       return [];
     }
@@ -505,7 +506,7 @@ class OrderAttributionRevenueReader {
 
   /**
    * @param int[] $newsletterIds
-   * @return array<int, array{order_id: numeric-string|int, date_created_gmt: string, newsletter_id: string, subscriber_id: string|null}>
+   * @return AttributionRow[]
    */
   private function getWooAttributedOrders(
     \DateTimeInterface $from,
@@ -527,6 +528,7 @@ class OrderAttributionRevenueReader {
       OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_CLICK_ID,
       OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_NEWSLETTER_ID,
       OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_SUBSCRIBER_ID,
+      OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_QUEUE_ID,
     ];
 
     $having = 'click_id IS NOT NULL AND click_id <> \'\' AND newsletter_id IS NOT NULL AND newsletter_id <> \'\'';
@@ -548,10 +550,11 @@ class OrderAttributionRevenueReader {
           ' . $orderDateColumn . ' AS date_created_gmt,
           MAX(CASE WHEN meta.meta_key = %s THEN meta.meta_value END) AS click_id,
           MAX(CASE WHEN meta.meta_key = %s THEN meta.meta_value END) AS newsletter_id,
-          MAX(CASE WHEN meta.meta_key = %s THEN meta.meta_value END) AS subscriber_id
+          MAX(CASE WHEN meta.meta_key = %s THEN meta.meta_value END) AS subscriber_id,
+          MAX(CASE WHEN meta.meta_key = %s THEN meta.meta_value END) AS queue_id
         FROM %i woo_order
         INNER JOIN %i meta ON meta.%i = ' . $orderIdColumn . '
-          AND meta.meta_key IN (%s, %s, %s)
+          AND meta.meta_key IN (%s, %s, %s, %s)
         WHERE 1 = 1
           ' . $typeSql . '
           ' . $dateSql . '
@@ -575,6 +578,49 @@ class OrderAttributionRevenueReader {
 
     $rows = $wpdb->get_results($query, ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
     return $this->normalizeAttributionRows(is_array($rows) ? $rows : []);
+  }
+
+  /**
+   * @param AttributionRow[] $rows
+   * @return AttributionRow[]
+   */
+  private function excludeReplayAttributionRows(array $rows): array {
+    $queueIds = $this->normalizeIds(array_map(function(array $row): int {
+      return (int)($row['queue_id'] ?? 0);
+    }, $rows));
+    if (!$queueIds) {
+      return $rows;
+    }
+
+    global $wpdb;
+
+    $placeholders = implode(',', array_fill(0, count($queueIds), '%d'));
+    // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic fragments are trusted placeholders; values are prepared below.
+    $query = $wpdb->prepare(
+      '
+        SELECT id
+        FROM %i
+        WHERE id IN (' . $placeholders . ')
+          AND meta LIKE %s
+      ',
+      array_merge(
+        [$wpdb->prefix . 'mailpoet_sending_queues'],
+        $queueIds,
+        [NewsletterReplayMetadata::getMetaLikePattern()]
+      )
+    );
+    // phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+    $replayQueueIds = array_map('intval', (array)$wpdb->get_col($query)); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
+    if (!$replayQueueIds) {
+      return $rows;
+    }
+
+    $replayQueueIds = array_flip($replayQueueIds);
+    return array_values(array_filter($rows, function(array $row) use ($replayQueueIds): bool {
+      $queueId = (int)($row['queue_id'] ?? 0);
+      return $queueId <= 0 || !isset($replayQueueIds[$queueId]);
+    }));
   }
 
   /**
@@ -822,7 +868,7 @@ class OrderAttributionRevenueReader {
 
   /**
    * @param array<int, mixed> $rows
-   * @return array<int, array{order_id: int, date_created_gmt: string, newsletter_id: string, subscriber_id: string|null}>
+   * @return AttributionRow[]
    */
   private function normalizeAttributionRows(array $rows): array {
     $result = [];
@@ -834,6 +880,7 @@ class OrderAttributionRevenueReader {
       $dateCreated = $this->toString($row['date_created_gmt'] ?? null);
       $newsletterId = $this->toString($row['newsletter_id'] ?? null);
       $subscriberId = $this->toString($row['subscriber_id'] ?? null);
+      $queueId = $this->toString($row['queue_id'] ?? null);
       if ($orderId === null || $dateCreated === null || $newsletterId === null) {
         continue;
       }
@@ -842,6 +889,7 @@ class OrderAttributionRevenueReader {
         'date_created_gmt' => $dateCreated,
         'newsletter_id' => $newsletterId,
         'subscriber_id' => $subscriberId,
+        'queue_id' => $queueId,
       ];
     }
     return $result;

--- a/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
@@ -1,0 +1,894 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use MailPoet\Features\FeaturesController;
+use MailPoet\Newsletter\Sending\NewsletterReplayMetadata;
+use MailPoet\WP\Functions as WPFunctions;
+use WC_Order;
+
+/**
+ * @phpstan-type OrderRow array{created_at: string, newsletter_id: int, order_id: int, total: float, subscriber_id: int, first_name:string, last_name:string, email:string, subject:string, status:string}
+ */
+class OrderAttributionRevenueReader {
+  const COMPLETE_FOR_NEWSLETTER = 'newsletter';
+  const COMPLETE_FOR_SUBSCRIBER = 'subscriber';
+
+  /** @var FeaturesController */
+  private $featuresController;
+
+  /** @var Helper */
+  private $wooHelper;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    FeaturesController $featuresController,
+    Helper $wooHelper,
+    WPFunctions $wp
+  ) {
+    $this->featuresController = $featuresController;
+    $this->wooHelper = $wooHelper;
+    $this->wp = $wp;
+  }
+
+  /**
+   * @param int[] $newsletterIds
+   * @return array<int, array{total: float, count: int}>|null
+   */
+  public function getNewsletterRevenues(
+    array $newsletterIds,
+    ?\DateTimeImmutable $from = null,
+    ?\DateTimeImmutable $to = null
+  ): ?array {
+    $boundary = $this->getReadBoundary();
+    if ($boundary === null) {
+      return null;
+    }
+
+    $newsletterIds = $this->normalizeIds($newsletterIds);
+    if (!$newsletterIds) {
+      return [];
+    }
+
+    $currency = $this->wooHelper->getWoocommerceCurrency();
+    $purchaseStates = $this->wooHelper->getPurchaseStates();
+    $revenues = [];
+    $beforeBoundaryTo = $this->getBeforeBoundaryTo($to, $boundary);
+    $afterBoundaryFrom = $this->getAfterBoundaryFrom($from, $boundary);
+
+    $this->mergeNewsletterRows(
+      $revenues,
+      $this->getLegacyNewsletterRevenues($newsletterIds, $currency, $purchaseStates, $from, $beforeBoundaryTo, false, $this->isBoundaryUpperLimit($to, $boundary))
+    );
+    $this->mergeNewsletterRows(
+      $revenues,
+      $this->getWooNewsletterRevenues($newsletterIds, $currency, $purchaseStates, $afterBoundaryFrom, $to)
+    );
+    $this->mergeNewsletterRows(
+      $revenues,
+      $this->getLegacyNewsletterRevenues($newsletterIds, $currency, $purchaseStates, $afterBoundaryFrom, $to, true, false)
+    );
+
+    return $revenues;
+  }
+
+  /**
+   * @return array{total: float, count: int}|null
+   */
+  public function getSubscriberRevenue(int $subscriberId, ?\DateTimeInterface $startTime = null): ?array {
+    $boundary = $this->getReadBoundary();
+    if ($boundary === null) {
+      return null;
+    }
+
+    $currency = $this->wooHelper->getWoocommerceCurrency();
+    $purchaseStates = $this->wooHelper->getPurchaseStates();
+    $revenue = ['total' => 0.0, 'count' => 0];
+    $beforeBoundaryTo = $this->getBeforeBoundaryTo(null, $boundary);
+    $afterBoundaryFrom = $this->getAfterBoundaryFrom($startTime, $boundary);
+
+    $this->mergeRevenue(
+      $revenue,
+      $this->getLegacySubscriberRevenue($subscriberId, $currency, $purchaseStates, $startTime, $beforeBoundaryTo, false, true)
+    );
+    $this->mergeRevenue(
+      $revenue,
+      $this->getWooSubscriberRevenue($subscriberId, $currency, $purchaseStates, $afterBoundaryFrom, null)
+    );
+    $this->mergeRevenue(
+      $revenue,
+      $this->getLegacySubscriberRevenue($subscriberId, $currency, $purchaseStates, $afterBoundaryFrom, null, true, false)
+    );
+
+    return $revenue;
+  }
+
+  /**
+   * @param int[] $newsletterIds
+   * @return OrderRow[]|null
+   */
+  public function getNewsletterOrderRows(
+    array $newsletterIds,
+    \DateTimeImmutable $from,
+    \DateTimeImmutable $to
+  ): ?array {
+    $boundary = $this->getReadBoundary();
+    if ($boundary === null) {
+      return null;
+    }
+
+    $newsletterIds = $this->normalizeIds($newsletterIds);
+    if (!$newsletterIds) {
+      return [];
+    }
+
+    $beforeBoundaryTo = $this->getBeforeBoundaryTo($to, $boundary);
+    $afterBoundaryFrom = $this->getAfterBoundaryFrom($from, $boundary);
+
+    return array_merge(
+      $this->getLegacyNewsletterOrderRows($newsletterIds, $from, $beforeBoundaryTo, false, $this->isBoundaryUpperLimit($to, $boundary)),
+      $this->getWooNewsletterOrderRows($newsletterIds, $afterBoundaryFrom, $to),
+      $this->getLegacyNewsletterOrderRows($newsletterIds, $afterBoundaryFrom, $to, true, false)
+    );
+  }
+
+  private function getReadBoundary(): ?\DateTimeImmutable {
+    if (!$this->wooHelper->isWooCommerceActive()) {
+      return null;
+    }
+    if (!$this->featuresController->isSupported(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING)) {
+      return null;
+    }
+
+    $boundary = $this->wp->getOption(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
+    if (!is_string($boundary) || $boundary === '') {
+      return null;
+    }
+
+    try {
+      return new \DateTimeImmutable($boundary, new \DateTimeZone('UTC'));
+    } catch (\Exception $e) {
+      return null;
+    }
+  }
+
+  /**
+   * @param int[] $ids
+   * @return int[]
+   */
+  private function normalizeIds(array $ids): array {
+    $ids = array_map('intval', $ids);
+    $ids = array_filter($ids, function(int $id): bool {
+      return $id > 0;
+    });
+    return array_values(array_unique($ids));
+  }
+
+  private function getBeforeBoundaryTo(?\DateTimeInterface $to, \DateTimeImmutable $boundary): \DateTimeInterface {
+    if ($to !== null && $to->getTimestamp() < $boundary->getTimestamp()) {
+      return $to;
+    }
+    return $boundary;
+  }
+
+  private function getAfterBoundaryFrom(?\DateTimeInterface $from, \DateTimeImmutable $boundary): \DateTimeInterface {
+    if ($from !== null && $from->getTimestamp() > $boundary->getTimestamp()) {
+      return $from;
+    }
+    return $boundary;
+  }
+
+  private function isBoundaryUpperLimit(?\DateTimeInterface $to, \DateTimeImmutable $boundary): bool {
+    return $to === null || $to->getTimestamp() >= $boundary->getTimestamp();
+  }
+
+  /**
+   * @param int[] $newsletterIds
+   * @param string[] $purchaseStates
+   * @return array<int, array{total: float, count: int}>
+   */
+  private function getLegacyNewsletterRevenues(
+    array $newsletterIds,
+    string $currency,
+    array $purchaseStates,
+    ?\DateTimeInterface $from,
+    ?\DateTimeInterface $to,
+    bool $excludeCompleteWooAttribution,
+    bool $excludeTo
+  ): array {
+    if (!$purchaseStates || $this->isEmptyDateRange($from, $to, $excludeTo)) {
+      return [];
+    }
+
+    global $wpdb;
+
+    $dateParams = [];
+    $dateSql = $this->getDateRangeSql('swp.created_at', $from, $to, true, $excludeTo, $dateParams);
+    $excludeParams = [];
+    $excludeSql = $excludeCompleteWooAttribution ? $this->getCompleteWooAttributionExclusionSql(self::COMPLETE_FOR_NEWSLETTER, 'swp.order_id', $excludeParams) : '';
+    $newsletterPlaceholders = implode(',', array_fill(0, count($newsletterIds), '%d'));
+    $statePlaceholders = implode(',', array_fill(0, count($purchaseStates), '%s'));
+
+    // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic fragments are trusted identifiers/placeholders; values are prepared below.
+    $query = $wpdb->prepare(
+      '
+        SELECT swp.newsletter_id AS newsletter_id, SUM(swp.order_price_total) AS total, COUNT(swp.id) AS count
+        FROM %i swp
+        LEFT JOIN %i q ON q.id = swp.queue_id
+        WHERE swp.newsletter_id IN (' . $newsletterPlaceholders . ')
+          AND swp.order_currency = %s
+          AND swp.status IN (' . $statePlaceholders . ')
+          AND (q.id IS NULL OR q.meta IS NULL OR q.meta NOT LIKE %s)
+          ' . $dateSql . '
+          ' . $excludeSql . '
+        GROUP BY swp.newsletter_id
+      ',
+      array_merge(
+        [
+          $wpdb->prefix . 'mailpoet_statistics_woocommerce_purchases',
+          $wpdb->prefix . 'mailpoet_sending_queues',
+        ],
+        $newsletterIds,
+        [$currency],
+        $purchaseStates,
+        [NewsletterReplayMetadata::getMetaLikePattern()],
+        $dateParams,
+        $excludeParams
+      )
+    );
+    // phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+    $rows = $wpdb->get_results($query, ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
+    $result = [];
+    foreach ($rows ?: [] as $row) {
+      $result[(int)$row['newsletter_id']] = [
+        'total' => (float)$row['total'],
+        'count' => (int)$row['count'],
+      ];
+    }
+    return $result;
+  }
+
+  /**
+   * @param int[] $newsletterIds
+   * @param string[] $purchaseStates
+   * @return array<int, array{total: float, count: int}>
+   */
+  private function getWooNewsletterRevenues(
+    array $newsletterIds,
+    string $currency,
+    array $purchaseStates,
+    \DateTimeInterface $from,
+    ?\DateTimeInterface $to
+  ): array {
+    if ($this->isEmptyDateRange($from, $to, false)) {
+      return [];
+    }
+
+    $rows = $this->getWooAttributedOrders($from, $to, $newsletterIds, null);
+    $result = [];
+    foreach ($rows as $row) {
+      $order = $this->wooHelper->wcGetOrder((int)$row['order_id']);
+      if (!$this->isRevenueOrder($order, $currency, $purchaseStates)) {
+        continue;
+      }
+      $newsletterId = (int)$row['newsletter_id'];
+      $this->addNewsletterRevenue($result, $newsletterId, (float)$order->get_remaining_refund_amount(), 1);
+    }
+    return $result;
+  }
+
+  /**
+   * @param string[] $purchaseStates
+   * @return array{total: float, count: int}
+   */
+  private function getLegacySubscriberRevenue(
+    int $subscriberId,
+    string $currency,
+    array $purchaseStates,
+    ?\DateTimeInterface $from,
+    ?\DateTimeInterface $to,
+    bool $excludeCompleteWooAttribution,
+    bool $excludeTo
+  ): array {
+    if (!$purchaseStates || $this->isEmptyDateRange($from, $to, $excludeTo)) {
+      return ['total' => 0.0, 'count' => 0];
+    }
+
+    global $wpdb;
+
+    $dateParams = [];
+    $dateSql = $this->getDateRangeSql('swp.created_at', $from, $to, true, $excludeTo, $dateParams);
+    $excludeParams = [];
+    $excludeSql = $excludeCompleteWooAttribution ? $this->getCompleteWooAttributionExclusionSql(self::COMPLETE_FOR_SUBSCRIBER, 'swp.order_id', $excludeParams) : '';
+    $statePlaceholders = implode(',', array_fill(0, count($purchaseStates), '%s'));
+
+    // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic fragments are trusted identifiers/placeholders; values are prepared below.
+    $query = $wpdb->prepare(
+      '
+        SELECT swp.order_id, swp.order_price_total
+        FROM %i swp
+        WHERE swp.subscriber_id = %d
+          AND swp.order_currency = %s
+          AND swp.status IN (' . $statePlaceholders . ')
+          ' . $dateSql . '
+          ' . $excludeSql . '
+        GROUP BY swp.order_id, swp.order_price_total
+      ',
+      array_merge(
+        [
+          $wpdb->prefix . 'mailpoet_statistics_woocommerce_purchases',
+          $subscriberId,
+          $currency,
+        ],
+        $purchaseStates,
+        $dateParams,
+        $excludeParams
+      )
+    );
+    // phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+    $rows = $wpdb->get_results($query, ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
+    $revenue = ['total' => 0.0, 'count' => 0];
+    foreach ($rows ?: [] as $row) {
+      $this->mergeRevenue($revenue, [
+        'total' => (float)$row['order_price_total'],
+        'count' => 1,
+      ]);
+    }
+    return $revenue;
+  }
+
+  /**
+   * @param string[] $purchaseStates
+   * @return array{total: float, count: int}
+   */
+  private function getWooSubscriberRevenue(
+    int $subscriberId,
+    string $currency,
+    array $purchaseStates,
+    \DateTimeInterface $from,
+    ?\DateTimeInterface $to
+  ): array {
+    if ($this->isEmptyDateRange($from, $to, false)) {
+      return ['total' => 0.0, 'count' => 0];
+    }
+
+    $rows = $this->getWooAttributedOrders($from, $to, [], $subscriberId);
+    $revenue = ['total' => 0.0, 'count' => 0];
+    foreach ($rows as $row) {
+      $order = $this->wooHelper->wcGetOrder((int)$row['order_id']);
+      if (!$this->isRevenueOrder($order, $currency, $purchaseStates)) {
+        continue;
+      }
+      $this->mergeRevenue($revenue, [
+        'total' => (float)$order->get_remaining_refund_amount(),
+        'count' => 1,
+      ]);
+    }
+    return $revenue;
+  }
+
+  /**
+   * @param int[] $newsletterIds
+   * @return OrderRow[]
+   */
+  private function getLegacyNewsletterOrderRows(
+    array $newsletterIds,
+    ?\DateTimeInterface $from,
+    ?\DateTimeInterface $to,
+    bool $excludeCompleteWooAttribution,
+    bool $excludeTo
+  ): array {
+    if ($this->isEmptyDateRange($from, $to, $excludeTo)) {
+      return [];
+    }
+
+    global $wpdb;
+
+    $dateParams = [];
+    $dateSql = $this->getDateRangeSql('swp.created_at', $from, $to, true, $excludeTo, $dateParams);
+    $excludeParams = [];
+    $excludeSql = $excludeCompleteWooAttribution ? $this->getCompleteWooAttributionExclusionSql(self::COMPLETE_FOR_SUBSCRIBER, 'swp.order_id', $excludeParams) : '';
+    $newsletterPlaceholders = implode(',', array_fill(0, count($newsletterIds), '%d'));
+    $orderTable = $this->getOrderTable();
+    $orderStatusColumn = $this->wooHelper->isWooCommerceCustomOrdersTableEnabled()
+      ? '`woo_order`.`status`'
+      : '`woo_order`.`post_status`';
+
+    // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic fragments are trusted identifiers/placeholders; values are prepared below.
+    $query = $wpdb->prepare(
+      '
+        SELECT
+          swp.created_at,
+          swp.newsletter_id,
+          swp.order_id,
+          swp.order_price_total AS total,
+          swp.subscriber_id,
+          subscriber.first_name,
+          subscriber.last_name,
+          subscriber.email,
+          newsletter.subject,
+          ' . $orderStatusColumn . ' AS status
+        FROM %i swp
+        INNER JOIN %i woo_order ON swp.order_id = woo_order.ID
+        INNER JOIN %i subscriber ON subscriber.ID = swp.subscriber_id
+        INNER JOIN %i newsletter ON newsletter.ID = swp.newsletter_id
+        WHERE swp.newsletter_id IN (' . $newsletterPlaceholders . ')
+          ' . $dateSql . '
+          ' . $excludeSql . '
+      ',
+      array_merge(
+        [
+          $wpdb->prefix . 'mailpoet_statistics_woocommerce_purchases',
+          $orderTable,
+          $wpdb->prefix . 'mailpoet_subscribers',
+          $wpdb->prefix . 'mailpoet_newsletters',
+        ],
+        $newsletterIds,
+        $dateParams,
+        $excludeParams
+      )
+    );
+    // phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+    $rows = $wpdb->get_results($query, ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
+    return $this->normalizeOrderRows(is_array($rows) ? $rows : []);
+  }
+
+  /**
+   * @param int[] $newsletterIds
+   * @return OrderRow[]
+   */
+  private function getWooNewsletterOrderRows(
+    array $newsletterIds,
+    \DateTimeInterface $from,
+    ?\DateTimeInterface $to
+  ): array {
+    if ($this->isEmptyDateRange($from, $to, false)) {
+      return [];
+    }
+
+    $attributionRows = $this->getWooAttributedOrders($from, $to, $newsletterIds, null);
+    if (!$attributionRows) {
+      return [];
+    }
+
+    $subscriberIds = $this->normalizeIds(array_map(function(array $row): int {
+      return (int)($row['subscriber_id'] ?? 0);
+    }, $attributionRows));
+    $newsletterIds = $this->normalizeIds(array_map(function(array $row): int {
+      return (int)$row['newsletter_id'];
+    }, $attributionRows));
+    $subscribers = $this->getSubscribersByIds($subscriberIds);
+    $newsletters = $this->getNewslettersByIds($newsletterIds);
+
+    $rows = [];
+    foreach ($attributionRows as $row) {
+      $subscriberId = (int)($row['subscriber_id'] ?? 0);
+      $newsletterId = (int)$row['newsletter_id'];
+      if (!isset($subscribers[$subscriberId], $newsletters[$newsletterId])) {
+        continue;
+      }
+
+      $order = $this->wooHelper->wcGetOrder((int)$row['order_id']);
+      if (!$order instanceof WC_Order) {
+        continue;
+      }
+
+      $subscriber = $subscribers[$subscriberId];
+      $newsletter = $newsletters[$newsletterId];
+      $rows[] = [
+        'created_at' => (string)$row['date_created_gmt'],
+        'newsletter_id' => $newsletterId,
+        'order_id' => (int)$row['order_id'],
+        'total' => (float)$order->get_remaining_refund_amount(),
+        'subscriber_id' => $subscriberId,
+        'first_name' => $subscriber['first_name'],
+        'last_name' => $subscriber['last_name'],
+        'email' => $subscriber['email'],
+        'subject' => $newsletter['subject'],
+        'status' => 'wc-' . $order->get_status(),
+      ];
+    }
+    return $rows;
+  }
+
+  /**
+   * @param int[] $newsletterIds
+   * @return array<int, array{order_id: numeric-string|int, date_created_gmt: string, newsletter_id: string, subscriber_id: string|null}>
+   */
+  private function getWooAttributedOrders(
+    \DateTimeInterface $from,
+    ?\DateTimeInterface $to,
+    array $newsletterIds,
+    ?int $subscriberId
+  ): array {
+    global $wpdb;
+
+    $orderLookup = $this->getOrderLookupTable();
+    $orderIdColumn = 'woo_order.' . $orderLookup['id_column'];
+    $orderDateColumn = 'woo_order.' . $orderLookup['date_column'];
+    $dateParams = [];
+    $dateSql = $this->getDateRangeSql($orderDateColumn, $from, $to, true, false, $dateParams);
+    $typeSql = $orderLookup['type_column'] !== null ? ' AND woo_order.' . $orderLookup['type_column'] . ' = %s' : '';
+    $typeParams = $orderLookup['type_column'] !== null ? ['shop_order'] : [];
+    $meta = $this->getOrderMetaTable();
+    $metaKeys = [
+      OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_CLICK_ID,
+      OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_NEWSLETTER_ID,
+      OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_SUBSCRIBER_ID,
+    ];
+
+    $having = 'click_id IS NOT NULL AND click_id <> \'\' AND newsletter_id IS NOT NULL AND newsletter_id <> \'\'';
+    $havingParams = [];
+    if ($newsletterIds) {
+      $having .= ' AND newsletter_id IN (' . implode(',', array_fill(0, count($newsletterIds), '%s')) . ')';
+      $havingParams = array_merge($havingParams, array_map('strval', $newsletterIds));
+    }
+    if ($subscriberId !== null) {
+      $having .= ' AND subscriber_id IS NOT NULL AND subscriber_id <> \'\' AND subscriber_id = %s';
+      $havingParams[] = (string)$subscriberId;
+    }
+
+    // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic fragments are trusted identifiers/placeholders; values are prepared below.
+    $query = $wpdb->prepare(
+      '
+        SELECT
+          ' . $orderIdColumn . ' AS order_id,
+          ' . $orderDateColumn . ' AS date_created_gmt,
+          MAX(CASE WHEN meta.meta_key = %s THEN meta.meta_value END) AS click_id,
+          MAX(CASE WHEN meta.meta_key = %s THEN meta.meta_value END) AS newsletter_id,
+          MAX(CASE WHEN meta.meta_key = %s THEN meta.meta_value END) AS subscriber_id
+        FROM %i woo_order
+        INNER JOIN %i meta ON meta.%i = ' . $orderIdColumn . '
+          AND meta.meta_key IN (%s, %s, %s)
+        WHERE 1 = 1
+          ' . $typeSql . '
+          ' . $dateSql . '
+        GROUP BY ' . $orderIdColumn . ', ' . $orderDateColumn . '
+        HAVING ' . $having . '
+      ',
+      array_merge(
+        $metaKeys,
+        [
+          $orderLookup['table'],
+          $meta['table'],
+          $meta['order_id_column'],
+        ],
+        $metaKeys,
+        $typeParams,
+        $dateParams,
+        $havingParams
+      )
+    );
+    // phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+    $rows = $wpdb->get_results($query, ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
+    return $this->normalizeAttributionRows(is_array($rows) ? $rows : []);
+  }
+
+  /**
+   * @return array{table: string, order_id_column: string}
+   */
+  private function getOrderMetaTable(): array {
+    global $wpdb;
+
+    if ($this->wooHelper->isWooCommerceCustomOrdersTableEnabled()) {
+      return [
+        'table' => $wpdb->prefix . 'wc_orders_meta',
+        'order_id_column' => 'order_id',
+      ];
+    }
+
+    return [
+      'table' => $wpdb->postmeta,
+      'order_id_column' => 'post_id',
+    ];
+  }
+
+  private function getOrderTable(): string {
+    global $wpdb;
+
+    return $this->wooHelper->isWooCommerceCustomOrdersTableEnabled()
+      ? $wpdb->prefix . 'wc_orders'
+      : $wpdb->posts;
+  }
+
+  /**
+   * @return array{table: string, id_column: string, date_column: string, type_column: string|null}
+   */
+  private function getOrderLookupTable(): array {
+    global $wpdb;
+
+    if ($this->wooHelper->isWooCommerceCustomOrdersTableEnabled()) {
+      return [
+        'table' => $wpdb->prefix . 'wc_orders',
+        'id_column' => 'ID',
+        'date_column' => 'date_created_gmt',
+        'type_column' => 'type',
+      ];
+    }
+
+    return [
+      'table' => $wpdb->posts,
+      'id_column' => 'ID',
+      'date_column' => 'post_date_gmt',
+      'type_column' => 'post_type',
+    ];
+  }
+
+  private function getDateRangeSql(
+    string $column,
+    ?\DateTimeInterface $from,
+    ?\DateTimeInterface $to,
+    bool $includeFrom,
+    bool $excludeTo,
+    array &$params
+  ): string {
+    $params = [];
+    $sql = '';
+    if ($from !== null) {
+      $sql .= ' AND ' . $column . ($includeFrom ? ' >= %s' : ' > %s');
+      $params[] = $this->formatDate($from);
+    }
+    if ($to !== null) {
+      $sql .= ' AND ' . $column . ($excludeTo ? ' < %s' : ' <= %s');
+      $params[] = $this->formatDate($to);
+    }
+    return $sql;
+  }
+
+  private function isEmptyDateRange(?\DateTimeInterface $from, ?\DateTimeInterface $to, bool $excludeTo): bool {
+    if ($from === null || $to === null) {
+      return false;
+    }
+    if ($excludeTo) {
+      return $from->getTimestamp() >= $to->getTimestamp();
+    }
+    return $from->getTimestamp() > $to->getTimestamp();
+  }
+
+  /**
+   * @param array<int, string|int> $params
+   */
+  private function getCompleteWooAttributionExclusionSql(string $completeFor, string $orderIdExpression, array &$params): string {
+    $meta = $this->getOrderMetaTable();
+    $requiredFields = [
+      OrderAttributionFields::FIELD_CLICK_ID,
+      OrderAttributionFields::FIELD_NEWSLETTER_ID,
+    ];
+    if ($completeFor === self::COMPLETE_FOR_SUBSCRIBER) {
+      $requiredFields[] = OrderAttributionFields::FIELD_SUBSCRIBER_ID;
+    }
+
+    $params = [];
+    $exists = [];
+    foreach ($requiredFields as $fieldName) {
+      $exists[] = 'EXISTS (SELECT 1 FROM %i woo_meta WHERE woo_meta.%i = ' . $orderIdExpression . ' AND woo_meta.meta_key = %s AND woo_meta.meta_value <> \'\')';
+      $params[] = $meta['table'];
+      $params[] = $meta['order_id_column'];
+      $params[] = OrderAttributionWriter::META_PREFIX . $fieldName;
+    }
+
+    return ' AND NOT (' . implode(' AND ', $exists) . ')';
+  }
+
+  /**
+   * @param int[] $subscriberIds
+   * @return array<int, array{first_name:string, last_name:string, email:string}>
+   */
+  private function getSubscribersByIds(array $subscriberIds): array {
+    if (!$subscriberIds) {
+      return [];
+    }
+
+    global $wpdb;
+
+    $placeholders = implode(',', array_fill(0, count($subscriberIds), '%d'));
+    // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic fragments are trusted placeholders; values are prepared below.
+    $query = $wpdb->prepare(
+      '
+        SELECT ID, first_name, last_name, email
+        FROM %i
+        WHERE ID IN (' . $placeholders . ')
+      ',
+      array_merge(
+        [$wpdb->prefix . 'mailpoet_subscribers'],
+        $subscriberIds
+      )
+    );
+    // phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+    $rows = $wpdb->get_results($query, ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
+    $subscribers = [];
+    foreach ($rows ?: [] as $row) {
+      $subscribers[(int)$row['ID']] = [
+        'first_name' => (string)$row['first_name'],
+        'last_name' => (string)$row['last_name'],
+        'email' => (string)$row['email'],
+      ];
+    }
+    return $subscribers;
+  }
+
+  /**
+   * @param int[] $newsletterIds
+   * @return array<int, array{subject:string}>
+   */
+  private function getNewslettersByIds(array $newsletterIds): array {
+    if (!$newsletterIds) {
+      return [];
+    }
+
+    global $wpdb;
+
+    $placeholders = implode(',', array_fill(0, count($newsletterIds), '%d'));
+    // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic fragments are trusted placeholders; values are prepared below.
+    $query = $wpdb->prepare(
+      '
+        SELECT ID, subject
+        FROM %i
+        WHERE ID IN (' . $placeholders . ')
+      ',
+      array_merge(
+        [$wpdb->prefix . 'mailpoet_newsletters'],
+        $newsletterIds
+      )
+    );
+    // phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+    $rows = $wpdb->get_results($query, ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
+    $newsletters = [];
+    foreach ($rows ?: [] as $row) {
+      $newsletters[(int)$row['ID']] = [
+        'subject' => (string)$row['subject'],
+      ];
+    }
+    return $newsletters;
+  }
+
+  /**
+   * @param array<int, mixed> $rows
+   * @return OrderRow[]
+   */
+  private function normalizeOrderRows(array $rows): array {
+    $result = [];
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $normalized = $this->normalizeOrderRow($row);
+      if ($normalized !== null) {
+        $result[] = $normalized;
+      }
+    }
+    return $result;
+  }
+
+  /**
+   * @param array<mixed, mixed> $row
+   * @return OrderRow|null
+   */
+  private function normalizeOrderRow(array $row): ?array {
+    $createdAt = $this->toString($row['created_at'] ?? null);
+    $newsletterId = $this->toInt($row['newsletter_id'] ?? null);
+    $orderId = $this->toInt($row['order_id'] ?? null);
+    $total = $this->toFloat($row['total'] ?? null);
+    $subscriberId = $this->toInt($row['subscriber_id'] ?? null);
+    $firstName = $this->toString($row['first_name'] ?? null);
+    $lastName = $this->toString($row['last_name'] ?? null);
+    $email = $this->toString($row['email'] ?? null);
+    $subject = $this->toString($row['subject'] ?? null);
+    $status = $this->toString($row['status'] ?? null);
+
+    if (
+      $createdAt === null
+      || $newsletterId === null
+      || $orderId === null
+      || $total === null
+      || $subscriberId === null
+      || $firstName === null
+      || $lastName === null
+      || $email === null
+      || $subject === null
+      || $status === null
+    ) {
+      return null;
+    }
+
+    return [
+      'created_at' => $createdAt,
+      'newsletter_id' => $newsletterId,
+      'order_id' => $orderId,
+      'total' => $total,
+      'subscriber_id' => $subscriberId,
+      'first_name' => $firstName,
+      'last_name' => $lastName,
+      'email' => $email,
+      'subject' => $subject,
+      'status' => $status,
+    ];
+  }
+
+  /**
+   * @param array<int, mixed> $rows
+   * @return array<int, array{order_id: int, date_created_gmt: string, newsletter_id: string, subscriber_id: string|null}>
+   */
+  private function normalizeAttributionRows(array $rows): array {
+    $result = [];
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+      $orderId = $this->toInt($row['order_id'] ?? null);
+      $dateCreated = $this->toString($row['date_created_gmt'] ?? null);
+      $newsletterId = $this->toString($row['newsletter_id'] ?? null);
+      $subscriberId = $this->toString($row['subscriber_id'] ?? null);
+      if ($orderId === null || $dateCreated === null || $newsletterId === null) {
+        continue;
+      }
+      $result[] = [
+        'order_id' => $orderId,
+        'date_created_gmt' => $dateCreated,
+        'newsletter_id' => $newsletterId,
+        'subscriber_id' => $subscriberId,
+      ];
+    }
+    return $result;
+  }
+
+  private function toString($value): ?string {
+    return is_scalar($value) ? (string)$value : null;
+  }
+
+  private function toInt($value): ?int {
+    return is_numeric($value) ? (int)$value : null;
+  }
+
+  private function toFloat($value): ?float {
+    return is_numeric($value) ? (float)$value : null;
+  }
+
+  private function isRevenueOrder($order, string $currency, array $purchaseStates): bool {
+    return $order instanceof WC_Order
+      && $order->get_currency() === $currency
+      && in_array($order->get_status(), $purchaseStates, true);
+  }
+
+  private function formatDate(\DateTimeInterface $date): string {
+    return gmdate('Y-m-d H:i:s', $date->getTimestamp());
+  }
+
+  /**
+   * @param array<int, array{total: float, count: int}> $target
+   * @param array<int, array{total: float, count: int}> $rows
+   */
+  private function mergeNewsletterRows(array &$target, array $rows): void {
+    foreach ($rows as $newsletterId => $row) {
+      $this->addNewsletterRevenue($target, (int)$newsletterId, $row['total'], $row['count']);
+    }
+  }
+
+  /**
+   * @param array<int, array{total: float, count: int}> $target
+   */
+  private function addNewsletterRevenue(array &$target, int $newsletterId, float $total, int $count): void {
+    if (!isset($target[$newsletterId])) {
+      $target[$newsletterId] = ['total' => 0.0, 'count' => 0];
+    }
+    $target[$newsletterId]['total'] += $total;
+    $target[$newsletterId]['count'] += $count;
+  }
+
+  /**
+   * @param array{total: float, count: int} $target
+   * @param array{total: float, count: int} $source
+   */
+  private function mergeRevenue(array &$target, array $source): void {
+    $target['total'] += $source['total'];
+    $target['count'] += $source['count'];
+  }
+}

--- a/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
@@ -397,6 +397,9 @@ class OrderAttributionRevenueReader {
     $orderStatusColumn = $this->wooHelper->isWooCommerceCustomOrdersTableEnabled()
       ? '`woo_order`.`status`'
       : '`woo_order`.`post_status`';
+    $orderIdColumn = $this->wooHelper->isWooCommerceCustomOrdersTableEnabled()
+      ? '`woo_order`.`id`'
+      : '`woo_order`.`ID`';
 
     // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic fragments are trusted identifiers/placeholders; values are prepared below.
     $query = $wpdb->prepare(
@@ -413,10 +416,12 @@ class OrderAttributionRevenueReader {
           newsletter.subject,
           ' . $orderStatusColumn . ' AS status
         FROM %i swp
-        INNER JOIN %i woo_order ON swp.order_id = woo_order.ID
+        INNER JOIN %i woo_order ON swp.order_id = ' . $orderIdColumn . '
         INNER JOIN %i subscriber ON subscriber.ID = swp.subscriber_id
         INNER JOIN %i newsletter ON newsletter.ID = swp.newsletter_id
+        LEFT JOIN %i q ON q.id = swp.queue_id
         WHERE swp.newsletter_id IN (' . $newsletterPlaceholders . ')
+          AND (q.id IS NULL OR q.meta IS NULL OR q.meta NOT LIKE %s)
           ' . $dateSql . '
           ' . $excludeSql . '
       ',
@@ -426,8 +431,10 @@ class OrderAttributionRevenueReader {
           $orderTable,
           $wpdb->prefix . 'mailpoet_subscribers',
           $wpdb->prefix . 'mailpoet_newsletters',
+          $wpdb->prefix . 'mailpoet_sending_queues',
         ],
         $newsletterIds,
+        [NewsletterReplayMetadata::getMetaLikePattern()],
         $dateParams,
         $excludeParams
       )
@@ -606,7 +613,7 @@ class OrderAttributionRevenueReader {
     if ($this->wooHelper->isWooCommerceCustomOrdersTableEnabled()) {
       return [
         'table' => $wpdb->prefix . 'wc_orders',
-        'id_column' => 'ID',
+        'id_column' => 'id',
         'date_column' => 'date_created_gmt',
         'type_column' => 'type',
       ];

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -25,6 +25,7 @@ use MailPoet\Statistics\StatisticsUnsubscribesRepository;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterOption;
 use MailPoet\WooCommerce\Helper as WCHelper;
+use MailPoet\WooCommerce\OrderAttributionRevenueReader;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -59,7 +60,8 @@ class NewslettersTest extends \MailPoetTest {
           new NewsletterStatisticsRepository(
             $this->diContainer->get(EntityManager::class),
             $this->makeEmpty(WCHelper::class),
-            $this->diContainer->get(TrackingConfig::class)
+            $this->diContainer->get(TrackingConfig::class),
+            $this->diContainer->get(OrderAttributionRevenueReader::class)
           ),
           $this->diContainer->get(Url::class),
           $this->diContainer->get(SendingQueuesRepository::class),

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
@@ -6,16 +6,22 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
+use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
+use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterLink;
 use MailPoet\Test\DataFactories\StatisticsClicks;
 use MailPoet\Test\DataFactories\StatisticsOpens;
+use MailPoet\Test\DataFactories\StatisticsWooCommercePurchases;
 use MailPoet\Test\DataFactories\Subscriber;
+use MailPoet\WooCommerce\OrderAttributionFields;
+use MailPoet\WooCommerce\OrderAttributionWriter;
+use WC_Order;
 
 /**
  * @group woo
@@ -47,6 +53,9 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
   public function _before() {
     $this->testee = $this->diContainer->get(NewsletterStatisticsRepository::class);
     $this->revenueRepository = $this->diContainer->get(StatisticsWooCommercePurchasesRepository::class);
+    (new Features())->withFeatureDisabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
+    $this->diContainer->get(FeaturesController::class)->resetCache();
+    delete_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
     $this->newsletter = (new Newsletter())->withSendingQueue()->create();
     $this->assertInstanceOf(NewsletterEntity::class, $this->newsletter);
     $this->subscriber = (new Subscriber())->create();
@@ -108,5 +117,75 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
     $this->assertInstanceOf(WooCommerceRevenue::class, $revenue);
     $this->assertEquals(1, $revenue->getOrdersCount());
     $this->assertEquals(10, $revenue->getValue());
+  }
+
+  public function testWooBackedRevenueIsIgnoredWhenFeatureFlagIsDisabled(): void {
+    $this->createCompletedOrderWithAttribution($this->click1, 'manual-attribution@example.com', 15);
+
+    $revenue = $this->testee->getWooCommerceRevenue($this->newsletter);
+
+    $this->assertNull($revenue);
+  }
+
+  public function testWooBackedRevenueBlendsHistoricalLegacyWithPostBoundaryWooAttribution(): void {
+    $this->enableWooBackedRevenueReadModel();
+    (new StatisticsWooCommercePurchases($this->click1, [
+      'id' => 1001,
+      'currency' => 'USD',
+      'total' => 10.00,
+    ]))->withCreatedAt(new \DateTimeImmutable('-2 hours'))->create();
+
+    $order = $this->createCompletedOrderWithAttribution($this->click1, 'manual-attribution@example.com', 20);
+    $refund = wc_create_refund([
+      'order_id' => $order->get_id(),
+      'amount' => 5,
+    ]);
+    $this->assertNotInstanceOf(\WP_Error::class, $refund);
+
+    $revenue = $this->testee->getWooCommerceRevenue($this->newsletter);
+
+    $this->assertInstanceOf(WooCommerceRevenue::class, $revenue);
+    $this->assertEquals(2, $revenue->getOrdersCount());
+    $this->assertEquals(25, $revenue->getValue());
+  }
+
+  public function testWooBackedRevenueFallsBackToLegacyWhenPostBoundaryWooAttributionIsMissing(): void {
+    $this->enableWooBackedRevenueReadModel();
+    (new StatisticsWooCommercePurchases($this->click1, [
+      'id' => 1002,
+      'currency' => 'USD',
+      'total' => 12.00,
+    ]))->withCreatedAt(new \DateTimeImmutable('-30 minutes'))->create();
+
+    $revenue = $this->testee->getWooCommerceRevenue($this->newsletter);
+
+    $this->assertInstanceOf(WooCommerceRevenue::class, $revenue);
+    $this->assertEquals(1, $revenue->getOrdersCount());
+    $this->assertEquals(12, $revenue->getValue());
+  }
+
+  private function enableWooBackedRevenueReadModel(): void {
+    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
+    $this->diContainer->get(FeaturesController::class)->resetCache();
+    update_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION, gmdate('Y-m-d H:i:s', time() - HOUR_IN_SECONDS));
+  }
+
+  private function createCompletedOrderWithAttribution(StatisticsClickEntity $click, string $billingEmail, float $total): WC_Order {
+    $queue = $click->getQueue();
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
+
+    $order = wc_create_order();
+    $this->assertInstanceOf(WC_Order::class, $order);
+    $order->set_billing_email($billingEmail);
+    $order->set_currency('USD');
+    $order->set_total((string)$total);
+    $order->set_status('completed');
+    $order->save();
+    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_CLICK_ID, (string)$click->getId());
+    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_NEWSLETTER_ID, (string)$this->newsletter->getId());
+    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_QUEUE_ID, (string)$queue->getId());
+    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_SUBSCRIBER_ID, (string)$this->subscriber->getId());
+    $order->save_meta_data();
+    return $order;
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
 use MailPoet\Features\FeaturesController;
+use MailPoet\Newsletter\Sending\NewsletterReplayMetadata;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
 use MailPoet\Settings\SettingsController;
@@ -147,6 +148,20 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
     $this->assertInstanceOf(WooCommerceRevenue::class, $revenue);
     $this->assertEquals(2, $revenue->getOrdersCount());
     $this->assertEquals(25, $revenue->getValue());
+  }
+
+  public function testWooBackedRevenueExcludesReplayQueueAttribution(): void {
+    $this->enableWooBackedRevenueReadModel();
+    $queue = $this->newsletter->getLatestQueue();
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
+    $queue->setMeta([NewsletterReplayMetadata::LATEST_NEWSLETTER_REPLAY => true]);
+    $this->entityManager->flush();
+
+    $this->createCompletedOrderWithAttribution($this->click1, 'replay-attribution@example.com', 20);
+
+    $revenue = $this->testee->getWooCommerceRevenue($this->newsletter);
+
+    $this->assertNull($revenue);
   }
 
   public function testWooBackedRevenueFallsBackToLegacyWhenPostBoundaryWooAttributionIsMissing(): void {

--- a/mailpoet/tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php
@@ -275,6 +275,43 @@ class SubscriberStatisticsRepositoryTest extends \MailPoetTest {
     verify($result->getValue())->equals(18.00);
   }
 
+  public function testWooBackedSubscriberRevenueFallsBackToLegacyWhenOrderAttributionIsPartial(): void {
+    $this->enableWooBackedRevenueReadModel();
+    $subscriber = (new Subscriber())->create();
+    $newsletter = (new Newsletter())->withSendingQueue()->create();
+    $link = (new NewsletterLink($newsletter))->create();
+    $click = (new StatisticsClicks($link, $subscriber))->create();
+    $queue = $click->getQueue();
+    $this->assertNotNull($queue);
+
+    // Post-boundary Woo order carrying click + newsletter attribution but no
+    // subscriber meta: the Woo subscriber path must skip it and the legacy
+    // purchase row must supply the value instead of it being dropped.
+    $order = wc_create_order();
+    $this->assertInstanceOf(WC_Order::class, $order);
+    $order->set_billing_email('partial-attribution@example.com');
+    $order->set_currency('USD');
+    $order->set_total('40');
+    $order->set_status('completed');
+    $order->save();
+    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_CLICK_ID, (string)$click->getId());
+    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_NEWSLETTER_ID, (string)$newsletter->getId());
+    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_QUEUE_ID, (string)$queue->getId());
+    $order->save_meta_data();
+
+    (new StatisticsWooCommercePurchases($click, [
+      'id' => $order->get_id(),
+      'currency' => 'USD',
+      'total' => 18.00,
+    ]))->withCreatedAt(new \DateTimeImmutable('-30 minutes'))->create();
+
+    $result = $this->repository->getWooCommerceRevenue($subscriber, Carbon::now()->subHour());
+
+    $this->assertInstanceOf(WooCommerceRevenue::class, $result);
+    verify($result->getOrdersCount())->equals(1);
+    verify($result->getValue())->equals(18.00);
+  }
+
   private function enableWooBackedRevenueReadModel(): void {
     (new Features())->withFeatureEnabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
     $this->diContainer->get(FeaturesController::class)->resetCache();

--- a/mailpoet/tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php
@@ -2,10 +2,13 @@
 
 namespace MailPoet\Subscribers\Statistics;
 
+use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
+use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterLink;
 use MailPoet\Test\DataFactories\StatisticsClicks;
@@ -13,7 +16,10 @@ use MailPoet\Test\DataFactories\StatisticsNewsletters;
 use MailPoet\Test\DataFactories\StatisticsOpens;
 use MailPoet\Test\DataFactories\StatisticsWooCommercePurchases;
 use MailPoet\Test\DataFactories\Subscriber;
+use MailPoet\WooCommerce\OrderAttributionFields;
+use MailPoet\WooCommerce\OrderAttributionWriter;
 use MailPoetVendor\Carbon\Carbon;
+use WC_Order;
 
 /**
  * @group woo
@@ -29,6 +35,9 @@ class SubscriberStatisticsRepositoryTest extends \MailPoetTest {
     parent::_before();
     $this->repository = $this->diContainer->get(SubscriberStatisticsRepository::class);
     $this->settings = SettingsController::getInstance();
+    (new Features())->withFeatureDisabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
+    $this->diContainer->get(FeaturesController::class)->resetCache();
+    delete_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
   }
 
   public function testItFetchesClickCount(): void {
@@ -228,6 +237,73 @@ class SubscriberStatisticsRepositoryTest extends \MailPoetTest {
     $this->assertInstanceOf(WooCommerceRevenue::class, $daysAgoResult);
     verify($daysAgoResult->getOrdersCount())->equals(0);
     verify($daysAgoResult->getValue())->equals(0.00);
+  }
+
+  public function testItFetchesWooBackedSubscriberRevenueWhenFeatureFlagIsEnabled(): void {
+    $this->enableWooBackedRevenueReadModel();
+    $subscriber = (new Subscriber())->create();
+    $newsletter = (new Newsletter())->withSendingQueue()->create();
+    $link = (new NewsletterLink($newsletter))->create();
+    $click = (new StatisticsClicks($link, $subscriber))->create();
+
+    $order = $this->createCompletedOrderWithAttribution($click, $subscriber, 30);
+
+    $result = $this->repository->getWooCommerceRevenue($subscriber, Carbon::now()->subHour());
+
+    $this->assertInstanceOf(WooCommerceRevenue::class, $result);
+    verify($result->getOrdersCount())->equals(1);
+    verify($result->getValue())->equals((float)$order->get_remaining_refund_amount());
+  }
+
+  public function testWooBackedSubscriberRevenueFallsBackToLegacyWhenSubscriberMetaIsMissing(): void {
+    $this->enableWooBackedRevenueReadModel();
+    $subscriber = (new Subscriber())->create();
+    $newsletter = (new Newsletter())->withSendingQueue()->create();
+    $link = (new NewsletterLink($newsletter))->create();
+    $click = (new StatisticsClicks($link, $subscriber))->create();
+
+    (new StatisticsWooCommercePurchases($click, [
+      'id' => 2001,
+      'currency' => 'USD',
+      'total' => 18.00,
+    ]))->withCreatedAt(new \DateTimeImmutable('-30 minutes'))->create();
+
+    $result = $this->repository->getWooCommerceRevenue($subscriber, Carbon::now()->subHour());
+
+    $this->assertInstanceOf(WooCommerceRevenue::class, $result);
+    verify($result->getOrdersCount())->equals(1);
+    verify($result->getValue())->equals(18.00);
+  }
+
+  private function enableWooBackedRevenueReadModel(): void {
+    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
+    $this->diContainer->get(FeaturesController::class)->resetCache();
+    update_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION, gmdate('Y-m-d H:i:s', time() - HOUR_IN_SECONDS));
+  }
+
+  private function createCompletedOrderWithAttribution(
+    StatisticsClickEntity $click,
+    SubscriberEntity $subscriber,
+    float $total
+  ): WC_Order {
+    $newsletter = $click->getNewsletter();
+    $queue = $click->getQueue();
+    $this->assertNotNull($newsletter);
+    $this->assertNotNull($queue);
+
+    $order = wc_create_order();
+    $this->assertInstanceOf(WC_Order::class, $order);
+    $order->set_billing_email('manual-attribution@example.com');
+    $order->set_currency('USD');
+    $order->set_total((string)$total);
+    $order->set_status('completed');
+    $order->save();
+    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_CLICK_ID, (string)$click->getId());
+    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_NEWSLETTER_ID, (string)$newsletter->getId());
+    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_QUEUE_ID, (string)$queue->getId());
+    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_SUBSCRIBER_ID, (string)$subscriber->getId());
+    $order->save_meta_data();
+    return $order;
   }
 
   private function createSentEmails(SubscriberEntity $subscriber, int $count, Carbon $sentAt): void {


### PR DESCRIPTION
## Description

Adds feature-flagged WooCommerce order-attribution backed revenue reporting for newsletters and subscribers, with legacy fallback when attribution data is unavailable.

## Code review notes

The new path is default-off and only activates after the attribution write boundary option exists. It falls back to legacy stats for pre-boundary data and post-boundary orders missing complete Woo attribution metadata.

## QA notes

- `php -l` on touched PHP files
- `pnpm test:integration --file=tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php`
- `pnpm test:integration --file=tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php`
- `./do qa:code-sniffer` on touched files
- `pnpm qa:phpstan`
- `./do qa:prettier-check`
- Full `./do qa` was attempted, but local ignored `mailpoet/tests/plugins/` third-party files exhausted PHPCS memory before completing

## Linked PRs

- https://github.com/mailpoet/mailpoet-premium/pull/1093

## Linked tickets

STOMAIL-8138

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8138-woo-backed-revenue-reporting)

_The latest successful build from `add/stomail-8138-woo-backed-revenue-reporting` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
1 issue found:
- Suggestion: Translations and TypeScript adoption were not completed (missing internationalization and TypeScript migration coverage noted).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->