### PR TITLE
Add log deletion controls to Logs page

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_logs.scss
+++ b/mailpoet/assets/css/src/components-plugin/_logs.scss
@@ -88,3 +88,20 @@
     flex-basis: 100%;
   }
 }
+
+.mailpoet-logs-delete-modal {
+  .components-modal__content {
+    min-width: 420px;
+  }
+
+  .components-notice {
+    margin: 0 0 $grid-gap;
+  }
+}
+
+.mailpoet-logs-delete-modal__actions {
+  display: flex;
+  gap: $grid-gap-half;
+  justify-content: flex-end;
+  margin-top: $grid-gap;
+}

--- a/mailpoet/assets/js/src/logs/api.ts
+++ b/mailpoet/assets/js/src/logs/api.ts
@@ -33,6 +33,10 @@ export type LogListingItem = {
   created_at: string | null;
 };
 
+type ApiEnvelope<T> = {
+  data: T;
+};
+
 export function buildLogsRequestParams(
   params: ListingQueryParams,
   filters: LogsFilter,
@@ -56,4 +60,25 @@ export async function getLogs(
     signal,
   });
   return response.data;
+}
+
+// Deletes the logs matching the listing's current filters and search, so a
+// deletion removes exactly the rows the filtered listing shows. `all` confirms
+// the unrestricted case (no filters, no search) where every log is removed.
+export async function deleteLogs(
+  filter: LogsFilter,
+  search: string | undefined,
+  all: boolean,
+): Promise<number> {
+  ensureInitialized();
+  const response = await apiFetch<ApiEnvelope<{ deleted: number }>>({
+    path: '/mailpoet/v1/logs/delete',
+    method: 'POST',
+    data: {
+      filter,
+      search: search?.trim() || undefined,
+      all,
+    },
+  });
+  return response.data.deleted;
 }

--- a/mailpoet/assets/js/src/logs/delete-modal.tsx
+++ b/mailpoet/assets/js/src/logs/delete-modal.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useState } from 'react';
+import { Modal, Notice } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+import { Button } from 'common';
+import { deleteLogs } from './api';
+import type { LogsFilter } from './url-state';
+
+type Props = {
+  count: number;
+  filter: LogsFilter;
+  search: string | undefined;
+  isUnrestricted: boolean;
+  onClose: () => void;
+  onDeleted: (deleted: number) => void;
+};
+
+function getErrorMessage(error: unknown): string {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return error.message;
+  }
+  return __('Something went wrong. Please try again.', 'mailpoet');
+}
+
+export function DeleteLogsModal({
+  count,
+  filter,
+  search,
+  isUnrestricted,
+  onClose,
+  onDeleted,
+}: Props): JSX.Element {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const formattedCount = count.toLocaleString();
+  const message = isUnrestricted
+    ? sprintf(
+        _n(
+          'This permanently deletes the only log. This cannot be undone.',
+          'This permanently deletes all %s logs. This cannot be undone.',
+          count,
+          'mailpoet',
+        ),
+        formattedCount,
+      )
+    : sprintf(
+        _n(
+          'This permanently deletes %s log matching the current filters. This cannot be undone.',
+          'This permanently deletes %s logs matching the current filters. This cannot be undone.',
+          count,
+          'mailpoet',
+        ),
+        formattedCount,
+      );
+
+  const handleDelete = useCallback(async (): Promise<void> => {
+    setIsDeleting(true);
+    setErrorMessage(null);
+    try {
+      const deleted = await deleteLogs(filter, search, isUnrestricted);
+      onDeleted(deleted);
+      onClose();
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+      setIsDeleting(false);
+    }
+  }, [filter, search, isUnrestricted, onClose, onDeleted]);
+
+  return (
+    <Modal
+      className="mailpoet-logs-delete-modal"
+      title={__('Delete logs', 'mailpoet')}
+      onRequestClose={onClose}
+      isDismissible={!isDeleting}
+    >
+      {errorMessage && (
+        <Notice status="error" isDismissible={false}>
+          {errorMessage}
+        </Notice>
+      )}
+
+      <p>{message}</p>
+
+      <div className="mailpoet-logs-delete-modal__actions">
+        <Button
+          dimension="small"
+          variant="secondary"
+          onClick={onClose}
+          isDisabled={isDeleting}
+        >
+          {__('Cancel', 'mailpoet')}
+        </Button>
+        <Button
+          dimension="small"
+          variant="destructive"
+          onClick={handleDelete}
+          isDisabled={isDeleting}
+          withSpinner={isDeleting}
+        >
+          {sprintf(
+            _n('Delete %s log', 'Delete %s logs', count, 'mailpoet'),
+            formattedCount,
+          )}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Notice } from '@wordpress/components';
 import { DataViews, View } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 import { Button } from 'common';
 import {
@@ -12,6 +12,7 @@ import {
   type ListingQueryParams,
 } from 'common/dataviews';
 import { getLogs, type LogListingItem } from './api';
+import { DeleteLogsModal } from './delete-modal';
 import { getLogActions, getLogFieldDefinitions, getLogFields } from './fields';
 import {
   getLogFilterOptions,
@@ -72,6 +73,8 @@ export function List({ defaultFrom }: Props): JSX.Element {
   const [expandedLogIds, setExpandedLogIds] = useState<Set<number>>(
     () => new Set(),
   );
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const didMountRef = useRef(false);
 
   const load = useCallback(
@@ -105,13 +108,17 @@ export function List({ defaultFrom }: Props): JSX.Element {
       filterToExtraParams(viewFiltersToRequestFilter(currentView.filters)),
   });
 
-  const dateRangeError = getDateRangeError(
-    viewFiltersToRequestFilter(view.filters),
-  );
+  const requestFilter = viewFiltersToRequestFilter(view.filters);
+  const dateRangeError = getDateRangeError(requestFilter);
   const emptyState =
     loadError || dateRangeError ? null : (
       <div>{__('No logs found.', 'mailpoet')}</div>
     );
+
+  const searchTerm = view.search?.trim() || undefined;
+  const isUnrestrictedDelete =
+    Object.keys(requestFilter).length === 0 && !searchTerm;
+  const canDelete = !isLoading && !dateRangeError && meta.count > 0;
 
   const persistedViewChange = usePersistedDataViewsPreference(
     'logs',
@@ -169,8 +176,27 @@ export function List({ defaultFrom }: Props): JSX.Element {
     refresh();
   }, [clearLoadError, refresh]);
 
+  const handleDeleted = useCallback(
+    (deleted: number): void => {
+      setSuccessMessage(
+        sprintf(
+          _n('%s log deleted.', '%s logs deleted.', deleted, 'mailpoet'),
+          deleted.toLocaleString(),
+        ),
+      );
+      refresh();
+    },
+    [refresh],
+  );
+
   return (
     <div className="mailpoet-listing mailpoet-logs mailpoet-dataviews mailpoet-logs-dataviews">
+      {successMessage && (
+        <Notice status="success" onRemove={() => setSuccessMessage(null)}>
+          {successMessage}
+        </Notice>
+      )}
+
       {loadError && (
         <Notice status="error" isDismissible={false}>
           <div className="mailpoet-logs-error">
@@ -211,6 +237,14 @@ export function List({ defaultFrom }: Props): JSX.Element {
           <DataViews.Search label={__('Search logs', 'mailpoet')} />
           <DataViews.FiltersToggle />
           <div className="mailpoet-dataviews__toolbar-end">
+            <Button
+              dimension="small"
+              variant="destructive"
+              onClick={() => setIsDeleteModalOpen(true)}
+              isDisabled={!canDelete}
+            >
+              {__('Delete logs...', 'mailpoet')}
+            </Button>
             <DataViews.ViewConfig />
           </div>
         </div>
@@ -218,6 +252,16 @@ export function List({ defaultFrom }: Props): JSX.Element {
         <DataViews.Layout />
         <DataViews.Footer />
       </DataViews>
+      {isDeleteModalOpen && (
+        <DeleteLogsModal
+          count={meta.count}
+          filter={requestFilter}
+          search={searchTerm}
+          isUnrestricted={isUnrestrictedDelete}
+          onClose={() => setIsDeleteModalOpen(false)}
+          onDeleted={handleDeleted}
+        />
+      )}
     </div>
   );
 }

--- a/mailpoet/changelog/2026-06-13-09-04-03-added-add-log-deletion-controls-to-the-logs-page.md
+++ b/mailpoet/changelog/2026-06-13-09-04-03-added-add-log-deletion-controls-to-the-logs-page.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Log deletion from the Logs page, removing the logs matching the current filters and search

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -776,6 +776,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Logs REST API
     $container->autowire(\MailPoet\Logging\RestApi\Api::class)->setPublic(true);
     $container->autowire(\MailPoet\Logging\RestApi\Endpoints\LogsListingEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Logging\RestApi\Endpoints\LogsDeleteEndpoint::class)->setPublic(true);
     // Subscribers REST API
     $container->autowire(\MailPoet\Subscribers\RestApi\Api::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\RestApi\Endpoints\SubscribersListingEndpoint::class)->setPublic(true);

--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -8,6 +8,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Util\Helpers;
 use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\DBAL\ParameterType;
 
 /**
@@ -136,6 +137,32 @@ class LogRepository extends Repository {
     return (int)$result;
   }
 
+  /**
+   * Delete logs matching the listing's filter shape (`from`/`to`/`name`/`level`)
+   * and free-text search, so a deletion removes exactly what the filtered
+   * listing shows. Deletes in batches to keep each statement bounded on large
+   * log tables, mirroring purgeOldLogs().
+   *
+   * @param array{from?: string, to?: string, name?: string[], level?: int[]} $filter
+   */
+  public function deleteLogs(array $filter, ?string $search = null, int $batchSize = 1000): int {
+    $logsTable = $this->entityManager->getClassMetadata(LogEntity::class)->getTableName();
+    [$where, $parameters, $types] = $this->buildFilterSql($filter, $search);
+    $parameters['batch_limit'] = $batchSize;
+    $types['batch_limit'] = ParameterType::INTEGER;
+
+    $sql = "DELETE FROM `{$logsTable}`{$where} ORDER BY `created_at` ASC, `id` ASC LIMIT :batch_limit";
+    $connection = $this->entityManager->getConnection();
+
+    $deleted = 0;
+    do {
+      $affected = (int)$connection->executeStatement($sql, $parameters, $types);
+      $deleted += $affected;
+    } while ($affected === $batchSize);
+
+    return $deleted;
+  }
+
   public function getRawMessagesForNewsletter(NewsletterEntity $newsletter, string $topic): array {
     return $this->entityManager->createQueryBuilder()
       ->select('DISTINCT logs.rawMessage message')
@@ -159,5 +186,51 @@ class LogRepository extends Repository {
 
   protected function getEntityClassName() {
     return LogEntity::class;
+  }
+
+  /**
+   * Build the WHERE clause shared by log deletion. Day boundaries
+   * (`00:00:00`–`23:59:59`) and the literal LOCATE() search match
+   * LogListingRepository so deleting honours the same rows the listing shows.
+   *
+   * @param array{from?: string, to?: string, name?: string[], level?: int[]} $filter
+   * @return array{0: string, 1: array<string, mixed>, 2: array<string, int>}
+   */
+  private function buildFilterSql(array $filter, ?string $search): array {
+    $conditions = [];
+    $parameters = [];
+    $types = [];
+
+    if (!empty($filter['from'])) {
+      $conditions[] = '`created_at` >= :date_from';
+      $parameters['date_from'] = $filter['from'] . ' 00:00:00';
+      $types['date_from'] = ParameterType::STRING;
+    }
+    if (!empty($filter['to'])) {
+      $conditions[] = '`created_at` <= :date_to';
+      $parameters['date_to'] = $filter['to'] . ' 23:59:59';
+      $types['date_to'] = ParameterType::STRING;
+    }
+    if (!empty($filter['name'])) {
+      $conditions[] = '`name` IN (:names)';
+      $parameters['names'] = array_values($filter['name']);
+      $types['names'] = ArrayParameterType::STRING;
+    }
+    if (!empty($filter['level'])) {
+      $conditions[] = '`level` IN (:levels)';
+      $parameters['levels'] = array_values($filter['level']);
+      $types['levels'] = ArrayParameterType::INTEGER;
+    }
+    if ($search !== null && trim($search) !== '') {
+      $conditions[] = '(LOCATE(:search, `name`) > 0 OR LOCATE(:search, `message`) > 0)';
+      $parameters['search'] = trim($search);
+      $types['search'] = ParameterType::STRING;
+    }
+
+    return [
+      $conditions === [] ? '' : ' WHERE ' . implode(' AND ', $conditions),
+      $parameters,
+      $types,
+    ];
   }
 }

--- a/mailpoet/lib/Logging/RestApi/Api.php
+++ b/mailpoet/lib/Logging/RestApi/Api.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Logging\RestApi;
 
 use MailPoet\API\REST\API as RestApi;
+use MailPoet\Logging\RestApi\Endpoints\LogsDeleteEndpoint;
 use MailPoet\Logging\RestApi\Endpoints\LogsListingEndpoint;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -24,6 +25,7 @@ class Api {
   public function initialize(): void {
     $this->wp->addAction(RestApi::REST_API_INIT_ACTION, function (): void {
       $this->api->registerGetRoute('logs', LogsListingEndpoint::class);
+      $this->api->registerPostRoute('logs/delete', LogsDeleteEndpoint::class);
     });
   }
 }

--- a/mailpoet/lib/Logging/RestApi/Endpoints/LogsDeleteEndpoint.php
+++ b/mailpoet/lib/Logging/RestApi/Endpoints/LogsDeleteEndpoint.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Logging\RestApi\Endpoints;
+
+use MailPoet\API\REST\ApiException;
+use MailPoet\API\REST\Endpoint;
+use MailPoet\API\REST\ListingRequestValidationTrait;
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Config\AccessControl;
+use MailPoet\Logging\LogRepository;
+use MailPoet\Logging\RestApi\LogsFilterTrait;
+use MailPoet\Validator\Builder;
+use MailPoet\WP\Functions as WPFunctions;
+
+class LogsDeleteEndpoint extends Endpoint {
+  use ListingRequestValidationTrait;
+  use LogsFilterTrait;
+
+  // Referenced by ListingRequestValidationTrait's pagination helpers, which this
+  // endpoint composes for filter/date validation but never calls (it does not
+  // paginate). Values mirror AbstractListingEndpoint.
+  private const MAX_PER_PAGE = 100;
+  private const MAX_PAGE = 100000;
+
+  /** @var LogRepository */
+  private $logRepository;
+
+  public function __construct(
+    LogRepository $logRepository
+  ) {
+    $this->logRepository = $logRepository;
+  }
+
+  public function handle(Request $request): Response {
+    $filter = $this->validateAndNormalizeLogsFilter($request->getParam('filter'));
+    $search = $this->validateSearch($request->getParam('search'));
+
+    $isUnrestricted = $filter === [] && $search === null;
+    if ($isUnrestricted && $request->getParam('all') !== true) {
+      throw new ApiException(
+        __('Deleting all logs requires confirmation.', 'mailpoet'),
+        400,
+        'mailpoet_logs_delete_confirmation_required'
+      );
+    }
+
+    return new Response([
+      'deleted' => $this->logRepository->deleteLogs($filter, $search),
+    ]);
+  }
+
+  public function checkPermissions(): bool {
+    return WPFunctions::get()->currentUserCan(AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'filter' => Builder::object(),
+      'search' => Builder::string(),
+      'all' => Builder::boolean(),
+    ];
+  }
+
+  protected function getListingValidationErrorPrefix(): string {
+    return 'logs';
+  }
+
+  /** @param mixed $search */
+  private function validateSearch($search): ?string {
+    if ($search === null || (is_string($search) && trim($search) === '')) {
+      return null;
+    }
+    if (!is_string($search)) {
+      throw $this->listingValidationError(__('Search must be a string.', 'mailpoet'), 'search');
+    }
+    return $search;
+  }
+}

--- a/mailpoet/lib/Logging/RestApi/Endpoints/LogsListingEndpoint.php
+++ b/mailpoet/lib/Logging/RestApi/Endpoints/LogsListingEndpoint.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Logging\RestApi\Endpoints;
 
 use MailPoet\API\REST\AbstractListingEndpoint;
-use MailPoet\API\REST\ApiException;
 use MailPoet\API\REST\ListingRequestValidationTrait;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
@@ -13,16 +12,17 @@ use MailPoet\Listing\Handler as ListingHandler;
 use MailPoet\Listing\ListingDefinition;
 use MailPoet\Listing\ListingRepository;
 use MailPoet\Logging\LogListingRepository;
+use MailPoet\Logging\RestApi\LogsFilterTrait;
 use MailPoet\Validator\Builder;
 use MailPoet\WP\Functions as WPFunctions;
 
 class LogsListingEndpoint extends AbstractListingEndpoint {
   use ListingRequestValidationTrait;
+  use LogsFilterTrait;
 
   private const ALLOWED_SORT_FIELDS = ['created_at', 'name'];
   private const DEFAULT_SORT_FIELD = 'created_at';
   private const DEFAULT_SORT_ORDER = 'desc';
-  private const ALLOWED_FILTERS = ['from', 'to', 'name', 'level'];
 
   /** @var LogListingRepository */
   private $logListingRepository;
@@ -96,90 +96,7 @@ class LogsListingEndpoint extends AbstractListingEndpoint {
     $this->validateSortOrder($request->getParam('order'));
     $this->validateSortOrder($request->getParam('sort_order'));
     $this->validatePagination($request);
-    $this->validateFilters($request->getParam('filter'));
-  }
-
-  /** @param mixed $filters */
-  private function validateFilters($filters): void {
-    if ($filters === null || $filters === []) {
-      return;
-    }
-    if (!is_array($filters)) {
-      throw new ApiException(
-        __('Filters must be an object.', 'mailpoet'),
-        400,
-        'mailpoet_logs_invalid_filter'
-      );
-    }
-
-    $normalizedFilters = [];
-    foreach ($filters as $filter => $value) {
-      if (!is_string($filter) || !in_array($filter, self::ALLOWED_FILTERS, true)) {
-        throw new ApiException(
-          __('Unsupported logs filter.', 'mailpoet'),
-          400,
-          'mailpoet_logs_invalid_filter'
-        );
-      }
-      $normalizedFilters[$filter] = $value;
-    }
-
-    $this->validateStringListFilter($normalizedFilters, 'name');
-    $this->validateLevelFilter($normalizedFilters);
-
     // Keep the range check in sync with getDateRangeError() in logs/url-state.ts.
-    $from = $this->validateDateFilter($normalizedFilters, 'from');
-    $to = $this->validateDateFilter($normalizedFilters, 'to');
-    $this->validateDateRange($from, $to);
-  }
-
-  /**
-   * @param array<string, mixed> $filters
-   */
-  private function validateStringListFilter(array $filters, string $field): void {
-    if (!array_key_exists($field, $filters) || $filters[$field] === '' || $filters[$field] === []) {
-      return;
-    }
-    if (!is_array($filters[$field])) {
-      throw new ApiException(
-        __('The name filter must be an array of strings.', 'mailpoet'),
-        400,
-        'mailpoet_logs_invalid_' . $field
-      );
-    }
-    foreach ($filters[$field] as $value) {
-      if (!is_string($value)) {
-        throw new ApiException(
-          __('The name filter must be an array of strings.', 'mailpoet'),
-          400,
-          'mailpoet_logs_invalid_' . $field
-        );
-      }
-    }
-  }
-
-  /**
-   * @param array<string, mixed> $filters
-   */
-  private function validateLevelFilter(array $filters): void {
-    if (!array_key_exists('level', $filters) || $filters['level'] === '' || $filters['level'] === []) {
-      return;
-    }
-    if (!is_array($filters['level'])) {
-      throw new ApiException(
-        __('The level filter must be an array of integers.', 'mailpoet'),
-        400,
-        'mailpoet_logs_invalid_level'
-      );
-    }
-    foreach ($filters['level'] as $value) {
-      if ($this->getIntegerValue($value) === null) {
-        throw new ApiException(
-          __('The level filter must be an array of integers.', 'mailpoet'),
-          400,
-          'mailpoet_logs_invalid_level'
-        );
-      }
-    }
+    $this->validateAndNormalizeLogsFilter($request->getParam('filter'));
   }
 }

--- a/mailpoet/lib/Logging/RestApi/LogsFilterTrait.php
+++ b/mailpoet/lib/Logging/RestApi/LogsFilterTrait.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Logging\RestApi;
+
+/**
+ * Validates and normalizes the logs filter object (`from`/`to`/`name`/`level`)
+ * shared by the logs listing and deletion endpoints, so both interpret the same
+ * filter shape identically. Host endpoints must also use
+ * {@see \MailPoet\API\REST\ListingRequestValidationTrait} for the date helpers
+ * and namespaced error codes.
+ */
+trait LogsFilterTrait {
+  /**
+   * @param mixed $filters
+   * @return array{from?: string, to?: string, name?: string[], level?: int[]}
+   */
+  protected function validateAndNormalizeLogsFilter($filters): array {
+    if ($filters === null || $filters === []) {
+      return [];
+    }
+    if (!is_array($filters)) {
+      throw $this->listingValidationError(__('Filters must be an object.', 'mailpoet'), 'filter');
+    }
+    $allowedKeys = ['from', 'to', 'name', 'level'];
+    $normalizedFilters = [];
+    foreach ($filters as $key => $value) {
+      if (!is_string($key) || !in_array($key, $allowedKeys, true)) {
+        throw $this->listingValidationError(__('Unsupported logs filter.', 'mailpoet'), 'filter');
+      }
+      $normalizedFilters[$key] = $value;
+    }
+
+    $criteria = [];
+    $names = $this->normalizeLogsNameFilter($normalizedFilters);
+    if ($names !== []) {
+      $criteria['name'] = $names;
+    }
+    $levels = $this->normalizeLogsLevelFilter($normalizedFilters);
+    if ($levels !== []) {
+      $criteria['level'] = $levels;
+    }
+
+    $from = $this->validateDateFilter($normalizedFilters, 'from');
+    $to = $this->validateDateFilter($normalizedFilters, 'to');
+    $this->validateDateRange($from, $to);
+    if ($from) {
+      $criteria['from'] = $from->format('Y-m-d');
+    }
+    if ($to) {
+      $criteria['to'] = $to->format('Y-m-d');
+    }
+
+    return $criteria;
+  }
+
+  /**
+   * @param array<string, mixed> $filters
+   * @return string[]
+   */
+  private function normalizeLogsNameFilter(array $filters): array {
+    if (!array_key_exists('name', $filters) || $filters['name'] === '' || $filters['name'] === []) {
+      return [];
+    }
+    if (!is_array($filters['name'])) {
+      throw $this->listingValidationError(__('The name filter must be an array of strings.', 'mailpoet'), 'name');
+    }
+    $names = [];
+    foreach ($filters['name'] as $value) {
+      if (!is_string($value)) {
+        throw $this->listingValidationError(__('The name filter must be an array of strings.', 'mailpoet'), 'name');
+      }
+      $names[] = $value;
+    }
+    return array_values(array_unique($names));
+  }
+
+  /**
+   * @param array<string, mixed> $filters
+   * @return int[]
+   */
+  private function normalizeLogsLevelFilter(array $filters): array {
+    if (!array_key_exists('level', $filters) || $filters['level'] === '' || $filters['level'] === []) {
+      return [];
+    }
+    if (!is_array($filters['level'])) {
+      throw $this->listingValidationError(__('The level filter must be an array of integers.', 'mailpoet'), 'level');
+    }
+    $levels = [];
+    foreach ($filters['level'] as $value) {
+      $integer = $this->getIntegerValue($value);
+      if ($integer === null) {
+        throw $this->listingValidationError(__('The level filter must be an array of integers.', 'mailpoet'), 'level');
+      }
+      $levels[] = $integer;
+    }
+    return array_values(array_unique($levels));
+  }
+}

--- a/mailpoet/tests/integration/Logging/LogRepositoryTest.php
+++ b/mailpoet/tests/integration/Logging/LogRepositoryTest.php
@@ -31,4 +31,66 @@ class LogRepositoryTest extends \MailPoetTest {
     sort($logsInDB);
     verify([$log2->getId(), $log3->getId(), $log4->getId()])->equals($logsInDB);
   }
+
+  public function testDeleteLogsRemovesEverythingInBatches() {
+    $logFactory = new Log();
+    for ($i = 0; $i < 5; $i++) {
+      $logFactory->create();
+    }
+
+    // Batch size below the row count forces the loop to run multiple times.
+    $deleted = $this->repository->deleteLogs([], null, 2);
+
+    verify($deleted)->equals(5);
+    verify($this->repository->getLogs())->arrayCount(0);
+  }
+
+  public function testDeleteLogsAppliesFilterAndDateBoundaries() {
+    $logFactory = new Log();
+    $match = $logFactory
+      ->withName('api')
+      ->withLevel(400)
+      ->withCreatedAt(new Carbon('2025-04-10 23:30:00'))
+      ->create();
+    $keepLevel = $logFactory
+      ->withName('api')
+      ->withLevel(100)
+      ->withCreatedAt(new Carbon('2025-04-10 12:00:00'))
+      ->create();
+    $keepDate = $logFactory
+      ->withName('api')
+      ->withLevel(400)
+      ->withCreatedAt(new Carbon('2025-04-11 00:00:01'))
+      ->create();
+
+    $deleted = $this->repository->deleteLogs([
+      'from' => '2025-04-10',
+      'to' => '2025-04-10',
+      'name' => ['api'],
+      'level' => [400],
+    ]);
+
+    verify($deleted)->equals(1);
+    $remaining = array_map(function ($log) {
+      return $log->getId();
+    }, $this->repository->getLogs());
+    sort($remaining);
+    verify([$keepLevel->getId(), $keepDate->getId()])->equals($remaining);
+    verify(in_array($match->getId(), $remaining, true))->false();
+  }
+
+  public function testDeleteLogsTreatsSearchWildcardsLiterally() {
+    $logFactory = new Log();
+    $literal = $logFactory->withMessage('value a%b literal')->create();
+    $other = $logFactory->withMessage('value axxb other')->create();
+
+    $deleted = $this->repository->deleteLogs([], '%');
+
+    verify($deleted)->equals(1);
+    $remaining = array_map(function ($log) {
+      return $log->getId();
+    }, $this->repository->getLogs());
+    verify($remaining)->equals([$other->getId()]);
+    verify(in_array($literal->getId(), $remaining, true))->false();
+  }
 }

--- a/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
@@ -431,11 +431,103 @@ class LogsEndpointsTest extends Test {
     );
   }
 
+  public function testDeleteRemovesOnlyLogsMatchingDateNameAndLevel(): void {
+    $suffix = uniqid();
+    $match = (new LogFactory())
+      ->withName("api-{$suffix}")
+      ->withMessage("delete-match-{$suffix}")
+      ->withLevel(400)
+      ->withCreatedAt(new Carbon('2025-04-10 12:00:00'))
+      ->create();
+    $differentName = (new LogFactory())
+      ->withName("cron-{$suffix}")
+      ->withMessage("delete-keep-name-{$suffix}")
+      ->withLevel(400)
+      ->withCreatedAt(new Carbon('2025-04-10 12:00:00'))
+      ->create();
+    $differentLevel = (new LogFactory())
+      ->withName("api-{$suffix}")
+      ->withMessage("delete-keep-level-{$suffix}")
+      ->withLevel(100)
+      ->withCreatedAt(new Carbon('2025-04-10 12:00:00'))
+      ->create();
+    $differentDate = (new LogFactory())
+      ->withName("api-{$suffix}")
+      ->withMessage("delete-keep-date-{$suffix}")
+      ->withLevel(400)
+      ->withCreatedAt(new Carbon('2025-04-11 00:00:00'))
+      ->create();
+
+    $data = $this->post(self::BASE_PATH . '/delete', ['json' => [
+      'filter' => [
+        'from' => '2025-04-10',
+        'to' => '2025-04-10',
+        'name' => ["api-{$suffix}"],
+        'level' => [400],
+      ],
+    ]]);
+
+    $this->assertSame(1, $data['data']['deleted']);
+
+    $remainingIds = $this->getIdsForSearch($suffix);
+    $this->assertNotContains((int)$match->getId(), $remainingIds);
+    $this->assertContains((int)$differentName->getId(), $remainingIds);
+    $this->assertContains((int)$differentLevel->getId(), $remainingIds);
+    $this->assertContains((int)$differentDate->getId(), $remainingIds);
+  }
+
+  public function testDeleteRemovesOnlyLogsMatchingSearch(): void {
+    $suffix = uniqid();
+    $match = (new LogFactory())
+      ->withName("api-{$suffix}")
+      ->withMessage("delete-search-match-{$suffix}")
+      ->create();
+    $other = (new LogFactory())
+      ->withName("cron-{$suffix}")
+      ->withMessage("delete-search-keep-{$suffix}")
+      ->create();
+
+    // A search-only deletion is restricted (not "delete all"), so it needs no
+    // confirmation flag.
+    $data = $this->post(self::BASE_PATH . '/delete', ['json' => [
+      'search' => "delete-search-match-{$suffix}",
+    ]]);
+
+    $this->assertSame(1, $data['data']['deleted']);
+    $remainingIds = $this->getIdsForSearch($suffix);
+    $this->assertNotContains((int)$match->getId(), $remainingIds);
+    $this->assertContains((int)$other->getId(), $remainingIds);
+  }
+
+  public function testDeleteRequiresConfirmationOnlyForUnrestrictedDelete(): void {
+    (new LogFactory())->create();
+
+    $error = $this->post(self::BASE_PATH . '/delete', ['json' => []]);
+    $this->assertSame('mailpoet_logs_delete_confirmation_required', $error['code']);
+
+    $data = $this->post(self::BASE_PATH . '/delete', ['json' => ['all' => true]]);
+    $this->assertGreaterThanOrEqual(1, $data['data']['deleted']);
+  }
+
+  public function testDeleteRejectsInvalidFilters(): void {
+    $this->assertSame('mailpoet_logs_invalid_filter', $this->post(self::BASE_PATH . '/delete', ['json' => ['filter' => ['unsupported' => 'x']]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_from', $this->post(self::BASE_PATH . '/delete', ['json' => ['filter' => ['from' => '2025-02-30']]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_date_range', $this->post(self::BASE_PATH . '/delete', ['json' => ['filter' => ['from' => '2025-02-02', 'to' => '2025-02-01']]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_name', $this->post(self::BASE_PATH . '/delete', ['json' => ['filter' => ['name' => 'not-an-array']]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_level', $this->post(self::BASE_PATH . '/delete', ['json' => ['filter' => ['level' => ['x']]]])['code']);
+  }
+
   public function testGetRejectsUsersWithoutPermission(): void {
     wp_set_current_user($this->editorUserId);
 
     $data = $this->get(self::BASE_PATH);
     $this->assertSame('rest_forbidden', $data['code']);
+  }
+
+  public function testDeleteRejectsUsersWithoutPermission(): void {
+    wp_set_current_user($this->editorUserId);
+
+    $this->assertSame('rest_forbidden', $this->post(self::BASE_PATH . '/delete', ['json' => ['all' => true]])['code']);
   }
 
   /** @return int[] */

--- a/mailpoet/tests/integration/REST/Test.php
+++ b/mailpoet/tests/integration/REST/Test.php
@@ -38,17 +38,11 @@ abstract class Test extends MailPoetTest {
     $_SERVER['REQUEST_METHOD'] = $method;
     $_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
 
-    if (isset($options['query'])) {
-      $_GET = $options['query'];
-    }
-
-    if (isset($options['post'])) {
-      $_POST = $options['post'];
-    }
-
-    if (isset($options['json'])) {
-      $GLOBALS['HTTP_RAW_POST_DATA'] = json_encode($options['json']);
-    }
+    // Reset request state so params from a previous request in the same test
+    // (e.g. a POST body) don't leak into the next one.
+    $_GET = $options['query'] ?? [];
+    $_POST = $options['post'] ?? [];
+    $GLOBALS['HTTP_RAW_POST_DATA'] = isset($options['json']) ? json_encode($options['json']) : '';
 
     $server = rest_get_server();
     ob_start();


### PR DESCRIPTION
## Description

A **Delete logs...** action in the listing toolbar deletes the logs matching the listing's current filters (date range, type, level) and search. A confirmation modal shows the count of logs that will be deleted.

Backend: `POST /logs/delete` endpoint taking the same `{from,to,name,level}` filter shape as the listing plus `search`. Deletes run in bounded batches (like `purgeOldLogs`) to keep each statement small on large log tables. A shared `LogsFilterTrait` validates the filter for both the listing and delete endpoints.

## Code review notes

- Permission-checked (`PERMISSION_ACCESS_PLUGIN_ADMIN`), parameterized SQL, `LOCATE()` literal search (no wildcard injection).
- Server requires `all: true` when no filters/search are set, so deleting all logs is deliberate.
- Drive-by: REST test helper `request()` now resets `$_GET`/`$_POST`/raw body between calls — a prior POST body was leaking into a following GET.

## QA notes

1. Logs page → set filters/search → **Delete logs...** → confirm. Only matching logs are removed; count in the dialog matches the listing.
2. No filters/search → button deletes all logs but only after the explicit confirm.
3. Button disabled when nothing matches.

## Screenshots

<img width="1526" height="651" alt="Screenshot 2026-06-19 at 10 56 56" src="https://github.com/user-attachments/assets/92c632f6-0c26-4f87-90cd-628af7ff2086" />
<img width="1521" height="703" alt="Screenshot 2026-06-19 at 11 10 14" src="https://github.com/user-attachments/assets/19b26fee-d2a8-43d5-817f-d4f323956cc7" />


## Linked tickets

STOMAIL-8165

## Tasks

- [x] I have added a changelog entry
- [x] I followed best practices for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8165-add-log-deletion-controls-to-mailpoet-logs-page)

_The latest successful build from `stomail-8165-add-log-deletion-controls-to-mailpoet-logs-page` will be used. If none is available, the link won't work._