### PR TITLE
Add win-back customer email patterns

### DIFF
--- a/mailpoet/changelog/2026-06-03-15-05-59-added-email-content-patterns-for-win-back-inactive-custo.md
+++ b/mailpoet/changelog/2026-06-03-15-05-59-added-email-content-patterns-for-win-back-inactive-custo.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Email content patterns for win-back inactive customer automations

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
@@ -4,6 +4,8 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor;
+use MailPoet\Util\CdnAssetUrl;
 
 /**
  * Win Back Customer email pattern.
@@ -15,12 +17,51 @@ class WinBackCustomerPattern extends Pattern {
   protected $categories = ['purchase'];
   protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
+  /** @var bool */
+  private $isReminder;
+
+  /** @var bool */
+  private $isFinalNudge;
+
+  public function __construct(
+    CdnAssetUrl $cdnAssetUrl,
+    bool $isReminder = false,
+    bool $isFinalNudge = false
+  ) {
+    parent::__construct($cdnAssetUrl);
+    $this->isReminder = $isReminder;
+    $this->isFinalNudge = $isFinalNudge;
+    if ($isReminder) {
+      $this->name = 'win-back-customer-reminder';
+    } elseif ($isFinalNudge) {
+      $this->name = 'win-back-customer-final-nudge';
+    }
+  }
+
   /**
    * Get pattern content.
    *
    * @return string Pattern HTML content.
    */
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->isReminder) {
+      return $this->buildReminderContent($this->getProductPlaceholderColumns([
+        'product-small-02.jpg',
+        'product-small-06.jpg',
+        'product-small-03.jpg',
+        'product-small-05.jpg',
+      ]));
+    }
+
+    if ($this->isFinalNudge) {
+      return $this->buildFinalNudgeContent($this->getProductPlaceholderColumns([
+        'product-small-02.jpg',
+        'product-small-06.jpg',
+        'product-small-03.jpg',
+        'product-small-05.jpg',
+      ]));
+    }
+
     return $this->buildContent($this->getProductPlaceholderColumns([
       'product-small-02.jpg',
       'product-small-06.jpg',
@@ -30,7 +71,116 @@ class WinBackCustomerPattern extends Pattern {
   }
 
   public function get_email_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    return $this->buildContent($this->getRecommendedProductCollectionBlock('new-arrivals'));
+    $recommendedProducts = $this->getRecommendedProductCollectionBlock(
+      OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS,
+      'popularity'
+    );
+
+    if ($this->isReminder) {
+      return $this->buildReminderContent($recommendedProducts);
+    }
+
+    if ($this->isFinalNudge) {
+      return $this->buildFinalNudgeContent($recommendedProducts);
+    }
+
+    return $this->buildContent($recommendedProducts);
+  }
+
+  private function buildReminderContent(string $productSection): string {
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' . __('We miss you', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
+      /* translators: %s is a placeholder for the first name */
+      sprintf(__('Hi %s, it’s been a little while since your last visit, and we’d love to welcome you back.', 'mailpoet'), '<!--[woocommerce/customer-first-name]-->') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('New favorites may be waiting for you in the shop. We picked a few products that go well with your last order.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
+      <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+
+      <!-- wp:heading {"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}},"typography":{"fontSize":"24px"}}} -->
+      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('New arrivals you might like', 'mailpoet') . '</h2>
+      <!-- /wp:heading -->
+
+      ' . $productSection . '
+
+      <!-- wp:spacer {"height":"30px"} -->
+      <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+      <!-- /wp:spacer -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . __('See you soon,', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  private function buildFinalNudgeContent(string $productSection): string {
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' . __('Still thinking it over?', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
+      /* translators: %s is a placeholder for the first name */
+      sprintf(__('Hi %s, there’s still time to find something you’ll love. These picks are based on what you bought last time.', 'mailpoet'), '<!--[woocommerce/customer-first-name]-->') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('Come back when you’re ready and continue where you left off.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
+      <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Browse recommendations', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+
+      <!-- wp:heading {"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}},"typography":{"fontSize":"24px"}}} -->
+      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('Recommended for your return', 'mailpoet') . '</h2>
+      <!-- /wp:heading -->
+
+      ' . $productSection . '
+
+      <!-- wp:spacer {"height":"30px"} -->
+      <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+      <!-- /wp:spacer -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . __('Happy shopping!', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
   }
 
   private function buildContent(string $productSection): string {
@@ -93,6 +243,14 @@ class WinBackCustomerPattern extends Pattern {
   }
 
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->isReminder) {
+      return __('Win Back Customer Reminder', 'mailpoet');
+    }
+
+    if ($this->isFinalNudge) {
+      return __('Win Back Customer Final Nudge', 'mailpoet');
+    }
+
     /* translators: Name of a content pattern used as starting content of an email */
     return __('Win Back Customer', 'mailpoet');
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
@@ -114,7 +114,7 @@ class WinBackCustomerPattern extends Pattern {
       <!-- /wp:buttons -->
 
       <!-- wp:heading {"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}},"typography":{"fontSize":"24px"}}} -->
-      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('New arrivals you might like', 'mailpoet') . '</h2>
+      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('You might also like', 'mailpoet') . '</h2>
       <!-- /wp:heading -->
 
       ' . $productSection . '
@@ -194,7 +194,7 @@ class WinBackCustomerPattern extends Pattern {
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
       <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
       /* translators: %s is a placeholder for the first name */
-      sprintf(__('Hi %s, come see what’s new — we’ve added fresh arrivals and exclusive deals just for you.', 'mailpoet'), '<!--[woocommerce/customer-first-name]-->') . '</p>
+      sprintf(__('Hi %s, we’ve got an exclusive deal waiting just for you.', 'mailpoet'), '<!--[woocommerce/customer-first-name]-->') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -114,6 +114,8 @@ class PatternsController {
         new ProductPurchaseFollowUpPattern($this->cdnAssetUrl),
         new TagPurchaseFollowUpPattern($this->cdnAssetUrl),
         new CategoryPurchaseFollowUpPattern($this->cdnAssetUrl),
+        new WinBackCustomerPattern($this->cdnAssetUrl, true),
+        new WinBackCustomerPattern($this->cdnAssetUrl, false, true),
         new AbandonedCartPattern($this->cdnAssetUrl),
         new AbandonedCartReminderPattern($this->cdnAssetUrl),
         new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'positive-follow-up'),

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -45,6 +45,8 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/product-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/tag-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/category-purchase-follow-up', $patternNames);
+    $this->assertContains('mailpoet/win-back-customer-reminder', $patternNames);
+    $this->assertContains('mailpoet/win-back-customer-final-nudge', $patternNames);
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/positive-review-follow-up', $patternNames);
     $this->assertContains('mailpoet/negative-review-follow-up', $patternNames);
@@ -58,7 +60,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(22, $blockPatterns);
+    $this->assertCount(24, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
@@ -142,6 +144,8 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/product-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/tag-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/category-purchase-follow-up', $patternNames);
+    $this->assertContains('mailpoet/win-back-customer-reminder', $patternNames);
+    $this->assertContains('mailpoet/win-back-customer-final-nudge', $patternNames);
     $this->assertContains('mailpoet/ask-for-review-post-purchase', $patternNames);
     $this->assertContains('mailpoet/positive-review-follow-up', $patternNames);
     $this->assertContains('mailpoet/negative-review-follow-up', $patternNames);
@@ -155,7 +159,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/reward-positive-reviewer', $patternNames);
 
     // Verify total count (all patterns except 4 coupon patterns)
-    $this->assertCount(18, $blockPatterns);
+    $this->assertCount(20, $blockPatterns);
   }
 
   /**
@@ -217,6 +221,53 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertStringContainsString('"expiryDay":10', $patternsByName['mailpoet/welcome-with-discount-email-content']['content']);
     $this->assertStringContainsString('"amount":15', $patternsByName['mailpoet/win-back-customer']['content']);
     $this->assertStringContainsString('"expiryDay":1', $patternsByName['mailpoet/abandoned-cart-with-discount-content']['content']);
+
+    $winBackEmailContent = $patterns->getPatternContent('win-back-customer');
+    $this->assertIsString($winBackEmailContent);
+    $this->assertStringContainsString('wp:woocommerce/coupon-code', $winBackEmailContent);
+    $this->assertStringContainsString('mailpoet/product-collection/order-cross-sells', $winBackEmailContent);
+  }
+
+  public function testWinBackReminderPatternDoesNotUseGeneratedCouponBlock(): void {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.7.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
+
+    $patterns = new PatternsController(
+      $this->diContainer->get(CdnAssetUrl::class),
+      $this->diContainer->get(WPFunctions::class),
+      $wooCommerceHelper
+    );
+
+    $content = $patterns->getPatternContent('win-back-customer-reminder');
+
+    $this->assertIsString($content);
+    $this->assertStringContainsString('We miss you', $content);
+    $this->assertStringContainsString('wp:button', $content);
+    $this->assertStringContainsString('mailpoet/product-collection/order-cross-sells', $content);
+    $this->assertStringNotContainsString('wp:woocommerce/coupon-code', $content);
+  }
+
+  public function testWinBackFinalNudgePatternDoesNotUseGeneratedCouponBlock(): void {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.7.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
+
+    $patterns = new PatternsController(
+      $this->diContainer->get(CdnAssetUrl::class),
+      $this->diContainer->get(WPFunctions::class),
+      $wooCommerceHelper
+    );
+
+    $content = $patterns->getPatternContent('win-back-customer-final-nudge');
+
+    $this->assertIsString($content);
+    $this->assertStringContainsString('Still thinking it over?', $content);
+    $this->assertStringContainsString('mailpoet/product-collection/order-cross-sells', $content);
+    $this->assertStringNotContainsString('[coupon code]', $content);
+    $this->assertStringNotContainsString('wp:woocommerce/coupon-code', $content);
   }
 
   public function testAskForReviewPatternContainsReviewButtonWithOrderReviewUrlTag(): void {
@@ -421,6 +472,8 @@ class PatternsControllerTest extends \MailPoetTest {
       'mailpoet/product-purchase-follow-up',
       'mailpoet/tag-purchase-follow-up',
       'mailpoet/category-purchase-follow-up',
+      'mailpoet/win-back-customer-reminder',
+      'mailpoet/win-back-customer-final-nudge',
       'mailpoet/win-back-customer',
       'mailpoet/abandoned-cart-content',
       'mailpoet/abandoned-cart-reminder-content',


### PR DESCRIPTION
## Description

Adds reusable email content patterns for win-back inactive customer automations. New patterns live in `WinBackCustomerPattern` and are registered in `PatternsController` so the email editor can offer them. The premium plugin consumes these patterns to build its win-back templates (see linked PR).

## Code review notes

_N/A_

## QA notes

PHPStan and PHPCS pass on the changed files.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1094

## Linked tickets

STOMAIL-8124

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I followed best practices for translations
- [x] I added sufficient test coverage

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8124-add-email-templates-for-product-follow-up-automations)

_The latest successful build from `stomail-8124-add-email-templates-for-product-follow-up-automations` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->