### PR TITLE
Add native DataViews filters and sorting to segment listings

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/fields.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/fields.ts
@@ -38,6 +38,7 @@ export const dynamicSegmentFields: Field<DynamicSegmentListingItem>[] = [
     type: 'text',
     enableSorting: true,
     enableGlobalSearch: true,
+    filterBy: false,
     render: ({ item }) =>
       createElement(
         'div',
@@ -103,11 +104,25 @@ export const dynamicSegmentFields: Field<DynamicSegmentListingItem>[] = [
     },
   },
   {
-    id: 'updated_at',
-    label: __('Modified', 'mailpoet'),
-    type: 'datetime',
+    id: 'created_at',
+    label: __('Created', 'mailpoet'),
+    type: 'date',
     enableSorting: true,
     enableGlobalSearch: false,
+    filterBy: {
+      operators: ['on', 'beforeInc', 'afterInc', 'between'],
+    },
+    render: ({ item }) => dateTime(item.created_at),
+  },
+  {
+    id: 'updated_at',
+    label: __('Modified', 'mailpoet'),
+    type: 'date',
+    enableSorting: true,
+    enableGlobalSearch: false,
+    filterBy: {
+      operators: ['on', 'beforeInc', 'afterInc', 'between'],
+    },
     render: ({ item }) => dateTime(item.updated_at, item.id),
   },
 ];

--- a/mailpoet/assets/js/src/segments/dynamic/filters.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/filters.ts
@@ -1,0 +1,63 @@
+import type { Filter } from '@wordpress/dataviews';
+import { dateRangeFromFilter } from 'common/dataviews';
+
+export const CREATED_AT_FIELD = 'created_at';
+export const UPDATED_AT_FIELD = 'updated_at';
+
+export type DynamicSegmentsRequestFilter = {
+  created_from?: string;
+  created_to?: string;
+  updated_from?: string;
+  updated_to?: string;
+};
+
+function dateRangeKeys(
+  fromKey: 'created_from' | 'updated_from',
+  toKey: 'created_to' | 'updated_to',
+  operator: string,
+  value: unknown,
+): DynamicSegmentsRequestFilter {
+  const { from, to } = dateRangeFromFilter(operator, value);
+  return {
+    ...(from ? { [fromKey]: from } : {}),
+    ...(to ? { [toKey]: to } : {}),
+  };
+}
+
+/**
+ * Translate DataViews native filters into the REST `filter` object the dynamic
+ * segments listing endpoint understands (`{ created_from, created_to,
+ * updated_from, updated_to }`). The two date columns use distinct keys so they
+ * can be filtered independently. Empty filters are omitted.
+ */
+export function viewFiltersToRequestFilter(
+  filters: Filter[] | undefined,
+): DynamicSegmentsRequestFilter {
+  const result: DynamicSegmentsRequestFilter = {};
+
+  (filters ?? []).forEach((filter) => {
+    if (filter.field === CREATED_AT_FIELD) {
+      Object.assign(
+        result,
+        dateRangeKeys(
+          'created_from',
+          'created_to',
+          filter.operator,
+          filter.value,
+        ),
+      );
+    } else if (filter.field === UPDATED_AT_FIELD) {
+      Object.assign(
+        result,
+        dateRangeKeys(
+          'updated_from',
+          'updated_to',
+          filter.operator,
+          filter.value,
+        ),
+      );
+    }
+  });
+
+  return result;
+}

--- a/mailpoet/assets/js/src/segments/dynamic/list.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list.tsx
@@ -11,8 +11,10 @@ import {
   getDataViewsPreference,
   usePersistedDataViewsPreference,
   useDataViewsQuery,
+  filterToExtraParams,
   type ListingQueryParams,
 } from 'common/dataviews';
+import { viewFiltersToRequestFilter } from './filters';
 import { Notices } from './list/notices';
 import { getSegmentsQuery, updateSegmentsQuery } from './list/query';
 import * as ROUTES from '../routes';
@@ -272,6 +274,9 @@ export function DynamicSegmentList(): JSX.Element {
     initialView: viewFromQuery(initialQuery, defaultView),
     load,
     extraParams: (currentView) => {
+      const filterParams = filterToExtraParams(
+        viewFiltersToRequestFilter(currentView.filters),
+      );
       if (
         legacyOffsetRef.current !== null &&
         viewMatchesQuery(currentView, {
@@ -286,9 +291,10 @@ export function DynamicSegmentList(): JSX.Element {
           limit: currentView.perPage ?? initialQuery.limit,
           sort_by: currentView.sort?.field ?? 'updated_at',
           sort_order: currentView.sort?.direction ?? 'desc',
+          ...filterParams,
         };
       }
-      return {};
+      return filterParams;
     },
   });
 
@@ -608,10 +614,12 @@ export function DynamicSegmentList(): JSX.Element {
             >
               <div className="mailpoet-segments-dataviews__toolbar">
                 <DataViews.Search label={__('Search', 'mailpoet')} />
+                <DataViews.FiltersToggle />
                 <div className="mailpoet-dataviews__toolbar-end">
                   <DataViews.ViewConfig />
                 </div>
               </div>
+              <DataViews.Filters />
               <DataViews.Layout />
               <DataViews.Footer />
             </DataViews>

--- a/mailpoet/assets/js/src/segments/static/fields.ts
+++ b/mailpoet/assets/js/src/segments/static/fields.ts
@@ -32,8 +32,12 @@ const engagementScoreFields: Field<SegmentListingItem>[] = MailPoet
       {
         id: 'average_engagement_score',
         label: MailPoet.I18n.t('listScore'),
+        type: 'integer',
         enableSorting: true,
         enableGlobalSearch: false,
+        filterBy: {
+          operators: ['lessThan', 'greaterThan', 'between'],
+        },
         render: ({ item }) =>
           createElement(ListingsEngagementScore, {
             id: Number(item.id),
@@ -50,6 +54,7 @@ export const segmentFields: Field<SegmentListingItem>[] = [
     type: 'text',
     enableSorting: true,
     enableGlobalSearch: false,
+    filterBy: false,
     render: ({ item }) => {
       const privateLabel =
         Number(item.show_in_manage_subscription_page) === 0
@@ -98,20 +103,6 @@ export const segmentFields: Field<SegmentListingItem>[] = [
     enableSorting: false,
     enableGlobalSearch: false,
   },
-  {
-    id: 'type',
-    label: __('Type', 'mailpoet'),
-    elements: [
-      { value: 'default', label: __('List', 'mailpoet') },
-      { value: 'wp_users', label: __('WordPress users', 'mailpoet') },
-      {
-        value: 'woocommerce_users',
-        label: __('WooCommerce customers', 'mailpoet'),
-      },
-    ],
-    enableSorting: false,
-    enableGlobalSearch: false,
-  },
   ...engagementScoreFields,
   {
     id: 'subscribed',
@@ -151,9 +142,12 @@ export const segmentFields: Field<SegmentListingItem>[] = [
   {
     id: 'created_at',
     label: MailPoet.I18n.t('createdOn'),
-    type: 'datetime',
+    type: 'date',
     enableSorting: true,
     enableGlobalSearch: false,
+    filterBy: {
+      operators: ['on', 'beforeInc', 'afterInc', 'between'],
+    },
     render: ({ item }) => dateTime(item.created_at),
   },
 ];

--- a/mailpoet/assets/js/src/segments/static/filters.ts
+++ b/mailpoet/assets/js/src/segments/static/filters.ts
@@ -1,0 +1,82 @@
+import type { Filter } from '@wordpress/dataviews';
+import { dateRangeFromFilter } from 'common/dataviews';
+
+export const CREATED_AT_FIELD = 'created_at';
+export const SCORE_FIELD = 'average_engagement_score';
+
+export type SegmentsRequestFilter = {
+  created_from?: string;
+  created_to?: string;
+  score_min?: number;
+  score_max?: number;
+};
+
+/**
+ * Coerce a score-control value to a finite number, rejecting empty strings and
+ * null (which `Number()` would silently turn into 0 and activate an unintended
+ * filter). Returns undefined for anything that isn't a real number.
+ */
+function toFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '') return undefined;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Translate the engagement-score numeric filter into `{ score_min, score_max }`.
+ * `between` yields both bounds; `greaterThan`/`lessThan` yield a single bound.
+ * Non-numeric input is dropped so a half-configured control sends nothing.
+ */
+function scoreKeys(operator: string, value: unknown): SegmentsRequestFilter {
+  if (operator === 'between') {
+    const range = Array.isArray(value) ? value : [];
+    const min = toFiniteNumber(range[0]);
+    const max = toFiniteNumber(range[1]);
+    return {
+      ...(min !== undefined ? { score_min: min } : {}),
+      ...(max !== undefined ? { score_max: max } : {}),
+    };
+  }
+  const num = toFiniteNumber(value);
+  if (num === undefined) {
+    return {};
+  }
+  if (operator === 'greaterThan') {
+    return { score_min: num };
+  }
+  if (operator === 'lessThan') {
+    return { score_max: num };
+  }
+  return {};
+}
+
+/**
+ * Translate DataViews native filters into the REST `filter` object the segments
+ * (lists) listing endpoint understands (`{ created_from, created_to, score_min,
+ * score_max }`). Empty filters are omitted so an inactive control never sends a
+ * key.
+ */
+export function viewFiltersToRequestFilter(
+  filters: Filter[] | undefined,
+): SegmentsRequestFilter {
+  const result: SegmentsRequestFilter = {};
+
+  (filters ?? []).forEach((filter) => {
+    if (filter.field === CREATED_AT_FIELD) {
+      const { from, to } = dateRangeFromFilter(filter.operator, filter.value);
+      if (from) result.created_from = from;
+      if (to) result.created_to = to;
+    } else if (filter.field === SCORE_FIELD) {
+      Object.assign(result, scoreKeys(filter.operator, filter.value));
+    }
+  });
+
+  return result;
+}

--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -13,6 +13,7 @@ import {
   getDataViewsPreference,
   usePersistedDataViewsPreference,
   useDataViewsQuery,
+  filterToExtraParams,
   type ListingQueryParams,
 } from 'common/dataviews';
 import { ListHeading } from 'segments/static/heading';
@@ -24,6 +25,7 @@ import {
   type SegmentListingItem,
 } from './api';
 import { segmentFields } from './fields';
+import { viewFiltersToRequestFilter } from './filters';
 
 type Group = 'all' | 'trash';
 type SelectAllParams = Partial<ListingQueryParams> & { select_all?: boolean };
@@ -295,6 +297,8 @@ function SegmentListComponent(): JSX.Element {
   } = useDataViewsQuery<SegmentListingItem>({
     initialView,
     load,
+    extraParams: (currentView) =>
+      filterToExtraParams(viewFiltersToRequestFilter(currentView.filters)),
   });
   const handleViewChange = usePersistedDataViewsPreference(
     'static-segments',
@@ -638,10 +642,12 @@ function SegmentListComponent(): JSX.Element {
             >
               <div className="mailpoet-segments-dataviews__toolbar">
                 <DataViews.Search label={__('Search', 'mailpoet')} />
+                <DataViews.FiltersToggle />
                 <div className="mailpoet-dataviews__toolbar-end">
                   <DataViews.ViewConfig />
                 </div>
               </div>
+              <DataViews.Filters />
               {group === 'trash' && (groupCounts.trash ?? 0) > 0 && (
                 <div className="mailpoet-segments-dataviews__toolbar">
                   <button

--- a/mailpoet/changelog/2026-06-19-10-34-42-added-native-dataviews-filters-and-sorting-on-the-lists-.md
+++ b/mailpoet/changelog/2026-06-19-10-34-42-added-native-dataviews-filters-and-sorting-on-the-lists-.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Native DataViews filters and sorting on the Lists and Segments listings, including filtering by type, creation and modification date, and list engagement score

--- a/mailpoet/lib/Segments/DynamicSegments/DynamicSegmentsListingRepository.php
+++ b/mailpoet/lib/Segments/DynamicSegments/DynamicSegmentsListingRepository.php
@@ -7,6 +7,11 @@ use MailPoet\Segments\SegmentListingRepository;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 class DynamicSegmentsListingRepository extends SegmentListingRepository {
+  protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
+    $this->applyDateRangeFilter($queryBuilder, 's.createdAt', $filters, 'created_from', 'created_to');
+    $this->applyDateRangeFilter($queryBuilder, 's.updatedAt', $filters, 'updated_from', 'updated_to');
+  }
+
   protected function applyParameters(QueryBuilder $queryBuilder, array $parameters): void {
     $queryBuilder
       ->andWhere('s.type = :type')

--- a/mailpoet/lib/Segments/RestApi/Endpoints/AbstractSegmentsListingEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/AbstractSegmentsListingEndpoint.php
@@ -4,6 +4,7 @@ namespace MailPoet\Segments\RestApi\Endpoints;
 
 use MailPoet\API\REST\AbstractListingEndpoint;
 use MailPoet\API\REST\ApiException;
+use MailPoet\API\REST\ListingRequestValidationTrait;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Listing\Handler as ListingHandler;
@@ -11,6 +12,10 @@ use MailPoet\Validator\Builder;
 
 abstract class AbstractSegmentsListingEndpoint extends AbstractListingEndpoint {
   use SegmentRequestValidationTrait;
+  // Reused only for the shared `yyyy-MM-dd` date filter validators
+  // (validateDateFilter / validateDateRange); pagination and sort use the
+  // segment-specific SegmentRequestValidationTrait above.
+  use ListingRequestValidationTrait;
 
   /** @var string[] */
   private $allowedSortFields;
@@ -47,6 +52,18 @@ abstract class AbstractSegmentsListingEndpoint extends AbstractListingEndpoint {
 
   abstract protected function allowsSearch(): bool;
 
+  /**
+   * Filter keys this listing accepts in the `filter` request param. Each
+   * listing declares its own so unknown keys are rejected with a 400.
+   *
+   * @return string[]
+   */
+  abstract protected function getAllowedFilters(): array;
+
+  protected function getListingValidationErrorPrefix(): string {
+    return 'segments';
+  }
+
   protected function getDefaultGroup(): ?string {
     return 'all';
   }
@@ -82,6 +99,66 @@ abstract class AbstractSegmentsListingEndpoint extends AbstractListingEndpoint {
         400,
         'mailpoet_segments_search_not_supported'
       );
+    }
+
+    $this->validateFilters($request);
+  }
+
+  protected function validateFilters(Request $request): void {
+    $filters = $request->getParam('filter');
+    if ($filters === null || $filters === []) {
+      return;
+    }
+    if (!is_array($filters)) {
+      throw new ApiException(
+        __('Filters must be an object.', 'mailpoet'),
+        400,
+        'mailpoet_segments_invalid_filter'
+      );
+    }
+
+    $allowed = $this->getAllowedFilters();
+    // Rebuild with verified string keys so the typed validators below receive an
+    // array<string, mixed> rather than the request's array<mixed, mixed>.
+    $normalizedFilters = [];
+    foreach ($filters as $key => $value) {
+      if (!is_string($key) || !in_array($key, $allowed, true)) {
+        throw new ApiException(
+          __('Unsupported segments filter.', 'mailpoet'),
+          400,
+          'mailpoet_segments_invalid_filter'
+        );
+      }
+      $normalizedFilters[$key] = $value;
+    }
+
+    $this->validateScoreFilter($normalizedFilters);
+
+    foreach ([['created_from', 'created_to'], ['updated_from', 'updated_to']] as [$fromKey, $toKey]) {
+      if (!in_array($fromKey, $allowed, true)) {
+        continue;
+      }
+      $from = $this->validateDateFilter($normalizedFilters, $fromKey);
+      $to = $this->validateDateFilter($normalizedFilters, $toKey);
+      $this->validateDateRange($from, $to);
+    }
+  }
+
+  /**
+   * @param array<string, mixed> $filters
+   */
+  private function validateScoreFilter(array $filters): void {
+    foreach (['score_min', 'score_max'] as $key) {
+      if (!array_key_exists($key, $filters) || $filters[$key] === '') {
+        continue;
+      }
+      if (!is_numeric($filters[$key])) {
+        throw new ApiException(
+          __('The engagement score filter must be numeric.', 'mailpoet'),
+          400,
+          'mailpoet_segments_invalid_' . $key
+        );
+      }
     }
   }
 

--- a/mailpoet/lib/Segments/RestApi/Endpoints/DynamicSegmentsListingEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/DynamicSegmentsListingEndpoint.php
@@ -55,6 +55,10 @@ class DynamicSegmentsListingEndpoint extends AbstractSegmentsListingEndpoint {
     return true;
   }
 
+  protected function getAllowedFilters(): array {
+    return ['created_from', 'created_to', 'updated_from', 'updated_to'];
+  }
+
   protected function getDefaultParameters(): array {
     return ['segments'];
   }

--- a/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsListingEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsListingEndpoint.php
@@ -56,6 +56,10 @@ class SegmentsListingEndpoint extends AbstractSegmentsListingEndpoint {
     return true;
   }
 
+  protected function getAllowedFilters(): array {
+    return ['created_from', 'created_to', 'score_min', 'score_max'];
+  }
+
   protected function getDefaultParameters(): array {
     return ['lists'];
   }

--- a/mailpoet/lib/Segments/SegmentListingRepository.php
+++ b/mailpoet/lib/Segments/SegmentListingRepository.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Segments;
 
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Listing\ListingDateRangeFilterTrait;
 use MailPoet\Listing\ListingDefinition;
 use MailPoet\Listing\ListingRepository;
 use MailPoet\Util\Helpers;
@@ -10,6 +11,8 @@ use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 class SegmentListingRepository extends ListingRepository {
+  use ListingDateRangeFilterTrait;
+
   const DEFAULT_SORT_BY = 'name';
 
   /** @var WooCommerce */
@@ -47,6 +50,26 @@ class SegmentListingRepository extends ListingRepository {
   }
 
   protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
+    $this->applyDateRangeFilter($queryBuilder, 's.createdAt', $filters, 'created_from', 'created_to');
+    $this->applyScoreFilter($queryBuilder, $filters);
+  }
+
+  /**
+   * @param array<string, mixed> $filters
+   */
+  private function applyScoreFilter(QueryBuilder $queryBuilder, array $filters): void {
+    $min = $filters['score_min'] ?? null;
+    if (is_numeric($min)) {
+      $queryBuilder
+        ->andWhere('s.averageEngagementScore >= :scoreMin')
+        ->setParameter('scoreMin', (float)$min);
+    }
+    $max = $filters['score_max'] ?? null;
+    if (is_numeric($max)) {
+      $queryBuilder
+        ->andWhere('s.averageEngagementScore <= :scoreMax')
+        ->setParameter('scoreMax', (float)$max);
+    }
   }
 
   protected function applyParameters(QueryBuilder $queryBuilder, array $parameters) {

--- a/mailpoet/tests/acceptance/Lists/ListsListingFiltersCest.php
+++ b/mailpoet/tests/acceptance/Lists/ListsListingFiltersCest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Test\DataFactories\Segment;
+
+/**
+ * Date-range and engagement-score filtering of the lists listing is exercised
+ * at the SQL level in SegmentListingRepositoryTest. This cest guards the
+ * listing's legacy trash deep link.
+ *
+ * @group frontend
+ */
+class ListsListingFiltersCest {
+  public function preservesLegacyTrashDeepLink(\AcceptanceTester $i) {
+    $i->wantTo('Keep the legacy lists trash hash route working');
+
+    $trashedListName = 'Legacy Trash Deep Link List';
+    (new Segment())->withName($trashedListName)->withDeleted()->create();
+
+    $i->login();
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-lists#/lists/group[trash]');
+    $i->waitForText($trashedListName, 5, '[data-automation-id="segments_listing"]');
+    $i->seeInCurrentUrl(urlencode('group[trash]'));
+    $i->seeNoJSErrors();
+  }
+}

--- a/mailpoet/tests/acceptance/Segments/DynamicSegmentsListingFiltersCest.php
+++ b/mailpoet/tests/acceptance/Segments/DynamicSegmentsListingFiltersCest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Test\DataFactories\DynamicSegment;
+
+/**
+ * Date-range filtering of the dynamic segments listing is exercised at the SQL
+ * level in DynamicSegmentsListingRepositoryTest. This cest guards the listing's
+ * legacy deep link, which shares the `extraParams` callback the native filters
+ * feed into.
+ *
+ * @group frontend
+ */
+class DynamicSegmentsListingFiltersCest {
+  public function preservesLegacyOffsetDeepLink(\AcceptanceTester $i) {
+    $i->wantTo('Keep the legacy dynamic segments offset hash route working');
+
+    $segmentNames = ['Legacy Offset Segment A', 'Legacy Offset Segment B', 'Legacy Offset Segment C'];
+    foreach ($segmentNames as $name) {
+      (new DynamicSegment())->withName($name)->withUserRoleFilter('editor')->create();
+    }
+
+    $i->login();
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-segments#/segments/limit[2]/offset[2]');
+    $i->waitForElement('[data-automation-id="dynamic_segments_listing"]');
+    $i->seeInCurrentUrl(urlencode('offset[2]'));
+    $i->seeNoJSErrors();
+  }
+}

--- a/mailpoet/tests/integration/Segments/DynamicSegments/DynamicSegmentsListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/DynamicSegmentsListingRepositoryTest.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments;
+
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Listing\Handler;
+
+class DynamicSegmentsListingRepositoryTest extends \MailPoetTest {
+  /** @var Handler */
+  private $listingHandler;
+
+  /** @var DynamicSegmentsListingRepository */
+  private $repository;
+
+  public function _before() {
+    parent::_before();
+    $this->listingHandler = new Handler();
+    $this->repository = $this->diContainer->get(DynamicSegmentsListingRepository::class);
+  }
+
+  public function testItReturnsOnlyDynamicSegments(): void {
+    $this->createSegment('Dynamic', SegmentEntity::TYPE_DYNAMIC);
+    $this->createSegment('List', SegmentEntity::TYPE_DEFAULT);
+
+    $definition = $this->listingHandler->getListingDefinition(['params' => ['segments']]);
+    $segments = $this->repository->getData($definition);
+    verify($segments)->arrayCount(1);
+    verify($segments[0]->getName())->same('Dynamic');
+  }
+
+  public function testItFiltersByCreatedDateRange(): void {
+    $older = $this->createSegment('Older', SegmentEntity::TYPE_DYNAMIC);
+    $newer = $this->createSegment('Newer', SegmentEntity::TYPE_DYNAMIC);
+    $older->setCreatedAt(new \DateTimeImmutable('2020-01-01 10:00:00'));
+    $newer->setCreatedAt(new \DateTimeImmutable('2020-06-01 10:00:00'));
+    $this->entityManager->flush();
+
+    $segments = $this->repository->getData(
+      $this->listingHandler->getListingDefinition(['params' => ['segments'], 'filter' => ['created_from' => '2020-03-01']])
+    );
+    verify($segments)->arrayCount(1);
+    verify($segments[0]->getName())->same('Newer');
+
+    $segments = $this->repository->getData(
+      $this->listingHandler->getListingDefinition(['params' => ['segments'], 'filter' => ['created_to' => '2020-03-01']])
+    );
+    verify($segments)->arrayCount(1);
+    verify($segments[0]->getName())->same('Older');
+  }
+
+  public function testItFiltersByModifiedDateRange(): void {
+    $older = $this->createSegment('Older', SegmentEntity::TYPE_DYNAMIC);
+    $newer = $this->createSegment('Newer', SegmentEntity::TYPE_DYNAMIC);
+    // updatedAt is reset on every flush, so pin deterministic values with a DQL UPDATE.
+    $this->setUpdatedAt($older, '2020-01-01 10:00:00');
+    $this->setUpdatedAt($newer, '2020-06-01 10:00:00');
+
+    $segments = $this->repository->getData(
+      $this->listingHandler->getListingDefinition(['params' => ['segments'], 'filter' => ['updated_from' => '2020-03-01']])
+    );
+    verify($segments)->arrayCount(1);
+    verify($segments[0]->getName())->same('Newer');
+
+    $segments = $this->repository->getData(
+      $this->listingHandler->getListingDefinition(['params' => ['segments'], 'filter' => ['updated_to' => '2020-03-01']])
+    );
+    verify($segments)->arrayCount(1);
+    verify($segments[0]->getName())->same('Older');
+  }
+
+  public function testItFiltersByCreatedAndModifiedDateIndependently(): void {
+    $segmentA = $this->createSegment('A', SegmentEntity::TYPE_DYNAMIC);
+    $segmentB = $this->createSegment('B', SegmentEntity::TYPE_DYNAMIC);
+    $segmentA->setCreatedAt(new \DateTimeImmutable('2020-01-01 10:00:00'));
+    $segmentB->setCreatedAt(new \DateTimeImmutable('2020-06-01 10:00:00'));
+    $this->entityManager->flush();
+    $this->setUpdatedAt($segmentA, '2020-12-01 10:00:00');
+    $this->setUpdatedAt($segmentB, '2020-06-15 10:00:00');
+
+    // Created before March AND modified after October → only A. Exercises both
+    // ranges coexisting on one query without parameter collisions.
+    $segments = $this->repository->getData(
+      $this->listingHandler->getListingDefinition([
+        'params' => ['segments'],
+        'filter' => ['created_to' => '2020-03-01', 'updated_from' => '2020-10-01'],
+      ])
+    );
+    verify($segments)->arrayCount(1);
+    verify($segments[0]->getName())->same('A');
+  }
+
+  private function createSegment(string $name, string $type): SegmentEntity {
+    $segment = new SegmentEntity($name, $type, '');
+    $this->entityManager->persist($segment);
+    $this->entityManager->flush();
+    return $segment;
+  }
+
+  private function setUpdatedAt(SegmentEntity $segment, string $date): void {
+    $this->entityManager
+      ->createQuery('UPDATE ' . SegmentEntity::class . ' s SET s.updatedAt = :date WHERE s.id = :id')
+      ->setParameter('date', new \DateTimeImmutable($date))
+      ->setParameter('id', $segment->getId())
+      ->execute();
+  }
+}

--- a/mailpoet/tests/integration/Segments/SegmentListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentListingRepositoryTest.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments;
+
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Listing\Handler;
+
+class SegmentListingRepositoryTest extends \MailPoetTest {
+  /** @var Handler */
+  private $listingHandler;
+
+  /** @var SegmentListingRepository */
+  private $repository;
+
+  public function _before() {
+    parent::_before();
+    $this->listingHandler = new Handler();
+    $this->repository = $this->diContainer->get(SegmentListingRepository::class);
+  }
+
+  public function testItFiltersByCreatedDateRange(): void {
+    $older = $this->createSegment('Older', SegmentEntity::TYPE_DEFAULT);
+    $newer = $this->createSegment('Newer', SegmentEntity::TYPE_DEFAULT);
+    $older->setCreatedAt(new \DateTimeImmutable('2020-01-01 10:00:00'));
+    $newer->setCreatedAt(new \DateTimeImmutable('2020-06-01 10:00:00'));
+    $this->entityManager->flush();
+
+    $segments = $this->repository->getData(
+      $this->listingHandler->getListingDefinition(['filter' => ['created_from' => '2020-03-01']])
+    );
+    verify($segments)->arrayCount(1);
+    verify($segments[0]->getName())->same('Newer');
+
+    $segments = $this->repository->getData(
+      $this->listingHandler->getListingDefinition(['filter' => ['created_to' => '2020-03-01']])
+    );
+    verify($segments)->arrayCount(1);
+    verify($segments[0]->getName())->same('Older');
+
+    $segments = $this->repository->getData(
+      $this->listingHandler->getListingDefinition(['filter' => ['created_from' => '2020-01-01', 'created_to' => '2020-06-01']])
+    );
+    verify($segments)->arrayCount(2);
+  }
+
+  public function testItFiltersByEngagementScore(): void {
+    $low = $this->createSegment('Low', SegmentEntity::TYPE_DEFAULT);
+    $high = $this->createSegment('High', SegmentEntity::TYPE_DEFAULT);
+    $low->setAverageEngagementScore(10.0);
+    $high->setAverageEngagementScore(80.0);
+    $this->entityManager->flush();
+
+    // score_min keeps only the high one
+    $segments = $this->repository->getData(
+      $this->listingHandler->getListingDefinition(['filter' => ['score_min' => 50]])
+    );
+    verify($segments)->arrayCount(1);
+    verify($segments[0]->getName())->same('High');
+
+    // score_max keeps only the low one
+    $segments = $this->repository->getData(
+      $this->listingHandler->getListingDefinition(['filter' => ['score_max' => 50]])
+    );
+    verify($segments)->arrayCount(1);
+    verify($segments[0]->getName())->same('Low');
+
+    // bounded range keeps both
+    $segments = $this->repository->getData(
+      $this->listingHandler->getListingDefinition(['filter' => ['score_min' => 5, 'score_max' => 90]])
+    );
+    verify($segments)->arrayCount(2);
+  }
+
+  public function testItSortsByCreatedAt(): void {
+    $first = $this->createSegment('First', SegmentEntity::TYPE_DEFAULT);
+    $second = $this->createSegment('Second', SegmentEntity::TYPE_DEFAULT);
+    $first->setCreatedAt(new \DateTimeImmutable('2020-06-01 10:00:00'));
+    $second->setCreatedAt(new \DateTimeImmutable('2020-01-01 10:00:00'));
+    $this->entityManager->flush();
+
+    $segments = $this->repository->getData($this->listingHandler->getListingDefinition([
+      'sort_by' => 'created_at',
+      'sort_order' => 'asc',
+    ]));
+    verify($segments[0]->getName())->same('Second');
+    verify($segments[1]->getName())->same('First');
+  }
+
+  private function createSegment(string $name, string $type): SegmentEntity {
+    $segment = new SegmentEntity($name, $type, '');
+    $this->entityManager->persist($segment);
+    $this->entityManager->flush();
+    return $segment;
+  }
+}

--- a/mailpoet/tests/javascript/segments/dynamic/filters.spec.ts
+++ b/mailpoet/tests/javascript/segments/dynamic/filters.spec.ts
@@ -1,0 +1,59 @@
+import { viewFiltersToRequestFilter } from '../../../../assets/js/src/segments/dynamic/filters';
+
+describe('dynamic segments filters translation', () => {
+  it('maps a between created-date filter to created_from/created_to', () => {
+    const filter = viewFiltersToRequestFilter([
+      {
+        field: 'created_at',
+        operator: 'between',
+        value: ['2026-05-01', '2026-05-18'],
+      },
+    ]);
+
+    expect(filter).to.deep.equal({
+      created_from: '2026-05-01',
+      created_to: '2026-05-18',
+    });
+  });
+
+  it('maps the modified-date filter to its own updated_from/updated_to keys', () => {
+    const filter = viewFiltersToRequestFilter([
+      {
+        field: 'updated_at',
+        operator: 'between',
+        value: ['2026-04-01', '2026-04-30'],
+      },
+    ]);
+
+    expect(filter).to.deep.equal({
+      updated_from: '2026-04-01',
+      updated_to: '2026-04-30',
+    });
+  });
+
+  it('keeps created and modified date ranges independent', () => {
+    const filter = viewFiltersToRequestFilter([
+      { field: 'created_at', operator: 'afterInc', value: '2026-05-01' },
+      { field: 'updated_at', operator: 'beforeInc', value: '2026-06-01' },
+    ]);
+
+    expect(filter).to.deep.equal({
+      created_from: '2026-05-01',
+      updated_to: '2026-06-01',
+    });
+  });
+
+  it('ignores invalid dates', () => {
+    const filter = viewFiltersToRequestFilter([
+      { field: 'created_at', operator: 'after', value: 'not-a-date' },
+      { field: 'updated_at', operator: 'after', value: 'nope' },
+    ]);
+
+    expect(filter).to.deep.equal({});
+  });
+
+  it('returns an empty object when no filters are active', () => {
+    expect(viewFiltersToRequestFilter(undefined)).to.deep.equal({});
+    expect(viewFiltersToRequestFilter([])).to.deep.equal({});
+  });
+});

--- a/mailpoet/tests/javascript/segments/static/filters.spec.ts
+++ b/mailpoet/tests/javascript/segments/static/filters.spec.ts
@@ -1,0 +1,103 @@
+import { viewFiltersToRequestFilter } from '../../../../assets/js/src/segments/static/filters';
+
+describe('segments (lists) filters translation', () => {
+  it('maps a between created-date filter to created_from/created_to', () => {
+    const filter = viewFiltersToRequestFilter([
+      {
+        field: 'created_at',
+        operator: 'between',
+        value: ['2026-05-01', '2026-05-18'],
+      },
+    ]);
+
+    expect(filter).to.deep.equal({
+      created_from: '2026-05-01',
+      created_to: '2026-05-18',
+    });
+  });
+
+  it('maps inclusive and exclusive single-bound created-date operators', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'on', value: '2026-05-10' },
+      ]),
+    ).to.deep.equal({ created_from: '2026-05-10', created_to: '2026-05-10' });
+
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'before', value: '2026-05-18' },
+      ]),
+    ).to.deep.equal({ created_to: '2026-05-17' });
+  });
+
+  it('maps a between engagement-score filter to score_min/score_max', () => {
+    const filter = viewFiltersToRequestFilter([
+      {
+        field: 'average_engagement_score',
+        operator: 'between',
+        value: [10, 80],
+      },
+    ]);
+
+    expect(filter).to.deep.equal({ score_min: 10, score_max: 80 });
+  });
+
+  it('maps single-bound engagement-score operators', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        {
+          field: 'average_engagement_score',
+          operator: 'greaterThan',
+          value: 25,
+        },
+      ]),
+    ).to.deep.equal({ score_min: 25 });
+
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'average_engagement_score', operator: 'lessThan', value: 50 },
+      ]),
+    ).to.deep.equal({ score_max: 50 });
+  });
+
+  it('ignores non-numeric score values and invalid dates', () => {
+    const filter = viewFiltersToRequestFilter([
+      {
+        field: 'average_engagement_score',
+        operator: 'greaterThan',
+        value: 'nope',
+      },
+      { field: 'created_at', operator: 'after', value: 'not-a-date' },
+    ]);
+
+    expect(filter).to.deep.equal({});
+  });
+
+  it('drops empty score bounds instead of coercing them to 0', () => {
+    // A cleared `between` bound must not emit score_min/score_max: 0.
+    expect(
+      viewFiltersToRequestFilter([
+        {
+          field: 'average_engagement_score',
+          operator: 'between',
+          value: ['10', ''],
+        },
+      ]),
+    ).to.deep.equal({ score_min: 10 });
+
+    expect(
+      viewFiltersToRequestFilter([
+        {
+          field: 'average_engagement_score',
+          operator: 'greaterThan',
+          value: '',
+        },
+      ]),
+    ).to.deep.equal({});
+  });
+
+  it('returns an empty object when no filters are active', () => {
+    expect(viewFiltersToRequestFilter(undefined)).to.deep.equal({});
+    expect(viewFiltersToRequestFilter([])).to.deep.equal({});
+  });
+});


### PR DESCRIPTION
## Description

Adds native DataViews filters + sorting to the Lists and Segments listings, applied entirely server-side in SQL via the shared REST listing infrastructure (`AbstractListingEndpoint` → `ListingRepository`).

- **Lists:** filter by Created date and engagement-score range; sort by name / created / score.
- **Segments:** filter by Created and Modified date; sort by name / created / modified. Added a Created column.
- Legacy hash deep links (`#/lists/group[...]`, `#/segments/offset[...]`) preserved.

## Code review notes

- Filters/sorting are **SQL-only** (Doctrine `WHERE`/`ORDER BY`) and not computed in PHP or in memory.

## QA notes

- Lists: use the Filter button → Created date and engagement-score range; verify column sorting (name / created / score).
- Segments: use the Filter button → Created and Modified date; verify sorting. 
- Confirm legacy URLs still load: `…page=mailpoet-lists#/lists/group[trash]` and `…page=mailpoet-segments#/segments/limit[2]/offset[2]`.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8169

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

| Before | After | 
| ---- | ----- |
| <img width="1131" height="737" alt="Screenshot 2026-06-19 at 16 49 42" src="https://github.com/user-attachments/assets/61d24ba0-91c5-4fc3-a21a-5e65d75e7a0c" /> | <img width="1134" height="772" alt="Screenshot 2026-06-19 at 16 46 53" src="https://github.com/user-attachments/assets/0082f354-21ce-41d1-ae6e-9947e998d1cb" /> |
| <img width="1234" height="976" alt="Screenshot 2026-06-19 at 16 49 52" src="https://github.com/user-attachments/assets/c2491bc0-a679-40b9-b8c5-7ee9e3693329" /> | <img width="1238" height="946" alt="Screenshot 2026-06-19 at 16 48 00" src="https://github.com/user-attachments/assets/cf0d51e0-c4d3-4a22-8a98-2a2793637382" /> |


## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8169-dataviews-native-filters-sorting-for-segments-listings)

_The latest successful build from `add/stomail-8169-dataviews-native-filters-sorting-for-segments-listings` will be used. If none is available, the link won't work._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**1 issue found**

**Category: Bug (Semantic/Logic Error)**

**Issue:** Engagement score filter operator semantics don’t match backend SQL comparisons.

- Frontend maps DataViews operators directly to bounds:
  - `greaterThan` → `score_min`
  - `lessThan` → `score_max`
- Backend applies inclusive SQL predicates:
  - `score_min` uses `averageEngagementScore >= :scoreMin`
  - `score_max` uses `averageEngagementScore <= :scoreMax`

So values selected as “greater than”/“less than” are treated as “greater than or equal”/“less than or equal” in SQL.

**Where:**
- `mailpoet/assets/js/src/segments/static/filters.ts` (maps `greaterThan`/`lessThan` to `score_min`/`score_max`)
- `mailpoet/lib/Segments/SegmentListingRepository.php` (uses `>=` / `<=`)
- `mailpoet/tests/javascript/segments/static/filters.spec.ts` (asserts this mapping)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->