### PR TITLE
Add native DataViews filters and sorting to the Logs listing

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_logs.scss
+++ b/mailpoet/assets/css/src/components-plugin/_logs.scss
@@ -41,13 +41,12 @@
   }
 
   .dataviews-view-table
-    col[class^='dataviews-view-table__col-'].dataviews-view-table__col-action {
-    width: 120px !important;
-  }
-
-  .dataviews-view-table
     col[class^='dataviews-view-table__col-'].dataviews-view-table__col-created_at {
     width: 180px !important;
+  }
+
+  .dataviews-view-table col.dataviews-view-table__col-actions {
+    width: 120px !important;
   }
 
   .dataviews-view-table td,

--- a/mailpoet/assets/css/src/components-plugin/_logs.scss
+++ b/mailpoet/assets/css/src/components-plugin/_logs.scss
@@ -15,17 +15,6 @@
   width: 1px;
 }
 
-.mailpoet-logs {
-  .mailpoet-datepicker {
-    margin-left: $grid-gap;
-    margin-right: $grid-gap;
-  }
-
-  .mailpoet-form-input-small {
-    margin-right: $grid-gap;
-  }
-}
-
 .mailpoet-logs-dataviews {
   .dataviews-view-table {
     max-width: 100%;
@@ -34,7 +23,9 @@
   }
 
   // DataViews table column sizing is exposed through generated column classes;
-  // keep these selectors aligned with getLogFields() when columns change.
+  // keep these selectors aligned with getLogFields() when columns change. Every
+  // optional column needs an explicit width — under table-layout: fixed an
+  // unlisted column collapses to zero width when toggled on.
   .dataviews-view-table col.dataviews-view-table__col-first-data {
     width: 240px !important;
   }
@@ -45,6 +36,11 @@
   }
 
   .dataviews-view-table
+    col[class^='dataviews-view-table__col-'].dataviews-view-table__col-level {
+    width: 140px !important;
+  }
+
+  .dataviews-view-table
     col[class^='dataviews-view-table__col-'].dataviews-view-table__col-action {
     width: 120px !important;
   }
@@ -52,18 +48,6 @@
   .dataviews-view-table
     col[class^='dataviews-view-table__col-'].dataviews-view-table__col-created_at {
     width: 180px !important;
-  }
-
-  .dataviews-view-table tr > :nth-child(1) {
-    width: 240px;
-  }
-
-  .dataviews-view-table tr > :nth-child(3) {
-    width: 120px;
-  }
-
-  .dataviews-view-table tr > :nth-child(4) {
-    width: 180px;
   }
 
   .dataviews-view-table td,
@@ -93,27 +77,11 @@
     margin-bottom: $grid-gap;
   }
 
-  .mailpoet-logs-date-filters,
   .mailpoet-logs-error {
     align-items: center;
     display: flex;
     flex-wrap: wrap;
     gap: $grid-gap-half;
-  }
-
-  .mailpoet-logs-date-filter {
-    align-items: center;
-    display: flex;
-    gap: $grid-gap-half;
-  }
-
-  .mailpoet-datepicker {
-    margin-left: 0;
-    margin-right: 0;
-  }
-
-  .react-datepicker-popper {
-    z-index: 20;
   }
 
   .mailpoet-logs-date-error {

--- a/mailpoet/assets/js/src/logs/api.ts
+++ b/mailpoet/assets/js/src/logs/api.ts
@@ -5,7 +5,7 @@ import type {
   ListingQueryParams,
   ListingResponse,
 } from 'common/dataviews';
-import type { DateFilters } from './url-state';
+import type { LogsFilter } from './url-state';
 
 declare global {
   interface Window {
@@ -28,19 +28,20 @@ function ensureInitialized(): void {
 export type LogListingItem = {
   id: number;
   name: string;
+  level: number | null;
   message: string;
   created_at: string | null;
 };
 
 export function buildLogsRequestParams(
   params: ListingQueryParams,
-  dateFilters: DateFilters,
+  filters: LogsFilter,
 ): ListingQueryParams {
   const search = params.search?.trim();
   return {
     ...params,
     search: search || undefined,
-    filter: dateFilters,
+    filter: filters,
   };
 }
 

--- a/mailpoet/assets/js/src/logs/fields.tsx
+++ b/mailpoet/assets/js/src/logs/fields.tsx
@@ -61,7 +61,7 @@ export function getLogFields(
       render: ({ item }) => {
         const isExpanded = expandedLogIds.has(item.id);
         return createElement(
-          'div',
+          'pre',
           {
             id: `mailpoet-log-message-${item.id}`,
             className: `mailpoet-logs-message ${

--- a/mailpoet/assets/js/src/logs/fields.tsx
+++ b/mailpoet/assets/js/src/logs/fields.tsx
@@ -1,6 +1,6 @@
 import { createElement } from 'react';
-import { __, sprintf } from '@wordpress/i18n';
-import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import type { Action, Field } from '@wordpress/dataviews';
 import { MailPoetDate } from '../date';
 import type { LogListingItem } from './api';
 import {
@@ -14,50 +14,8 @@ export function formatCreatedAt(createdAt: string | null): string {
   return createdAt ? MailPoetDate.full(createdAt) : '—';
 }
 
-type LogExpansionButtonProps = {
-  item: LogListingItem;
-  isExpanded: boolean;
-  onToggle: (logId: number) => void;
-};
-
-function LogExpansionButton({
-  item,
-  isExpanded,
-  onToggle,
-}: LogExpansionButtonProps): JSX.Element {
-  const messageId = `mailpoet-log-message-${item.id}`;
-
-  return (
-    <button
-      type="button"
-      className="button button-secondary button-small mailpoet-button"
-      aria-expanded={isExpanded}
-      aria-controls={messageId}
-      aria-label={
-        isExpanded
-          ? sprintf(
-              // translators: %d is a log entry ID.
-              __('Show less of log message %d', 'mailpoet'),
-              item.id,
-            )
-          : sprintf(
-              // translators: %d is a log entry ID.
-              __('Show more of log message %d', 'mailpoet'),
-              item.id,
-            )
-      }
-      onClick={() => onToggle(item.id)}
-    >
-      <span>
-        {isExpanded ? __('Show less', 'mailpoet') : __('Show more', 'mailpoet')}
-      </span>
-    </button>
-  );
-}
-
 export function getLogFields(
   expandedLogIds: Set<number>,
-  onToggleExpanded: (logId: number) => void,
   options: LogFilterOptions = getLogFilterOptions(),
 ): Field<LogListingItem>[] {
   return [
@@ -115,19 +73,6 @@ export function getLogFields(
       },
     },
     {
-      id: 'action',
-      label: __('Action', 'mailpoet'),
-      enableSorting: false,
-      enableGlobalSearch: false,
-      filterBy: false,
-      render: ({ item }) =>
-        createElement(LogExpansionButton, {
-          item,
-          isExpanded: expandedLogIds.has(item.id),
-          onToggle: onToggleExpanded,
-        }),
-    },
-    {
       id: 'created_at',
       label: __('Created On', 'mailpoet'),
       type: 'date',
@@ -144,13 +89,36 @@ export function getLogFields(
   ];
 }
 
+// Native primary row action that toggles the truncated message open/closed.
+// The label reflects the row's current expanded state.
+export function getLogActions(
+  expandedLogIds: Set<number>,
+  onToggleExpanded: (logId: number) => void,
+): Action<LogListingItem>[] {
+  return [
+    {
+      id: 'toggle-message',
+      isPrimary: true,
+      label: (items) =>
+        items[0] && expandedLogIds.has(items[0].id)
+          ? __('Show less', 'mailpoet')
+          : __('Show more', 'mailpoet'),
+      callback: (items) => {
+        const item = items[0];
+        if (item) {
+          onToggleExpanded(item.id);
+        }
+      },
+    },
+  ];
+}
+
 const EMPTY_EXPANDED_LOG_IDS = new Set<number>();
-const NOOP_TOGGLE = (): void => undefined;
 
 // Stable field definitions for callers that only need the field schema (e.g.
 // DataViews preference validation), without per-row expand/collapse state.
 export function getLogFieldDefinitions(
   options: LogFilterOptions = getLogFilterOptions(),
 ): Field<LogListingItem>[] {
-  return getLogFields(EMPTY_EXPANDED_LOG_IDS, NOOP_TOGGLE, options);
+  return getLogFields(EMPTY_EXPANDED_LOG_IDS, options);
 }

--- a/mailpoet/assets/js/src/logs/fields.tsx
+++ b/mailpoet/assets/js/src/logs/fields.tsx
@@ -3,6 +3,12 @@ import { __, sprintf } from '@wordpress/i18n';
 import type { Field } from '@wordpress/dataviews';
 import { MailPoetDate } from '../date';
 import type { LogListingItem } from './api';
+import {
+  getLogFilterOptions,
+  getLogSeverityElements,
+  getLogSeverityLabel,
+  type LogFilterOptions,
+} from './filters';
 
 export function formatCreatedAt(createdAt: string | null): string {
   return createdAt ? MailPoetDate.full(createdAt) : '—';
@@ -52,20 +58,39 @@ function LogExpansionButton({
 export function getLogFields(
   expandedLogIds: Set<number>,
   onToggleExpanded: (logId: number) => void,
+  options: LogFilterOptions = getLogFilterOptions(),
 ): Field<LogListingItem>[] {
   return [
     {
       id: 'name',
       label: __('Name', 'mailpoet'),
       type: 'text',
-      enableSorting: false,
+      enableSorting: true,
       enableGlobalSearch: false,
-      filterBy: false,
+      elements: options.names.map((name) => ({ value: name, label: name })),
+      filterBy: { operators: ['isAny'] },
       render: ({ item }) =>
         createElement(
           'span',
           { className: 'mailpoet-logs-min-width' },
           item.name,
+        ),
+    },
+    {
+      // Rendered as a textual severity label, so use the text type to keep the
+      // column left-aligned; the integer type would right-align header + cells.
+      id: 'level',
+      label: __('Severity', 'mailpoet'),
+      type: 'text',
+      enableSorting: false,
+      enableGlobalSearch: false,
+      elements: getLogSeverityElements(),
+      filterBy: { operators: ['isAny'] },
+      render: ({ item }) =>
+        createElement(
+          'span',
+          null,
+          item.level === null ? '—' : getLogSeverityLabel(item.level),
         ),
     },
     {
@@ -105,10 +130,10 @@ export function getLogFields(
     {
       id: 'created_at',
       label: __('Created On', 'mailpoet'),
-      type: 'datetime',
-      enableSorting: false,
+      type: 'date',
+      enableSorting: true,
       enableGlobalSearch: false,
-      filterBy: false,
+      filterBy: { operators: ['on', 'before', 'after', 'between'] },
       render: ({ item }) =>
         createElement(
           'span',
@@ -124,6 +149,8 @@ const NOOP_TOGGLE = (): void => undefined;
 
 // Stable field definitions for callers that only need the field schema (e.g.
 // DataViews preference validation), without per-row expand/collapse state.
-export function getLogFieldDefinitions(): Field<LogListingItem>[] {
-  return getLogFields(EMPTY_EXPANDED_LOG_IDS, NOOP_TOGGLE);
+export function getLogFieldDefinitions(
+  options: LogFilterOptions = getLogFilterOptions(),
+): Field<LogListingItem>[] {
+  return getLogFields(EMPTY_EXPANDED_LOG_IDS, NOOP_TOGGLE, options);
 }

--- a/mailpoet/assets/js/src/logs/filters.ts
+++ b/mailpoet/assets/js/src/logs/filters.ts
@@ -1,0 +1,174 @@
+import { __ } from '@wordpress/i18n';
+import type { Filter } from '@wordpress/dataviews';
+import { isStrictDateString, type LogsFilter } from './url-state';
+
+export const CREATED_AT_FIELD = 'created_at';
+export const NAME_FIELD = 'name';
+export const LEVEL_FIELD = 'level';
+
+// Monolog severity levels mapped to human labels. Keep in sync with the
+// integer levels stored on the `level` column (see MailPoet\Logging\LogHandler).
+export const LOG_SEVERITY_LABELS: Record<number, string> = {
+  100: __('Debug', 'mailpoet'),
+  200: __('Info', 'mailpoet'),
+  250: __('Notice', 'mailpoet'),
+  300: __('Warning', 'mailpoet'),
+  400: __('Error', 'mailpoet'),
+  500: __('Critical', 'mailpoet'),
+  550: __('Alert', 'mailpoet'),
+  600: __('Emergency', 'mailpoet'),
+};
+
+export function getLogSeverityLabel(level: number): string {
+  return LOG_SEVERITY_LABELS[level] ?? String(level);
+}
+
+// Severity is a finite Monolog enum, so the filter offers every level rather
+// than only the ones already present in storage (no DB query needed).
+export function getLogSeverityElements(): { value: number; label: string }[] {
+  return Object.keys(LOG_SEVERITY_LABELS).map((level) => ({
+    value: Number(level),
+    label: LOG_SEVERITY_LABELS[Number(level)],
+  }));
+}
+
+export type LogFilterOptions = {
+  names: string[];
+};
+
+declare global {
+  interface Window {
+    mailpoet_logs_filter_options?: {
+      names?: string[];
+    };
+  }
+}
+
+export function getLogFilterOptions(): LogFilterOptions {
+  const options = window.mailpoet_logs_filter_options;
+  return {
+    names: Array.isArray(options?.names) ? options.names : [],
+  };
+}
+
+function normalizeYmd(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  // The DataViews date control emits `yyyy-MM-dd`; defensively trim any time
+  // portion a bookmarked value might carry.
+  const candidate = value.slice(0, 10);
+  return isStrictDateString(candidate) ? candidate : undefined;
+}
+
+function dateFilterToRange(operator: string, value: unknown): LogsFilter {
+  if (operator === 'between') {
+    const range = Array.isArray(value) ? value : [];
+    const from = normalizeYmd(range[0]);
+    const to = normalizeYmd(range[1]);
+    return { ...(from ? { from } : {}), ...(to ? { to } : {}) };
+  }
+
+  const ymd = normalizeYmd(value);
+  if (!ymd) {
+    return {};
+  }
+  if (operator === 'before' || operator === 'beforeInc') {
+    return { to: ymd };
+  }
+  if (operator === 'after' || operator === 'afterInc') {
+    return { from: ymd };
+  }
+  if (operator === 'on') {
+    return { from: ymd, to: ymd };
+  }
+  return {};
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => String(entry).trim())
+    .filter((entry) => entry !== '');
+}
+
+function toNumberArray(value: unknown): number[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => Number(entry))
+    .filter((entry) => Number.isInteger(entry));
+}
+
+/**
+ * Translate DataViews native filters into the REST `filter` object the logs
+ * endpoint understands (`{ from, to, name, level }`). The output doubles as the
+ * persisted URL/query-string shape (see buildLogsUrl).
+ */
+export function viewFiltersToRequestFilter(
+  filters: Filter[] | undefined,
+): LogsFilter {
+  const result: LogsFilter = {};
+
+  (filters ?? []).forEach((filter) => {
+    if (filter.field === CREATED_AT_FIELD) {
+      Object.assign(result, dateFilterToRange(filter.operator, filter.value));
+    } else if (filter.field === NAME_FIELD) {
+      const names = toStringArray(filter.value);
+      if (names.length > 0) {
+        result.name = names;
+      }
+    } else if (filter.field === LEVEL_FIELD) {
+      const levels = toNumberArray(filter.value);
+      if (levels.length > 0) {
+        result.level = levels;
+      }
+    }
+  });
+
+  return result;
+}
+
+function datesToFilter(from?: string, to?: string): Filter | null {
+  if (from && to) {
+    return from === to
+      ? { field: CREATED_AT_FIELD, operator: 'on', value: from }
+      : { field: CREATED_AT_FIELD, operator: 'between', value: [from, to] };
+  }
+  if (from) {
+    return { field: CREATED_AT_FIELD, operator: 'after', value: from };
+  }
+  if (to) {
+    return { field: CREATED_AT_FIELD, operator: 'before', value: to };
+  }
+  return null;
+}
+
+/**
+ * Seed DataViews native filters from a parsed (legacy or current) URL filter
+ * state. Maps a from+to range to a single `between` filter so it stays editable
+ * as one native control.
+ */
+export function requestFilterToViewFilters(filter: LogsFilter): Filter[] {
+  const filters: Filter[] = [];
+
+  const dateFilter = datesToFilter(filter.from, filter.to);
+  if (dateFilter) {
+    filters.push(dateFilter);
+  }
+  if (filter.name && filter.name.length > 0) {
+    filters.push({ field: NAME_FIELD, operator: 'isAny', value: filter.name });
+  }
+  if (filter.level && filter.level.length > 0) {
+    filters.push({
+      field: LEVEL_FIELD,
+      operator: 'isAny',
+      value: filter.level,
+    });
+  }
+
+  return filters;
+}

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -10,16 +10,18 @@ import {
   useDataViewsQuery,
   type ListingQueryParams,
 } from 'common/dataviews';
-import { Datepicker } from '../common/datepicker/datepicker';
-import { buildLogsRequestParams, getLogs, type LogListingItem } from './api';
+import { getLogs, type LogListingItem } from './api';
 import { getLogFieldDefinitions, getLogFields } from './fields';
 import {
+  getLogFilterOptions,
+  requestFilterToViewFilters,
+  viewFiltersToRequestFilter,
+} from './filters';
+import {
   buildLogsUrl,
-  dateFromString,
-  formatDateAsYmd,
   getDateRangeError,
   parseLogsUrlState,
-  type DateFilters,
+  type LogsFilter,
 } from './url-state';
 
 const DEFAULT_VIEW: View = {
@@ -36,10 +38,7 @@ type Props = {
   defaultFrom: string;
 };
 
-function buildInitialView(defaultFrom: string): {
-  view: View;
-  dateFilters: DateFilters;
-} {
+function buildInitialView(defaultFrom: string): View {
   const currentUrl = window.location.href;
   const state = parseLogsUrlState(currentUrl, defaultFrom);
   const searchParams = new URL(currentUrl).searchParams;
@@ -52,27 +51,22 @@ function buildInitialView(defaultFrom: string): {
   );
 
   return {
-    view: {
-      ...preferredView,
-      page: state.page,
-      perPage: hasPerPageUrlState ? state.perPage : preferredView.perPage,
-      search: state.search,
-    },
-    dateFilters: state.dateFilters,
+    ...preferredView,
+    page: state.page,
+    perPage: hasPerPageUrlState ? state.perPage : preferredView.perPage,
+    search: state.search,
+    filters: requestFilterToViewFilters(state.filters),
   };
 }
 
+function filtersKey(view: View): string {
+  return JSON.stringify(view.filters ?? []);
+}
+
 export function List({ defaultFrom }: Props): JSX.Element {
-  const dateRangeErrorId = 'mailpoet-logs-date-error';
-  const initialState = useMemo(
+  const initialView = useMemo(
     () => buildInitialView(defaultFrom),
     [defaultFrom],
-  );
-  const [dateFilters, setDateFilters] = useState<DateFilters>(
-    initialState.dateFilters,
-  );
-  const [pendingDateFilters, setPendingDateFilters] = useState<DateFilters>(
-    initialState.dateFilters,
   );
   const [expandedLogIds, setExpandedLogIds] = useState<Set<number>>(
     () => new Set(),
@@ -81,17 +75,17 @@ export function List({ defaultFrom }: Props): JSX.Element {
 
   const load = useCallback(
     (params: ListingQueryParams, signal?: AbortSignal) => {
-      if (getDateRangeError(dateFilters)) {
-        // Invalid bookmarked ranges are rendered as validation errors instead
-        // of being sent to REST.
-        return Promise.resolve({
-          items: [],
-          meta: { count: 0, pages: 0 },
-        });
+      if (getDateRangeError((params.filter as LogsFilter) ?? {})) {
+        // Invalid bookmarked ranges are surfaced as a validation message
+        // instead of being sent to REST (which would 400).
+        return Promise.resolve({ items: [], meta: { count: 0, pages: 0 } });
       }
-      return getLogs(buildLogsRequestParams(params, dateFilters), signal);
+      return getLogs(
+        { ...params, search: params.search?.trim() || undefined },
+        signal,
+      );
     },
-    [dateFilters],
+    [],
   );
 
   const {
@@ -104,11 +98,16 @@ export function List({ defaultFrom }: Props): JSX.Element {
     clearError: clearLoadError,
     refresh,
   } = useDataViewsQuery<LogListingItem>({
-    initialView: initialState.view,
+    initialView,
     load,
+    extraParams: (currentView) => ({
+      filter: viewFiltersToRequestFilter(currentView.filters),
+    }),
   });
 
-  const dateRangeError = getDateRangeError(pendingDateFilters);
+  const dateRangeError = getDateRangeError(
+    viewFiltersToRequestFilter(view.filters),
+  );
   const emptyState =
     loadError || dateRangeError ? null : (
       <div>{__('No logs found.', 'mailpoet')}</div>
@@ -118,10 +117,12 @@ export function List({ defaultFrom }: Props): JSX.Element {
     (nextView: View) => {
       const searchChanged = (nextView.search ?? '') !== (view.search ?? '');
       const perPageChanged = nextView.perPage !== view.perPage;
+      const filtersChanged = filtersKey(nextView) !== filtersKey(view);
 
       setView({
         ...nextView,
-        page: searchChanged || perPageChanged ? 1 : nextView.page,
+        page:
+          searchChanged || perPageChanged || filtersChanged ? 1 : nextView.page,
       });
     },
     [setView, view],
@@ -138,13 +139,18 @@ export function List({ defaultFrom }: Props): JSX.Element {
       return;
     }
 
-    const nextUrl = buildLogsUrl(window.location.href, view, dateFilters);
+    const nextUrl = buildLogsUrl(
+      window.location.href,
+      view,
+      viewFiltersToRequestFilter(view.filters),
+    );
     window.history.replaceState({}, '', nextUrl);
-  }, [dateFilters, view]);
+  }, [view]);
 
+  const viewFiltersKey = filtersKey(view);
   useEffect(() => {
     setExpandedLogIds((current) => (current.size > 0 ? new Set() : current));
-  }, [dateFilters, view.page, view.perPage, view.search]);
+  }, [viewFiltersKey, view.page, view.perPage, view.search]);
 
   const toggleExpanded = useCallback((logId: number): void => {
     setExpandedLogIds((current) => {
@@ -159,7 +165,7 @@ export function List({ defaultFrom }: Props): JSX.Element {
   }, []);
 
   const fields = useMemo(
-    () => getLogFields(expandedLogIds, toggleExpanded),
+    () => getLogFields(expandedLogIds, toggleExpanded, getLogFilterOptions()),
     [expandedLogIds, toggleExpanded],
   );
 
@@ -168,28 +174,13 @@ export function List({ defaultFrom }: Props): JSX.Element {
     [meta],
   );
 
-  const applyDateFilters = useCallback((): void => {
-    if (dateRangeError) {
-      return;
-    }
-    setDateFilters(pendingDateFilters);
-    setView((currentView) => ({ ...currentView, page: 1 }));
-  }, [dateRangeError, pendingDateFilters, setView]);
-
-  const clearDateFilters = useCallback((): void => {
-    const emptyFilters: DateFilters = {};
-    setPendingDateFilters(emptyFilters);
-    setDateFilters(emptyFilters);
-    setView((currentView) => ({ ...currentView, page: 1 }));
-  }, [setView]);
-
   const retryLoading = useCallback((): void => {
     clearLoadError();
     refresh();
   }, [clearLoadError, refresh]);
 
   return (
-    <div className="mailpoet-listing mailpoet-logs mailpoet-logs-dataviews">
+    <div className="mailpoet-listing mailpoet-logs mailpoet-dataviews mailpoet-logs-dataviews">
       {loadError && (
         <Notice status="error" isDismissible={false}>
           <div className="mailpoet-logs-error">
@@ -202,6 +193,14 @@ export function List({ defaultFrom }: Props): JSX.Element {
             >
               {__('Retry', 'mailpoet')}
             </Button>
+          </div>
+        </Notice>
+      )}
+
+      {dateRangeError && (
+        <Notice status="error" isDismissible={false}>
+          <div className="mailpoet-logs-date-error" role="alert">
+            {dateRangeError}
           </div>
         </Notice>
       )}
@@ -219,84 +218,12 @@ export function List({ defaultFrom }: Props): JSX.Element {
       >
         <div className="mailpoet-logs-dataviews__toolbar">
           <DataViews.Search label={__('Search logs', 'mailpoet')} />
-          <div className="mailpoet-logs-date-filters">
-            <label
-              className="mailpoet-logs-date-filter"
-              htmlFor="mailpoet-logs-from"
-            >
-              <span>{__('From', 'mailpoet')}</span>
-              <Datepicker
-                id="mailpoet-logs-from"
-                dateFormat="MMMM d, yyyy"
-                onChange={(date: Date | null): void =>
-                  setPendingDateFilters((current) => ({
-                    ...current,
-                    from: formatDateAsYmd(date),
-                  }))
-                }
-                maxDate={new Date()}
-                selected={dateFromString(pendingDateFilters.from)}
-                dimension="small"
-                disabled={isLoading}
-                isClearable
-                aria-label={__('Filter logs from date', 'mailpoet')}
-                aria-invalid={Boolean(dateRangeError) || undefined}
-                aria-describedby={dateRangeError ? dateRangeErrorId : undefined}
-              />
-            </label>
-            <label
-              className="mailpoet-logs-date-filter"
-              htmlFor="mailpoet-logs-to"
-            >
-              <span>{__('To', 'mailpoet')}</span>
-              <Datepicker
-                id="mailpoet-logs-to"
-                dateFormat="MMMM d, yyyy"
-                onChange={(date: Date | null): void =>
-                  setPendingDateFilters((current) => ({
-                    ...current,
-                    to: formatDateAsYmd(date),
-                  }))
-                }
-                maxDate={new Date()}
-                selected={dateFromString(pendingDateFilters.to)}
-                dimension="small"
-                disabled={isLoading}
-                isClearable
-                aria-label={__('Filter logs to date', 'mailpoet')}
-                aria-invalid={Boolean(dateRangeError) || undefined}
-                aria-describedby={dateRangeError ? dateRangeErrorId : undefined}
-              />
-            </label>
-            <Button
-              dimension="small"
-              onClick={applyDateFilters}
-              isDisabled={isLoading || Boolean(dateRangeError)}
-            >
-              {__('Apply', 'mailpoet')}
-            </Button>
-            <Button
-              dimension="small"
-              variant="secondary"
-              onClick={clearDateFilters}
-              isDisabled={isLoading}
-            >
-              {__('Clear', 'mailpoet')}
-            </Button>
-          </div>
+          <DataViews.FiltersToggle />
           <div className="mailpoet-dataviews__toolbar-end">
             <DataViews.ViewConfig />
           </div>
-          {dateRangeError && (
-            <div
-              className="mailpoet-logs-date-error"
-              id={dateRangeErrorId}
-              role="alert"
-            >
-              {dateRangeError}
-            </div>
-          )}
         </div>
+        <DataViews.Filters />
         <DataViews.Layout />
         <DataViews.Footer />
       </DataViews>

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -11,7 +11,7 @@ import {
   type ListingQueryParams,
 } from 'common/dataviews';
 import { getLogs, type LogListingItem } from './api';
-import { getLogFieldDefinitions, getLogFields } from './fields';
+import { getLogActions, getLogFieldDefinitions, getLogFields } from './fields';
 import {
   getLogFilterOptions,
   requestFilterToViewFilters,
@@ -29,7 +29,7 @@ const DEFAULT_VIEW: View = {
   perPage: 20,
   page: 1,
   sort: { field: 'created_at', direction: 'desc' },
-  fields: ['message', 'action', 'created_at'],
+  fields: ['message', 'created_at'],
   titleField: 'name',
   showTitle: true,
 };
@@ -165,7 +165,11 @@ export function List({ defaultFrom }: Props): JSX.Element {
   }, []);
 
   const fields = useMemo(
-    () => getLogFields(expandedLogIds, toggleExpanded, getLogFilterOptions()),
+    () => getLogFields(expandedLogIds, getLogFilterOptions()),
+    [expandedLogIds],
+  );
+  const actions = useMemo(
+    () => getLogActions(expandedLogIds, toggleExpanded),
     [expandedLogIds, toggleExpanded],
   );
 
@@ -208,6 +212,7 @@ export function List({ defaultFrom }: Props): JSX.Element {
       <DataViews<LogListingItem>
         data={items}
         fields={fields}
+        actions={actions}
         view={view}
         onChangeView={persistedViewChange}
         paginationInfo={paginationInfo}

--- a/mailpoet/assets/js/src/logs/url-state.ts
+++ b/mailpoet/assets/js/src/logs/url-state.ts
@@ -5,16 +5,18 @@ export const DEFAULT_PAGE = 1;
 export const DEFAULT_PER_PAGE = 20;
 export const MAX_PER_PAGE = 100;
 
-export type DateFilters = {
+export type LogsFilter = {
   from?: string;
   to?: string;
+  name?: string[];
+  level?: number[];
 };
 
 export type LogsUrlState = {
   page: number;
   perPage: number;
   search?: string;
-  dateFilters: DateFilters;
+  filters: LogsFilter;
 };
 
 function parsePositiveInt(value: string | null): number | undefined {
@@ -112,22 +114,50 @@ function getSearch(searchParams: URLSearchParams): string | undefined {
   return search || undefined;
 }
 
-function getDateFilters(
+function getNameFilter(searchParams: URLSearchParams): string[] | undefined {
+  const names = searchParams
+    .getAll('log_name')
+    .map((value) => value.trim())
+    .filter((value) => value !== '');
+
+  return names.length > 0 ? names : undefined;
+}
+
+function getLevelFilter(searchParams: URLSearchParams): number[] | undefined {
+  const levels = searchParams
+    .getAll('log_level')
+    .map((value) => Number(value))
+    .filter((value) => Number.isInteger(value));
+
+  return levels.length > 0 ? levels : undefined;
+}
+
+function getFilters(
   searchParams: URLSearchParams,
   defaultFrom: string,
-): DateFilters {
+): LogsFilter {
   const from = searchParams.get('from');
   const to = searchParams.get('to');
-  const filters: DateFilters = {};
+  const filters: LogsFilter = {};
 
   if (isStrictDateString(from)) {
-    filters.from = from;
+    filters.from = from ?? undefined;
   } else if (isStrictDateString(defaultFrom)) {
     filters.from = defaultFrom;
   }
 
   if (isStrictDateString(to)) {
-    filters.to = to;
+    filters.to = to ?? undefined;
+  }
+
+  const names = getNameFilter(searchParams);
+  if (names) {
+    filters.name = names;
+  }
+
+  const levels = getLevelFilter(searchParams);
+  if (levels) {
+    filters.level = levels;
   }
 
   return filters;
@@ -167,14 +197,14 @@ export function parseLogsUrlState(
     page: getPage(searchParams, perPage),
     perPage,
     search: getSearch(searchParams),
-    dateFilters: getDateFilters(searchParams, defaultFrom),
+    filters: getFilters(searchParams, defaultFrom),
   };
 }
 
 export function buildLogsUrl(
   currentUrl: string,
   view: View,
-  dateFilters: DateFilters,
+  filters: LogsFilter,
 ): string {
   const url = new URL(currentUrl);
   const search = view.search?.trim();
@@ -185,16 +215,24 @@ export function buildLogsUrl(
   url.searchParams.delete('search');
   url.searchParams.delete('from');
   url.searchParams.delete('to');
+  url.searchParams.delete('log_name');
+  url.searchParams.delete('log_level');
 
   if (search) {
     url.searchParams.set('search', search);
   }
-  if (dateFilters.from) {
-    url.searchParams.set('from', dateFilters.from);
+  if (filters.from) {
+    url.searchParams.set('from', filters.from);
   }
-  if (dateFilters.to) {
-    url.searchParams.set('to', dateFilters.to);
+  if (filters.to) {
+    url.searchParams.set('to', filters.to);
   }
+  (filters.name ?? []).forEach((name) => {
+    url.searchParams.append('log_name', name);
+  });
+  (filters.level ?? []).forEach((level) => {
+    url.searchParams.append('log_level', String(level));
+  });
 
   url.searchParams.set('logs_page', String(view.page ?? DEFAULT_PAGE));
   url.searchParams.set(
@@ -205,7 +243,7 @@ export function buildLogsUrl(
   return url.href;
 }
 
-export function getDateRangeError(dateFilters: DateFilters): string | null {
+export function getDateRangeError(dateFilters: LogsFilter): string | null {
   // Keep in sync with LogsListingEndpoint::validateFilters; the browser blocks
   // invalid ranges, while REST validates direct requests.
   if (dateFilters.from && dateFilters.to && dateFilters.from > dateFilters.to) {

--- a/mailpoet/changelog/2026-06-13-15-55-52-added-native-filters-and-sorting-on-the-logs-listing.md
+++ b/mailpoet/changelog/2026-06-13-15-55-52-added-native-filters-and-sorting-on-the-logs-listing.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Native filters and sorting on the Logs listing

--- a/mailpoet/lib/AdminPages/Pages/Logs.php
+++ b/mailpoet/lib/AdminPages/Pages/Logs.php
@@ -4,6 +4,7 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\AssetsController;
 use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Logging\LogRepository;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -17,14 +18,19 @@ class Logs {
   /** @var WPFunctions */
   private $wp;
 
+  /** @var LogRepository */
+  private $logRepository;
+
   public function __construct(
     AssetsController $assetsController,
     PageRenderer $pageRenderer,
-    WPFunctions $wp
+    WPFunctions $wp,
+    LogRepository $logRepository
   ) {
     $this->assetsController = $assetsController;
     $this->pageRenderer = $pageRenderer;
     $this->wp = $wp;
+    $this->logRepository = $logRepository;
   }
 
   public function render() {
@@ -33,6 +39,9 @@ class Logs {
     $dateFrom = (new Carbon())->subDays(7);
     $data = [
       'logs_default_from' => $dateFrom->format('Y-m-d'),
+      'logs_filter_options' => [
+        'names' => $this->logRepository->getDistinctNames(),
+      ],
       'api' => [
         'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
         'nonce' => $this->wp->wpCreateNonce('wp_rest'),

--- a/mailpoet/lib/Logging/LogListingRepository.php
+++ b/mailpoet/lib/Logging/LogListingRepository.php
@@ -8,7 +8,7 @@ use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 class LogListingRepository extends ListingRepository {
   protected function applySelectClause(QueryBuilder $queryBuilder) {
-    $queryBuilder->select('PARTIAL l.{id,name,message,createdAt}');
+    $queryBuilder->select('PARTIAL l.{id,name,level,message,createdAt}');
   }
 
   protected function applyFromClause(QueryBuilder $queryBuilder) {
@@ -19,9 +19,17 @@ class LogListingRepository extends ListingRepository {
     // Logs listing does not support groups.
   }
 
+  private const SORTABLE_FIELDS = [
+    'created_at' => 'createdAt',
+    'name' => 'name',
+    'id' => 'id',
+  ];
+
   protected function applySorting(QueryBuilder $queryBuilder, string $sortBy, string $sortOrder) {
-    $queryBuilder->addOrderBy("l.$sortBy", $sortOrder);
-    if ($sortBy !== 'id') {
+    // Whitelist the column to keep arbitrary input out of the DQL ORDER BY.
+    $field = self::SORTABLE_FIELDS[$sortBy] ?? 'createdAt';
+    $queryBuilder->addOrderBy("l.$field", $sortOrder);
+    if ($field !== 'id') {
       $queryBuilder->addOrderBy('l.id', $sortOrder);
     }
   }
@@ -48,6 +56,22 @@ class LogListingRepository extends ListingRepository {
       $queryBuilder
         ->andWhere('l.createdAt <= :dateTo')
         ->setParameter('dateTo', $filters['to'] . ' 23:59:59');
+    }
+    if (!empty($filters['name']) && is_array($filters['name'])) {
+      $queryBuilder
+        ->andWhere('l.name IN (:names)')
+        ->setParameter('names', array_values($filters['name']));
+    }
+    if (!empty($filters['level']) && is_array($filters['level'])) {
+      $levels = [];
+      foreach ($filters['level'] as $level) {
+        if (is_numeric($level)) {
+          $levels[] = (int)$level;
+        }
+      }
+      $queryBuilder
+        ->andWhere('l.level IN (:levels)')
+        ->setParameter('levels', $levels);
     }
   }
 

--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -90,6 +90,30 @@ class LogRepository extends Repository {
     return $query->getQuery()->getResult();
   }
 
+  /**
+   * Distinct log names (sources), used to populate the listing's name filter.
+   *
+   * @return string[]
+   */
+  public function getDistinctNames(): array {
+    $rows = $this->entityManager->createQueryBuilder()
+      ->select('DISTINCT l.name')
+      ->from(LogEntity::class, 'l')
+      ->where('l.name IS NOT NULL')
+      ->andWhere("l.name != ''")
+      ->orderBy('l.name', 'asc')
+      ->getQuery()
+      ->getSingleColumnResult();
+
+    $names = [];
+    foreach ($rows as $row) {
+      if (is_string($row)) {
+        $names[] = $row;
+      }
+    }
+    return $names;
+  }
+
   public function purgeOldLogs(int $daysToKeepLogs, int $limit = 1000): int {
     $logsTable = $this->entityManager->getClassMetadata(LogEntity::class)->getTableName();
     $result = $this->entityManager->getConnection()->executeStatement(

--- a/mailpoet/lib/Logging/RestApi/Endpoints/LogsListingEndpoint.php
+++ b/mailpoet/lib/Logging/RestApi/Endpoints/LogsListingEndpoint.php
@@ -17,8 +17,11 @@ use MailPoet\Validator\Builder;
 use MailPoet\WP\Functions as WPFunctions;
 
 class LogsListingEndpoint extends AbstractListingEndpoint {
-  private const ALLOWED_SORT_FIELD = 'created_at';
-  private const ALLOWED_SORT_ORDER = 'desc';
+  private const ALLOWED_SORT_FIELDS = ['created_at', 'name'];
+  private const ALLOWED_SORT_ORDERS = ['asc', 'desc'];
+  private const DEFAULT_SORT_FIELD = 'created_at';
+  private const DEFAULT_SORT_ORDER = 'desc';
+  private const ALLOWED_FILTERS = ['from', 'to', 'name', 'level'];
 
   /** @var LogListingRepository */
   private $logListingRepository;
@@ -68,17 +71,18 @@ class LogsListingEndpoint extends AbstractListingEndpoint {
     return [
       'id' => (int)$log->getId(),
       'name' => $log->getName() ?? '',
+      'level' => $log->getLevel(),
       'message' => $log->getMessage() ?? '',
       'created_at' => $createdAt ? $createdAt->format('Y-m-d H:i:s') : null,
     ];
   }
 
   protected function getDefaultSortBy(): string {
-    return self::ALLOWED_SORT_FIELD;
+    return self::DEFAULT_SORT_FIELD;
   }
 
   protected function getDefaultSortOrder(): string {
-    return self::ALLOWED_SORT_ORDER;
+    return self::DEFAULT_SORT_ORDER;
   }
 
   private function validateRequest(Request $request): void {
@@ -98,9 +102,13 @@ class LogsListingEndpoint extends AbstractListingEndpoint {
     if ($sortField === null || $sortField === '') {
       return;
     }
-    if (!is_string($sortField) || $sortField !== self::ALLOWED_SORT_FIELD) {
+    if (!is_string($sortField) || !in_array($sortField, self::ALLOWED_SORT_FIELDS, true)) {
       throw new ApiException(
-        __('Unsupported sort field. Allowed values are: created_at.', 'mailpoet'),
+        sprintf(
+          // translators: %s is a comma-separated list of allowed sort fields.
+          __('Unsupported sort field. Allowed values are: %s.', 'mailpoet'),
+          implode(', ', self::ALLOWED_SORT_FIELDS)
+        ),
         400,
         'mailpoet_logs_invalid_orderby'
       );
@@ -112,9 +120,13 @@ class LogsListingEndpoint extends AbstractListingEndpoint {
     if ($sortOrder === null || $sortOrder === '') {
       return;
     }
-    if (!is_string($sortOrder) || strtolower($sortOrder) !== self::ALLOWED_SORT_ORDER) {
+    if (!is_string($sortOrder) || !in_array(strtolower($sortOrder), self::ALLOWED_SORT_ORDERS, true)) {
       throw new ApiException(
-        __('Unsupported sort order. Allowed values are: desc.', 'mailpoet'),
+        sprintf(
+          // translators: %s is a comma-separated list of allowed sort orders.
+          __('Unsupported sort order. Allowed values are: %s.', 'mailpoet'),
+          implode(', ', self::ALLOWED_SORT_ORDERS)
+        ),
         400,
         'mailpoet_logs_invalid_order'
       );
@@ -169,7 +181,7 @@ class LogsListingEndpoint extends AbstractListingEndpoint {
 
     $normalizedFilters = [];
     foreach ($filters as $filter => $value) {
-      if (!is_string($filter) || !in_array($filter, ['from', 'to'], true)) {
+      if (!is_string($filter) || !in_array($filter, self::ALLOWED_FILTERS, true)) {
         throw new ApiException(
           __('Unsupported logs filter.', 'mailpoet'),
           400,
@@ -178,6 +190,9 @@ class LogsListingEndpoint extends AbstractListingEndpoint {
       }
       $normalizedFilters[$filter] = $value;
     }
+
+    $this->validateStringListFilter($normalizedFilters, 'name');
+    $this->validateLevelFilter($normalizedFilters);
 
     $from = $this->validateDateFilter($normalizedFilters, 'from');
     $to = $this->validateDateFilter($normalizedFilters, 'to');
@@ -216,5 +231,55 @@ class LogsListingEndpoint extends AbstractListingEndpoint {
       );
     }
     return $date;
+  }
+
+  /**
+   * @param array<string, mixed> $filters
+   */
+  private function validateStringListFilter(array $filters, string $field): void {
+    if (!array_key_exists($field, $filters) || $filters[$field] === '' || $filters[$field] === []) {
+      return;
+    }
+    if (!is_array($filters[$field])) {
+      throw new ApiException(
+        __('The name filter must be an array of strings.', 'mailpoet'),
+        400,
+        'mailpoet_logs_invalid_' . $field
+      );
+    }
+    foreach ($filters[$field] as $value) {
+      if (!is_string($value)) {
+        throw new ApiException(
+          __('The name filter must be an array of strings.', 'mailpoet'),
+          400,
+          'mailpoet_logs_invalid_' . $field
+        );
+      }
+    }
+  }
+
+  /**
+   * @param array<string, mixed> $filters
+   */
+  private function validateLevelFilter(array $filters): void {
+    if (!array_key_exists('level', $filters) || $filters['level'] === '' || $filters['level'] === []) {
+      return;
+    }
+    if (!is_array($filters['level'])) {
+      throw new ApiException(
+        __('The level filter must be an array of integers.', 'mailpoet'),
+        400,
+        'mailpoet_logs_invalid_level'
+      );
+    }
+    foreach ($filters['level'] as $value) {
+      if ($this->getIntegerValue($value) === null) {
+        throw new ApiException(
+          __('The level filter must be an array of integers.', 'mailpoet'),
+          400,
+          'mailpoet_logs_invalid_level'
+        );
+      }
+    }
   }
 }

--- a/mailpoet/tests/DataFactories/Log.php
+++ b/mailpoet/tests/DataFactories/Log.php
@@ -45,6 +45,13 @@ class Log {
     return $this->update('message', $message);
   }
 
+  /**
+   * @return static
+   */
+  public function withLevel(?int $level): Log {
+    return $this->update('level', $level);
+  }
+
   public function create(): LogEntity {
     $entity = new LogEntity();
     $entity->setName($this->data['name']);

--- a/mailpoet/tests/acceptance/Misc/LogsListingCest.php
+++ b/mailpoet/tests/acceptance/Misc/LogsListingCest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Test\DataFactories\Log as LogFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+class LogsListingCest {
+  public function logsNativeFiltersAndSorting(\AcceptanceTester $i) {
+    $i->wantTo('Filter and sort the logs listing with native DataViews controls');
+
+    $suffix = 'logfilter' . uniqid();
+    $twoDaysAgo = Carbon::now()->subDays(2);
+    $oneDayAgo = Carbon::now()->subDays(1);
+    $today = Carbon::now();
+
+    (new LogFactory())
+      ->withName("cron-{$suffix}")
+      ->withMessage("error-message-{$suffix}")
+      ->withLevel(400)
+      ->withCreatedAt($twoDaysAgo)
+      ->create();
+    (new LogFactory())
+      ->withName("mailer-{$suffix}")
+      ->withMessage("warning-message-{$suffix}")
+      ->withLevel(300)
+      ->withCreatedAt($oneDayAgo)
+      ->create();
+    (new LogFactory())
+      ->withName("queue-{$suffix}")
+      ->withMessage("debug-message-{$suffix}")
+      ->withLevel(100)
+      ->withCreatedAt($today)
+      ->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('logs');
+    $i->searchFor($suffix);
+    $i->waitForText("error-message-{$suffix}");
+    $i->waitForText("warning-message-{$suffix}");
+    $i->waitForText("debug-message-{$suffix}");
+
+    $i->wantTo('Apply a native Severity filter and keep only Error logs');
+    $i->click('Add filter');
+    $i->waitForText('Severity');
+    $i->click(['xpath' => '//*[@role="menuitem"][contains(normalize-space(.), "Severity")]']);
+    $i->waitForElement('.dataviews-filters__search-widget-listitem');
+    $i->click(['xpath' => '//*[contains(@class, "dataviews-filters__search-widget-listitem")][.//text()[contains(., "Error")]]']);
+    $i->pressKey('body', \Facebook\WebDriver\WebDriverKeys::ESCAPE);
+    $i->waitForText("error-message-{$suffix}");
+    // Wait for the filtered re-fetch to drop the non-matching rows before
+    // asserting; error-message is present before and after, so it can't gate.
+    $i->waitForJS(<<<JS
+      const text = document.querySelector('.mailpoet-logs-dataviews')?.innerText ?? '';
+      return !text.includes('warning-message-{$suffix}') &&
+        !text.includes('debug-message-{$suffix}');
+    JS, 10);
+    $i->dontSee("warning-message-{$suffix}");
+    $i->dontSee("debug-message-{$suffix}");
+    $i->seeInCurrentUrl('log_level=400');
+
+    $i->wantTo('Honor the new log_level query param on direct navigation');
+    $i->amOnPage("/wp-admin/admin.php?page=mailpoet-logs&search={$suffix}&log_level=300");
+    $i->waitForText("warning-message-{$suffix}");
+    $i->dontSee("error-message-{$suffix}");
+    $i->dontSee("debug-message-{$suffix}");
+
+    $i->wantTo('Honor legacy from/to/search query params on direct navigation');
+    $i->amOnPage(
+      "/wp-admin/admin.php?page=mailpoet-logs&search={$suffix}" .
+      '&from=' . $oneDayAgo->format('Y-m-d') .
+      '&to=' . $oneDayAgo->format('Y-m-d')
+    );
+    $i->waitForText("warning-message-{$suffix}");
+    $i->dontSee("error-message-{$suffix}");
+    $i->dontSee("debug-message-{$suffix}");
+
+    $i->wantTo('Sort the logs by creation date in ascending order');
+    $i->amOnMailpoetPage('logs');
+    $i->searchFor($suffix);
+    $i->waitForText("error-message-{$suffix}");
+    $i->click(['xpath' => '//th//button[contains(., "Created On")]']);
+    $i->waitForText('Sort ascending');
+    $i->click(['xpath' => '//*[@role="menuitemradio"][contains(normalize-space(.), "Sort ascending")]']);
+    $i->waitForText("error-message-{$suffix}");
+    // Wait for the ascending re-fetch to re-render before snapshotting the order.
+    $i->waitForJS(<<<JS
+      const text = Array.from(document.querySelectorAll('.mailpoet-logs-dataviews tbody tr'))
+        .map((row) => row.textContent)
+        .join('||');
+      const errorAt = text.indexOf('error-message-{$suffix}');
+      const debugAt = text.indexOf('debug-message-{$suffix}');
+      return errorAt !== -1 && debugAt !== -1 && errorAt < debugAt;
+    JS, 10);
+    $orderedMessages = $i->executeJS(<<<JS
+      return Array.from(document.querySelectorAll('.mailpoet-logs-dataviews tbody tr'))
+        .map((row) => row.textContent)
+        .join('||');
+    JS);
+    \PHPUnit\Framework\Assert::assertIsString($orderedMessages);
+    $errorPosition = strpos($orderedMessages, "error-message-{$suffix}");
+    $debugPosition = strpos($orderedMessages, "debug-message-{$suffix}");
+    \PHPUnit\Framework\Assert::assertNotFalse($errorPosition);
+    \PHPUnit\Framework\Assert::assertNotFalse($debugPosition);
+    \PHPUnit\Framework\Assert::assertLessThan(
+      $debugPosition,
+      $errorPosition,
+      'Oldest log (Error) should sort before the newest log (Debug) ascending'
+    );
+  }
+}

--- a/mailpoet/tests/acceptance/Misc/LogsListingCest.php
+++ b/mailpoet/tests/acceptance/Misc/LogsListingCest.php
@@ -40,6 +40,26 @@ class LogsListingCest {
     $i->waitForText("warning-message-{$suffix}");
     $i->waitForText("debug-message-{$suffix}");
 
+    $i->wantTo('Toggle a message open and closed with the native row action');
+    // The primary action button sits behind the cell wrapper for Selenium's
+    // hit-test, so drive it with a JS click by its (state-dependent) label.
+    $clickRowAction = function (string $label) use ($i): void {
+      $i->executeJS(
+        "Array.from(document.querySelectorAll('.mailpoet-logs-dataviews button'))" .
+        ".find((b) => b.textContent.trim() === " . json_encode($label) . ")?.click();"
+      );
+    };
+    $clickRowAction('Show more');
+    $i->waitForJS(
+      "return document.querySelector('.mailpoet-logs-message-full') !== null;",
+      10
+    );
+    $clickRowAction('Show less');
+    $i->waitForJS(
+      "return document.querySelector('.mailpoet-logs-message-full') === null;",
+      10
+    );
+
     $i->wantTo('Apply a native Severity filter and keep only Error logs');
     $i->click('Add filter');
     $i->waitForText('Severity');

--- a/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
@@ -275,10 +275,10 @@ class LogsEndpointsTest extends Test {
   }
 
   public function testGetRejectsInvalidListingParams(): void {
-    $this->assertSame('mailpoet_logs_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['orderby' => 'name']])['code']);
-    $this->assertSame('mailpoet_logs_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['sort_by' => 'name']])['code']);
-    $this->assertSame('mailpoet_logs_invalid_order', $this->get(self::BASE_PATH, ['query' => ['order' => 'asc']])['code']);
-    $this->assertSame('mailpoet_logs_invalid_order', $this->get(self::BASE_PATH, ['query' => ['sort_order' => 'asc']])['code']);
+    $this->assertSame('mailpoet_logs_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['orderby' => 'message']])['code']);
+    $this->assertSame('mailpoet_logs_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['sort_by' => 'message']])['code']);
+    $this->assertSame('mailpoet_logs_invalid_order', $this->get(self::BASE_PATH, ['query' => ['order' => 'sideways']])['code']);
+    $this->assertSame('mailpoet_logs_invalid_order', $this->get(self::BASE_PATH, ['query' => ['sort_order' => 'sideways']])['code']);
     $this->assertSame('mailpoet_logs_invalid_page', $this->get(self::BASE_PATH, ['query' => ['page' => 0]])['code']);
     $this->assertSame('mailpoet_logs_invalid_per_page', $this->get(self::BASE_PATH, ['query' => ['per_page' => 101]])['code']);
     $this->assertSame('mailpoet_logs_invalid_limit', $this->get(self::BASE_PATH, ['query' => ['limit' => 0]])['code']);
@@ -289,7 +289,146 @@ class LogsEndpointsTest extends Test {
     $this->assertSame('mailpoet_logs_invalid_from', $this->get(self::BASE_PATH, ['query' => ['filter' => ['from' => '2025-02-30']]])['code']);
     $this->assertSame('mailpoet_logs_invalid_to', $this->get(self::BASE_PATH, ['query' => ['filter' => ['to' => '2025-2-01']]])['code']);
     $this->assertSame('mailpoet_logs_invalid_date_range', $this->get(self::BASE_PATH, ['query' => ['filter' => ['from' => '2025-02-02', 'to' => '2025-02-01']]])['code']);
-    $this->assertSame('mailpoet_logs_invalid_filter', $this->get(self::BASE_PATH, ['query' => ['filter' => ['level' => 'error']]])['code']);
+  }
+
+  public function testGetRejectsUnsupportedAndMalformedFilters(): void {
+    $this->assertSame('mailpoet_logs_invalid_filter', $this->get(self::BASE_PATH, ['query' => ['filter' => ['unknown' => 'x']]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_level', $this->get(self::BASE_PATH, ['query' => ['filter' => ['level' => 'error']]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_level', $this->get(self::BASE_PATH, ['query' => ['filter' => ['level' => ['oops']]]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_name', $this->get(self::BASE_PATH, ['query' => ['filter' => ['name' => [['nested']]]]])['code']);
+  }
+
+  public function testGetExposesLogLevel(): void {
+    $suffix = uniqid();
+    $log = (new LogFactory())->withName("level-field-{$suffix}")->withLevel(400)->create();
+    // Drop the identity map so the listing hydrates a fresh (partial) entity,
+    // catching a PARTIAL select that omits the level column.
+    $this->entityManager->clear();
+
+    $data = $this->get(self::BASE_PATH, ['query' => ['search' => $suffix, 'per_page' => 100]]);
+    $items = array_values(array_filter(
+      $data['data']['items'],
+      fn($item) => (int)$item['id'] === (int)$log->getId()
+    ));
+
+    $this->assertCount(1, $items);
+    $this->assertSame(400, $items[0]['level']);
+  }
+
+  public function testGetFiltersByName(): void {
+    $suffix = uniqid();
+    $cron = (new LogFactory())->withName("cron-{$suffix}")->withMessage($suffix)->create();
+    $mailer = (new LogFactory())->withName("mailer-{$suffix}")->withMessage($suffix)->create();
+    (new LogFactory())->withName("other-{$suffix}")->withMessage($suffix)->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'filter' => ['name' => ["cron-{$suffix}", "mailer-{$suffix}"]],
+      'per_page' => 100,
+    ]]);
+
+    $ids = array_map('intval', array_column($data['data']['items'], 'id'));
+    sort($ids);
+    $expected = [(int)$cron->getId(), (int)$mailer->getId()];
+    sort($expected);
+    $this->assertSame($expected, $ids);
+  }
+
+  public function testGetFiltersByLevel(): void {
+    $suffix = uniqid();
+    $warning = (new LogFactory())->withName("warn-{$suffix}")->withMessage($suffix)->withLevel(300)->create();
+    $error = (new LogFactory())->withName("error-{$suffix}")->withMessage($suffix)->withLevel(400)->create();
+    (new LogFactory())->withName("debug-{$suffix}")->withMessage($suffix)->withLevel(100)->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'filter' => ['level' => [300, 400]],
+      'per_page' => 100,
+    ]]);
+
+    $ids = array_map('intval', array_column($data['data']['items'], 'id'));
+    sort($ids);
+    $expected = [(int)$warning->getId(), (int)$error->getId()];
+    sort($expected);
+    $this->assertSame($expected, $ids);
+  }
+
+  public function testGetCombinesNameLevelAndDateFilters(): void {
+    $suffix = uniqid();
+    $match = (new LogFactory())
+      ->withName("combo-{$suffix}")
+      ->withMessage($suffix)
+      ->withLevel(400)
+      ->withCreatedAt(new Carbon('2025-04-10 12:00:00'))
+      ->create();
+    $wrongLevel = (new LogFactory())
+      ->withName("combo-{$suffix}")
+      ->withMessage($suffix)
+      ->withLevel(100)
+      ->withCreatedAt(new Carbon('2025-04-10 12:00:00'))
+      ->create();
+    $wrongDate = (new LogFactory())
+      ->withName("combo-{$suffix}")
+      ->withMessage($suffix)
+      ->withLevel(400)
+      ->withCreatedAt(new Carbon('2025-04-20 12:00:00'))
+      ->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'filter' => [
+        'name' => ["combo-{$suffix}"],
+        'level' => [400],
+        'from' => '2025-04-10',
+        'to' => '2025-04-10',
+      ],
+      'per_page' => 100,
+    ]]);
+
+    $ids = array_map('intval', array_column($data['data']['items'], 'id'));
+    $this->assertSame([(int)$match->getId()], $ids);
+    $this->assertNotContains((int)$wrongLevel->getId(), $ids);
+    $this->assertNotContains((int)$wrongDate->getId(), $ids);
+  }
+
+  public function testGetSortsByNameAndCreatedAtInBothDirections(): void {
+    $suffix = uniqid();
+    $alpha = (new LogFactory())->withName("aaa-{$suffix}")->withMessage($suffix)->withCreatedAt(new Carbon('2025-05-01 00:00:00'))->create();
+    $beta = (new LogFactory())->withName("bbb-{$suffix}")->withMessage($suffix)->withCreatedAt(new Carbon('2025-05-02 00:00:00'))->create();
+    $gamma = (new LogFactory())->withName("ccc-{$suffix}")->withMessage($suffix)->withCreatedAt(new Carbon('2025-05-03 00:00:00'))->create();
+
+    $nameAsc = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'sort_by' => 'name',
+      'sort_order' => 'asc',
+      'per_page' => 100,
+    ]]);
+    $this->assertSame(
+      [(int)$alpha->getId(), (int)$beta->getId(), (int)$gamma->getId()],
+      array_map('intval', array_column($nameAsc['data']['items'], 'id'))
+    );
+
+    $createdAtAsc = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'orderby' => 'created_at',
+      'order' => 'asc',
+      'per_page' => 100,
+    ]]);
+    $this->assertSame(
+      [(int)$alpha->getId(), (int)$beta->getId(), (int)$gamma->getId()],
+      array_map('intval', array_column($createdAtAsc['data']['items'], 'id'))
+    );
+
+    $createdAtDesc = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'orderby' => 'created_at',
+      'order' => 'desc',
+      'per_page' => 100,
+    ]]);
+    $this->assertSame(
+      [(int)$gamma->getId(), (int)$beta->getId(), (int)$alpha->getId()],
+      array_map('intval', array_column($createdAtDesc['data']['items'], 'id'))
+    );
   }
 
   public function testGetRejectsUsersWithoutPermission(): void {

--- a/mailpoet/tests/javascript/logs/fields.spec.ts
+++ b/mailpoet/tests/javascript/logs/fields.spec.ts
@@ -1,7 +1,9 @@
 import {
   formatCreatedAt,
+  getLogActions,
   getLogFields,
 } from '../../../assets/js/src/logs/fields';
+import type { LogListingItem } from '../../../assets/js/src/logs/api';
 
 describe('logs fields', () => {
   it('does not render Invalid date for null created_at values', () => {
@@ -10,7 +12,7 @@ describe('logs fields', () => {
   });
 
   it('enables native filters and sorting on the supported columns', () => {
-    const fields = getLogFields(new Set(), () => {}, {
+    const fields = getLogFields(new Set(), {
       names: ['cron', 'mailer'],
     });
     const byId = Object.fromEntries(fields.map((field) => [field.id, field]));
@@ -41,6 +43,32 @@ describe('logs fields', () => {
     expect(byId.created_at.enableSorting).to.equal(true);
 
     expect(byId.message.filterBy).to.equal(false);
-    expect(byId.action.filterBy).to.equal(false);
+    // The message expand toggle is a native row action, not a column.
+    expect(byId.action).to.equal(undefined);
+  });
+
+  it('exposes a primary toggle action whose label tracks expanded state', () => {
+    const item = { id: 7 } as LogListingItem;
+    const toggled: number[] = [];
+
+    const collapsed = getLogActions(new Set(), (id) => toggled.push(id))[0];
+    expect(collapsed.isPrimary).to.equal(true);
+    expect(
+      typeof collapsed.label === 'function'
+        ? collapsed.label([item])
+        : collapsed.label,
+    ).to.equal('Show more');
+
+    const expanded = getLogActions(new Set([7]), () => {})[0];
+    expect(
+      typeof expanded.label === 'function'
+        ? expanded.label([item])
+        : expanded.label,
+    ).to.equal('Show less');
+
+    if ('callback' in collapsed) {
+      collapsed.callback([item], {} as never);
+    }
+    expect(toggled).to.deep.equal([7]);
   });
 });

--- a/mailpoet/tests/javascript/logs/fields.spec.ts
+++ b/mailpoet/tests/javascript/logs/fields.spec.ts
@@ -9,14 +9,38 @@ describe('logs fields', () => {
     expect(formatCreatedAt(null)).not.to.equal('Invalid date');
   });
 
-  it('does not expose unsupported DataViews column filters', () => {
-    const fields = getLogFields(new Set(), () => {});
+  it('enables native filters and sorting on the supported columns', () => {
+    const fields = getLogFields(new Set(), () => {}, {
+      names: ['cron', 'mailer'],
+    });
+    const byId = Object.fromEntries(fields.map((field) => [field.id, field]));
 
-    expect(fields.map((field) => field.filterBy)).to.deep.equal([
-      false,
-      false,
-      false,
-      false,
+    expect(byId.name.filterBy).to.deep.equal({ operators: ['isAny'] });
+    expect(byId.name.enableSorting).to.equal(true);
+    expect(byId.name.elements).to.deep.equal([
+      { value: 'cron', label: 'cron' },
+      { value: 'mailer', label: 'mailer' },
     ]);
+
+    expect(byId.level.filterBy).to.deep.equal({ operators: ['isAny'] });
+    // Severity offers the full Monolog enum, not only logged levels.
+    expect(byId.level.elements).to.deep.equal([
+      { value: 100, label: 'Debug' },
+      { value: 200, label: 'Info' },
+      { value: 250, label: 'Notice' },
+      { value: 300, label: 'Warning' },
+      { value: 400, label: 'Error' },
+      { value: 500, label: 'Critical' },
+      { value: 550, label: 'Alert' },
+      { value: 600, label: 'Emergency' },
+    ]);
+
+    expect(byId.created_at.filterBy).to.deep.equal({
+      operators: ['on', 'before', 'after', 'between'],
+    });
+    expect(byId.created_at.enableSorting).to.equal(true);
+
+    expect(byId.message.filterBy).to.equal(false);
+    expect(byId.action.filterBy).to.equal(false);
   });
 });

--- a/mailpoet/tests/javascript/logs/filters.spec.ts
+++ b/mailpoet/tests/javascript/logs/filters.spec.ts
@@ -1,0 +1,94 @@
+import {
+  requestFilterToViewFilters,
+  viewFiltersToRequestFilter,
+} from '../../../assets/js/src/logs/filters';
+
+describe('logs filters translation', () => {
+  it('maps a between date filter to from/to', () => {
+    const filter = viewFiltersToRequestFilter([
+      {
+        field: 'created_at',
+        operator: 'between',
+        value: ['2026-05-01', '2026-05-18'],
+      },
+    ]);
+
+    expect(filter).to.deep.equal({ from: '2026-05-01', to: '2026-05-18' });
+  });
+
+  it('maps single-bound date operators', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'after', value: '2026-05-01' },
+      ]),
+    ).to.deep.equal({ from: '2026-05-01' });
+
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'before', value: '2026-05-18' },
+      ]),
+    ).to.deep.equal({ to: '2026-05-18' });
+
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'on', value: '2026-05-10' },
+      ]),
+    ).to.deep.equal({ from: '2026-05-10', to: '2026-05-10' });
+  });
+
+  it('maps name and level multi-select filters', () => {
+    const filter = viewFiltersToRequestFilter([
+      { field: 'name', operator: 'isAny', value: ['cron', 'mailer'] },
+      { field: 'level', operator: 'isAny', value: [300, 400] },
+    ]);
+
+    expect(filter).to.deep.equal({
+      name: ['cron', 'mailer'],
+      level: [300, 400],
+    });
+  });
+
+  it('ignores invalid date and empty multi-select values', () => {
+    const filter = viewFiltersToRequestFilter([
+      { field: 'created_at', operator: 'after', value: 'not-a-date' },
+      { field: 'name', operator: 'isAny', value: [] },
+      { field: 'level', operator: 'isAny', value: [] },
+    ]);
+
+    expect(filter).to.deep.equal({});
+  });
+
+  it('seeds a between filter from a from/to range', () => {
+    expect(
+      requestFilterToViewFilters({ from: '2026-05-01', to: '2026-05-18' }),
+    ).to.deep.equal([
+      {
+        field: 'created_at',
+        operator: 'between',
+        value: ['2026-05-01', '2026-05-18'],
+      },
+    ]);
+  });
+
+  it('seeds an "on" filter when from equals to', () => {
+    expect(
+      requestFilterToViewFilters({ from: '2026-05-10', to: '2026-05-10' }),
+    ).to.deep.equal([
+      { field: 'created_at', operator: 'on', value: '2026-05-10' },
+    ]);
+  });
+
+  it('seeds single-bound and multi-select filters', () => {
+    expect(
+      requestFilterToViewFilters({
+        from: '2026-05-01',
+        name: ['cron'],
+        level: [400],
+      }),
+    ).to.deep.equal([
+      { field: 'created_at', operator: 'after', value: '2026-05-01' },
+      { field: 'name', operator: 'isAny', value: ['cron'] },
+      { field: 'level', operator: 'isAny', value: [400] },
+    ]);
+  });
+});

--- a/mailpoet/tests/javascript/logs/url-state.spec.ts
+++ b/mailpoet/tests/javascript/logs/url-state.spec.ts
@@ -20,7 +20,7 @@ describe('logs URL state', () => {
       page: 1,
       perPage: 20,
       search: undefined,
-      dateFilters: { from: defaultFrom },
+      filters: { from: defaultFrom },
     });
   });
 
@@ -61,9 +61,22 @@ describe('logs URL state', () => {
     );
 
     expect(state.search).to.equal('error');
-    expect(state.dateFilters).to.deep.equal({
+    expect(state.filters).to.deep.equal({
       from: defaultFrom,
       to: '2026-05-18',
+    });
+  });
+
+  it('parses name and level filters from the URL', () => {
+    const state = parseLogsUrlState(
+      'http://example.test/wp-admin/admin.php?page=mailpoet-logs&log_name=cron&log_name=mailer&log_level=300&log_level=400&from=',
+      defaultFrom,
+    );
+
+    expect(state.filters).to.deep.equal({
+      from: defaultFrom,
+      name: ['cron', 'mailer'],
+      level: [300, 400],
     });
   });
 
@@ -89,6 +102,22 @@ describe('logs URL state', () => {
     expect(searchParams.get('per_page')).to.equal('40');
     expect(searchParams.has('offset')).to.equal(false);
     expect(searchParams.has('limit')).to.equal(false);
+  });
+
+  it('serializes name and level filters as repeated query params', () => {
+    const url = buildLogsUrl(
+      'http://example.test/wp-admin/admin.php?page=mailpoet-logs&log_name=stale&log_level=100',
+      {
+        type: 'table',
+        page: 1,
+        perPage: 20,
+      },
+      { name: ['cron', 'mailer'], level: [300, 400] },
+    );
+    const searchParams = new URL(url).searchParams;
+
+    expect(searchParams.getAll('log_name')).to.deep.equal(['cron', 'mailer']);
+    expect(searchParams.getAll('log_level')).to.deep.equal(['300', '400']);
   });
 
   it('validates strict dates and date ranges', () => {

--- a/mailpoet/views/logs.html
+++ b/mailpoet/views/logs.html
@@ -10,6 +10,7 @@
   <script type="text/javascript">
     <% autoescape 'js' %>
       var mailpoet_logs_default_from = '<%= logs_default_from %>';
+      var mailpoet_logs_filter_options = <%= json_encode(logs_filter_options) %>;
       var mailpoet_logs_api = <%= json_encode(api) %>;
     <% endautoescape %>
   </script>


### PR DESCRIPTION
## Description

Replaces the custom from/to date pickers on the Logs listing with native DataViews filters, enables column sorting, and moves the message expand/collapse to a native row action.

- **Native filters**
  - **Date** on `created_at` — `on` / `before` / `after` / `between`
  - **Log name / source** — multi-select, values bootstrapped from the names present in the log
  - **Severity / level** — multi-select over the Monolog levels (Debug … Emergency)
- **Sorting** — `created_at` (both directions) and `name`
- **Message expand/collapse** — now a native DataViews primary row action ("Show more" / "Show less") instead of a custom column button; the message renders in a `<pre>` and is truncated when collapsed
- **REST endpoint** — extended to accept name/level filters and `sort_by`/`sort_order` alongside the existing date/search params; the repository whitelists sort columns and applies `IN` filters
- **Backwards compatible** — legacy `from` / `to` / `search` query params keep working; new `log_name` / `log_level` params added

## Code review notes

- The date filter uses the DataViews `date` field type (not `datetime`) so `between` renders a native range picker — `datetime` doesn't expose `between` in this version.
- `view.filters` is translated to the REST `filter` object via the listing query hook's `extraParams`, so the shared `useDataViewsQuery` is untouched.
- Severity options come from a static Monolog enum (no query); name options come from a distinct-name query bootstrapped on the page (the name set is open-ended — automation slugs, premium, third-party loggers).

## QA notes

On `?page=mailpoet-logs`: apply each filter and sort, expand/collapse a message with the row action, and confirm bookmarked legacy `from` / `to` / `search` URLs still filter correctly.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8172

## After-merge notes

_N/A_

## Screenshots or screencast

| Before | After | 
| ----- | ----- | 
| <img width="1382" height="746" alt="Screenshot 2026-06-18 at 12 53 19" src="https://github.com/user-attachments/assets/e4d5b655-86e9-48c6-b316-89ecea8f51e8" /> | <img width="1365" height="657" alt="Screenshot 2026-06-18 at 13 38 05" src="https://github.com/user-attachments/assets/225126ee-aecd-4180-b815-1bc0d48f800f" /> | 

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8172-dataviews-native-filters-sorting-for-logs-listing)

_The latest successful build from `add/stomail-8172-dataviews-native-filters-sorting-for-logs-listing` will be used. If none is available, the link won't work._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->