### PR TITLE
Add native DataViews filters and sorting to forms listing

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -385,7 +385,10 @@ class RoboFile extends \Robo\Tasks {
   }
 
   public function testJavascript($xmlOutputFile = null) {
-    $command = './node_modules/.bin/mocha --recursive --require tests/javascript/mocha-env.mjs  tests/javascript --extension spec.ts';
+    // NODE_PATH lets specs resolve bare `common/...` module specifiers the same
+    // way Webpack's resolve.modules does (kept in sync with the `test` script in
+    // package.json).
+    $command = 'env NODE_PATH=$NODE_PATH:./assets/js/src ./node_modules/.bin/mocha --recursive --require tests/javascript/mocha-env.mjs  tests/javascript --extension spec.ts';
 
     if (!empty($xmlOutputFile)) {
       $command .= sprintf(

--- a/mailpoet/assets/js/src/common/dataviews/filters.ts
+++ b/mailpoet/assets/js/src/common/dataviews/filters.ts
@@ -57,9 +57,26 @@ export function normalizeYmd(value: unknown): string | undefined {
 }
 
 /**
- * Translate a single DataViews date filter into a `{ from, to }` range. Supports
- * the standard date operators (`on`, `before`/`beforeInc`, `after`/`afterInc`,
- * `between`). Unrecognized or invalid input yields an empty range.
+ * Shift a `yyyy-MM-dd` string by whole days, preserving the `yyyy-MM-dd` shape.
+ */
+function shiftYmd(ymd: string, deltaDays: number): string {
+  const [year, month, day] = ymd.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day + deltaDays));
+  const shiftedMonth = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const shiftedDay = String(date.getUTCDate()).padStart(2, '0');
+  return `${date.getUTCFullYear()}-${shiftedMonth}-${shiftedDay}`;
+}
+
+/**
+ * Translate a single DataViews date filter into a `{ from, to }` range the
+ * listing endpoints apply as inclusive whole days (`>= from 00:00:00`,
+ * `<= to 23:59:59`). Supports the standard date operators (`on`,
+ * `beforeInc`/`afterInc` inclusive, `before`/`after` exclusive, `between`).
+ *
+ * Because the backend boundaries are inclusive, the exclusive `before`/`after`
+ * operators are shifted one day so they exclude the picked day, while the
+ * inclusive `beforeInc`/`afterInc` map straight onto the boundary. Unrecognized
+ * or invalid input yields an empty range.
  */
 export function dateRangeFromFilter(
   operator: string,
@@ -76,11 +93,17 @@ export function dateRangeFromFilter(
   if (!ymd) {
     return {};
   }
-  if (operator === 'before' || operator === 'beforeInc') {
+  if (operator === 'beforeInc') {
     return { to: ymd };
   }
-  if (operator === 'after' || operator === 'afterInc') {
+  if (operator === 'before') {
+    return { to: shiftYmd(ymd, -1) };
+  }
+  if (operator === 'afterInc') {
     return { from: ymd };
+  }
+  if (operator === 'after') {
+    return { from: shiftYmd(ymd, 1) };
   }
   if (operator === 'on') {
     return { from: ymd, to: ymd };

--- a/mailpoet/assets/js/src/common/dataviews/filters.ts
+++ b/mailpoet/assets/js/src/common/dataviews/filters.ts
@@ -1,0 +1,102 @@
+import type { Filter } from '@wordpress/dataviews';
+
+/**
+ * Shared helpers for translating `@wordpress/dataviews` native filters into the
+ * REST query shape MailPoet listing endpoints expect. Every DataViews-backed
+ * listing should reuse these so date handling stays identical across listings.
+ */
+
+function hasOnlyDigits(value: string): boolean {
+  return value
+    .split('')
+    .every((character) => character >= '0' && character <= '9');
+}
+
+/**
+ * True only for a calendar-valid `yyyy-MM-dd` string (rejects e.g. `2025-02-30`).
+ */
+export function isStrictDateString(value: string | undefined | null): boolean {
+  if (!value || value.length !== 10) {
+    return false;
+  }
+
+  const parts = value.split('-');
+  if (
+    parts.length !== 3 ||
+    parts[0].length !== 4 ||
+    parts[1].length !== 2 ||
+    parts[2].length !== 2 ||
+    !parts.every(hasOnlyDigits)
+  ) {
+    return false;
+  }
+
+  const year = Number(parts[0]);
+  const month = Number(parts[1]);
+  const day = Number(parts[2]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+/**
+ * Coerce a DataViews date-control value to a valid `yyyy-MM-dd` string, or
+ * undefined if it isn't one. The control emits `yyyy-MM-dd`; we defensively trim
+ * any time portion a bookmarked value might carry.
+ */
+export function normalizeYmd(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const candidate = value.slice(0, 10);
+  return isStrictDateString(candidate) ? candidate : undefined;
+}
+
+/**
+ * Translate a single DataViews date filter into a `{ from, to }` range. Supports
+ * the standard date operators (`on`, `before`/`beforeInc`, `after`/`afterInc`,
+ * `between`). Unrecognized or invalid input yields an empty range.
+ */
+export function dateRangeFromFilter(
+  operator: string,
+  value: unknown,
+): { from?: string; to?: string } {
+  if (operator === 'between') {
+    const range = Array.isArray(value) ? value : [];
+    const from = normalizeYmd(range[0]);
+    const to = normalizeYmd(range[1]);
+    return { ...(from ? { from } : {}), ...(to ? { to } : {}) };
+  }
+
+  const ymd = normalizeYmd(value);
+  if (!ymd) {
+    return {};
+  }
+  if (operator === 'before' || operator === 'beforeInc') {
+    return { to: ymd };
+  }
+  if (operator === 'after' || operator === 'afterInc') {
+    return { from: ymd };
+  }
+  if (operator === 'on') {
+    return { from: ymd, to: ymd };
+  }
+  return {};
+}
+
+/**
+ * Build the `{ filter }` object for {@link useDataViewsQuery}'s `extraParams`
+ * from an already-serialized request filter, omitting it entirely when empty so
+ * an inactive listing never sends a `filter` param.
+ */
+export function filterToExtraParams(filter: Record<string, unknown>): {
+  filter?: Record<string, unknown>;
+} {
+  return Object.keys(filter).length > 0 ? { filter } : {};
+}
+
+export type FilterList = Filter[] | undefined;

--- a/mailpoet/assets/js/src/common/dataviews/index.ts
+++ b/mailpoet/assets/js/src/common/dataviews/index.ts
@@ -14,6 +14,13 @@ export {
   restPut,
 } from './rest-listing';
 export type { RestApiConfig, RestApiError } from './rest-listing';
+export {
+  dateRangeFromFilter,
+  filterToExtraParams,
+  isStrictDateString,
+  normalizeYmd,
+  type FilterList,
+} from './filters';
 export type {
   ListingEnvelope,
   ListingGroup,

--- a/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
+++ b/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
@@ -100,10 +100,14 @@ export function useDataViewsQuery<T>({
       const searchChanged =
         (nextView.search ?? '') !== (currentView.search ?? '');
       const perPageChanged = nextView.perPage !== currentView.perPage;
+      const filtersChanged =
+        JSON.stringify(currentView.filters ?? []) !==
+        JSON.stringify(nextView.filters ?? []);
 
       return {
         ...nextView,
-        page: searchChanged || perPageChanged ? 1 : nextView.page,
+        page:
+          searchChanged || perPageChanged || filtersChanged ? 1 : nextView.page,
       };
     });
   }, []);

--- a/mailpoet/assets/js/src/forms/fields.ts
+++ b/mailpoet/assets/js/src/forms/fields.ts
@@ -115,7 +115,7 @@ export const listFields: Field<FormListingItem>[] = [
     type: 'date',
     enableSorting: true,
     enableGlobalSearch: false,
-    filterBy: { operators: ['on', 'before', 'after', 'between'] },
+    filterBy: { operators: ['on', 'beforeInc', 'afterInc', 'between'] },
     render: ({ item }) => renderDateTime(item.created_at),
   },
   {
@@ -124,7 +124,7 @@ export const listFields: Field<FormListingItem>[] = [
     type: 'date',
     enableSorting: true,
     enableGlobalSearch: false,
-    filterBy: { operators: ['on', 'before', 'after', 'between'] },
+    filterBy: { operators: ['on', 'beforeInc', 'afterInc', 'between'] },
     render: ({ item }) => renderDateTime(item.updated_at),
   },
 ];

--- a/mailpoet/assets/js/src/forms/fields.ts
+++ b/mailpoet/assets/js/src/forms/fields.ts
@@ -111,7 +111,7 @@ export const listFields: Field<FormListingItem>[] = [
   },
   {
     id: 'created_at',
-    label: __('Created on', 'mailpoet'),
+    label: __('Created date', 'mailpoet'),
     type: 'date',
     enableSorting: true,
     enableGlobalSearch: false,
@@ -120,7 +120,7 @@ export const listFields: Field<FormListingItem>[] = [
   },
   {
     id: 'updated_at',
-    label: __('Modified on', 'mailpoet'),
+    label: __('Modified date', 'mailpoet'),
     type: 'date',
     enableSorting: true,
     enableGlobalSearch: false,

--- a/mailpoet/assets/js/src/forms/fields.ts
+++ b/mailpoet/assets/js/src/forms/fields.ts
@@ -32,6 +32,21 @@ function getFormPlacement(settings: FormListingItem['settings']): string {
   return __('Others (widget)', 'mailpoet');
 }
 
+function renderDateTime(value: string | null): JSX.Element {
+  if (!value) {
+    return createElement('span', null, '—');
+  }
+  const date = MailPoet.Date.short(value);
+  const time = MailPoet.Date.time(value);
+  return createElement(
+    'span',
+    null,
+    createElement('span', null, date),
+    createElement('br', null),
+    createElement('span', null, time),
+  );
+}
+
 export const listFields: Field<FormListingItem>[] = [
   {
     id: 'name',
@@ -39,6 +54,8 @@ export const listFields: Field<FormListingItem>[] = [
     type: 'text',
     enableSorting: true,
     enableGlobalSearch: false,
+    // Name is covered by the search box, so don't expose a redundant filter.
+    filterBy: false,
     render: ({ item }) =>
       createElement(
         'a',
@@ -85,27 +102,29 @@ export const listFields: Field<FormListingItem>[] = [
     label: __('Status', 'mailpoet'),
     enableSorting: false,
     enableGlobalSearch: false,
+    elements: [
+      { value: 'enabled', label: __('Enabled', 'mailpoet') },
+      { value: 'disabled', label: __('Disabled', 'mailpoet') },
+    ],
+    filterBy: { operators: ['isAny'] },
     render: ({ item }) => createElement(FormStatusToggle, { form: item }),
+  },
+  {
+    id: 'created_at',
+    label: __('Created on', 'mailpoet'),
+    type: 'date',
+    enableSorting: true,
+    enableGlobalSearch: false,
+    filterBy: { operators: ['on', 'before', 'after', 'between'] },
+    render: ({ item }) => renderDateTime(item.created_at),
   },
   {
     id: 'updated_at',
     label: __('Modified date', 'mailpoet'),
-    type: 'datetime',
+    type: 'date',
     enableSorting: true,
     enableGlobalSearch: false,
-    render: ({ item }) => {
-      if (!item.updated_at) {
-        return createElement('span', null, '—');
-      }
-      const date = MailPoet.Date.short(item.updated_at);
-      const time = MailPoet.Date.time(item.updated_at);
-      return createElement(
-        'span',
-        null,
-        createElement('span', null, date),
-        createElement('br', null),
-        createElement('span', null, time),
-      );
-    },
+    filterBy: { operators: ['on', 'before', 'after', 'between'] },
+    render: ({ item }) => renderDateTime(item.updated_at),
   },
 ];

--- a/mailpoet/assets/js/src/forms/fields.ts
+++ b/mailpoet/assets/js/src/forms/fields.ts
@@ -120,7 +120,7 @@ export const listFields: Field<FormListingItem>[] = [
   },
   {
     id: 'updated_at',
-    label: __('Modified date', 'mailpoet'),
+    label: __('Modified on', 'mailpoet'),
     type: 'date',
     enableSorting: true,
     enableGlobalSearch: false,

--- a/mailpoet/assets/js/src/forms/filters.ts
+++ b/mailpoet/assets/js/src/forms/filters.ts
@@ -1,0 +1,78 @@
+import type { Filter } from '@wordpress/dataviews';
+import { dateRangeFromFilter } from 'common/dataviews';
+
+export const STATUS_FIELD = 'status';
+export const CREATED_AT_FIELD = 'created_at';
+export const UPDATED_AT_FIELD = 'updated_at';
+
+export type FormsRequestFilter = {
+  status?: string[];
+  created_from?: string;
+  created_to?: string;
+  updated_from?: string;
+  updated_to?: string;
+};
+
+function toStatusArray(value: unknown): string[] {
+  const values = Array.isArray(value) ? value : [value];
+  return values
+    .map((entry) => String(entry))
+    .filter((entry) => entry === 'enabled' || entry === 'disabled');
+}
+
+function dateRangeKeys(
+  fromKey: 'created_from' | 'updated_from',
+  toKey: 'created_to' | 'updated_to',
+  operator: string,
+  value: unknown,
+): FormsRequestFilter {
+  const { from, to } = dateRangeFromFilter(operator, value);
+  return {
+    ...(from ? { [fromKey]: from } : {}),
+    ...(to ? { [toKey]: to } : {}),
+  };
+}
+
+/**
+ * Translate DataViews native filters into the REST `filter` object the forms
+ * listing endpoint understands (`{ status, created_from, created_to,
+ * updated_from, updated_to }`). The two date columns use distinct keys so they
+ * can be filtered independently. Empty filters are omitted so an inactive
+ * control never sends a key.
+ */
+export function viewFiltersToRequestFilter(
+  filters: Filter[] | undefined,
+): FormsRequestFilter {
+  const result: FormsRequestFilter = {};
+
+  (filters ?? []).forEach((filter) => {
+    if (filter.field === STATUS_FIELD) {
+      const statuses = toStatusArray(filter.value);
+      if (statuses.length > 0) {
+        result.status = statuses;
+      }
+    } else if (filter.field === CREATED_AT_FIELD) {
+      Object.assign(
+        result,
+        dateRangeKeys(
+          'created_from',
+          'created_to',
+          filter.operator,
+          filter.value,
+        ),
+      );
+    } else if (filter.field === UPDATED_AT_FIELD) {
+      Object.assign(
+        result,
+        dateRangeKeys(
+          'updated_from',
+          'updated_to',
+          filter.operator,
+          filter.value,
+        ),
+      );
+    }
+  });
+
+  return result;
+}

--- a/mailpoet/assets/js/src/forms/list.tsx
+++ b/mailpoet/assets/js/src/forms/list.tsx
@@ -10,10 +10,12 @@ import {
   getDataViewsPreference,
   usePersistedDataViewsPreference,
   useDataViewsQuery,
+  filterToExtraParams,
   type ListingQueryParams,
 } from 'common/dataviews';
 import { FormsHeading, onAddNewForm } from './heading';
 import { listFields } from './fields';
+import { viewFiltersToRequestFilter } from './filters';
 import {
   bulkAction,
   getForms,
@@ -28,7 +30,7 @@ const DEFAULT_VIEW: View = {
   perPage: 20,
   page: 1,
   sort: { field: 'updated_at', direction: 'desc' },
-  fields: ['segments', 'type', 'status', 'updated_at'],
+  fields: ['segments', 'type', 'status', 'created_at', 'updated_at'],
   titleField: 'name',
   showTitle: true,
 };
@@ -104,6 +106,8 @@ function FormListComponent(): JSX.Element {
   } = useDataViewsQuery<FormListingItem>({
     initialView,
     load,
+    extraParams: (currentView) =>
+      filterToExtraParams(viewFiltersToRequestFilter(currentView.filters)),
   });
   const handleViewChange = usePersistedDataViewsPreference(
     'forms',
@@ -369,10 +373,12 @@ function FormListComponent(): JSX.Element {
             >
               <div className="mailpoet-forms-dataviews__toolbar">
                 <DataViews.Search label={__('Search forms', 'mailpoet')} />
+                <DataViews.FiltersToggle />
                 <div className="mailpoet-dataviews__toolbar-end">
                   <DataViews.ViewConfig />
                 </div>
               </div>
+              <DataViews.Filters />
               <DataViews.Layout />
               <DataViews.Footer />
             </DataViews>

--- a/mailpoet/assets/js/src/logs/fields.tsx
+++ b/mailpoet/assets/js/src/logs/fields.tsx
@@ -78,7 +78,7 @@ export function getLogFields(
       type: 'date',
       enableSorting: true,
       enableGlobalSearch: false,
-      filterBy: { operators: ['on', 'before', 'after', 'between'] },
+      filterBy: { operators: ['on', 'beforeInc', 'afterInc', 'between'] },
       render: ({ item }) =>
         createElement(
           'span',

--- a/mailpoet/assets/js/src/logs/filters.ts
+++ b/mailpoet/assets/js/src/logs/filters.ts
@@ -105,11 +105,13 @@ function datesToFilter(from?: string, to?: string): Filter | null {
       ? { field: CREATED_AT_FIELD, operator: 'on', value: from }
       : { field: CREATED_AT_FIELD, operator: 'between', value: [from, to] };
   }
+  // Stored `from`/`to` are inclusive whole-day boundaries, so seed the inclusive
+  // operators; the exclusive `after`/`before` would shift the day on re-serialize.
   if (from) {
-    return { field: CREATED_AT_FIELD, operator: 'after', value: from };
+    return { field: CREATED_AT_FIELD, operator: 'afterInc', value: from };
   }
   if (to) {
-    return { field: CREATED_AT_FIELD, operator: 'before', value: to };
+    return { field: CREATED_AT_FIELD, operator: 'beforeInc', value: to };
   }
   return null;
 }

--- a/mailpoet/assets/js/src/logs/filters.ts
+++ b/mailpoet/assets/js/src/logs/filters.ts
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import type { Filter } from '@wordpress/dataviews';
-import { isStrictDateString, type LogsFilter } from './url-state';
+import { dateRangeFromFilter } from 'common/dataviews';
+import type { LogsFilter } from './url-state';
 
 export const CREATED_AT_FIELD = 'created_at';
 export const NAME_FIELD = 'name';
@@ -51,40 +52,6 @@ export function getLogFilterOptions(): LogFilterOptions {
   };
 }
 
-function normalizeYmd(value: unknown): string | undefined {
-  if (typeof value !== 'string') {
-    return undefined;
-  }
-  // The DataViews date control emits `yyyy-MM-dd`; defensively trim any time
-  // portion a bookmarked value might carry.
-  const candidate = value.slice(0, 10);
-  return isStrictDateString(candidate) ? candidate : undefined;
-}
-
-function dateFilterToRange(operator: string, value: unknown): LogsFilter {
-  if (operator === 'between') {
-    const range = Array.isArray(value) ? value : [];
-    const from = normalizeYmd(range[0]);
-    const to = normalizeYmd(range[1]);
-    return { ...(from ? { from } : {}), ...(to ? { to } : {}) };
-  }
-
-  const ymd = normalizeYmd(value);
-  if (!ymd) {
-    return {};
-  }
-  if (operator === 'before' || operator === 'beforeInc') {
-    return { to: ymd };
-  }
-  if (operator === 'after' || operator === 'afterInc') {
-    return { from: ymd };
-  }
-  if (operator === 'on') {
-    return { from: ymd, to: ymd };
-  }
-  return {};
-}
-
 function toStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return [];
@@ -115,7 +82,7 @@ export function viewFiltersToRequestFilter(
 
   (filters ?? []).forEach((filter) => {
     if (filter.field === CREATED_AT_FIELD) {
-      Object.assign(result, dateFilterToRange(filter.operator, filter.value));
+      Object.assign(result, dateRangeFromFilter(filter.operator, filter.value));
     } else if (filter.field === NAME_FIELD) {
       const names = toStringArray(filter.value);
       if (names.length > 0) {

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -8,6 +8,7 @@ import {
   getDataViewsPreference,
   usePersistedDataViewsPreference,
   useDataViewsQuery,
+  filterToExtraParams,
   type ListingQueryParams,
 } from 'common/dataviews';
 import { getLogs, type LogListingItem } from './api';
@@ -90,19 +91,18 @@ export function List({ defaultFrom }: Props): JSX.Element {
 
   const {
     view,
-    setView,
     items,
     meta,
     isLoading,
     error: loadError,
+    onChangeView,
     clearError: clearLoadError,
     refresh,
   } = useDataViewsQuery<LogListingItem>({
     initialView,
     load,
-    extraParams: (currentView) => ({
-      filter: viewFiltersToRequestFilter(currentView.filters),
-    }),
+    extraParams: (currentView) =>
+      filterToExtraParams(viewFiltersToRequestFilter(currentView.filters)),
   });
 
   const dateRangeError = getDateRangeError(
@@ -113,24 +113,10 @@ export function List({ defaultFrom }: Props): JSX.Element {
       <div>{__('No logs found.', 'mailpoet')}</div>
     );
 
-  const updateView = useCallback(
-    (nextView: View) => {
-      const searchChanged = (nextView.search ?? '') !== (view.search ?? '');
-      const perPageChanged = nextView.perPage !== view.perPage;
-      const filtersChanged = filtersKey(nextView) !== filtersKey(view);
-
-      setView({
-        ...nextView,
-        page:
-          searchChanged || perPageChanged || filtersChanged ? 1 : nextView.page,
-      });
-    },
-    [setView, view],
-  );
   const persistedViewChange = usePersistedDataViewsPreference(
     'logs',
     view,
-    updateView,
+    onChangeView,
   );
 
   useEffect(() => {

--- a/mailpoet/assets/js/src/logs/url-state.ts
+++ b/mailpoet/assets/js/src/logs/url-state.ts
@@ -1,5 +1,10 @@
 import { __ } from '@wordpress/i18n';
 import type { View } from '@wordpress/dataviews';
+import { isStrictDateString } from 'common/dataviews';
+
+// Re-exported for the logs URL-state consumers/tests that historically imported
+// it from here; the implementation now lives in the shared dataviews helpers.
+export { isStrictDateString };
 
 export const DEFAULT_PAGE = 1;
 export const DEFAULT_PER_PAGE = 20;
@@ -48,40 +53,6 @@ function parseOffset(value: string | null): number | undefined {
   }
 
   return parsed;
-}
-
-function hasOnlyDigits(value: string): boolean {
-  return value
-    .split('')
-    .every((character) => character >= '0' && character <= '9');
-}
-
-export function isStrictDateString(value: string | undefined | null): boolean {
-  if (!value || value.length !== 10) {
-    return false;
-  }
-
-  const parts = value.split('-');
-  if (
-    parts.length !== 3 ||
-    parts[0].length !== 4 ||
-    parts[1].length !== 2 ||
-    parts[2].length !== 2 ||
-    !parts.every(hasOnlyDigits)
-  ) {
-    return false;
-  }
-
-  const year = Number(parts[0]);
-  const month = Number(parts[1]);
-  const day = Number(parts[2]);
-  const date = new Date(Date.UTC(year, month - 1, day));
-
-  return (
-    date.getUTCFullYear() === year &&
-    date.getUTCMonth() === month - 1 &&
-    date.getUTCDate() === day
-  );
 }
 
 export function dateFromString(value: string | undefined): Date | undefined {

--- a/mailpoet/changelog/2026-06-18-11-51-38-added-filtering-by-status-and-creation-date-plus-sorting.md
+++ b/mailpoet/changelog/2026-06-18-11-51-38-added-filtering-by-status-and-creation-date-plus-sorting.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Filtering by status, creation date and modified date plus sorting by creation and modified date on the Forms listing

--- a/mailpoet/lib/API/REST/ListingRequestValidationTrait.php
+++ b/mailpoet/lib/API/REST/ListingRequestValidationTrait.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\API\REST;
+
+use DateTimeImmutable;
+
+/**
+ * Shared request validation for DataViews-backed listing endpoints
+ * (see {@see AbstractListingEndpoint}). Provides the reusable building blocks —
+ * sort field/order, pagination integers, and `yyyy-MM-dd` date filters — so each
+ * listing only declares its own allowed sort fields and filter keys.
+ *
+ * Error codes are namespaced per listing via {@see getListingValidationErrorPrefix()}
+ * so a 400 still says which listing rejected the request
+ * (e.g. `mailpoet_logs_invalid_orderby`).
+ */
+trait ListingRequestValidationTrait {
+  /** Lowercase listing slug used to build error codes, e.g. `logs` or `forms`. */
+  abstract protected function getListingValidationErrorPrefix(): string;
+
+  private function listingValidationError(string $message, string $suffix): ApiException {
+    return new ApiException(
+      $message,
+      400,
+      'mailpoet_' . $this->getListingValidationErrorPrefix() . '_invalid_' . $suffix
+    );
+  }
+
+  /**
+   * @param mixed $sortField
+   * @param string[] $allowedFields
+   */
+  protected function validateSortField($sortField, array $allowedFields): void {
+    if ($sortField === null || $sortField === '') {
+      return;
+    }
+    if (!is_string($sortField) || !in_array($sortField, $allowedFields, true)) {
+      throw $this->listingValidationError(
+        sprintf(
+          // translators: %s is a comma-separated list of allowed sort fields.
+          __('Unsupported sort field. Allowed values are: %s.', 'mailpoet'),
+          implode(', ', $allowedFields)
+        ),
+        'orderby'
+      );
+    }
+  }
+
+  /** @param mixed $sortOrder */
+  protected function validateSortOrder($sortOrder): void {
+    if ($sortOrder === null || $sortOrder === '') {
+      return;
+    }
+    if (!is_string($sortOrder) || !in_array(strtolower($sortOrder), ['asc', 'desc'], true)) {
+      throw $this->listingValidationError(
+        sprintf(
+          // translators: %s is a comma-separated list of allowed sort orders.
+          __('Unsupported sort order. Allowed values are: %s.', 'mailpoet'),
+          implode(', ', ['asc', 'desc'])
+        ),
+        'order'
+      );
+    }
+  }
+
+  protected function validatePagination(Request $request): void {
+    $this->validatePositiveInteger($request->getParam('page'), 'page', 1, self::MAX_PAGE);
+    $this->validatePositiveInteger($request->getParam('per_page'), 'per_page', 1, self::MAX_PER_PAGE);
+    $this->validatePositiveInteger($request->getParam('limit'), 'limit', 1, self::MAX_PER_PAGE);
+    $this->validatePositiveInteger($request->getParam('offset'), 'offset', 0, self::MAX_PAGE);
+  }
+
+  /** @param mixed $value */
+  private function validatePositiveInteger($value, string $name, int $min, int $max): void {
+    if ($value === null || $value === '') {
+      return;
+    }
+    $integer = $this->getIntegerValue($value);
+    if ($integer === null || $integer < $min || $integer > $max) {
+      throw $this->listingValidationError(
+        sprintf(
+          // translators: %1$s is a request parameter name, %2$d is the maximum accepted value.
+          __('%1$s must be an integer no greater than %2$d.', 'mailpoet'),
+          $name,
+          $max
+        ),
+        $name
+      );
+    }
+  }
+
+  /** @param mixed $value */
+  private function getIntegerValue($value): ?int {
+    if (is_int($value)) {
+      return $value;
+    }
+    if (is_string($value) && ctype_digit($value)) {
+      return (int)$value;
+    }
+    return null;
+  }
+
+  /**
+   * @param array<string, mixed> $filters
+   */
+  protected function validateDateFilter(array $filters, string $field): ?DateTimeImmutable {
+    if (!array_key_exists($field, $filters) || $filters[$field] === '') {
+      return null;
+    }
+    if (!is_string($filters[$field])) {
+      throw $this->listingValidationError(
+        __('Date filters must use the YYYY-MM-DD format.', 'mailpoet'),
+        $field
+      );
+    }
+
+    $date = DateTimeImmutable::createFromFormat('!Y-m-d', $filters[$field]);
+    $errors = DateTimeImmutable::getLastErrors();
+    if (!$date || (is_array($errors) && ($errors['warning_count'] > 0 || $errors['error_count'] > 0)) || $date->format('Y-m-d') !== $filters[$field]) {
+      throw $this->listingValidationError(
+        __('Date filters must use the YYYY-MM-DD format.', 'mailpoet'),
+        $field
+      );
+    }
+    return $date;
+  }
+
+  protected function validateDateRange(?DateTimeImmutable $from, ?DateTimeImmutable $to): void {
+    if ($from && $to && $from > $to) {
+      throw $this->listingValidationError(
+        __('The from date must be before or equal to the to date.', 'mailpoet'),
+        'date_range'
+      );
+    }
+  }
+}

--- a/mailpoet/lib/Form/Listing/FormListingRepository.php
+++ b/mailpoet/lib/Form/Listing/FormListingRepository.php
@@ -3,13 +3,19 @@
 namespace MailPoet\Form\Listing;
 
 use MailPoet\Entities\FormEntity;
+use MailPoet\Listing\ListingDateRangeFilterTrait;
 use MailPoet\Listing\ListingDefinition;
 use MailPoet\Listing\ListingRepository;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 class FormListingRepository extends ListingRepository {
+  use ListingDateRangeFilterTrait;
+
+  // Keys are the camelCased sort field (ListingRepository::getData converts the
+  // request's snake_case `sort_by` before calling applySorting).
   private const SORT_FIELDS = [
     'name' => 'name',
+    'createdAt' => 'createdAt',
     'updatedAt' => 'updatedAt',
   ];
 
@@ -90,7 +96,22 @@ class FormListingRepository extends ListingRepository {
   }
 
   protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
-    // the parent class requires this method, but forms listing doesn't currently support this feature.
+    $statuses = $filters['status'] ?? null;
+    if (!empty($statuses)) {
+      $statuses = is_array($statuses) ? $statuses : [$statuses];
+      $statuses = array_values(array_intersect(
+        $statuses,
+        [FormEntity::STATUS_ENABLED, FormEntity::STATUS_DISABLED]
+      ));
+      if ($statuses) {
+        $queryBuilder
+          ->andWhere('f.status IN (:statuses)')
+          ->setParameter('statuses', $statuses);
+      }
+    }
+
+    $this->applyDateRangeFilter($queryBuilder, 'f.createdAt', $filters, 'created_from', 'created_to');
+    $this->applyDateRangeFilter($queryBuilder, 'f.updatedAt', $filters, 'updated_from', 'updated_to');
   }
 
   protected function applyParameters(QueryBuilder $queryBuilder, array $parameters) {

--- a/mailpoet/lib/Form/RestApi/Endpoints/FormsListingEndpoint.php
+++ b/mailpoet/lib/Form/RestApi/Endpoints/FormsListingEndpoint.php
@@ -4,14 +4,25 @@ namespace MailPoet\Form\RestApi\Endpoints;
 
 use MailPoet\API\JSON\ResponseBuilders\FormsResponseBuilder;
 use MailPoet\API\REST\AbstractListingEndpoint;
+use MailPoet\API\REST\ApiException;
+use MailPoet\API\REST\ListingRequestValidationTrait;
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
 use MailPoet\Config\AccessControl;
+use MailPoet\Entities\FormEntity;
 use MailPoet\Form\Listing\FormListingRepository;
 use MailPoet\Listing\Handler as ListingHandler;
 use MailPoet\Listing\ListingDefinition;
 use MailPoet\Listing\ListingRepository;
+use MailPoet\Validator\Builder;
 use MailPoet\WP\Functions as WPFunctions;
 
 class FormsListingEndpoint extends AbstractListingEndpoint {
+  use ListingRequestValidationTrait;
+
+  private const ALLOWED_SORT_FIELDS = ['name', 'created_at', 'updated_at'];
+  private const ALLOWED_FILTERS = ['status', 'created_from', 'created_to', 'updated_from', 'updated_to'];
+
   /** @var FormListingRepository */
   private $formListingRepository;
 
@@ -28,8 +39,21 @@ class FormsListingEndpoint extends AbstractListingEndpoint {
     $this->formsResponseBuilder = $formsResponseBuilder;
   }
 
+  public function handle(Request $request): Response {
+    $this->validateRequest($request);
+    return parent::handle($request);
+  }
+
   public function checkPermissions(): bool {
     return WPFunctions::get()->currentUserCan(AccessControl::PERMISSION_MANAGE_FORMS);
+  }
+
+  public static function getRequestSchema(): array {
+    $schema = parent::getRequestSchema();
+    $schema['limit'] = Builder::integer();
+    $schema['offset'] = Builder::integer();
+    $schema['filter'] = Builder::object();
+    return $schema;
   }
 
   protected function getListingRepository(): ListingRepository {
@@ -50,5 +74,76 @@ class FormsListingEndpoint extends AbstractListingEndpoint {
 
   protected function getDefaultGroup(): ?string {
     return 'all';
+  }
+
+  protected function getListingValidationErrorPrefix(): string {
+    return 'forms';
+  }
+
+  private function validateRequest(Request $request): void {
+    $this->validateSortField($request->getParam('orderby'), self::ALLOWED_SORT_FIELDS);
+    $this->validateSortField($request->getParam('sort_by'), self::ALLOWED_SORT_FIELDS);
+    $this->validateSortOrder($request->getParam('order'));
+    $this->validateSortOrder($request->getParam('sort_order'));
+    $this->validatePagination($request);
+    $this->validateFilters($request->getParam('filter'));
+  }
+
+  /** @param mixed $filters */
+  private function validateFilters($filters): void {
+    if ($filters === null || $filters === []) {
+      return;
+    }
+    if (!is_array($filters)) {
+      throw new ApiException(
+        __('Filters must be an object.', 'mailpoet'),
+        400,
+        'mailpoet_forms_invalid_filter'
+      );
+    }
+
+    $normalizedFilters = [];
+    foreach ($filters as $filter => $value) {
+      if (!is_string($filter) || !in_array($filter, self::ALLOWED_FILTERS, true)) {
+        throw new ApiException(
+          __('Unsupported forms filter.', 'mailpoet'),
+          400,
+          'mailpoet_forms_invalid_filter'
+        );
+      }
+      $normalizedFilters[$filter] = $value;
+    }
+
+    $this->validateStatusFilter($normalizedFilters);
+    $this->validateDateRange(
+      $this->validateDateFilter($normalizedFilters, 'created_from'),
+      $this->validateDateFilter($normalizedFilters, 'created_to')
+    );
+    $this->validateDateRange(
+      $this->validateDateFilter($normalizedFilters, 'updated_from'),
+      $this->validateDateFilter($normalizedFilters, 'updated_to')
+    );
+  }
+
+  /** @param array<string, mixed> $filters */
+  private function validateStatusFilter(array $filters): void {
+    if (!array_key_exists('status', $filters) || $filters['status'] === '' || $filters['status'] === []) {
+      return;
+    }
+    $statuses = is_array($filters['status']) ? $filters['status'] : [$filters['status']];
+    $allowed = [FormEntity::STATUS_ENABLED, FormEntity::STATUS_DISABLED];
+    foreach ($statuses as $status) {
+      if (!is_string($status) || !in_array($status, $allowed, true)) {
+        throw new ApiException(
+          sprintf(
+            // translators: %s is a comma-separated list of allowed form statuses.
+            __('Unsupported status filter. Allowed values are: %s.', 'mailpoet'),
+            implode(', ', $allowed)
+          ),
+          400,
+          'mailpoet_forms_invalid_status'
+        );
+      }
+    }
   }
 }

--- a/mailpoet/lib/Listing/ListingDateRangeFilterTrait.php
+++ b/mailpoet/lib/Listing/ListingDateRangeFilterTrait.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Listing;
+
+use MailPoetVendor\Doctrine\ORM\QueryBuilder;
+
+/**
+ * Applies an inclusive `from`/`to` date-range filter to a listing query. Shared
+ * by DataViews-backed listing repositories so the day-boundary handling (whole
+ * days, `00:00:00`–`23:59:59`) stays identical across listings.
+ */
+trait ListingDateRangeFilterTrait {
+  /**
+   * @param array<string, mixed> $filters
+   * @param string $field Fully-qualified DQL field, e.g. `f.createdAt`.
+   */
+  protected function applyDateRangeFilter(
+    QueryBuilder $queryBuilder,
+    string $field,
+    array $filters,
+    string $fromKey = 'from',
+    string $toKey = 'to'
+  ): void {
+    // Derive parameter names from the filter keys so multiple ranges on the
+    // same query (e.g. created + modified) don't clobber each other's bindings.
+    $fromParam = 'dateRange_' . $fromKey;
+    $toParam = 'dateRange_' . $toKey;
+
+    $from = $filters[$fromKey] ?? null;
+    if (is_string($from) && $from !== '') {
+      $queryBuilder
+        ->andWhere("$field >= :$fromParam")
+        ->setParameter($fromParam, $from . ' 00:00:00');
+    }
+    $to = $filters[$toKey] ?? null;
+    if (is_string($to) && $to !== '') {
+      $queryBuilder
+        ->andWhere("$field <= :$toParam")
+        ->setParameter($toParam, $to . ' 23:59:59');
+    }
+  }
+}

--- a/mailpoet/lib/Logging/LogListingRepository.php
+++ b/mailpoet/lib/Logging/LogListingRepository.php
@@ -3,10 +3,13 @@
 namespace MailPoet\Logging;
 
 use MailPoet\Entities\LogEntity;
+use MailPoet\Listing\ListingDateRangeFilterTrait;
 use MailPoet\Listing\ListingRepository;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 class LogListingRepository extends ListingRepository {
+  use ListingDateRangeFilterTrait;
+
   protected function applySelectClause(QueryBuilder $queryBuilder) {
     $queryBuilder->select('PARTIAL l.{id,name,level,message,createdAt}');
   }
@@ -47,16 +50,7 @@ class LogListingRepository extends ListingRepository {
   }
 
   protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
-    if (!empty($filters['from'])) {
-      $queryBuilder
-        ->andWhere('l.createdAt >= :dateFrom')
-        ->setParameter('dateFrom', $filters['from'] . ' 00:00:00');
-    }
-    if (!empty($filters['to'])) {
-      $queryBuilder
-        ->andWhere('l.createdAt <= :dateTo')
-        ->setParameter('dateTo', $filters['to'] . ' 23:59:59');
-    }
+    $this->applyDateRangeFilter($queryBuilder, 'l.createdAt', $filters);
     if (!empty($filters['name']) && is_array($filters['name'])) {
       $queryBuilder
         ->andWhere('l.name IN (:names)')

--- a/mailpoet/lib/Logging/RestApi/Endpoints/LogsListingEndpoint.php
+++ b/mailpoet/lib/Logging/RestApi/Endpoints/LogsListingEndpoint.php
@@ -2,9 +2,9 @@
 
 namespace MailPoet\Logging\RestApi\Endpoints;
 
-use DateTimeImmutable;
 use MailPoet\API\REST\AbstractListingEndpoint;
 use MailPoet\API\REST\ApiException;
+use MailPoet\API\REST\ListingRequestValidationTrait;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Config\AccessControl;
@@ -17,8 +17,9 @@ use MailPoet\Validator\Builder;
 use MailPoet\WP\Functions as WPFunctions;
 
 class LogsListingEndpoint extends AbstractListingEndpoint {
+  use ListingRequestValidationTrait;
+
   private const ALLOWED_SORT_FIELDS = ['created_at', 'name'];
-  private const ALLOWED_SORT_ORDERS = ['asc', 'desc'];
   private const DEFAULT_SORT_FIELD = 'created_at';
   private const DEFAULT_SORT_ORDER = 'desc';
   private const ALLOWED_FILTERS = ['from', 'to', 'name', 'level'];
@@ -85,85 +86,17 @@ class LogsListingEndpoint extends AbstractListingEndpoint {
     return self::DEFAULT_SORT_ORDER;
   }
 
+  protected function getListingValidationErrorPrefix(): string {
+    return 'logs';
+  }
+
   private function validateRequest(Request $request): void {
-    $this->validateSortField($request->getParam('orderby'));
-    $this->validateSortField($request->getParam('sort_by'));
+    $this->validateSortField($request->getParam('orderby'), self::ALLOWED_SORT_FIELDS);
+    $this->validateSortField($request->getParam('sort_by'), self::ALLOWED_SORT_FIELDS);
     $this->validateSortOrder($request->getParam('order'));
     $this->validateSortOrder($request->getParam('sort_order'));
-    $this->validatePositiveInteger($request->getParam('page'), 'page', 1, self::MAX_PAGE);
-    $this->validatePositiveInteger($request->getParam('per_page'), 'per_page', 1, self::MAX_PER_PAGE);
-    $this->validatePositiveInteger($request->getParam('limit'), 'limit', 1, self::MAX_PER_PAGE);
-    $this->validatePositiveInteger($request->getParam('offset'), 'offset', 0, self::MAX_PAGE);
+    $this->validatePagination($request);
     $this->validateFilters($request->getParam('filter'));
-  }
-
-  /** @param mixed $sortField */
-  private function validateSortField($sortField): void {
-    if ($sortField === null || $sortField === '') {
-      return;
-    }
-    if (!is_string($sortField) || !in_array($sortField, self::ALLOWED_SORT_FIELDS, true)) {
-      throw new ApiException(
-        sprintf(
-          // translators: %s is a comma-separated list of allowed sort fields.
-          __('Unsupported sort field. Allowed values are: %s.', 'mailpoet'),
-          implode(', ', self::ALLOWED_SORT_FIELDS)
-        ),
-        400,
-        'mailpoet_logs_invalid_orderby'
-      );
-    }
-  }
-
-  /** @param mixed $sortOrder */
-  private function validateSortOrder($sortOrder): void {
-    if ($sortOrder === null || $sortOrder === '') {
-      return;
-    }
-    if (!is_string($sortOrder) || !in_array(strtolower($sortOrder), self::ALLOWED_SORT_ORDERS, true)) {
-      throw new ApiException(
-        sprintf(
-          // translators: %s is a comma-separated list of allowed sort orders.
-          __('Unsupported sort order. Allowed values are: %s.', 'mailpoet'),
-          implode(', ', self::ALLOWED_SORT_ORDERS)
-        ),
-        400,
-        'mailpoet_logs_invalid_order'
-      );
-    }
-  }
-
-  /**
-   * @param mixed $value
-   */
-  private function validatePositiveInteger($value, string $name, int $min, int $max): void {
-    if ($value === null || $value === '') {
-      return;
-    }
-    $integer = $this->getIntegerValue($value);
-    if ($integer === null || $integer < $min || $integer > $max) {
-      throw new ApiException(
-        sprintf(
-          // translators: %1$s is a request parameter name, %2$d is the maximum accepted value.
-          __('%1$s must be an integer no greater than %2$d.', 'mailpoet'),
-          $name,
-          $max
-        ),
-        400,
-        'mailpoet_logs_invalid_' . $name
-      );
-    }
-  }
-
-  /** @param mixed $value */
-  private function getIntegerValue($value): ?int {
-    if (is_int($value)) {
-      return $value;
-    }
-    if (is_string($value) && ctype_digit($value)) {
-      return (int)$value;
-    }
-    return null;
   }
 
   /** @param mixed $filters */
@@ -194,43 +127,10 @@ class LogsListingEndpoint extends AbstractListingEndpoint {
     $this->validateStringListFilter($normalizedFilters, 'name');
     $this->validateLevelFilter($normalizedFilters);
 
+    // Keep the range check in sync with getDateRangeError() in logs/url-state.ts.
     $from = $this->validateDateFilter($normalizedFilters, 'from');
     $to = $this->validateDateFilter($normalizedFilters, 'to');
-    // Keep in sync with getDateRangeError() in logs/url-state.ts.
-    if ($from && $to && $from > $to) {
-      throw new ApiException(
-        __('The from date must be before or equal to the to date.', 'mailpoet'),
-        400,
-        'mailpoet_logs_invalid_date_range'
-      );
-    }
-  }
-
-  /**
-   * @param array<string, mixed> $filters
-   */
-  private function validateDateFilter(array $filters, string $field): ?DateTimeImmutable {
-    if (!array_key_exists($field, $filters) || $filters[$field] === '') {
-      return null;
-    }
-    if (!is_string($filters[$field])) {
-      throw new ApiException(
-        __('Log date filters must use the YYYY-MM-DD format.', 'mailpoet'),
-        400,
-        'mailpoet_logs_invalid_' . $field
-      );
-    }
-
-    $date = DateTimeImmutable::createFromFormat('!Y-m-d', $filters[$field]);
-    $errors = DateTimeImmutable::getLastErrors();
-    if (!$date || (is_array($errors) && ($errors['warning_count'] > 0 || $errors['error_count'] > 0)) || $date->format('Y-m-d') !== $filters[$field]) {
-      throw new ApiException(
-        __('Log date filters must use the YYYY-MM-DD format.', 'mailpoet'),
-        400,
-        'mailpoet_logs_invalid_' . $field
-      );
-    }
-    return $date;
+    $this->validateDateRange($from, $to);
   }
 
   /**

--- a/mailpoet/tests/DataFactories/Form.php
+++ b/mailpoet/tests/DataFactories/Form.php
@@ -127,6 +127,22 @@ class Form {
   }
 
   /**
+   * @return $this
+   */
+  public function withStatus(string $status) {
+    $this->data['status'] = $status;
+    return $this;
+  }
+
+  /**
+   * @return $this
+   */
+  public function withCreatedAt(\DateTimeInterface $createdAt) {
+    $this->data['created_at'] = $createdAt;
+    return $this;
+  }
+
+  /**
    * @param SegmentEntity[] $segments
    * @return $this
    */
@@ -177,6 +193,14 @@ class Form {
 
   public function create(): FormEntity {
     $form = new FormEntity($this->data['name']);
+
+    if (is_string($this->data['status'])) {
+      $form->setStatus($this->data['status']);
+    }
+
+    if (isset($this->data['created_at']) && $this->data['created_at'] instanceof \DateTimeInterface) {
+      $form->setCreatedAt($this->data['created_at']);
+    }
 
     if (is_array($this->data['settings']) || is_null($this->data['settings'])) {
       $form->setSettings($this->data['settings']);

--- a/mailpoet/tests/acceptance/Forms/FormsListingCest.php
+++ b/mailpoet/tests/acceptance/Forms/FormsListingCest.php
@@ -66,7 +66,7 @@ class FormsListingCest {
     $i->amOnMailpoetPage('Forms');
     $i->searchFor($suffix);
     $i->waitForText($enabledName, 10, '[data-automation-id="forms_listing"]');
-    $i->click(['xpath' => '//th//button[contains(., "Created on")]']);
+    $i->click(['xpath' => '//th//button[contains(., "Created date")]']);
     $i->waitForText('Sort ascending');
     $i->click(['xpath' => '//*[@role="menuitemradio"][contains(normalize-space(.), "Sort ascending")]']);
     // Wait for the ascending re-fetch: oldest form (enabled) before newest (disabled).

--- a/mailpoet/tests/acceptance/Forms/FormsListingCest.php
+++ b/mailpoet/tests/acceptance/Forms/FormsListingCest.php
@@ -48,7 +48,11 @@ class FormsListingCest {
     $i->waitForText($disabledName, 10, '[data-automation-id="forms_listing"]');
 
     $i->wantTo('Apply a native Status filter and keep only Enabled forms');
-    $i->click('Add filter');
+    // The DataViews "Add filter" control is an icon-only button, so target its
+    // accessible name rather than visible text.
+    $addFilter = ['xpath' => '//button[@aria-label="Add filter"]'];
+    $i->waitForElementClickable($addFilter);
+    $i->click($addFilter);
     $i->waitForText('Status');
     $i->click(['xpath' => '//*[@role="menuitem"][contains(normalize-space(.), "Status")]']);
     $i->waitForElement('.dataviews-filters__search-widget-listitem');

--- a/mailpoet/tests/acceptance/Forms/FormsListingCest.php
+++ b/mailpoet/tests/acceptance/Forms/FormsListingCest.php
@@ -2,7 +2,9 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use MailPoet\Entities\FormEntity;
 use MailPoet\Test\DataFactories\Form;
+use MailPoetVendor\Carbon\Carbon;
 
 class FormsListingCest {
   public function formsListing(\AcceptanceTester $i) {
@@ -19,5 +21,77 @@ class FormsListingCest {
     $i->clickItemRowActionByItemName($formName, 'Move to trash');
     $i->waitForText('No forms were found. Why not create a new one?');
     $i->waitForElementVisible('[data-automation-id="add_new_form"]');
+  }
+
+  public function formsNativeFiltersAndSorting(\AcceptanceTester $i) {
+    $i->wantTo('Filter and sort the forms listing with native DataViews controls');
+
+    $suffix = 'formfilter' . uniqid();
+    $enabledName = "enabledform-{$suffix}";
+    $disabledName = "disabledform-{$suffix}";
+
+    (new Form())
+      ->withName($enabledName)
+      ->withStatus(FormEntity::STATUS_ENABLED)
+      ->withCreatedAt(Carbon::now()->subDays(2))
+      ->create();
+    (new Form())
+      ->withName($disabledName)
+      ->withStatus(FormEntity::STATUS_DISABLED)
+      ->withCreatedAt(Carbon::now())
+      ->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('Forms');
+    $i->searchFor($suffix);
+    $i->waitForText($enabledName, 10, '[data-automation-id="forms_listing"]');
+    $i->waitForText($disabledName, 10, '[data-automation-id="forms_listing"]');
+
+    $i->wantTo('Apply a native Status filter and keep only Enabled forms');
+    $i->click('Add filter');
+    $i->waitForText('Status');
+    $i->click(['xpath' => '//*[@role="menuitem"][contains(normalize-space(.), "Status")]']);
+    $i->waitForElement('.dataviews-filters__search-widget-listitem');
+    $i->click(['xpath' => '//*[contains(@class, "dataviews-filters__search-widget-listitem")][.//text()[contains(., "Enabled")]]']);
+    $i->pressKey('body', \Facebook\WebDriver\WebDriverKeys::ESCAPE);
+    $i->waitForText($enabledName);
+    // Wait for the filtered re-fetch to drop the disabled form before asserting.
+    $i->waitForJS(<<<JS
+      const text = document.querySelector('.mailpoet-forms-dataviews')?.innerText ?? '';
+      return text.includes('{$enabledName}') && !text.includes('{$disabledName}');
+    JS, 10);
+    $i->dontSee($disabledName);
+
+    $i->wantTo('Sort the forms by creation date in ascending order');
+    $i->amOnMailpoetPage('Forms');
+    $i->searchFor($suffix);
+    $i->waitForText($enabledName, 10, '[data-automation-id="forms_listing"]');
+    $i->click(['xpath' => '//th//button[contains(., "Created on")]']);
+    $i->waitForText('Sort ascending');
+    $i->click(['xpath' => '//*[@role="menuitemradio"][contains(normalize-space(.), "Sort ascending")]']);
+    // Wait for the ascending re-fetch: oldest form (enabled) before newest (disabled).
+    $i->waitForJS(<<<JS
+      const text = Array.from(document.querySelectorAll('.mailpoet-forms-dataviews tbody tr'))
+        .map((row) => row.textContent)
+        .join('||');
+      const enabledAt = text.indexOf('{$enabledName}');
+      const disabledAt = text.indexOf('{$disabledName}');
+      return enabledAt !== -1 && disabledAt !== -1 && enabledAt < disabledAt;
+    JS, 10);
+    $orderedNames = $i->executeJS(<<<JS
+      return Array.from(document.querySelectorAll('.mailpoet-forms-dataviews tbody tr'))
+        .map((row) => row.textContent)
+        .join('||');
+    JS);
+    \PHPUnit\Framework\Assert::assertIsString($orderedNames);
+    $enabledPosition = strpos($orderedNames, $enabledName);
+    $disabledPosition = strpos($orderedNames, $disabledName);
+    \PHPUnit\Framework\Assert::assertNotFalse($enabledPosition);
+    \PHPUnit\Framework\Assert::assertNotFalse($disabledPosition);
+    \PHPUnit\Framework\Assert::assertLessThan(
+      $disabledPosition,
+      $enabledPosition,
+      'Oldest form should sort before the newest form ascending'
+    );
   }
 }

--- a/mailpoet/tests/integration/Form/Listing/FormListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Form/Listing/FormListingRepositoryTest.php
@@ -81,6 +81,120 @@ class FormListingRepositoryTest extends \MailPoetTest {
     verify($forms[1]->getName())->same('Form 2');
   }
 
+  public function testItFiltersByStatus() {
+    $this->form1->setStatus(FormEntity::STATUS_ENABLED);
+    $this->form2->setStatus(FormEntity::STATUS_DISABLED);
+    $this->entityManager->flush();
+
+    $definition = $this->listingHandler->getListingDefinition(['filter' => ['status' => ['disabled']]]);
+    $forms = $this->formListingRepository->getData($definition);
+    verify($forms)->arrayCount(1);
+    verify($forms[0]->getName())->same('Form 2');
+    verify($this->formListingRepository->getCount($definition))->same(1);
+
+    $definition = $this->listingHandler->getListingDefinition(['filter' => ['status' => ['enabled', 'disabled']]]);
+    verify($this->formListingRepository->getData($definition))->arrayCount(2);
+  }
+
+  public function testItIgnoresUnknownStatusFilterValues() {
+    $definition = $this->listingHandler->getListingDefinition(['filter' => ['status' => ['bogus']]]);
+    // No valid statuses remain after the whitelist intersect, so the filter is a no-op.
+    verify($this->formListingRepository->getData($definition))->arrayCount(2);
+  }
+
+  public function testItFiltersByCreatedDateRange() {
+    $this->form1->setCreatedAt(new \DateTimeImmutable('2020-01-01 10:00:00'));
+    $this->form2->setCreatedAt(new \DateTimeImmutable('2020-06-01 10:00:00'));
+    $this->entityManager->flush();
+
+    // from only — keeps the newer form
+    $forms = $this->formListingRepository->getData(
+      $this->listingHandler->getListingDefinition(['filter' => ['created_from' => '2020-03-01']])
+    );
+    verify($forms)->arrayCount(1);
+    verify($forms[0]->getName())->same('Form 2');
+
+    // to only — keeps the older form
+    $forms = $this->formListingRepository->getData(
+      $this->listingHandler->getListingDefinition(['filter' => ['created_to' => '2020-03-01']])
+    );
+    verify($forms)->arrayCount(1);
+    verify($forms[0]->getName())->same('Form 1');
+
+    // range covering both
+    $forms = $this->formListingRepository->getData(
+      $this->listingHandler->getListingDefinition(['filter' => ['created_from' => '2020-01-01', 'created_to' => '2020-06-01']])
+    );
+    verify($forms)->arrayCount(2);
+  }
+
+  public function testItFiltersByModifiedDateRange() {
+    // A preUpdate listener resets updatedAt on every flush, so set it with a DQL
+    // UPDATE (which bypasses lifecycle events) to pin deterministic values.
+    $this->setUpdatedAt($this->form1, '2020-01-01 10:00:00');
+    $this->setUpdatedAt($this->form2, '2020-06-01 10:00:00');
+
+    $forms = $this->formListingRepository->getData(
+      $this->listingHandler->getListingDefinition(['filter' => ['updated_from' => '2020-03-01']])
+    );
+    verify($forms)->arrayCount(1);
+    verify($forms[0]->getName())->same('Form 2');
+
+    $forms = $this->formListingRepository->getData(
+      $this->listingHandler->getListingDefinition(['filter' => ['updated_to' => '2020-03-01']])
+    );
+    verify($forms)->arrayCount(1);
+    verify($forms[0]->getName())->same('Form 1');
+  }
+
+  public function testItFiltersByCreatedAndModifiedDateIndependently() {
+    $this->form1->setCreatedAt(new \DateTimeImmutable('2020-01-01 10:00:00'));
+    $this->form2->setCreatedAt(new \DateTimeImmutable('2020-06-01 10:00:00'));
+    $this->entityManager->flush();
+    $this->setUpdatedAt($this->form1, '2020-12-01 10:00:00');
+    $this->setUpdatedAt($this->form2, '2020-06-15 10:00:00');
+
+    // Created before March AND modified after October → only Form 1. Exercises
+    // both date ranges coexisting on one query without parameter collisions.
+    $forms = $this->formListingRepository->getData(
+      $this->listingHandler->getListingDefinition([
+        'filter' => ['created_to' => '2020-03-01', 'updated_from' => '2020-10-01'],
+      ])
+    );
+    verify($forms)->arrayCount(1);
+    verify($forms[0]->getName())->same('Form 1');
+  }
+
+  private function setUpdatedAt(FormEntity $form, string $date): void {
+    $this->entityManager
+      ->createQuery('UPDATE ' . FormEntity::class . ' f SET f.updatedAt = :date WHERE f.id = :id')
+      ->setParameter('date', new \DateTimeImmutable($date))
+      ->setParameter('id', $form->getId())
+      ->execute();
+  }
+
+  public function testItSortsByCreatedAt() {
+    $this->form1->setCreatedAt(new \DateTimeImmutable('2020-06-01 10:00:00'));
+    $this->form2->setCreatedAt(new \DateTimeImmutable('2020-01-01 10:00:00'));
+    $this->entityManager->flush();
+
+    // ASC — oldest first
+    $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition([
+      'sort_by' => 'created_at',
+      'sort_order' => 'asc',
+    ]));
+    verify($forms[0]->getName())->same('Form 2');
+    verify($forms[1]->getName())->same('Form 1');
+
+    // DESC — newest first
+    $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition([
+      'sort_by' => 'created_at',
+      'sort_order' => 'desc',
+    ]));
+    verify($forms[0]->getName())->same('Form 1');
+    verify($forms[1]->getName())->same('Form 2');
+  }
+
   public function testItAppliesLimitAndOffset() {
     // first page
     $forms = $this->formListingRepository->getData($this->listingHandler->getListingDefinition([

--- a/mailpoet/tests/integration/REST/Forms/FormsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Forms/FormsEndpointsTest.php
@@ -95,6 +95,49 @@ class FormsEndpointsTest extends Test {
     );
   }
 
+  public function testGetValidatesRequestParams(): void {
+    $this->assertSame('mailpoet_forms_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['orderby' => 'segments']])['code']);
+    $this->assertSame('mailpoet_forms_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['sort_by' => 'segments']])['code']);
+    $this->assertSame('mailpoet_forms_invalid_order', $this->get(self::BASE_PATH, ['query' => ['order' => 'sideways']])['code']);
+    $this->assertSame('mailpoet_forms_invalid_order', $this->get(self::BASE_PATH, ['query' => ['sort_order' => 'sideways']])['code']);
+    $this->assertSame('mailpoet_forms_invalid_page', $this->get(self::BASE_PATH, ['query' => ['page' => 0]])['code']);
+    $this->assertSame('mailpoet_forms_invalid_per_page', $this->get(self::BASE_PATH, ['query' => ['per_page' => 101]])['code']);
+    $this->assertSame('mailpoet_forms_invalid_limit', $this->get(self::BASE_PATH, ['query' => ['limit' => 0]])['code']);
+    $this->assertSame('mailpoet_forms_invalid_offset', $this->get(self::BASE_PATH, ['query' => ['offset' => 100001]])['code']);
+    $this->assertSame('mailpoet_forms_invalid_filter', $this->get(self::BASE_PATH, ['query' => ['filter' => ['unknown' => 'x']]])['code']);
+    $this->assertSame('mailpoet_forms_invalid_filter', $this->get(self::BASE_PATH, ['query' => ['filter' => ['from' => '2025-01-01']]])['code']);
+    $this->assertSame('mailpoet_forms_invalid_status', $this->get(self::BASE_PATH, ['query' => ['filter' => ['status' => ['bogus']]]])['code']);
+    $this->assertSame('mailpoet_forms_invalid_created_from', $this->get(self::BASE_PATH, ['query' => ['filter' => ['created_from' => '2025-02-30']]])['code']);
+    $this->assertSame('mailpoet_forms_invalid_created_to', $this->get(self::BASE_PATH, ['query' => ['filter' => ['created_to' => '2025-2-01']]])['code']);
+    $this->assertSame('mailpoet_forms_invalid_updated_from', $this->get(self::BASE_PATH, ['query' => ['filter' => ['updated_from' => '2025-13-01']]])['code']);
+    $this->assertSame('mailpoet_forms_invalid_date_range', $this->get(self::BASE_PATH, ['query' => ['filter' => ['created_from' => '2025-02-02', 'created_to' => '2025-02-01']]])['code']);
+    $this->assertSame('mailpoet_forms_invalid_date_range', $this->get(self::BASE_PATH, ['query' => ['filter' => ['updated_from' => '2025-02-02', 'updated_to' => '2025-02-01']]])['code']);
+  }
+
+  public function testGetFiltersByStatusAndCreatedDate(): void {
+    $suffix = uniqid();
+    (new FormFactory())
+      ->withName("enabled_{$suffix}")
+      ->withStatus(FormEntity::STATUS_ENABLED)
+      ->withCreatedAt(new \DateTimeImmutable('2020-01-01 10:00:00'))
+      ->create();
+    (new FormFactory())
+      ->withName("disabled_{$suffix}")
+      ->withStatus(FormEntity::STATUS_DISABLED)
+      ->withCreatedAt(new \DateTimeImmutable('2020-06-01 10:00:00'))
+      ->create();
+
+    $response = $this->get(self::BASE_PATH, ['query' => ['per_page' => 100, 'filter' => ['status' => ['disabled']]]]);
+    $names = array_column($response['data']['items'], 'name');
+    $this->assertContains("disabled_{$suffix}", $names);
+    $this->assertNotContains("enabled_{$suffix}", $names);
+
+    $response = $this->get(self::BASE_PATH, ['query' => ['per_page' => 100, 'filter' => ['created_from' => '2020-03-01']]]);
+    $names = array_column($response['data']['items'], 'name');
+    $this->assertContains("disabled_{$suffix}", $names);
+    $this->assertNotContains("enabled_{$suffix}", $names);
+  }
+
   public function testGetReturnsMetaConsistentWithItems(): void {
     $perPage = 7;
     $data = $this->get(self::BASE_PATH, ['query' => ['per_page' => $perPage]]);

--- a/mailpoet/tests/javascript/forms/filters.spec.ts
+++ b/mailpoet/tests/javascript/forms/filters.spec.ts
@@ -1,0 +1,88 @@
+import { viewFiltersToRequestFilter } from '../../../assets/js/src/forms/filters';
+
+describe('forms filters translation', () => {
+  it('maps a status multi-select filter', () => {
+    const filter = viewFiltersToRequestFilter([
+      { field: 'status', operator: 'isAny', value: ['enabled', 'disabled'] },
+    ]);
+
+    expect(filter).to.deep.equal({ status: ['enabled', 'disabled'] });
+  });
+
+  it('maps a between created-date filter to created_from/created_to', () => {
+    const filter = viewFiltersToRequestFilter([
+      {
+        field: 'created_at',
+        operator: 'between',
+        value: ['2026-05-01', '2026-05-18'],
+      },
+    ]);
+
+    expect(filter).to.deep.equal({
+      created_from: '2026-05-01',
+      created_to: '2026-05-18',
+    });
+  });
+
+  it('maps single-bound created-date operators', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'after', value: '2026-05-01' },
+      ]),
+    ).to.deep.equal({ created_from: '2026-05-01' });
+
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'before', value: '2026-05-18' },
+      ]),
+    ).to.deep.equal({ created_to: '2026-05-18' });
+
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'on', value: '2026-05-10' },
+      ]),
+    ).to.deep.equal({ created_from: '2026-05-10', created_to: '2026-05-10' });
+  });
+
+  it('maps the modified-date filter to its own updated_from/updated_to keys', () => {
+    const filter = viewFiltersToRequestFilter([
+      {
+        field: 'updated_at',
+        operator: 'between',
+        value: ['2026-04-01', '2026-04-30'],
+      },
+    ]);
+
+    expect(filter).to.deep.equal({
+      updated_from: '2026-04-01',
+      updated_to: '2026-04-30',
+    });
+  });
+
+  it('keeps created and modified date ranges independent', () => {
+    const filter = viewFiltersToRequestFilter([
+      { field: 'created_at', operator: 'after', value: '2026-05-01' },
+      { field: 'updated_at', operator: 'before', value: '2026-06-01' },
+    ]);
+
+    expect(filter).to.deep.equal({
+      created_from: '2026-05-01',
+      updated_to: '2026-06-01',
+    });
+  });
+
+  it('ignores invalid dates and unknown status values', () => {
+    const filter = viewFiltersToRequestFilter([
+      { field: 'created_at', operator: 'after', value: 'not-a-date' },
+      { field: 'updated_at', operator: 'after', value: 'nope' },
+      { field: 'status', operator: 'isAny', value: ['bogus'] },
+    ]);
+
+    expect(filter).to.deep.equal({});
+  });
+
+  it('returns an empty object when no filters are active', () => {
+    expect(viewFiltersToRequestFilter(undefined)).to.deep.equal({});
+    expect(viewFiltersToRequestFilter([])).to.deep.equal({});
+  });
+});

--- a/mailpoet/tests/javascript/forms/filters.spec.ts
+++ b/mailpoet/tests/javascript/forms/filters.spec.ts
@@ -24,16 +24,16 @@ describe('forms filters translation', () => {
     });
   });
 
-  it('maps single-bound created-date operators', () => {
+  it('maps inclusive single-bound created-date operators', () => {
     expect(
       viewFiltersToRequestFilter([
-        { field: 'created_at', operator: 'after', value: '2026-05-01' },
+        { field: 'created_at', operator: 'afterInc', value: '2026-05-01' },
       ]),
     ).to.deep.equal({ created_from: '2026-05-01' });
 
     expect(
       viewFiltersToRequestFilter([
-        { field: 'created_at', operator: 'before', value: '2026-05-18' },
+        { field: 'created_at', operator: 'beforeInc', value: '2026-05-18' },
       ]),
     ).to.deep.equal({ created_to: '2026-05-18' });
 
@@ -42,6 +42,20 @@ describe('forms filters translation', () => {
         { field: 'created_at', operator: 'on', value: '2026-05-10' },
       ]),
     ).to.deep.equal({ created_from: '2026-05-10', created_to: '2026-05-10' });
+  });
+
+  it('shifts exclusive single-bound created-date operators by a day', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'after', value: '2026-05-01' },
+      ]),
+    ).to.deep.equal({ created_from: '2026-05-02' });
+
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'before', value: '2026-05-18' },
+      ]),
+    ).to.deep.equal({ created_to: '2026-05-17' });
   });
 
   it('maps the modified-date filter to its own updated_from/updated_to keys', () => {
@@ -61,8 +75,8 @@ describe('forms filters translation', () => {
 
   it('keeps created and modified date ranges independent', () => {
     const filter = viewFiltersToRequestFilter([
-      { field: 'created_at', operator: 'after', value: '2026-05-01' },
-      { field: 'updated_at', operator: 'before', value: '2026-06-01' },
+      { field: 'created_at', operator: 'afterInc', value: '2026-05-01' },
+      { field: 'updated_at', operator: 'beforeInc', value: '2026-06-01' },
     ]);
 
     expect(filter).to.deep.equal({

--- a/mailpoet/tests/javascript/logs/fields.spec.ts
+++ b/mailpoet/tests/javascript/logs/fields.spec.ts
@@ -38,7 +38,7 @@ describe('logs fields', () => {
     ]);
 
     expect(byId.created_at.filterBy).to.deep.equal({
-      operators: ['on', 'before', 'after', 'between'],
+      operators: ['on', 'beforeInc', 'afterInc', 'between'],
     });
     expect(byId.created_at.enableSorting).to.equal(true);
 

--- a/mailpoet/tests/javascript/logs/filters.spec.ts
+++ b/mailpoet/tests/javascript/logs/filters.spec.ts
@@ -16,16 +16,16 @@ describe('logs filters translation', () => {
     expect(filter).to.deep.equal({ from: '2026-05-01', to: '2026-05-18' });
   });
 
-  it('maps single-bound date operators', () => {
+  it('maps inclusive single-bound date operators', () => {
     expect(
       viewFiltersToRequestFilter([
-        { field: 'created_at', operator: 'after', value: '2026-05-01' },
+        { field: 'created_at', operator: 'afterInc', value: '2026-05-01' },
       ]),
     ).to.deep.equal({ from: '2026-05-01' });
 
     expect(
       viewFiltersToRequestFilter([
-        { field: 'created_at', operator: 'before', value: '2026-05-18' },
+        { field: 'created_at', operator: 'beforeInc', value: '2026-05-18' },
       ]),
     ).to.deep.equal({ to: '2026-05-18' });
 
@@ -34,6 +34,20 @@ describe('logs filters translation', () => {
         { field: 'created_at', operator: 'on', value: '2026-05-10' },
       ]),
     ).to.deep.equal({ from: '2026-05-10', to: '2026-05-10' });
+  });
+
+  it('shifts exclusive single-bound date operators by a day', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'after', value: '2026-05-01' },
+      ]),
+    ).to.deep.equal({ from: '2026-05-02' });
+
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'before', value: '2026-05-18' },
+      ]),
+    ).to.deep.equal({ to: '2026-05-17' });
   });
 
   it('maps name and level multi-select filters', () => {
@@ -86,7 +100,7 @@ describe('logs filters translation', () => {
         level: [400],
       }),
     ).to.deep.equal([
-      { field: 'created_at', operator: 'after', value: '2026-05-01' },
+      { field: 'created_at', operator: 'afterInc', value: '2026-05-01' },
       { field: 'name', operator: 'isAny', value: ['cron'] },
       { field: 'level', operator: 'isAny', value: [400] },
     ]);


### PR DESCRIPTION
## Description

Adds native DataViews filtering and sorting to the Forms listing (previously had zero filters).

- **Filters:** status, created and modified dates
- **Sorting:** status, created and modified dates
- **REST:** forms listing endpoint applies the new `filter[...]` + `sort_by`/`sort_order` params

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8170

## Screenshots

| Before | After | 
| ---- | ---- | 
|  <img width="1388" height="727" alt="Screenshot 2026-06-18 at 15 15 00" src="https://github.com/user-attachments/assets/2c46e1a5-6d54-4376-a800-f6076382f88c" /> | <img width="1396" height="780" alt="Screenshot 2026-06-18 at 15 13 37" src="https://github.com/user-attachments/assets/54fd12e8-a69b-46a0-bf45-2e46b6ae143f" /> | 


## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed best practices for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8170-dataviews-native-filters-sorting-for-forms-listing)

_The latest successful build from `add/stomail-8170-dataviews-native-filters-sorting-for-forms-listing` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

This PR demonstrates solid implementation practices with comprehensive validation layers, proper test coverage (unit, integration, and acceptance tests), and type-safe TypeScript code. The changes include robust request validation in the REST endpoints, proper date-range handling with inclusive boundaries, and careful filter-to-query translation logic. All required development tasks appear to be completed as noted in the PR objectives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->