### PR TITLE
Add native DataViews filters and sorting for tags and custom fields

### DIFF
--- a/mailpoet/assets/js/src/common/dataviews/index.ts
+++ b/mailpoet/assets/js/src/common/dataviews/index.ts
@@ -1,4 +1,8 @@
-export { useDataViewsQuery, type LoadListing } from './use-dataviews-query';
+export {
+  useDataViewsQuery,
+  wasInitialUrlStateReset,
+  type LoadListing,
+} from './use-dataviews-query';
 export {
   getDataViewsPreference,
   getDataViewsPreferenceKey,

--- a/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
+++ b/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
@@ -46,7 +46,10 @@ type UseDataViewsQueryResult<T> = {
 const EMPTY_META: ListingMeta = { count: 0, pages: 0 };
 const EMPTY_FILTERS: ListingFilters = {};
 
-function wasInitialUrlStateReset(currentView: View, nextView: View): boolean {
+export function wasInitialUrlStateReset(
+  currentView: View,
+  nextView: View,
+): boolean {
   const pageReset = (currentView.page ?? 1) > 1 && (nextView.page ?? 1) === 1;
   const searchReset = Boolean(currentView.search) && !nextView.search;
 
@@ -143,8 +146,12 @@ export function useDataViewsQuery<T>({
         if (requestId !== latestRequestIdRef.current) {
           return;
         }
+        // Clamp the page when the dataset shrinks below the requested page —
+        // including when a filter/search yields zero rows (pages === 0), where
+        // lastValidPage falls back to 1. Skipping that case would strand a
+        // deep-linked page > 1 on an empty result.
         const lastValidPage = Math.max(1, result.meta.pages);
-        if (result.meta.pages > 0 && requestedPage > lastValidPage) {
+        if (requestedPage > lastValidPage) {
           // Avoid leaving a stale error visible while we re-fetch the
           // clamped page below.
           setError(null);

--- a/mailpoet/assets/js/src/subscribers/custom-fields/api.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/api.ts
@@ -5,6 +5,7 @@ import type {
   CustomFieldPayload,
   CustomFieldListGroup,
   CustomFieldListMeta,
+  CustomFieldsRequestFilter,
 } from './types';
 
 type WindowApi = {
@@ -33,6 +34,7 @@ type ListParams = {
   page?: number;
   per_page?: number;
   group?: 'all' | 'trash';
+  filter?: CustomFieldsRequestFilter;
 };
 
 type ApiEnvelope<T> = {

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Notice, TabPanel } from '@wordpress/components';
 import { DataViews, View, Action } from '@wordpress/dataviews';
@@ -20,6 +20,11 @@ import {
   getCustomFields,
   getSubscribersListingUrl,
 } from './api';
+import {
+  requestFilterToViewFilters,
+  viewFiltersToRequestFilter,
+} from './filters';
+import { buildCustomFieldsUrl, parseCustomFieldsUrlState } from './url-state';
 import type {
   ApiErrorResponse,
   CustomField,
@@ -43,6 +48,7 @@ const DEFAULT_VIEW: View = {
   fields: [
     'label',
     'type',
+    'required',
     'subscribers_count',
     'forms_count',
     'dynamic_segments_count',
@@ -99,16 +105,32 @@ function bulkActionSuccessMessage(
 }
 
 export function CustomFieldsPage() {
-  const [group, setGroup] = useState<Group>('all');
+  const initialUrlState = useMemo(
+    () => parseCustomFieldsUrlState(window.location.href),
+    [],
+  );
+  const [group, setGroup] = useState<Group>(initialUrlState.group);
   const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
   const [editingCustomField, setEditingCustomField] =
     useState<CustomField | null>(null);
   const [selection, setSelection] = useState<string[]>([]);
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
-  const [initialView] = useState<View>(() =>
-    getDataViewsPreference('custom-fields', DEFAULT_VIEW, listFields),
-  );
+  const [initialView] = useState<View>(() => {
+    const preferredView = getDataViewsPreference(
+      'custom-fields',
+      DEFAULT_VIEW,
+      listFields,
+    );
+    return {
+      ...preferredView,
+      page: initialUrlState.page,
+      perPage: initialUrlState.perPage ?? preferredView.perPage,
+      search: initialUrlState.search,
+      filters: requestFilterToViewFilters(initialUrlState.filter),
+    };
+  });
+  const didMountRef = useRef(false);
 
   const load = useCallback<LoadListing<CustomField>>(
     async (params) => {
@@ -119,6 +141,7 @@ export function CustomFieldsPage() {
         page: params.page,
         per_page: params.per_page,
         group,
+        filter: params.filter,
       });
       return {
         items: result.items,
@@ -127,6 +150,13 @@ export function CustomFieldsPage() {
       };
     },
     [group],
+  );
+
+  const extraParams = useCallback(
+    (currentView: View) => ({
+      filter: viewFiltersToRequestFilter(currentView.filters),
+    }),
+    [],
   );
 
   const {
@@ -143,12 +173,38 @@ export function CustomFieldsPage() {
   } = useDataViewsQuery<CustomField>({
     initialView,
     load,
+    extraParams,
   });
+
+  const onChangeViewWithFilterReset = useCallback(
+    (nextView: View): void => {
+      const filtersChanged =
+        JSON.stringify(nextView.filters ?? []) !==
+        JSON.stringify(view.filters ?? []);
+      onChangeView(filtersChanged ? { ...nextView, page: 1 } : nextView);
+    },
+    [onChangeView, view.filters],
+  );
+
   const handleViewChange = usePersistedDataViewsPreference(
     'custom-fields',
     view,
-    onChangeView,
+    onChangeViewWithFilterReset,
   );
+
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    const nextUrl = buildCustomFieldsUrl(
+      window.location.href,
+      view,
+      group,
+      viewFiltersToRequestFilter(view.filters),
+    );
+    window.history.replaceState({}, '', nextUrl);
+  }, [view, group]);
 
   const handleBulkAction = useCallback(
     async (
@@ -418,7 +474,7 @@ export function CustomFieldsPage() {
         onSelect={handleTabSelect}
       >
         {() => (
-          <div className="mailpoet-custom-fields-dataviews">
+          <div className="mailpoet-dataviews mailpoet-custom-fields-dataviews">
             <DataViews<CustomField>
               data={items}
               fields={listFields}
@@ -437,9 +493,13 @@ export function CustomFieldsPage() {
                 <DataViews.Search
                   label={__('Search custom fields', 'mailpoet')}
                 />
+                <DataViews.FiltersToggle />
                 <div className="mailpoet-dataviews__toolbar-end">
                   <DataViews.ViewConfig />
                 </div>
+              </div>
+              <div className="mailpoet-dataviews__filters">
+                <DataViews.Filters />
               </div>
               {group === 'trash' && (groupCounts.trash ?? 0) > 0 && (
                 <div className="mailpoet-custom-fields-dataviews__toolbar">

--- a/mailpoet/assets/js/src/subscribers/custom-fields/fields.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/fields.ts
@@ -20,6 +20,7 @@ export const listFields: Field<CustomField>[] = [
     type: 'text',
     enableGlobalSearch: true,
     enableSorting: true,
+    filterBy: false,
   },
   {
     id: 'label',
@@ -27,6 +28,7 @@ export const listFields: Field<CustomField>[] = [
     type: 'text',
     enableGlobalSearch: false,
     enableSorting: false,
+    filterBy: false,
     render: ({ item }) => createElement('span', null, item.label || '—'),
   },
   {
@@ -35,8 +37,29 @@ export const listFields: Field<CustomField>[] = [
     type: 'text',
     enableGlobalSearch: false,
     enableSorting: true,
+    elements: Object.entries(FIELD_TYPE_LABELS).map(([value, label]) => ({
+      value,
+      label,
+    })),
+    filterBy: { operators: ['isAny'] },
     render: ({ item }) =>
       createElement('span', null, FIELD_TYPE_LABELS[item.type] ?? item.type),
+  },
+  // `required` lives in the serialized params blob, so it cannot be filtered or
+  // sorted in SQL; it is a display-only column.
+  {
+    id: 'required',
+    label: __('Required', 'mailpoet'),
+    type: 'text',
+    enableGlobalSearch: false,
+    enableSorting: false,
+    filterBy: false,
+    render: ({ item }) =>
+      createElement(
+        'span',
+        null,
+        item.required ? __('Yes', 'mailpoet') : __('No', 'mailpoet'),
+      ),
   },
   {
     id: 'subscribers_count',
@@ -44,15 +67,19 @@ export const listFields: Field<CustomField>[] = [
     type: 'integer',
     enableGlobalSearch: false,
     enableSorting: true,
+    filterBy: false,
     render: ({ item }) =>
       createElement('span', null, item.subscribers_count.toLocaleString()),
   },
+  // forms_count and dynamic_segments_count are derived from JSON server-side and
+  // cannot be done in SQL, so they are display-only (not sortable, not filterable).
   {
     id: 'forms_count',
     label: __('Forms', 'mailpoet'),
     type: 'integer',
     enableGlobalSearch: false,
     enableSorting: false,
+    filterBy: false,
     render: ({ item }) =>
       createElement('span', null, item.forms_count.toLocaleString()),
   },
@@ -62,6 +89,7 @@ export const listFields: Field<CustomField>[] = [
     type: 'integer',
     enableGlobalSearch: false,
     enableSorting: false,
+    filterBy: false,
     render: ({ item }) =>
       createElement('span', null, item.dynamic_segments_count.toLocaleString()),
   },
@@ -71,6 +99,7 @@ export const listFields: Field<CustomField>[] = [
     type: 'datetime',
     enableGlobalSearch: false,
     enableSorting: true,
+    filterBy: false,
     render: ({ item }) =>
       createElement(
         'span',

--- a/mailpoet/assets/js/src/subscribers/custom-fields/filters.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/filters.ts
@@ -1,0 +1,50 @@
+import type { Filter } from '@wordpress/dataviews';
+import type { CustomFieldsRequestFilter } from './types';
+
+export const TYPE_FIELD = 'type';
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => String(entry).trim())
+    .filter((entry) => entry !== '');
+}
+
+/**
+ * Translate DataViews native filters into the REST `filter` object the custom
+ * fields endpoint understands (`{ type }`). The output doubles as the persisted
+ * URL/query-string shape.
+ */
+export function viewFiltersToRequestFilter(
+  filters: Filter[] | undefined,
+): CustomFieldsRequestFilter {
+  const result: CustomFieldsRequestFilter = {};
+
+  (filters ?? []).forEach((filter) => {
+    if (filter.field === TYPE_FIELD) {
+      const types = toStringArray(filter.value);
+      if (types.length > 0) {
+        result.type = types;
+      }
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Seed DataViews native filters from a parsed URL filter state.
+ */
+export function requestFilterToViewFilters(
+  filter: CustomFieldsRequestFilter,
+): Filter[] {
+  const filters: Filter[] = [];
+
+  if (filter.type && filter.type.length > 0) {
+    filters.push({ field: TYPE_FIELD, operator: 'isAny', value: filter.type });
+  }
+
+  return filters;
+}

--- a/mailpoet/assets/js/src/subscribers/custom-fields/types.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/types.ts
@@ -4,6 +4,7 @@ export type CustomField = {
   label: string;
   type: string;
   params: Record<string, unknown>;
+  required: boolean;
   subscribers_count: number;
   forms_count: number;
   dynamic_segments_count: number;
@@ -29,6 +30,10 @@ export type CustomFieldPayload = {
 export type CustomFieldDateSettings = {
   dateTypes: Array<{ label: string; value: string }>;
   dateFormats: Record<string, string[]>;
+};
+
+export type CustomFieldsRequestFilter = {
+  type?: string[];
 };
 
 export type CustomFieldListMeta = {

--- a/mailpoet/assets/js/src/subscribers/custom-fields/url-state.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/url-state.ts
@@ -1,0 +1,102 @@
+import type { View } from '@wordpress/dataviews';
+import type { CustomFieldsRequestFilter } from './types';
+
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PER_PAGE = 20;
+export const MAX_PER_PAGE = 100;
+
+export type CustomFieldsGroup = 'all' | 'trash';
+
+export type CustomFieldsUrlState = {
+  page: number;
+  perPage?: number;
+  search?: string;
+  group: CustomFieldsGroup;
+  filter: CustomFieldsRequestFilter;
+};
+
+const ALLOWED_TYPES = [
+  'text',
+  'textarea',
+  'radio',
+  'checkbox',
+  'select',
+  'date',
+];
+
+function parsePositiveInt(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function clampPerPage(perPage: number | undefined): number | undefined {
+  if (!perPage) {
+    return undefined;
+  }
+  return Math.min(perPage, MAX_PER_PAGE);
+}
+
+function parseTypes(value: string | null): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => ALLOWED_TYPES.includes(entry));
+}
+
+export function parseCustomFieldsUrlState(url: string): CustomFieldsUrlState {
+  const searchParams = new URL(url).searchParams;
+  const search = searchParams.get('search')?.trim();
+  const group = searchParams.get('group') === 'trash' ? 'trash' : 'all';
+
+  const filter: CustomFieldsRequestFilter = {};
+  const types = parseTypes(searchParams.get('type'));
+  if (types.length > 0) {
+    filter.type = types;
+  }
+
+  return {
+    page: parsePositiveInt(searchParams.get('cf_page')) ?? DEFAULT_PAGE,
+    perPage: clampPerPage(parsePositiveInt(searchParams.get('per_page'))),
+    search: search || undefined,
+    group,
+    filter,
+  };
+}
+
+export function buildCustomFieldsUrl(
+  currentUrl: string,
+  view: View,
+  group: CustomFieldsGroup,
+  filter: CustomFieldsRequestFilter,
+): string {
+  const url = new URL(currentUrl);
+  const search = view.search?.trim();
+
+  url.searchParams.set('page', 'mailpoet-custom-fields');
+  url.searchParams.delete('search');
+  url.searchParams.delete('group');
+  url.searchParams.delete('type');
+
+  if (search) {
+    url.searchParams.set('search', search);
+  }
+  if (group === 'trash') {
+    url.searchParams.set('group', 'trash');
+  }
+  if (filter.type && filter.type.length > 0) {
+    url.searchParams.set('type', filter.type.join(','));
+  }
+
+  url.searchParams.set('cf_page', String(view.page ?? DEFAULT_PAGE));
+  url.searchParams.set(
+    'per_page',
+    String(clampPerPage(view.perPage ?? DEFAULT_PER_PAGE) ?? DEFAULT_PER_PAGE),
+  );
+
+  return url.href;
+}

--- a/mailpoet/assets/js/src/subscribers/tags/api.ts
+++ b/mailpoet/assets/js/src/subscribers/tags/api.ts
@@ -1,6 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
-import type { Tag, TagListMeta } from './types';
+import type { Tag, TagListMeta, TagsRequestFilter } from './types';
 
 type WindowApi = {
   mailpoet_tags_api: {
@@ -27,6 +27,7 @@ type ListParams = {
   order?: 'asc' | 'desc';
   page?: number;
   per_page?: number;
+  filter?: TagsRequestFilter;
 };
 
 type ApiEnvelope<T> = {

--- a/mailpoet/assets/js/src/subscribers/tags/fields.ts
+++ b/mailpoet/assets/js/src/subscribers/tags/fields.ts
@@ -1,17 +1,18 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import { createElement } from 'react';
 import type { Field } from '@wordpress/dataviews';
-import type { Tag } from './types';
+import type { SubscriberCountBucket, Tag } from './types';
 import { getSubscribersListingUrl } from './api';
 
-export const listFields: Field<Tag>[] = [
+const baseListFields: Field<Tag>[] = [
   {
     id: 'name',
     label: __('Name', 'mailpoet'),
     type: 'text',
     enableGlobalSearch: true,
     enableSorting: true,
+    filterBy: false,
   },
   {
     id: 'description',
@@ -19,6 +20,7 @@ export const listFields: Field<Tag>[] = [
     type: 'text',
     enableSorting: false,
     enableGlobalSearch: false,
+    filterBy: false,
     render: ({ item }) => createElement('span', null, item.description || '—'),
   },
   {
@@ -27,6 +29,7 @@ export const listFields: Field<Tag>[] = [
     type: 'integer',
     enableSorting: true,
     enableGlobalSearch: false,
+    filterBy: false,
     render: ({ item }) =>
       createElement(
         'a',
@@ -39,9 +42,10 @@ export const listFields: Field<Tag>[] = [
   {
     id: 'created_at',
     label: __('Created', 'mailpoet'),
-    type: 'datetime',
+    type: 'date',
     enableSorting: true,
     enableGlobalSearch: false,
+    filterBy: { operators: ['on', 'beforeInc', 'afterInc', 'between'] },
     render: ({ item }) =>
       createElement(
         'span',
@@ -50,6 +54,66 @@ export const listFields: Field<Tag>[] = [
       ),
   },
 ];
+
+function bucketLabel(bucket: SubscriberCountBucket): string {
+  if (bucket.min === 0 && bucket.max === 0) {
+    return __('None', 'mailpoet');
+  }
+  if (bucket.max === null) {
+    return sprintf(
+      /* translators: %s is a subscriber count, e.g. "10,000+". */
+      __('%s+', 'mailpoet'),
+      bucket.min.toLocaleString(),
+    );
+  }
+  return `${bucket.min.toLocaleString()}–${bucket.max.toLocaleString()}`;
+}
+
+function bucketValueForCount(
+  count: number,
+  buckets: SubscriberCountBucket[],
+): string {
+  const match = buckets.find((bucket) =>
+    bucket.max === null
+      ? count >= bucket.min
+      : count >= bucket.min && count <= bucket.max,
+  );
+  return match ? match.value : '';
+}
+
+/**
+ * Build the listing fields. The subscriber-count filter is data-driven: its
+ * options are the decade buckets the endpoint returns for the current site, so
+ * it is only added when at least one tag has subscribers.
+ */
+export function buildListFields(
+  buckets: SubscriberCountBucket[],
+): Field<Tag>[] {
+  if (buckets.length === 0) {
+    return baseListFields;
+  }
+
+  return [
+    ...baseListFields,
+    // Filter-only field (not shown as a column): bridges to the REST
+    // `subscribers` filter, mapping a tag's count to its decade bucket.
+    {
+      id: 'subscribers',
+      label: __('Subscribers', 'mailpoet'),
+      type: 'text',
+      enableSorting: false,
+      enableGlobalSearch: false,
+      enableHiding: false,
+      filterBy: { operators: ['isAny'] },
+      elements: buckets.map((bucket) => ({
+        value: bucket.value,
+        label: bucketLabel(bucket),
+      })),
+      getValue: ({ item }) =>
+        bucketValueForCount(item.subscribers_count, buckets),
+    },
+  ];
+}
 
 export const formFields: Field<Tag>[] = [
   {

--- a/mailpoet/assets/js/src/subscribers/tags/filters.ts
+++ b/mailpoet/assets/js/src/subscribers/tags/filters.ts
@@ -1,0 +1,80 @@
+import type { Filter } from '@wordpress/dataviews';
+import { dateRangeFromFilter } from 'common/dataviews';
+import type { TagsRequestFilter } from './types';
+
+export const CREATED_AT_FIELD = 'created_at';
+export const SUBSCRIBERS_FIELD = 'subscribers';
+
+/**
+ * Translate DataViews native filters into the REST `filter` object the tags
+ * endpoint understands (`{ from, to, subscribers }`). `subscribers` is the list
+ * of selected subscriber-count bucket values. The output doubles as the
+ * persisted URL/query-string shape (see buildTagsUrl).
+ */
+export function viewFiltersToRequestFilter(
+  filters: Filter[] | undefined,
+): TagsRequestFilter {
+  const result: TagsRequestFilter = {};
+
+  (filters ?? []).forEach((filter) => {
+    if (filter.field === CREATED_AT_FIELD) {
+      const { from, to } = dateRangeFromFilter(filter.operator, filter.value);
+      if (from) {
+        result.from = from;
+      }
+      if (to) {
+        result.to = to;
+      }
+    } else if (filter.field === SUBSCRIBERS_FIELD) {
+      const values = (Array.isArray(filter.value) ? filter.value : [])
+        .map((entry) => String(entry))
+        .filter((entry) => entry !== '');
+      if (values.length > 0) {
+        result.subscribers = values;
+      }
+    }
+  });
+
+  return result;
+}
+
+function datesToFilter(from?: string, to?: string): Filter | null {
+  if (from && to) {
+    return from === to
+      ? { field: CREATED_AT_FIELD, operator: 'on', value: from }
+      : { field: CREATED_AT_FIELD, operator: 'between', value: [from, to] };
+  }
+  // Stored `from`/`to` are inclusive whole-day boundaries, so seed the inclusive
+  // operators; the exclusive `after`/`before` would shift the day on re-serialize.
+  if (from) {
+    return { field: CREATED_AT_FIELD, operator: 'afterInc', value: from };
+  }
+  if (to) {
+    return { field: CREATED_AT_FIELD, operator: 'beforeInc', value: to };
+  }
+  return null;
+}
+
+/**
+ * Seed DataViews native filters from a parsed URL filter state. Maps a from+to
+ * range to a single `between` filter so it stays editable as one native control.
+ */
+export function requestFilterToViewFilters(
+  filter: TagsRequestFilter,
+): Filter[] {
+  const filters: Filter[] = [];
+
+  const dateFilter = datesToFilter(filter.from, filter.to);
+  if (dateFilter) {
+    filters.push(dateFilter);
+  }
+  if (filter.subscribers && filter.subscribers.length > 0) {
+    filters.push({
+      field: SUBSCRIBERS_FIELD,
+      operator: 'isAny',
+      value: filter.subscribers,
+    });
+  }
+
+  return filters;
+}

--- a/mailpoet/assets/js/src/subscribers/tags/tags-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/tags/tags-page.tsx
@@ -5,10 +5,11 @@ import { DataViews, View, Action } from '@wordpress/dataviews';
 import {
   getDataViewsPreference,
   usePersistedDataViewsPreference,
+  wasInitialUrlStateReset,
 } from 'common/dataviews';
 import { BackButton, PageHeader } from 'common/page-header';
 import { TopBarWithBoundary } from 'common/top-bar/top-bar';
-import { listFields } from './fields';
+import { buildListFields } from './fields';
 import { TagsForm } from './tags-form';
 import {
   bulkDeleteTags,
@@ -16,6 +17,11 @@ import {
   getSubscribersListingUrl,
   getTags,
 } from './api';
+import {
+  requestFilterToViewFilters,
+  viewFiltersToRequestFilter,
+} from './filters';
+import { buildTagsUrl, parseTagsUrlState } from './url-state';
 import type { ApiErrorResponse, Tag, TagListMeta } from './types';
 
 type FormState =
@@ -33,30 +39,69 @@ const DEFAULT_VIEW: View = {
   showTitle: true,
 };
 
+// Column set is fixed; the subscriber-count filter is appended dynamically once
+// the listing returns the site's buckets.
+const baseFields = buildListFields([]);
+
+function buildInitialView(): View {
+  const preferredView = getDataViewsPreference(
+    'tags',
+    DEFAULT_VIEW,
+    baseFields,
+  );
+  const state = parseTagsUrlState(window.location.href);
+
+  return {
+    ...preferredView,
+    page: state.page,
+    perPage: state.perPage ?? preferredView.perPage,
+    search: state.search,
+    filters: requestFilterToViewFilters(state.filter),
+  };
+}
+
 function resetPageWhenQueryChanges(currentView: View, nextView: View): View {
   const searchChanged = (nextView.search ?? '') !== (currentView.search ?? '');
   const perPageChanged = nextView.perPage !== currentView.perPage;
+  const filtersChanged =
+    JSON.stringify(nextView.filters ?? []) !==
+    JSON.stringify(currentView.filters ?? []);
 
   return {
     ...nextView,
-    page: searchChanged || perPageChanged ? 1 : nextView.page,
+    page: searchChanged || perPageChanged || filtersChanged ? 1 : nextView.page,
   };
 }
 
 export function TagsPage() {
-  const [view, setView] = useState<View>(() =>
-    getDataViewsPreference('tags', DEFAULT_VIEW, listFields),
-  );
+  const [view, setView] = useState<View>(buildInitialView);
+  const didMountRef = useRef(false);
   const [items, setItems] = useState<Tag[]>([]);
-  const [meta, setMeta] = useState<TagListMeta>({ count: 0, pages: 0 });
+  const [meta, setMeta] = useState<TagListMeta>({
+    count: 0,
+    pages: 0,
+    subscriber_count_buckets: [],
+  });
   const [isLoading, setIsLoading] = useState(false);
   const [selection, setSelection] = useState<string[]>([]);
   const [formState, setFormState] = useState<FormState>({ kind: 'closed' });
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
   const latestRequestIdRef = useRef(0);
+  const completedInitialRequestRef = useRef(false);
   const updateView = useCallback((nextView: View): void => {
-    setView((currentView) => resetPageWhenQueryChanges(currentView, nextView));
+    setView((currentView) => {
+      // DataViews can emit an early onChangeView that drops the URL-hydrated
+      // page/search before the first fetch settles; ignore that reset so a
+      // deep-linked listing keeps its state.
+      if (
+        !completedInitialRequestRef.current &&
+        wasInitialUrlStateReset(currentView, nextView)
+      ) {
+        return currentView;
+      }
+      return resetPageWhenQueryChanges(currentView, nextView);
+    });
   }, []);
   const handleViewChange = usePersistedDataViewsPreference(
     'tags',
@@ -76,6 +121,7 @@ export function TagsPage() {
         order: view.sort?.direction ?? 'asc',
         page: requestedPage,
         per_page: view.perPage ?? 20,
+        filter: viewFiltersToRequestFilter(view.filters),
       });
 
       if (requestId !== latestRequestIdRef.current) {
@@ -103,14 +149,28 @@ export function TagsPage() {
       );
     } finally {
       if (requestId === latestRequestIdRef.current) {
+        completedInitialRequestRef.current = true;
         setIsLoading(false);
       }
     }
-  }, [view.search, view.sort, view.page, view.perPage]);
+  }, [view.search, view.sort, view.page, view.perPage, view.filters]);
 
   useEffect(() => {
     void loadTags();
   }, [loadTags]);
+
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    const nextUrl = buildTagsUrl(
+      window.location.href,
+      view,
+      viewFiltersToRequestFilter(view.filters),
+    );
+    window.history.replaceState({}, '', nextUrl);
+  }, [view]);
 
   const handleFormSuccess = (tag: Tag) => {
     setFormState({ kind: 'closed' });
@@ -208,6 +268,11 @@ export function TagsPage() {
     [meta],
   );
 
+  const fields = useMemo(
+    () => buildListFields(meta.subscriber_count_buckets),
+    [meta.subscriber_count_buckets],
+  );
+
   return (
     <>
       <TopBarWithBoundary />
@@ -242,10 +307,10 @@ export function TagsPage() {
         </Notice>
       )}
 
-      <div className="mailpoet-tags-dataviews">
+      <div className="mailpoet-dataviews mailpoet-tags-dataviews">
         <DataViews<Tag>
           data={items}
-          fields={listFields}
+          fields={fields}
           view={view}
           onChangeView={handleViewChange}
           actions={actions}
@@ -259,9 +324,13 @@ export function TagsPage() {
         >
           <div className="mailpoet-dataviews__toolbar">
             <DataViews.Search label={__('Search tags', 'mailpoet')} />
+            <DataViews.FiltersToggle />
             <div className="mailpoet-dataviews__toolbar-end">
               <DataViews.ViewConfig />
             </div>
+          </div>
+          <div className="mailpoet-dataviews__filters">
+            <DataViews.Filters />
           </div>
           <DataViews.Layout />
           <DataViews.Footer />

--- a/mailpoet/assets/js/src/subscribers/tags/types.ts
+++ b/mailpoet/assets/js/src/subscribers/tags/types.ts
@@ -7,9 +7,22 @@ export type Tag = {
   updated_at: string | null;
 };
 
+export type TagsRequestFilter = {
+  from?: string;
+  to?: string;
+  subscribers?: string[];
+};
+
+export type SubscriberCountBucket = {
+  value: string;
+  min: number;
+  max: number | null;
+};
+
 export type TagListMeta = {
   count: number;
   pages: number;
+  subscriber_count_buckets: SubscriberCountBucket[];
 };
 
 export type ApiErrorResponse = {

--- a/mailpoet/assets/js/src/subscribers/tags/url-state.ts
+++ b/mailpoet/assets/js/src/subscribers/tags/url-state.ts
@@ -1,0 +1,109 @@
+import type { View } from '@wordpress/dataviews';
+import { isStrictDateString } from 'common/dataviews';
+import type { TagsRequestFilter } from './types';
+
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PER_PAGE = 20;
+export const MAX_PER_PAGE = 100;
+
+export type TagsUrlState = {
+  page: number;
+  perPage?: number;
+  search?: string;
+  filter: TagsRequestFilter;
+};
+
+function parsePositiveInt(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function clampPerPage(perPage: number | undefined): number | undefined {
+  if (!perPage) {
+    return undefined;
+  }
+  return Math.min(perPage, MAX_PER_PAGE);
+}
+
+// Subscriber-count bucket values are the bucket's lower bound as a string
+// (e.g. "0", "10", "10000"). The endpoint validates them against the live
+// buckets, so here we only keep well-formed digit values.
+function parseSubscribers(value: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(
+      (entry) =>
+        entry !== '' &&
+        [...entry].every((character) => character >= '0' && character <= '9'),
+    );
+}
+
+export function parseTagsUrlState(url: string): TagsUrlState {
+  const searchParams = new URL(url).searchParams;
+  const search = searchParams.get('search')?.trim();
+  const from = searchParams.get('created_from');
+  const to = searchParams.get('created_to');
+  const subscribers = parseSubscribers(searchParams.get('subscribers'));
+
+  const filter: TagsRequestFilter = {};
+  if (isStrictDateString(from)) {
+    filter.from = from;
+  }
+  if (isStrictDateString(to)) {
+    filter.to = to;
+  }
+  if (subscribers.length > 0) {
+    filter.subscribers = subscribers;
+  }
+
+  return {
+    page: parsePositiveInt(searchParams.get('tags_page')) ?? DEFAULT_PAGE,
+    perPage: clampPerPage(parsePositiveInt(searchParams.get('per_page'))),
+    search: search || undefined,
+    filter,
+  };
+}
+
+export function buildTagsUrl(
+  currentUrl: string,
+  view: View,
+  filter: TagsRequestFilter,
+): string {
+  const url = new URL(currentUrl);
+  const search = view.search?.trim();
+
+  url.searchParams.set('page', 'mailpoet-tags');
+  url.searchParams.delete('search');
+  url.searchParams.delete('created_from');
+  url.searchParams.delete('created_to');
+  url.searchParams.delete('subscribers');
+
+  if (search) {
+    url.searchParams.set('search', search);
+  }
+  if (filter.from) {
+    url.searchParams.set('created_from', filter.from);
+  }
+  if (filter.to) {
+    url.searchParams.set('created_to', filter.to);
+  }
+  if (filter.subscribers && filter.subscribers.length > 0) {
+    url.searchParams.set('subscribers', filter.subscribers.join(','));
+  }
+
+  url.searchParams.set('tags_page', String(view.page ?? DEFAULT_PAGE));
+  url.searchParams.set(
+    'per_page',
+    String(clampPerPage(view.perPage ?? DEFAULT_PER_PAGE) ?? DEFAULT_PER_PAGE),
+  );
+
+  return url.href;
+}

--- a/mailpoet/changelog/2026-06-13-16-34-39-added-native-dataviews-filters-and-sorting-for-the-tags-.md
+++ b/mailpoet/changelog/2026-06-13-16-34-39-added-native-dataviews-filters-and-sorting-for-the-tags-.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Native DataViews filters and sorting for the Tags and Custom Fields listings

--- a/mailpoet/lib/CustomFields/CustomFieldsRepository.php
+++ b/mailpoet/lib/CustomFields/CustomFieldsRepository.php
@@ -194,8 +194,14 @@ class CustomFieldsRepository extends Repository {
   }
 
   /**
-   * @param array{search?: string, orderby?: string, order?: string, page?: int, per_page?: int, group?: string} $args
-   * @return array{items: array<int, array{id: int, name: string, label: string, type: string, params: array, subscribers_count: int, forms_count: int, dynamic_segments_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface, deleted_at: ?\DateTimeInterface}>, total: int, groups: array<int, array{name: string, label: string, count: int}>}
+   * Listing with subscriber counts + search + type filter + group + sort +
+   * pagination, all done in SQL. `forms_count` and `dynamic_segments_count` are
+   * derived from JSON (form body blocks, segment filter data) and cannot be
+   * expressed in SQL, so they are computed in PHP for the current page only and
+   * are display-only — they are intentionally not filterable or sortable.
+   *
+   * @param array{search?: string, orderby?: string, order?: string, page?: int, per_page?: int, group?: string, filter?: array{type?: string[]}} $args
+   * @return array{items: array<int, array{id: int, name: string, label: string, type: string, params: array, required: bool, subscribers_count: int, forms_count: int, dynamic_segments_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface, deleted_at: ?\DateTimeInterface}>, total: int, groups: array<int, array{name: string, label: string, count: int}>}
    */
   public function listWithCounts(array $args = []): array {
     $search = isset($args['search']) ? trim((string)$args['search']) : '';
@@ -204,6 +210,8 @@ class CustomFieldsRepository extends Repository {
     $page = isset($args['page']) ? max(1, (int)$args['page']) : 1;
     $perPage = isset($args['per_page']) ? max(1, min(100, (int)$args['per_page'])) : 25;
     $group = isset($args['group']) && $args['group'] === 'trash' ? 'trash' : 'all';
+    $filter = isset($args['filter']) && is_array($args['filter']) ? $args['filter'] : [];
+    $types = isset($filter['type']) && is_array($filter['type']) ? array_values(array_filter(array_map('strval', $filter['type']))) : [];
 
     $sortable = [
       'name' => 'cf.name',
@@ -221,6 +229,7 @@ class CustomFieldsRepository extends Repository {
       ->groupBy('cf.id')
       ->orderBy($orderByExpr, $order);
 
+    // Deterministic secondary ordering so paginated results are stable on ties.
     if ($orderby !== 'name') {
       $qb->addOrderBy('cf.name', 'ASC');
     }
@@ -228,25 +237,13 @@ class CustomFieldsRepository extends Repository {
       ->setFirstResult(($page - 1) * $perPage)
       ->setMaxResults($perPage);
 
-    if ($search !== '') {
-      $qb->andWhere('cf.name LIKE :search')
-        ->setParameter('search', '%' . $search . '%');
-    }
-    $this->applyGroup($qb, $group);
+    $this->applyListFilters($qb, $search, $types, $group);
 
     /** @var array<array{id: int, name: string, type: string, params: mixed, created_at: mixed, updated_at: mixed, deleted_at: mixed, subscribersCount: int|string}> $rows */
     $rows = $qb->getQuery()->getArrayResult();
 
-    $countQb = $this->entityManager->createQueryBuilder()
-      ->select('COUNT(cf.id)')
-      ->from(CustomFieldEntity::class, 'cf');
-    if ($search !== '') {
-      $countQb->andWhere('cf.name LIKE :search')
-        ->setParameter('search', '%' . $search . '%');
-    }
-    $this->applyGroup($countQb, $group);
-    $total = (int)$countQb->getQuery()->getSingleScalarResult();
     $groups = $this->getGroups();
+    $total = $this->countWithFilters($search, $types, $group);
 
     $customFieldIds = array_map('intval', array_column($rows, 'id'));
     $formsCounts = $this->getFormCountsByCustomFieldIds($customFieldIds);
@@ -260,12 +257,14 @@ class CustomFieldsRepository extends Repository {
       $createdAt = $row['created_at'] ?? null;
       $updatedAt = $row['updated_at'] ?? null;
       $deletedAt = $row['deleted_at'] ?? null;
+
       $items[] = [
         'id' => $id,
         'name' => (string)$row['name'],
         'label' => $label,
         'type' => (string)$row['type'],
         'params' => $params,
+        'required' => (bool)($params['required'] ?? false),
         'subscribers_count' => (int)$row['subscribersCount'],
         'forms_count' => $formsCounts[$id] ?? 0,
         'dynamic_segments_count' => $dynamicSegmentsCounts[$id] ?? 0,
@@ -276,6 +275,32 @@ class CustomFieldsRepository extends Repository {
     }
 
     return ['items' => $items, 'total' => $total, 'groups' => $groups];
+  }
+
+  /**
+   * @param string[] $types
+   */
+  private function applyListFilters(\MailPoetVendor\Doctrine\ORM\QueryBuilder $qb, string $search, array $types, string $group): void {
+    if ($search !== '') {
+      $qb->andWhere('cf.name LIKE :search')
+        ->setParameter('search', '%' . $search . '%');
+    }
+    if ($types) {
+      $qb->andWhere('cf.type IN (:types)')
+        ->setParameter('types', $types);
+    }
+    $this->applyGroup($qb, $group);
+  }
+
+  /**
+   * @param string[] $types
+   */
+  private function countWithFilters(string $search, array $types, string $group): int {
+    $qb = $this->entityManager->createQueryBuilder()
+      ->select('COUNT(cf.id)')
+      ->from(CustomFieldEntity::class, 'cf');
+    $this->applyListFilters($qb, $search, $types, $group);
+    return (int)$qb->getQuery()->getSingleScalarResult();
   }
 
   /**

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsEndpoint.php
@@ -23,6 +23,7 @@ abstract class CustomFieldsEndpoint extends Endpoint {
       'label' => $label,
       'type' => $customField->getType(),
       'params' => $params,
+      'required' => (bool)($params['required'] ?? false),
       'subscribers_count' => 0,
       'forms_count' => 0,
       'dynamic_segments_count' => 0,
@@ -33,7 +34,7 @@ abstract class CustomFieldsEndpoint extends Endpoint {
   }
 
   /**
-   * @param array{id: int, name: string, label: string, type: string, params: array, subscribers_count: int, forms_count: int, dynamic_segments_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface, deleted_at: ?\DateTimeInterface} $row
+   * @param array{id: int, name: string, label: string, type: string, params: array, required: bool, subscribers_count: int, forms_count: int, dynamic_segments_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface, deleted_at: ?\DateTimeInterface} $row
    */
   protected function buildItemFromRow(array $row): array {
     return [
@@ -42,6 +43,7 @@ abstract class CustomFieldsEndpoint extends Endpoint {
       'label' => (string)$row['label'],
       'type' => (string)$row['type'],
       'params' => $row['params'],
+      'required' => (bool)$row['required'],
       'subscribers_count' => (int)$row['subscribers_count'],
       'forms_count' => (int)$row['forms_count'],
       'dynamic_segments_count' => (int)$row['dynamic_segments_count'],

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsGetEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsGetEndpoint.php
@@ -5,9 +5,20 @@ namespace MailPoet\CustomFields\RestApi\Endpoints;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\CustomFields\RestApi\CustomFieldApiException;
+use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Validator\Builder;
 
 class CustomFieldsGetEndpoint extends CustomFieldsEndpoint {
+  private const ALLOWED_TYPES = [
+    CustomFieldEntity::TYPE_TEXT,
+    CustomFieldEntity::TYPE_TEXTAREA,
+    CustomFieldEntity::TYPE_RADIO,
+    CustomFieldEntity::TYPE_CHECKBOX,
+    CustomFieldEntity::TYPE_SELECT,
+    CustomFieldEntity::TYPE_DATE,
+  ];
+
   /** @var CustomFieldsRepository */
   private $customFieldsRepository;
 
@@ -24,6 +35,7 @@ class CustomFieldsGetEndpoint extends CustomFieldsEndpoint {
     $page = is_numeric($request->getParam('page')) ? max(1, (int)$request->getParam('page')) : 1;
     $perPage = is_numeric($request->getParam('per_page')) ? max(1, min(100, (int)$request->getParam('per_page'))) : 25;
     $group = is_string($request->getParam('group')) ? (string)$request->getParam('group') : 'all';
+    $filter = $this->parseFilter($request->getParam('filter'));
 
     $result = $this->customFieldsRepository->listWithCounts([
       'search' => $search,
@@ -32,6 +44,7 @@ class CustomFieldsGetEndpoint extends CustomFieldsEndpoint {
       'page' => $page,
       'per_page' => $perPage,
       'group' => $group,
+      'filter' => $filter,
     ]);
 
     $items = array_map([$this, 'buildItemFromRow'], $result['items']);
@@ -47,6 +60,64 @@ class CustomFieldsGetEndpoint extends CustomFieldsEndpoint {
     ]);
   }
 
+  /**
+   * @param mixed $rawFilter
+   * @return array{type?: string[]}
+   */
+  private function parseFilter($rawFilter): array {
+    if ($rawFilter === null || $rawFilter === '' || $rawFilter === []) {
+      return [];
+    }
+    if (!is_array($rawFilter)) {
+      throw new CustomFieldApiException(
+        __('Filters must be an object.', 'mailpoet'),
+        400,
+        'mailpoet_custom_fields_invalid_filter'
+      );
+    }
+
+    $allowed = ['type'];
+    foreach (array_keys($rawFilter) as $key) {
+      if (!in_array($key, $allowed, true)) {
+        throw new CustomFieldApiException(
+          __('Unsupported custom fields filter.', 'mailpoet'),
+          400,
+          'mailpoet_custom_fields_invalid_filter'
+        );
+      }
+    }
+
+    $filter = [];
+    if (array_key_exists('type', $rawFilter)) {
+      $filter['type'] = $this->parseTypeFilter($rawFilter['type']);
+    }
+
+    return $filter;
+  }
+
+  /**
+   * @param mixed $rawType
+   * @return string[]
+   */
+  private function parseTypeFilter($rawType): array {
+    if ($rawType === '' || $rawType === null) {
+      return [];
+    }
+    $values = is_array($rawType) ? $rawType : [$rawType];
+    $types = [];
+    foreach ($values as $value) {
+      if (!is_string($value) || !in_array($value, self::ALLOWED_TYPES, true)) {
+        throw new CustomFieldApiException(
+          __('Unsupported custom field type filter.', 'mailpoet'),
+          400,
+          'mailpoet_custom_fields_invalid_type'
+        );
+      }
+      $types[] = $value;
+    }
+    return array_values(array_unique($types));
+  }
+
   public static function getRequestSchema(): array {
     return [
       'search' => Builder::string(),
@@ -55,6 +126,7 @@ class CustomFieldsGetEndpoint extends CustomFieldsEndpoint {
       'page' => Builder::integer(),
       'per_page' => Builder::integer(),
       'group' => Builder::string(),
+      'filter' => Builder::object(),
     ];
   }
 }

--- a/mailpoet/lib/Tags/RestApi/Endpoints/TagsGetEndpoint.php
+++ b/mailpoet/lib/Tags/RestApi/Endpoints/TagsGetEndpoint.php
@@ -2,12 +2,21 @@
 
 namespace MailPoet\Tags\RestApi\Endpoints;
 
+use MailPoet\API\REST\ListingRequestValidationTrait;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
+use MailPoet\Tags\RestApi\TagApiException;
 use MailPoet\Tags\TagRepository;
 use MailPoet\Validator\Builder;
 
 class TagsGetEndpoint extends TagsEndpoint {
+  use ListingRequestValidationTrait;
+
+  // Bounds the shared validation trait relies on. Kept in sync with
+  // AbstractListingEndpoint so listing validation behaves the same everywhere.
+  public const MAX_PER_PAGE = 100;
+  public const MAX_PAGE = 100000;
+
   /** @var TagRepository */
   private $tagRepository;
 
@@ -23,6 +32,8 @@ class TagsGetEndpoint extends TagsEndpoint {
     $order = is_string($request->getParam('order')) ? (string)$request->getParam('order') : 'asc';
     $page = is_numeric($request->getParam('page')) ? max(1, (int)$request->getParam('page')) : 1;
     $perPage = is_numeric($request->getParam('per_page')) ? max(1, min(100, (int)$request->getParam('per_page'))) : 25;
+    $buckets = $this->tagRepository->getSubscriberCountBuckets();
+    $filter = $this->parseFilter($request->getParam('filter'), $buckets);
 
     $result = $this->tagRepository->listWithCounts([
       'search' => $search,
@@ -30,6 +41,7 @@ class TagsGetEndpoint extends TagsEndpoint {
       'order' => $order,
       'page' => $page,
       'per_page' => $perPage,
+      'filter' => $filter,
     ]);
 
     $items = array_map([$this, 'buildItemFromRow'], $result['items']);
@@ -40,8 +52,100 @@ class TagsGetEndpoint extends TagsEndpoint {
       'meta' => [
         'count' => $result['total'],
         'pages' => $pages,
+        'subscriber_count_buckets' => $buckets,
       ],
     ]);
+  }
+
+  /**
+   * @param mixed $rawFilter
+   * @param array<int, array{value: string, min: int, max: ?int}> $buckets
+   * @return array{from?: string, to?: string, subscriber_ranges?: array<int, array{min: int, max: ?int}>}
+   */
+  private function parseFilter($rawFilter, array $buckets): array {
+    if ($rawFilter === null || $rawFilter === '' || $rawFilter === []) {
+      return [];
+    }
+    if (!is_array($rawFilter)) {
+      throw new TagApiException(
+        __('Filters must be an object.', 'mailpoet'),
+        400,
+        'mailpoet_tags_invalid_filter'
+      );
+    }
+
+    $allowed = ['from', 'to', 'subscribers'];
+    $normalized = [];
+    foreach ($rawFilter as $key => $value) {
+      if (!is_string($key) || !in_array($key, $allowed, true)) {
+        throw new TagApiException(
+          __('Unsupported tags filter.', 'mailpoet'),
+          400,
+          'mailpoet_tags_invalid_filter'
+        );
+      }
+      $normalized[$key] = $value;
+    }
+
+    $filter = [];
+    $from = $this->validateDateFilter($normalized, 'from');
+    $to = $this->validateDateFilter($normalized, 'to');
+    $this->validateDateRange($from, $to);
+    if ($from !== null) {
+      $filter['from'] = $from->format('Y-m-d');
+    }
+    if ($to !== null) {
+      $filter['to'] = $to->format('Y-m-d');
+    }
+    if (array_key_exists('subscribers', $normalized)) {
+      $ranges = $this->parseSubscriberRanges($normalized['subscribers'], $buckets);
+      if ($ranges) {
+        $filter['subscriber_ranges'] = $ranges;
+      }
+    }
+
+    return $filter;
+  }
+
+  /**
+   * Resolve the selected bucket values into `{min, max}` ranges.
+   *
+   * Buckets are data-driven and change as the site's subscriber counts change,
+   * so a bookmarked or stale value may no longer match a current bucket. Unknown
+   * values are ignored rather than rejected, so a deep-linked listing still
+   * loads (e.g. `subscribers=0` on a site where no tag has subscribers and there
+   * are no buckets at all) instead of failing with a 400.
+   *
+   * @param mixed $rawValue
+   * @param array<int, array{value: string, min: int, max: ?int}> $buckets
+   * @return array<int, array{min: int, max: ?int}>
+   */
+  private function parseSubscriberRanges($rawValue, array $buckets): array {
+    if ($rawValue === '' || $rawValue === null || $rawValue === []) {
+      return [];
+    }
+    $values = is_array($rawValue) ? $rawValue : [$rawValue];
+
+    $bucketsByValue = [];
+    foreach ($buckets as $bucket) {
+      $bucketsByValue[$bucket['value']] = $bucket;
+    }
+
+    $ranges = [];
+    $seen = [];
+    foreach ($values as $value) {
+      $key = is_scalar($value) ? (string)$value : '';
+      if (!isset($bucketsByValue[$key]) || isset($seen[$key])) {
+        continue;
+      }
+      $seen[$key] = true;
+      $ranges[] = ['min' => $bucketsByValue[$key]['min'], 'max' => $bucketsByValue[$key]['max']];
+    }
+    return $ranges;
+  }
+
+  protected function getListingValidationErrorPrefix(): string {
+    return 'tags';
   }
 
   public static function getRequestSchema(): array {
@@ -51,6 +155,7 @@ class TagsGetEndpoint extends TagsEndpoint {
       'order' => Builder::string(),
       'page' => Builder::integer(),
       'per_page' => Builder::integer(),
+      'filter' => Builder::object(),
     ];
   }
 }

--- a/mailpoet/lib/Tags/TagRepository.php
+++ b/mailpoet/lib/Tags/TagRepository.php
@@ -5,6 +5,7 @@ namespace MailPoet\Tags;
 use MailPoet\Doctrine\Repository;
 use MailPoet\Entities\SubscriberTagEntity;
 use MailPoet\Entities\TagEntity;
+use MailPoet\Listing\ListingDateRangeFilterTrait;
 use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -12,6 +13,8 @@ use MailPoetVendor\Doctrine\ORM\EntityManager;
  * @extends Repository<TagEntity>
  */
 class TagRepository extends Repository {
+  use ListingDateRangeFilterTrait;
+
   protected function getEntityClassName() {
     return TagEntity::class;
   }
@@ -83,9 +86,9 @@ class TagRepository extends Repository {
   }
 
   /**
-   * Listing with subscriber counts + search + sort + pagination.
+   * Listing with subscriber counts + search + filters + sort + pagination.
    *
-   * @param array{search?: string, orderby?: string, order?: string, page?: int, per_page?: int} $args
+   * @param array{search?: string, orderby?: string, order?: string, page?: int, per_page?: int, filter?: array{from?: string, to?: string, subscriber_ranges?: array<int, array{min: int, max: ?int}>}} $args
    * @return array{items: array<int, array{id: int, name: string, description: string, subscribers_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface}>, total: int}
    */
   public function listWithCounts(array $args = []): array {
@@ -94,6 +97,10 @@ class TagRepository extends Repository {
     $order = isset($args['order']) && strtolower((string)$args['order']) === 'desc' ? 'DESC' : 'ASC';
     $page = isset($args['page']) ? max(1, (int)$args['page']) : 1;
     $perPage = isset($args['per_page']) ? max(1, min(100, (int)$args['per_page'])) : 25;
+    $filter = isset($args['filter']) && is_array($args['filter']) ? $args['filter'] : [];
+    $from = isset($filter['from']) && is_string($filter['from']) && $filter['from'] !== '' ? $filter['from'] : null;
+    $to = isset($filter['to']) && is_string($filter['to']) && $filter['to'] !== '' ? $filter['to'] : null;
+    $ranges = isset($filter['subscriber_ranges']) && is_array($filter['subscriber_ranges']) ? $filter['subscriber_ranges'] : [];
 
     $sortable = [
       'name' => 't.name',
@@ -122,18 +129,13 @@ class TagRepository extends Repository {
       $qb->andWhere('t.name LIKE :search OR t.description LIKE :search')
         ->setParameter('search', '%' . $search . '%');
     }
+    $this->applyDateRangeFilter($qb, 't.createdAt', ['from' => $from, 'to' => $to]);
+    $this->applySubscriberRanges($qb, $ranges);
 
     /** @var array<array{id: int, name: string, description: string, created_at: mixed, updated_at: mixed, subscribersCount: int|string}> $rows */
     $rows = $qb->getQuery()->getArrayResult();
 
-    $countQb = $this->entityManager->createQueryBuilder()
-      ->select('COUNT(t.id)')
-      ->from(TagEntity::class, 't');
-    if ($search !== '') {
-      $countQb->andWhere('t.name LIKE :search OR t.description LIKE :search')
-        ->setParameter('search', '%' . $search . '%');
-    }
-    $total = (int)$countQb->getQuery()->getSingleScalarResult();
+    $total = $this->countWithFilters($search, $from, $to, $ranges);
 
     $items = [];
     foreach ($rows as $row) {
@@ -150,6 +152,115 @@ class TagRepository extends Repository {
     }
 
     return ['items' => $items, 'total' => $total];
+  }
+
+  /**
+   * @param array<int, array{min: int, max: ?int}> $ranges
+   */
+  private function countWithFilters(string $search, ?string $from, ?string $to, array $ranges): int {
+    if ($ranges) {
+      // The subscriber-count filter needs HAVING on a grouped query, so count
+      // the matching tag ids. Bounded by the number of tags.
+      $qb = $this->entityManager->createQueryBuilder()
+        ->select('t.id')
+        ->from(TagEntity::class, 't')
+        ->leftJoin('t.subscriberTags', 'st')
+        ->leftJoin('st.subscriber', 's', 'WITH', 's.deletedAt IS NULL')
+        ->groupBy('t.id');
+      if ($search !== '') {
+        $qb->andWhere('t.name LIKE :search OR t.description LIKE :search')
+          ->setParameter('search', '%' . $search . '%');
+      }
+      $this->applyDateRangeFilter($qb, 't.createdAt', ['from' => $from, 'to' => $to]);
+      $this->applySubscriberRanges($qb, $ranges);
+      return count($qb->getQuery()->getArrayResult());
+    }
+
+    $qb = $this->entityManager->createQueryBuilder()
+      ->select('COUNT(t.id)')
+      ->from(TagEntity::class, 't');
+    if ($search !== '') {
+      $qb->andWhere('t.name LIKE :search OR t.description LIKE :search')
+        ->setParameter('search', '%' . $search . '%');
+    }
+    $this->applyDateRangeFilter($qb, 't.createdAt', ['from' => $from, 'to' => $to]);
+    return (int)$qb->getQuery()->getSingleScalarResult();
+  }
+
+  /**
+   * Apply the subscriber-count filter as an OR of HAVING conditions on the
+   * grouped subscriber count. Each range is a decade bucket; `max === null`
+   * means an open-ended top bucket, and `min === 0 && max === 0` is the
+   * "no subscribers" bucket.
+   *
+   * @param array<int, array{min: int, max: ?int}> $ranges
+   */
+  private function applySubscriberRanges(\MailPoetVendor\Doctrine\ORM\QueryBuilder $qb, array $ranges): void {
+    if (!$ranges) {
+      return;
+    }
+    $countExpr = 'COUNT(DISTINCT s.id)';
+    $conditions = [];
+    foreach ($ranges as $index => $range) {
+      $min = (int)$range['min'];
+      $max = $range['max'] ?? null;
+      if ($max === null) {
+        $conditions[] = "$countExpr >= :subMin$index";
+        $qb->setParameter("subMin$index", $min);
+      } elseif ($min === 0 && (int)$max === 0) {
+        $conditions[] = "$countExpr = 0";
+      } else {
+        $conditions[] = "$countExpr BETWEEN :subMin$index AND :subMax$index";
+        $qb->setParameter("subMin$index", $min);
+        $qb->setParameter("subMax$index", (int)$max);
+      }
+    }
+    $qb->andHaving('(' . implode(' OR ', $conditions) . ')');
+  }
+
+  /**
+   * Build decade (power-of-ten) subscriber-count buckets sized to the site's
+   * data: a "none" bucket (0), closed decade buckets, and an open-ended top
+   * bucket for the largest decade present. Returns an empty list when no tag
+   * has any subscriber, so the filter can be hidden.
+   *
+   * @return array<int, array{value: string, min: int, max: ?int}>
+   */
+  public function getSubscriberCountBuckets(): array {
+    $max = $this->getMaxSubscribersCount();
+    if ($max <= 0) {
+      return [];
+    }
+
+    // Largest power of ten not exceeding $max (integer-safe, avoids log10 drift).
+    $topDecade = 1;
+    while ($topDecade * 10 <= $max) {
+      $topDecade *= 10;
+    }
+
+    $buckets = [['value' => '0', 'min' => 0, 'max' => 0]];
+    for ($decade = 1; $decade < $topDecade; $decade *= 10) {
+      $buckets[] = ['value' => (string)$decade, 'min' => $decade, 'max' => $decade * 10 - 1];
+    }
+    $buckets[] = ['value' => (string)$topDecade, 'min' => $topDecade, 'max' => null];
+    return $buckets;
+  }
+
+  private function getMaxSubscribersCount(): int {
+    /** @var array<array{cnt: int|string}> $rows */
+    $rows = $this->entityManager->createQueryBuilder()
+      ->select('COUNT(DISTINCT s.id) AS cnt')
+      ->from(TagEntity::class, 't')
+      ->leftJoin('t.subscriberTags', 'st')
+      ->leftJoin('st.subscriber', 's', 'WITH', 's.deletedAt IS NULL')
+      ->groupBy('t.id')
+      ->getQuery()->getArrayResult();
+
+    $max = 0;
+    foreach ($rows as $row) {
+      $max = max($max, (int)$row['cnt']);
+    }
+    return $max;
   }
 
   /**

--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -121,6 +121,7 @@ class SwitchingLanguagesCest {
     $i->waitForText('Neues Formular hinzufügen');
     $i->waitForText('Unter Seiten');
     $i->waitForText('Registrierungen');
+    $i->waitForText(strtoupper('Erstelldatum'));
     $i->waitForText(strtoupper('Änderungsdatum'));
 
     $i->wantTo('Check Subscribers filter strings and button');

--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -121,7 +121,10 @@ class SwitchingLanguagesCest {
     $i->waitForText('Neues Formular hinzufügen');
     $i->waitForText('Unter Seiten');
     $i->waitForText('Registrierungen');
-    $i->waitForText(strtoupper('Erstelldatum'));
+    // NOTE: only the "Modified date" header is asserted here. "Created date"
+    // has no German translation on translate.wordpress.org yet, so the column
+    // renders untranslated (same as trunk). Re-add an "Erstelldatum" assertion
+    // once that string is translated upstream.
     $i->waitForText(strtoupper('Änderungsdatum'));
 
     $i->wantTo('Check Subscribers filter strings and button');

--- a/mailpoet/tests/acceptance/Subscribers/CustomFieldsListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/CustomFieldsListingCest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Test\DataFactories\CustomField as CustomFieldFactory;
+
+class CustomFieldsListingCest {
+  public function customFieldsNativeFiltersAndSorting(\AcceptanceTester $i) {
+    $i->wantTo('Filter and sort the custom fields listing with native DataViews controls');
+
+    $suffix = 'cffilter' . uniqid();
+    $textField = "Text-{$suffix}";
+    $dateField = "Date-{$suffix}";
+
+    (new CustomFieldFactory())->withName($textField)->withType('text')->create();
+    (new CustomFieldFactory())->withName($dateField)->withType('date')->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('custom-fields');
+    $i->searchFor($suffix);
+    $i->waitForText($textField);
+    $i->waitForText($dateField);
+
+    $i->wantTo('Apply the native Type filter and keep only Date fields');
+    $i->click(['xpath' => '//button[@aria-label="Add filter"]']);
+    $i->waitForText('Type');
+    $i->click(['xpath' => '//*[@role="menuitem"][contains(normalize-space(.), "Type")]']);
+    $i->waitForElement('.dataviews-filters__search-widget-listitem');
+    $i->click(['xpath' => '//*[contains(@class, "dataviews-filters__search-widget-listitem")][.//text()[contains(., "Date")]]']);
+    $i->pressKey('body', \Facebook\WebDriver\WebDriverKeys::ESCAPE);
+    $i->waitForText($dateField);
+    $i->dontSee($textField);
+    $i->seeInCurrentUrl('type=date');
+
+    $i->wantTo('Sort the custom fields by name descending');
+    $i->amOnMailpoetPage('custom-fields');
+    $i->searchFor($suffix);
+    $i->waitForText($textField);
+    $i->click(['xpath' => '//th//button[contains(., "Name")]']);
+    $i->waitForText('Sort descending');
+    $i->click(['xpath' => '//*[@role="menuitemradio"][contains(normalize-space(.), "Sort descending")]']);
+    $i->waitForText($textField);
+    $i->waitForJS(<<<JS
+      const text = Array.from(document.querySelectorAll('.mailpoet-custom-fields-dataviews tbody tr'))
+        .map((row) => row.textContent)
+        .join('||');
+      const textAt = text.indexOf('{$textField}');
+      const dateAt = text.indexOf('{$dateField}');
+      return textAt !== -1 && dateAt !== -1 && textAt < dateAt;
+    JS, 10);
+  }
+}

--- a/mailpoet/tests/acceptance/Subscribers/TagsListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/TagsListingCest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\Test\DataFactories\Tag as TagFactory;
+
+class TagsListingCest {
+  public function tagsNativeFiltersAndSorting(\AcceptanceTester $i) {
+    $i->wantTo('Filter and sort the tags listing with native DataViews controls');
+
+    $suffix = 'tagfilter' . uniqid();
+    $withSubs = "WithSubs-{$suffix}";
+    $empty = "Empty-{$suffix}";
+
+    $tag = (new TagFactory())->withName($withSubs)->create();
+    (new TagFactory())->withName($empty)->create();
+    (new SubscriberFactory())->withEmail("sub-{$suffix}@example.com")->withTags([$tag])->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('tags');
+    $i->searchFor($suffix);
+    $i->waitForText($withSubs);
+    $i->waitForText($empty);
+
+    // Only WithSubs has a subscriber, so the largest count is 1 and the buckets
+    // collapse to "None" and the open-ended "1+" bucket.
+    $i->wantTo('Apply the native data-driven "Subscribers" bucket filter');
+    $i->click(['xpath' => '//button[@aria-label="Add filter"]']);
+    $i->waitForText('Subscribers');
+    $i->click(['xpath' => '//*[@role="menuitem"][contains(normalize-space(.), "Subscribers")]']);
+    $i->waitForElement('.dataviews-filters__search-widget-listitem');
+    $i->click(['xpath' => '//*[contains(@class, "dataviews-filters__search-widget-listitem")][.//text()[contains(., "1+")]]']);
+    $i->pressKey('body', \Facebook\WebDriver\WebDriverKeys::ESCAPE);
+    $i->waitForText($withSubs);
+    $i->dontSee($empty);
+    $i->seeInCurrentUrl('subscribers=1');
+
+    $i->wantTo('Honor the subscribers bucket query param on direct navigation');
+    $i->amOnPage("/wp-admin/admin.php?page=mailpoet-tags&search={$suffix}&subscribers=1");
+    $i->waitForText($withSubs);
+    $i->dontSee($empty);
+
+    $i->wantTo('Honor the "none" subscribers bucket on direct navigation');
+    $i->amOnPage("/wp-admin/admin.php?page=mailpoet-tags&search={$suffix}&subscribers=0");
+    $i->waitForText($empty);
+    $i->dontSee($withSubs);
+
+    $i->wantTo('Honor the created date query params on direct navigation');
+    $i->amOnPage("/wp-admin/admin.php?page=mailpoet-tags&search={$suffix}&created_to=2000-01-01");
+    $i->waitForText('No tags');
+    $i->dontSee($withSubs);
+
+    $i->wantTo('Sort the tags by subscribers count descending');
+    $i->amOnMailpoetPage('tags');
+    $i->searchFor($suffix);
+    $i->waitForText($withSubs);
+    $i->click(['xpath' => '//th//button[contains(., "Subscribers")]']);
+    $i->waitForText('Sort descending');
+    $i->click(['xpath' => '//*[@role="menuitemradio"][contains(normalize-space(.), "Sort descending")]']);
+    $i->waitForText($withSubs);
+    $i->waitForJS(<<<JS
+      const text = Array.from(document.querySelectorAll('.mailpoet-tags-dataviews tbody tr'))
+        .map((row) => row.textContent)
+        .join('||');
+      const withSubsAt = text.indexOf('{$withSubs}');
+      const emptyAt = text.indexOf('{$empty}');
+      return withSubsAt !== -1 && emptyAt !== -1 && withSubsAt < emptyAt;
+    JS, 10);
+  }
+}

--- a/mailpoet/tests/integration/CustomFields/CustomFieldsRepositoryTest.php
+++ b/mailpoet/tests/integration/CustomFields/CustomFieldsRepositoryTest.php
@@ -173,6 +173,44 @@ class CustomFieldsRepositoryTest extends \MailPoetTest {
     $this->assertNotNull($this->repository->findOneById($active->getId()));
   }
 
+  public function testListWithCountsFiltersByType(): void {
+    (new CustomFieldFactory())->withName('TextField')->withType('text')->create();
+    (new CustomFieldFactory())->withName('DateField')->withType('date')->create();
+    (new CustomFieldFactory())->withName('SelectField')->withType('select')->withParams(['values' => [['value' => 'a']]])->create();
+
+    $result = $this->repository->listWithCounts(['filter' => ['type' => ['date', 'select']]]);
+    $this->assertSame(2, $result['total']);
+    $names = array_column($result['items'], 'name');
+    sort($names);
+    $this->assertSame(['DateField', 'SelectField'], $names);
+  }
+
+  public function testListWithCountsExposesRequiredFlag(): void {
+    (new CustomFieldFactory())->withName('Req')->withParams(['label' => 'Req', 'required' => '1'])->create();
+    (new CustomFieldFactory())->withName('Opt')->withParams(['label' => 'Opt'])->create();
+
+    $items = array_column($this->repository->listWithCounts()['items'], null, 'name');
+    $this->assertTrue($items['Req']['required']);
+    $this->assertFalse($items['Opt']['required']);
+  }
+
+  public function testListWithCountsSortsBySubscribersCount(): void {
+    $subscriberA = (new SubscriberFactory())->withEmail('sa@example.com')->create();
+    $subscriberB = (new SubscriberFactory())->withEmail('sb@example.com')->create();
+
+    (new CustomFieldFactory())->withName('NoSubs')->create();
+    (new CustomFieldFactory())->withName('OneSub')
+      ->withSubscriber($subscriberA->getId(), 'value')
+      ->create();
+    (new CustomFieldFactory())->withName('TwoSubs')
+      ->withSubscriber($subscriberA->getId(), 'value')
+      ->withSubscriber($subscriberB->getId(), 'value')
+      ->create();
+
+    $result = $this->repository->listWithCounts(['orderby' => 'subscribers_count', 'order' => 'desc']);
+    $this->assertSame(['TwoSubs', 'OneSub', 'NoSubs'], array_column($result['items'], 'name'));
+  }
+
   /**
    * @param array<int, array{name: string}> $items
    * @return array<string, array>

--- a/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
@@ -53,6 +53,16 @@ class CustomFieldsEndpointsTest extends Test {
     $this->assertSame(0, $this->getGroupCount($payload['groups'], 'trash'));
   }
 
+  public function testGetExposesRequiredFlag(): void {
+    (new CustomFieldFactory())->withName('Req')->withParams(['label' => 'Req', 'required' => '1'])->create();
+    (new CustomFieldFactory())->withName('Opt')->withParams(['label' => 'Opt'])->create();
+
+    $payload = $this->getListingPayload($this->get(self::BASE_PATH));
+    $byName = array_column($payload['items'], null, 'name');
+    $this->assertTrue($byName['Req']['required']);
+    $this->assertFalse($byName['Opt']['required']);
+  }
+
   public function testGetSupportsSearchAndPagination(): void {
     (new CustomFieldFactory())->withName('Customers')->create();
     (new CustomFieldFactory())->withName('Prospective')->create();
@@ -65,6 +75,27 @@ class CustomFieldsEndpointsTest extends Test {
     $page1 = $this->getListingPayload($this->get(self::BASE_PATH, ['query' => ['per_page' => 2, 'page' => 1, 'orderby' => 'name', 'order' => 'asc']]));
     $this->assertCount(2, $page1['items']);
     $this->assertSame(2, $page1['meta']['pages']);
+  }
+
+  public function testGetFiltersByType(): void {
+    (new CustomFieldFactory())->withName('TextField')->withType('text')->create();
+    (new CustomFieldFactory())->withName('DateField')->withType('date')->create();
+
+    $data = $this->getListingPayload($this->get(self::BASE_PATH, ['query' => ['filter' => ['type' => ['date']]]]));
+    $this->assertSame(1, $data['meta']['count']);
+    $this->assertSame('DateField', $data['items'][0]['name']);
+  }
+
+  public function testGetRejectsUnsupportedTypeFilter(): void {
+    $data = $this->get(self::BASE_PATH, ['query' => ['filter' => ['type' => ['bogus']]]]);
+    $this->assertSame('mailpoet_custom_fields_invalid_type', $data['code']);
+    $this->assertSame(400, $data['data']['status']);
+  }
+
+  public function testGetRejectsUnsupportedFilter(): void {
+    $data = $this->get(self::BASE_PATH, ['query' => ['filter' => ['bogus' => '1']]]);
+    $this->assertSame('mailpoet_custom_fields_invalid_filter', $data['code']);
+    $this->assertSame(400, $data['data']['status']);
   }
 
   public function testGetRejectsGuest(): void {

--- a/mailpoet/tests/integration/REST/Tags/TagsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Tags/TagsEndpointsTest.php
@@ -80,6 +80,73 @@ class TagsEndpointsTest extends Test {
     $this->assertSame(2, $page1['data']['meta']['pages']);
   }
 
+  public function testGetFiltersBySubscriberBucket(): void {
+    $withSubs = (new TagFactory())->withName('WithSubs')->create();
+    (new TagFactory())->withName('Empty')->create();
+    (new SubscriberFactory())->withEmail('hs@example.com')->withTags([$withSubs])->create();
+
+    // The endpoint advertises the data-driven buckets in the listing meta.
+    $all = $this->get(self::BASE_PATH);
+    $this->assertNotEmpty($all['data']['meta']['subscriber_count_buckets']);
+
+    // The "none" bucket (value "0") keeps only tags without subscribers.
+    $none = $this->get(self::BASE_PATH, ['query' => ['filter' => ['subscribers' => ['0']]]]);
+    $this->assertSame(1, $none['data']['meta']['count']);
+    $this->assertSame('Empty', $none['data']['items'][0]['name']);
+
+    // The non-zero bucket (value "1") keeps only tags that have subscribers.
+    $withSub = $this->get(self::BASE_PATH, ['query' => ['filter' => ['subscribers' => ['1']]]]);
+    $this->assertSame(1, $withSub['data']['meta']['count']);
+    $this->assertSame('WithSubs', $withSub['data']['items'][0]['name']);
+  }
+
+  public function testGetIgnoresUnknownSubscribersBucket(): void {
+    $tag = (new TagFactory())->withName('WithSubs')->create();
+    (new TagFactory())->withName('Empty')->create();
+    (new SubscriberFactory())->withEmail('hs@example.com')->withTags([$tag])->create();
+
+    // A stale/unknown bucket value is ignored, so the listing still loads.
+    $data = $this->get(self::BASE_PATH, ['query' => ['filter' => ['subscribers' => ['999999']]]]);
+    $this->assertSame(2, $data['data']['meta']['count']);
+  }
+
+  public function testGetIgnoresSubscribersFilterWhenNoBuckets(): void {
+    (new TagFactory())->withName('A')->create();
+    (new TagFactory())->withName('B')->create();
+
+    // No tag has subscribers, so there are no buckets at all.
+    $all = $this->get(self::BASE_PATH);
+    $this->assertSame([], $all['data']['meta']['subscriber_count_buckets']);
+
+    // A deep-linked subscribers=0 must not 400; it is ignored and all tags load.
+    $data = $this->get(self::BASE_PATH, ['query' => ['filter' => ['subscribers' => ['0']]]]);
+    $this->assertSame(2, $data['data']['meta']['count']);
+  }
+
+  public function testGetFiltersByCreatedAtRange(): void {
+    $old = (new TagFactory())->withName('Old')->create();
+    $recent = (new TagFactory())->withName('Recent')->create();
+    $old->setCreatedAt(new \DateTimeImmutable('2024-01-01 10:00:00'));
+    $recent->setCreatedAt(new \DateTimeImmutable('2024-12-31 10:00:00'));
+    $this->repository->flush();
+
+    $data = $this->get(self::BASE_PATH, ['query' => ['filter' => ['from' => '2024-06-01']]]);
+    $this->assertSame(1, $data['data']['meta']['count']);
+    $this->assertSame('Recent', $data['data']['items'][0]['name']);
+  }
+
+  public function testGetRejectsInvalidDateFilter(): void {
+    $data = $this->get(self::BASE_PATH, ['query' => ['filter' => ['from' => 'not-a-date']]]);
+    $this->assertSame('mailpoet_tags_invalid_from', $data['code']);
+    $this->assertSame(400, $data['data']['status']);
+  }
+
+  public function testGetRejectsUnsupportedFilter(): void {
+    $data = $this->get(self::BASE_PATH, ['query' => ['filter' => ['bogus' => '1']]]);
+    $this->assertSame('mailpoet_tags_invalid_filter', $data['code']);
+    $this->assertSame(400, $data['data']['status']);
+  }
+
   public function testGetRejectsGuest(): void {
     wp_set_current_user(0);
     $data = $this->get(self::BASE_PATH);

--- a/mailpoet/tests/integration/Tags/TagRepositoryTest.php
+++ b/mailpoet/tests/integration/Tags/TagRepositoryTest.php
@@ -102,6 +102,78 @@ class TagRepositoryTest extends \MailPoetTest {
     $this->assertSame(['Tag-05'], array_column($page3['items'], 'name'));
   }
 
+  public function testListWithCountsFiltersBySubscriberRanges(): void {
+    $withSubs = (new TagFactory())->withName('WithSubs')->create();
+    (new TagFactory())->withName('Empty')->create();
+    (new SubscriberFactory())->withEmail('hs@example.com')->withTags([$withSubs])->create();
+
+    // Open-ended bucket (>= 1) keeps only tags that have subscribers.
+    $hasSome = $this->repository->listWithCounts(['filter' => ['subscriber_ranges' => [['min' => 1, 'max' => null]]]]);
+    $this->assertSame(1, $hasSome['total']);
+    $this->assertSame(['WithSubs'], array_column($hasSome['items'], 'name'));
+
+    // The "none" bucket (0) keeps only tags without subscribers.
+    $none = $this->repository->listWithCounts(['filter' => ['subscriber_ranges' => [['min' => 0, 'max' => 0]]]]);
+    $this->assertSame(1, $none['total']);
+    $this->assertSame(['Empty'], array_column($none['items'], 'name'));
+
+    // Multiple selected buckets are OR-ed together.
+    $both = $this->repository->listWithCounts(['filter' => ['subscriber_ranges' => [['min' => 0, 'max' => 0], ['min' => 1, 'max' => null]]]]);
+    $this->assertSame(2, $both['total']);
+  }
+
+  public function testGetSubscriberCountBucketsScaleWithData(): void {
+    $this->assertSame([], $this->repository->getSubscriberCountBuckets());
+
+    $tag = (new TagFactory())->withName('Tagged')->create();
+    for ($i = 0; $i < 10; $i++) {
+      (new SubscriberFactory())->withEmail("b{$i}@example.com")->withTags([$tag])->create();
+    }
+
+    // max count = 10 -> top decade 10 -> none, 1-9, 10+
+    $this->assertSame(
+      [
+        ['value' => '0', 'min' => 0, 'max' => 0],
+        ['value' => '1', 'min' => 1, 'max' => 9],
+        ['value' => '10', 'min' => 10, 'max' => null],
+      ],
+      $this->repository->getSubscriberCountBuckets()
+    );
+  }
+
+  public function testListWithCountsFiltersByCreatedAtRange(): void {
+    $old = (new TagFactory())->withName('Old')->create();
+    $mid = (new TagFactory())->withName('Mid')->create();
+    $recent = (new TagFactory())->withName('Recent')->create();
+    $old->setCreatedAt(new \DateTimeImmutable('2024-01-01 10:00:00'));
+    $mid->setCreatedAt(new \DateTimeImmutable('2024-06-15 10:00:00'));
+    $recent->setCreatedAt(new \DateTimeImmutable('2024-12-31 10:00:00'));
+    $this->entityManager->flush();
+
+    $from = $this->repository->listWithCounts(['filter' => ['from' => '2024-06-01']]);
+    $this->assertSame(['Mid', 'Recent'], $this->sortedNames($from['items']));
+
+    $to = $this->repository->listWithCounts(['filter' => ['to' => '2024-06-30']]);
+    $this->assertSame(['Mid', 'Old'], $this->sortedNames($to['items']));
+
+    $between = $this->repository->listWithCounts(['filter' => ['from' => '2024-06-15', 'to' => '2024-06-15']]);
+    $this->assertSame(['Mid'], $this->sortedNames($between['items']));
+  }
+
+  public function testListWithCountsSortsByCreatedAt(): void {
+    $old = (new TagFactory())->withName('Old')->create();
+    $recent = (new TagFactory())->withName('Recent')->create();
+    $old->setCreatedAt(new \DateTimeImmutable('2024-01-01 10:00:00'));
+    $recent->setCreatedAt(new \DateTimeImmutable('2024-12-31 10:00:00'));
+    $this->entityManager->flush();
+
+    $asc = $this->repository->listWithCounts(['orderby' => 'created_at', 'order' => 'asc']);
+    $this->assertSame(['Old', 'Recent'], array_column($asc['items'], 'name'));
+
+    $desc = $this->repository->listWithCounts(['orderby' => 'created_at', 'order' => 'desc']);
+    $this->assertSame(['Recent', 'Old'], array_column($desc['items'], 'name'));
+  }
+
   public function testBulkDeleteRemovesTagsAndSubscriberLinks(): void {
     $tagA = (new TagFactory())->withName('A')->create();
     $tagB = (new TagFactory())->withName('B')->create();
@@ -146,6 +218,16 @@ class TagRepositoryTest extends \MailPoetTest {
       ->create();
 
     $this->assertSame(2, $this->repository->getSubscribersCount((int)$tag->getId()));
+  }
+
+  /**
+   * @param array<int, array{name: string}> $items
+   * @return string[]
+   */
+  private function sortedNames(array $items): array {
+    $names = array_column($items, 'name');
+    sort($names);
+    return $names;
   }
 
   /**

--- a/mailpoet/tests/javascript/subscribers/custom-fields/filters.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/custom-fields/filters.spec.ts
@@ -1,0 +1,39 @@
+import {
+  requestFilterToViewFilters,
+  viewFiltersToRequestFilter,
+} from '../../../../assets/js/src/subscribers/custom-fields/filters';
+
+describe('custom fields filters bridge', () => {
+  it('maps the type multi-select filter', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'type', operator: 'isAny', value: ['date', 'select'] },
+      ]),
+    ).to.deep.equal({ type: ['date', 'select'] });
+  });
+
+  it('ignores unsupported filter fields', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'used_in_forms', operator: 'is', value: 1 },
+        { field: 'type', operator: 'isAny', value: ['text'] },
+      ]),
+    ).to.deep.equal({ type: ['text'] });
+  });
+
+  it('drops empty type selections', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'type', operator: 'isAny', value: [] },
+      ]),
+    ).to.deep.equal({});
+  });
+
+  it('seeds view filters from a request filter', () => {
+    expect(
+      requestFilterToViewFilters({
+        type: ['text'],
+      }),
+    ).to.deep.equal([{ field: 'type', operator: 'isAny', value: ['text'] }]);
+  });
+});

--- a/mailpoet/tests/javascript/subscribers/custom-fields/url-state.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/custom-fields/url-state.spec.ts
@@ -1,0 +1,52 @@
+import type { View } from '@wordpress/dataviews';
+import {
+  buildCustomFieldsUrl,
+  parseCustomFieldsUrlState,
+} from '../../../../assets/js/src/subscribers/custom-fields/url-state';
+
+const BASE =
+  'http://example.test/wp-admin/admin.php?page=mailpoet-custom-fields';
+
+describe('custom fields URL state', () => {
+  it('uses defaults when no params are present', () => {
+    const state = parseCustomFieldsUrlState(BASE);
+    expect(state).to.deep.equal({
+      page: 1,
+      perPage: undefined,
+      search: undefined,
+      group: 'all',
+      filter: {},
+    });
+  });
+
+  it('parses pagination, group, search and filters', () => {
+    const state = parseCustomFieldsUrlState(
+      `${BASE}&cf_page=2&per_page=30&group=trash&search=%20color%20&type=text,date`,
+    );
+    expect(state).to.deep.equal({
+      page: 2,
+      perPage: 30,
+      search: 'color',
+      group: 'trash',
+      filter: {
+        type: ['text', 'date'],
+      },
+    });
+  });
+
+  it('ignores unknown type values', () => {
+    const state = parseCustomFieldsUrlState(`${BASE}&type=text,bogus`);
+    expect(state.filter).to.deep.equal({ type: ['text'] });
+  });
+
+  it('builds a URL from the view, group and filter', () => {
+    const view: View = { type: 'table', page: 2, perPage: 25 };
+    const url = buildCustomFieldsUrl(BASE, view, 'trash', {
+      type: ['text', 'date'],
+    });
+    expect(url).to.contain('cf_page=2');
+    expect(url).to.contain('per_page=25');
+    expect(url).to.contain('group=trash');
+    expect(url).to.contain('type=text%2Cdate');
+  });
+});

--- a/mailpoet/tests/javascript/subscribers/tags/filters.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/tags/filters.spec.ts
@@ -1,0 +1,109 @@
+import {
+  requestFilterToViewFilters,
+  viewFiltersToRequestFilter,
+} from '../../../../assets/js/src/subscribers/tags/filters';
+
+describe('tags filters bridge', () => {
+  it('maps inclusive date operators to a from/to range', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'afterInc', value: '2024-06-01' },
+      ]),
+    ).to.deep.equal({ from: '2024-06-01' });
+
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'beforeInc', value: '2024-06-30' },
+      ]),
+    ).to.deep.equal({ to: '2024-06-30' });
+
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'on', value: '2024-06-15' },
+      ]),
+    ).to.deep.equal({ from: '2024-06-15', to: '2024-06-15' });
+
+    expect(
+      viewFiltersToRequestFilter([
+        {
+          field: 'created_at',
+          operator: 'between',
+          value: ['2024-06-01', '2024-06-30'],
+        },
+      ]),
+    ).to.deep.equal({ from: '2024-06-01', to: '2024-06-30' });
+  });
+
+  it('shifts the exclusive before/after operators by a day', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'after', value: '2024-06-01' },
+      ]),
+    ).to.deep.equal({ from: '2024-06-02' });
+
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'before', value: '2024-06-30' },
+      ]),
+    ).to.deep.equal({ to: '2024-06-29' });
+  });
+
+  it('ignores invalid date values', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'created_at', operator: 'afterInc', value: 'nope' },
+      ]),
+    ).to.deep.equal({});
+  });
+
+  it('maps the subscribers bucket filter', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'subscribers', operator: 'isAny', value: ['0', '10'] },
+      ]),
+    ).to.deep.equal({ subscribers: ['0', '10'] });
+  });
+
+  it('drops an empty subscribers selection', () => {
+    expect(
+      viewFiltersToRequestFilter([
+        { field: 'subscribers', operator: 'isAny', value: [] },
+      ]),
+    ).to.deep.equal({});
+  });
+
+  it('seeds view filters from a request filter', () => {
+    expect(
+      requestFilterToViewFilters({
+        from: '2024-06-01',
+        to: '2024-06-30',
+        subscribers: ['0', '10'],
+      }),
+    ).to.deep.equal([
+      {
+        field: 'created_at',
+        operator: 'between',
+        value: ['2024-06-01', '2024-06-30'],
+      },
+      { field: 'subscribers', operator: 'isAny', value: ['0', '10'] },
+    ]);
+  });
+
+  it('uses the on operator when from equals to', () => {
+    expect(
+      requestFilterToViewFilters({ from: '2024-06-15', to: '2024-06-15' }),
+    ).to.deep.equal([
+      { field: 'created_at', operator: 'on', value: '2024-06-15' },
+    ]);
+  });
+
+  it('seeds inclusive operators for a single stored bound', () => {
+    expect(requestFilterToViewFilters({ from: '2024-06-01' })).to.deep.equal([
+      { field: 'created_at', operator: 'afterInc', value: '2024-06-01' },
+    ]);
+
+    expect(requestFilterToViewFilters({ to: '2024-06-30' })).to.deep.equal([
+      { field: 'created_at', operator: 'beforeInc', value: '2024-06-30' },
+    ]);
+  });
+});

--- a/mailpoet/tests/javascript/subscribers/tags/url-state.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/tags/url-state.spec.ts
@@ -1,0 +1,53 @@
+import type { View } from '@wordpress/dataviews';
+import {
+  buildTagsUrl,
+  parseTagsUrlState,
+} from '../../../../assets/js/src/subscribers/tags/url-state';
+
+const BASE = 'http://example.test/wp-admin/admin.php?page=mailpoet-tags';
+
+describe('tags URL state', () => {
+  it('uses defaults when no params are present', () => {
+    const state = parseTagsUrlState(BASE);
+    expect(state).to.deep.equal({
+      page: 1,
+      perPage: undefined,
+      search: undefined,
+      filter: {},
+    });
+  });
+
+  it('parses pagination, search and filters', () => {
+    const state = parseTagsUrlState(
+      `${BASE}&tags_page=3&per_page=50&search=%20vip%20&created_from=2024-06-01&created_to=2024-06-30&subscribers=0,10`,
+    );
+    expect(state).to.deep.equal({
+      page: 3,
+      perPage: 50,
+      search: 'vip',
+      filter: {
+        from: '2024-06-01',
+        to: '2024-06-30',
+        subscribers: ['0', '10'],
+      },
+    });
+  });
+
+  it('ignores invalid date params', () => {
+    const state = parseTagsUrlState(`${BASE}&created_from=2024-6-1`);
+    expect(state.filter).to.deep.equal({});
+  });
+
+  it('builds a URL from the view and filter', () => {
+    const view: View = { type: 'table', page: 2, perPage: 25 };
+    const url = buildTagsUrl(BASE, view, {
+      from: '2024-06-01',
+      subscribers: ['0', '10'],
+    });
+    expect(url).to.contain('tags_page=2');
+    expect(url).to.contain('per_page=25');
+    expect(url).to.contain('created_from=2024-06-01');
+    expect(url).to.contain('subscribers=0%2C10');
+    expect(url).to.not.contain('created_to=');
+  });
+});


### PR DESCRIPTION
## Description

Adds native DataViews filters and sorting to the Subscriber Tags and Custom Fields listings (previously filter-less), done server-side in SQL and persisted to the URL.

- **Tags** — pure SQL. Filters: created date (`on` / `beforeInc` / `afterInc` / `between`) and a data-driven **Subscribers** count filter. Sorting: name, subscribers, created date.
- **Custom fields** — pure SQL. Filter: type. Sorting: name, type, subscribers, created date.

### Subscribers count filter (Tags)

Instead of a boolean "has subscribers" toggle, the endpoint derives **decade (power-of-ten) buckets sized to the site's data** (e.g. a small site gets `None / 1–9 / 10+`, a large one `None / 1–9 / 10–99 / 100–999 / 1,000–9,999 / 10,000+`), returns them in the listing meta, and the UI renders them as a multi-select. Selected buckets are applied as an `OR` of `HAVING` ranges on the grouped subscriber count — all in SQL.

### Display-only columns (Custom fields)

`forms_count` and `dynamic_segments_count` (derived from JSON form body blocks / segment filter data) and `required` (stored in the serialized `params` blob) cannot be expressed in SQL, so they are shown as **display-only columns** — not filterable or sortable. No schema change. The JSON counts are computed in PHP for the current page only.

## Code review notes

Both listings now do all filtering, sorting and pagination in SQL — there is no in-memory (PHP) filtering/sorting. Anything that can't be expressed in SQL (custom field `forms_count`/`dynamic_segments_count` from JSON, the `required` flag from the serialized `params` column) is display-only rather than being processed in PHP.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8173

## After-merge notes

_N/A_

## Screenshots or screencast

| Before | After | 
| ---- | ---- | 
| <img width="1387" height="837" alt="Screenshot 2026-06-19 at 08 50 49" src="https://github.com/user-attachments/assets/a2d109fa-fc6c-4b26-af07-2ef575b8b420" /> | <img width="1392" height="878" alt="Screenshot 2026-06-19 at 08 45 00" src="https://github.com/user-attachments/assets/706052e1-05b2-44e3-b312-454ef4d5a9fd" /> |
| <img width="1385" height="790" alt="Screenshot 2026-06-19 at 08 50 26" src="https://github.com/user-attachments/assets/05186de2-e5b9-4585-9a2f-a95cc84fd50e" /> | <img width="1387" height="632" alt="Screenshot 2026-06-19 at 08 46 18" src="https://github.com/user-attachments/assets/523f6d68-6394-4fc5-8a99-96fdb0432d6c" /> | 



## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed best practices for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8173-dataviews-native-filters-sorting-for-tags-custom-fields)

_The latest successful build from `add/stomail-8173-dataviews-native-filters-sorting-for-tags-custom-fields` will be used. If none is available, the link won't work._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->