### PR TITLE
Pass newsletter to premium clicked-links and reasons stats filters

### DIFF
--- a/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
@@ -168,6 +168,7 @@ export function CampaignStatsPage() {
               'mailpoet_newsletters_clicked_links_table',
               <PremiumBanner />,
               newsletter.clicked_links,
+              newsletter,
             )}
           </Tab>
 
@@ -225,6 +226,7 @@ export function CampaignStatsPage() {
               'mailpoet_newsletters_unsubscribe_reasons',
               <PremiumBanner />,
               newsletter.statistics.unsubscribeReasons,
+              newsletter,
             )}
           </Tab>
         </Tabs>


### PR DESCRIPTION
## Description

Enabling change for the premium campaign-stats DataViews work (STOMAIL-8174). The premium clicked-links and unsubscribe-reasons tables now fetch their own data server-side, so they need the newsletter id. Pass `newsletter` to the `mailpoet_newsletters_clicked_links_table` and `mailpoet_newsletters_unsubscribe_reasons` filter hooks alongside the existing data argument.

No behaviour change on its own — the free `PremiumBanner` fallback ignores the extra argument.

## Code review notes

_N/A_

## QA notes

Requires the matching premium PR; without it there is no observable change.

## Linked PRs

mailpoet/mailpoet-premium#1095

## Linked tickets

STOMAIL-8174

## After-merge notes

_N/A_

## Tasks

- [x] I followed best practices for translations
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
