### PR TITLE
Add native DataViews filters and sorting to automations listing

### DIFF
--- a/mailpoet/assets/js/src/automation/config.ts
+++ b/mailpoet/assets/js/src/automation/config.ts
@@ -7,12 +7,14 @@ declare global {
     mailpoet_locale_full: string;
     mailpoet_automation_count: number;
     mailpoet_legacy_automation_count: number;
+    mailpoet_automation_trigger_options?: { value: string; label: string }[];
   }
 }
 
 export const api = window.mailpoet_automation_api;
 export const automationCount = window.mailpoet_automation_count;
 export const legacyAutomationCount = window.mailpoet_legacy_automation_count;
+export const triggerOptions = window.mailpoet_automation_trigger_options ?? [];
 
 // export locale to use with Intl APIs
 export const locale: Intl.Locale = (() => {

--- a/mailpoet/assets/js/src/automation/listing/automation.ts
+++ b/mailpoet/assets/js/src/automation/listing/automation.ts
@@ -9,6 +9,8 @@ export type Automation = {
   id: number;
   name: string;
   status: AutomationStatus;
+  created_at?: string;
+  updated_at?: string;
   stats: {
     totals: {
       entered: number;

--- a/mailpoet/assets/js/src/automation/listing/fields.tsx
+++ b/mailpoet/assets/js/src/automation/listing/fields.tsx
@@ -1,9 +1,22 @@
 import { __, _x } from '@wordpress/i18n';
 import type { Field } from '@wordpress/dataviews';
+import { MailPoet } from '../../mailpoet';
 import { AutomationStatus as AutomationStatusBadge } from '../components/status';
 import { Statistics } from '../components/statistics';
+import { triggerOptions } from '../config';
 import type { AutomationItem } from './store/types';
 import { getAutomationEditorUrl } from './urls';
+
+function dateTime(value?: string): JSX.Element {
+  if (!value) return <span>—</span>;
+  return (
+    <span>
+      <span>{MailPoet.Date.short(value)}</span>
+      <br />
+      <span>{MailPoet.Date.time(value)}</span>
+    </span>
+  );
+}
 
 export const automationFields: Field<AutomationItem>[] = [
   {
@@ -12,6 +25,7 @@ export const automationFields: Field<AutomationItem>[] = [
     type: 'text',
     enableGlobalSearch: true,
     enableSorting: true,
+    filterBy: false,
     render: ({ item }) => (
       <a href={getAutomationEditorUrl(item)}>{item.name}</a>
     ),
@@ -22,6 +36,7 @@ export const automationFields: Field<AutomationItem>[] = [
     enableGlobalSearch: false,
     enableSorting: false,
     enableHiding: false,
+    filterBy: false,
     render: ({ item }) =>
       item.description ? <div>{item.description}</div> : null,
   },
@@ -29,7 +44,8 @@ export const automationFields: Field<AutomationItem>[] = [
     id: 'subscribers',
     label: __('Subscribers', 'mailpoet'),
     enableGlobalSearch: false,
-    enableSorting: false,
+    enableSorting: true,
+    filterBy: false,
     getValue: ({ item }) => item.stats.totals.entered,
     render: ({ item }) => (
       <Statistics
@@ -61,12 +77,54 @@ export const automationFields: Field<AutomationItem>[] = [
     id: 'status',
     label: __('Status', 'mailpoet'),
     enableGlobalSearch: false,
-    enableSorting: false,
+    enableSorting: true,
+    filterBy: false,
     getValue: ({ item }) => item.status,
     render: ({ item }) => (
       <span className="mailpoet-automation-listing-cell-status">
         <AutomationStatusBadge status={item.status} />
       </span>
     ),
+  },
+  {
+    id: 'trigger',
+    label: __('Trigger', 'mailpoet'),
+    enableGlobalSearch: false,
+    enableSorting: false,
+    elements: triggerOptions,
+    filterBy: { operators: ['isAny', 'isNone'] },
+    getValue: () => '',
+    render: () => null,
+  },
+  {
+    id: 'activity',
+    label: __('Activity', 'mailpoet'),
+    enableGlobalSearch: false,
+    enableSorting: false,
+    elements: [
+      { value: 'has', label: __('Has subscribers entered', 'mailpoet') },
+      { value: 'none', label: __('No subscribers entered', 'mailpoet') },
+    ],
+    filterBy: { operators: ['is'] },
+    getValue: () => '',
+    render: () => null,
+  },
+  {
+    id: 'created_at',
+    label: __('Created on', 'mailpoet'),
+    type: 'datetime',
+    enableGlobalSearch: false,
+    enableSorting: true,
+    filterBy: { operators: ['before', 'after', 'between'] },
+    render: ({ item }) => dateTime(item.created_at),
+  },
+  {
+    id: 'updated_at',
+    label: __('Modified on', 'mailpoet'),
+    type: 'datetime',
+    enableGlobalSearch: false,
+    enableSorting: true,
+    filterBy: { operators: ['before', 'after', 'between'] },
+    render: ({ item }) => dateTime(item.updated_at),
   },
 ];

--- a/mailpoet/assets/js/src/automation/listing/filters.ts
+++ b/mailpoet/assets/js/src/automation/listing/filters.ts
@@ -1,0 +1,58 @@
+import type { View } from '@wordpress/dataviews';
+
+type FilterParam = Record<string, unknown>;
+
+function isEmpty(value: unknown): boolean {
+  if (value === undefined || value === null || value === '') return true;
+  return Array.isArray(value) && value.length === 0;
+}
+
+/**
+ * Translate a single date filter into the endpoint's `created_*` / `updated_*`
+ * bounds. DataViews date filters carry an operator (`before` / `after` /
+ * `between`) alongside the value; `between` stores a `[from, to]` tuple.
+ */
+function dateFilterParams(
+  field: 'created_at' | 'updated_at',
+  operator: string | undefined,
+  value: unknown,
+): FilterParam {
+  const prefix = field === 'created_at' ? 'created' : 'updated';
+  const params: FilterParam = {};
+
+  if (operator === 'between' && Array.isArray(value)) {
+    const [from, to] = value;
+    if (!isEmpty(from)) params[`${prefix}_after`] = from;
+    if (!isEmpty(to)) params[`${prefix}_before`] = to;
+    return params;
+  }
+  if (operator === 'after' || operator === 'afterInc') {
+    params[`${prefix}_after`] = value;
+    return params;
+  }
+  if (operator === 'before' || operator === 'beforeInc') {
+    params[`${prefix}_before`] = value;
+  }
+  return params;
+}
+
+/**
+ * Serialize DataViews filter state into the `filter[field]=value` shape the
+ * automations REST endpoint expects. Status is intentionally omitted — it is
+ * driven by the listing tabs, not a native filter. Empty filters are dropped so
+ * an inactive filter never reaches the request.
+ */
+export function filtersToParam(
+  filters: View['filters'],
+): Record<string, unknown> {
+  return (filters ?? []).reduce<FilterParam>((result, filter) => {
+    const { field, operator, value } = filter;
+    if (isEmpty(value)) return result;
+
+    if (field === 'created_at' || field === 'updated_at') {
+      return { ...result, ...dateFilterParams(field, operator, value) };
+    }
+
+    return { ...result, [field]: value };
+  }, {});
+}

--- a/mailpoet/assets/js/src/automation/listing/index.tsx
+++ b/mailpoet/assets/js/src/automation/listing/index.tsx
@@ -1,14 +1,12 @@
 import {
   __experimentalConfirmDialog as ConfirmDialog,
+  Notice,
   TabPanel,
 } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
-import {
-  DataViews,
-  filterSortAndPaginate,
-  View,
-  Action,
-} from '@wordpress/dataviews';
+import { DataViews, View, Action } from '@wordpress/dataviews';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -16,14 +14,17 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import {
   getDataViewsPreference,
   usePersistedDataViewsPreference,
+  useDataViewsQuery,
+  type ListingQueryParams,
+  type ListingResponse,
 } from 'common/dataviews';
 import { storeName } from './store/constants';
 import type { AutomationItem } from './store/types';
 import { AutomationStatus } from './automation';
-import { automationCount, legacyAutomationCount } from '../config';
 import { MailPoet } from '../../mailpoet';
 import { PageHeader } from '../../common/page-header';
 import { automationFields } from './fields';
+import { filtersToParam } from './filters';
 import { getAutomationAnalyticsUrl, getAutomationEditorUrl } from './urls';
 
 type Group =
@@ -110,9 +111,58 @@ function viewMatchesSearch(
   );
 }
 
-function formatTabTitle(label: string, count: number): string {
-  return count > 0 ? `${label} (${count})` : label;
+function formatTabTitle(label: string, count: number | null): string {
+  return count !== null && count > 0 ? `${label} (${count})` : label;
 }
+
+// Map the active listing tab to the status set sent to the endpoint. The "all"
+// tab shows every non-trashed automation, matching the previous UI.
+function statusParamForGroup(group?: string): string[] {
+  if (!group || group === 'all') {
+    return [
+      AutomationStatus.ACTIVE,
+      AutomationStatus.DRAFT,
+      AutomationStatus.DEACTIVATING,
+    ];
+  }
+  return [group];
+}
+
+// The "subscribers" column sorts by how many subscribers entered, which the
+// endpoint exposes as the synthetic `entered` order-by field.
+function mapSortField(field?: string): string | undefined {
+  return field === 'subscribers' ? 'entered' : field;
+}
+
+function legacyMatchesGroup(item: AutomationItem, group: Group): boolean {
+  if (group === 'all') return item.status !== AutomationStatus.TRASH;
+  return item.status === group;
+}
+
+// Server-side loader for the real automations. Legacy automations are not
+// served here — they are overlaid client-side in the default view only.
+const loadAutomationsListing = async (
+  params: ListingQueryParams,
+  signal?: AbortSignal,
+): Promise<ListingResponse<AutomationItem>> => {
+  const orderby = mapSortField(params.orderby);
+  const query: Record<string, unknown> = {
+    page: params.page,
+    per_page: params.per_page,
+    order: params.order,
+    status: statusParamForGroup(params.group),
+  };
+  if (params.search) query.search = params.search;
+  if (orderby) query.orderby = orderby;
+  if (params.filter) query.filter = params.filter;
+
+  const response = await apiFetch<{ data: ListingResponse<AutomationItem> }>({
+    path: addQueryArgs('/automations', query),
+    method: 'GET',
+    signal,
+  });
+  return response.data;
+};
 
 function getActionCopy(pendingAction: PendingAction): {
   title: string;
@@ -258,19 +308,14 @@ export function AutomationListing(): JSX.Element {
   const [group, setGroup] = useState<Group>(() =>
     getGroupFromSearch(new URLSearchParams(location.search)),
   );
-  const [view, setView] = useState<View>(() =>
-    getViewFromSearch(new URLSearchParams(location.search), defaultView),
-  );
   const [selection, setSelection] = useState<string[]>([]);
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
-  const latestGroupRef = useRef(group);
-  const latestViewRef = useRef(view);
 
-  const automations = useSelect((select) =>
-    select(storeName).getAllAutomations(),
+  const legacyAutomations = useSelect(
+    (select) => select(storeName).getLegacyAutomations(),
+    [],
   );
   const {
-    loadAutomations,
     loadLegacyAutomations,
     restoreAutomation,
     restoreLegacyAutomation,
@@ -281,42 +326,50 @@ export function AutomationListing(): JSX.Element {
     deleteLegacyAutomation,
   } = useDispatch(storeName);
 
-  useEffect(() => {
-    void loadAutomations();
-    void loadLegacyAutomations();
-  }, [loadAutomations, loadLegacyAutomations]);
+  const [initialView] = useState<View>(() =>
+    getViewFromSearch(new URLSearchParams(location.search), defaultView),
+  );
 
+  const groupRef = useRef(group);
+  groupRef.current = group;
+  const extraParams = useCallback(
+    (currentView: View): Partial<ListingQueryParams> => {
+      const filter = filtersToParam(currentView.filters);
+      return {
+        group: groupRef.current,
+        ...(Object.keys(filter).length > 0 ? { filter } : {}),
+      };
+    },
+    [],
+  );
+
+  const {
+    view,
+    setView,
+    onChangeView,
+    items,
+    meta,
+    groups,
+    isLoading,
+    error: loadError,
+    refresh,
+    clearError,
+  } = useDataViewsQuery<AutomationItem>({
+    initialView,
+    load: loadAutomationsListing,
+    extraParams,
+  });
+
+  const latestGroupRef = useRef(group);
+  const latestViewRef = useRef(view);
   useEffect(() => {
     latestGroupRef.current = group;
     latestViewRef.current = view;
   }, [group, view]);
 
   useEffect(() => {
-    const nextSearch = new URLSearchParams(location.search);
-    const nextGroup = getGroupFromSearch(nextSearch);
-    // Resolve omitted URL params against the current preference-merged
-    // defaults so browser navigation restores the view the URL was written
-    // against.
-    const currentDefaultView = getDataViewsPreference(
-      'automation',
-      DEFAULT_VIEW,
-      automationFields,
-    );
-    let selectionShouldBeCleared = false;
-    if (nextGroup !== latestGroupRef.current) {
-      setGroup(nextGroup);
-      selectionShouldBeCleared = true;
-    }
-    if (
-      !viewMatchesSearch(latestViewRef.current, nextSearch, currentDefaultView)
-    ) {
-      setView(getViewFromSearch(nextSearch, currentDefaultView));
-      selectionShouldBeCleared = true;
-    }
-    if (selectionShouldBeCleared) {
-      setSelection([]);
-    }
-  }, [location.search]);
+    void loadLegacyAutomations();
+  }, [loadLegacyAutomations]);
 
   const updateUrlSearchString = useCallback(
     (nextGroup: Group, nextView: View) => {
@@ -328,9 +381,6 @@ export function AutomationListing(): JSX.Element {
       } else {
         newSearch.delete('paged');
       }
-      // Compare against the preference-merged default, resolved at write time
-      // (not the hardcoded one, not a mount-time snapshot), so reloading a
-      // URL without `per_page` resolves to the same view it was written from.
       const defaultPerPage =
         getDataViewsPreference('automation', DEFAULT_VIEW, automationFields)
           .perPage ?? DEFAULT_PER_PAGE;
@@ -363,13 +413,39 @@ export function AutomationListing(): JSX.Element {
     [location.search, navigate],
   );
 
+  // Sync external URL changes (browser back/forward, ?status= deep-links) back
+  // into the listing state.
+  useEffect(() => {
+    const nextSearch = new URLSearchParams(location.search);
+    const nextGroup = getGroupFromSearch(nextSearch);
+    const currentDefaultView = getDataViewsPreference(
+      'automation',
+      DEFAULT_VIEW,
+      automationFields,
+    );
+    let selectionShouldBeCleared = false;
+    if (nextGroup !== latestGroupRef.current) {
+      setGroup(nextGroup);
+      selectionShouldBeCleared = true;
+    }
+    if (
+      !viewMatchesSearch(latestViewRef.current, nextSearch, currentDefaultView)
+    ) {
+      setView(getViewFromSearch(nextSearch, currentDefaultView));
+      selectionShouldBeCleared = true;
+    }
+    if (selectionShouldBeCleared) {
+      setSelection([]);
+    }
+  }, [location.search, setView]);
+
   const handleViewChange = useCallback(
     (nextView: View) => {
       setSelection([]);
-      setView(nextView);
+      onChangeView(nextView);
       updateUrlSearchString(group, nextView);
     },
-    [group, updateUrlSearchString],
+    [group, onChangeView, updateUrlSearchString],
   );
   const persistedViewChange = usePersistedDataViewsPreference(
     'automation',
@@ -389,64 +465,64 @@ export function AutomationListing(): JSX.Element {
     updateUrlSearchString(nextGroup, nextView);
   };
 
-  const groupedAutomations = useMemo<Record<Group, AutomationItem[]>>(() => {
-    const grouped: Record<Group, AutomationItem[]> = {
-      all: [],
-      [AutomationStatus.ACTIVE]: [],
-      [AutomationStatus.DRAFT]: [],
-      [AutomationStatus.TRASH]: [],
+  // Legacy automations are only shown while browsing the default view (no
+  // filter / search / sort). Any active filter, search, or sort switches to the
+  // server-filtered real automations only.
+  const isDefaultView = useMemo(
+    () => !view.search && !view.sort && (view.filters?.length ?? 0) === 0,
+    [view.search, view.sort, view.filters],
+  );
+
+  const legacyForDisplay = useMemo(() => {
+    if (!isDefaultView || (view.page ?? 1) !== 1) return [];
+    return (legacyAutomations ?? []).filter((item) =>
+      legacyMatchesGroup(item, group),
+    );
+  }, [isDefaultView, view.page, legacyAutomations, group]);
+
+  const data = useMemo(
+    () => [...items, ...legacyForDisplay],
+    [items, legacyForDisplay],
+  );
+
+  const paginationInfo = useMemo(
+    () => ({ totalItems: meta.count, totalPages: meta.pages }),
+    [meta],
+  );
+
+  const tabs = useMemo(() => {
+    const realCounts: Record<Group, number | null> = {
+      all: null,
+      [AutomationStatus.ACTIVE]: null,
+      [AutomationStatus.DRAFT]: null,
+      [AutomationStatus.TRASH]: null,
     };
-    (automations ?? []).forEach((automation) => {
-      if (automation.status in grouped) {
-        grouped[automation.status as Group].push(automation);
-      }
-      if (automation.status !== AutomationStatus.TRASH) {
-        grouped.all.push(automation);
+    (groups ?? []).forEach((entry) => {
+      if (entry.name in realCounts) {
+        realCounts[entry.name as Group] = entry.count;
       }
     });
-    return grouped;
-  }, [automations]);
-
-  const totalCount = automationCount + legacyAutomationCount;
-  const { data, paginationInfo } = useMemo(() => {
-    if (!automations) {
-      return {
-        data: [],
-        paginationInfo: {
-          totalItems: totalCount,
-          totalPages: Math.ceil(
-            totalCount / (view.perPage ?? DEFAULT_PER_PAGE),
-          ),
-        },
-      };
-    }
-    const filteredAutomations = groupedAutomations[group] ?? [];
-    return filterSortAndPaginate(filteredAutomations, view, automationFields);
-  }, [automations, group, groupedAutomations, totalCount, view]);
-
-  useEffect(() => {
-    const currentPage = view.page ?? 1;
-    const lastPage = paginationInfo.totalPages;
-    if (automations && lastPage > 0 && currentPage > lastPage) {
-      handleViewChange({ ...view, page: lastPage });
-    }
-  }, [automations, handleViewChange, paginationInfo.totalPages, view]);
-
-  const tabs = useMemo(
-    () => [
+    const total = (name: Group): number | null => {
+      const realCount = realCounts[name];
+      if (realCount === null) return null;
+      const legacy = isDefaultView
+        ? (legacyAutomations ?? []).filter((item) =>
+            legacyMatchesGroup(item, name),
+          ).length
+        : 0;
+      return realCount + legacy;
+    };
+    return [
       {
         name: 'all',
-        title: formatTabTitle(
-          __('All', 'mailpoet'),
-          groupedAutomations.all.length,
-        ),
+        title: formatTabTitle(__('All', 'mailpoet'), total('all')),
         className: 'mailpoet-dataviews-group-all mailpoet-tab-all',
       },
       {
         name: AutomationStatus.ACTIVE,
         title: formatTabTitle(
           __('Active', 'mailpoet'),
-          groupedAutomations[AutomationStatus.ACTIVE].length,
+          total(AutomationStatus.ACTIVE),
         ),
         className: 'mailpoet-tab-active',
       },
@@ -454,7 +530,7 @@ export function AutomationListing(): JSX.Element {
         name: AutomationStatus.DRAFT,
         title: formatTabTitle(
           _x('Inactive', 'noun', 'mailpoet'),
-          groupedAutomations[AutomationStatus.DRAFT].length,
+          total(AutomationStatus.DRAFT),
         ),
         className: 'mailpoet-tab-draft',
       },
@@ -462,13 +538,12 @@ export function AutomationListing(): JSX.Element {
         name: AutomationStatus.TRASH,
         title: formatTabTitle(
           _x('Trash', 'noun', 'mailpoet'),
-          groupedAutomations[AutomationStatus.TRASH].length,
+          total(AutomationStatus.TRASH),
         ),
         className: 'mailpoet-dataviews-group-trash mailpoet-tab-trash',
       },
-    ],
-    [groupedAutomations],
-  );
+    ];
+  }, [groups, isDefaultView, legacyAutomations]);
 
   const runAutomationAction = useCallback(
     async (
@@ -522,11 +597,15 @@ export function AutomationListing(): JSX.Element {
       }
 
       setSelection([]);
+      refresh();
+      void loadLegacyAutomations();
     },
     [
       deleteAutomation,
       deleteLegacyAutomation,
       duplicateAutomation,
+      loadLegacyAutomations,
+      refresh,
       restoreAutomation,
       restoreLegacyAutomation,
       trashAutomation,
@@ -618,9 +697,16 @@ export function AutomationListing(): JSX.Element {
       ? __('Trash is empty.', 'mailpoet')
       : __('No automations found.', 'mailpoet');
   const actionCopy = getActionCopy(pendingAction);
+  const listingIsLoading =
+    isLoading || (isDefaultView && legacyAutomations === undefined);
 
   return (
     <>
+      {loadError && (
+        <Notice status="error" onRemove={clearError}>
+          {loadError}
+        </Notice>
+      )}
       <TabPanel
         key={group}
         className="mailpoet-dataviews__tabs"
@@ -648,17 +734,19 @@ export function AutomationListing(): JSX.Element {
               }
               selection={selection}
               onChangeSelection={setSelection}
-              isLoading={!automations}
+              isLoading={listingIsLoading}
               empty={<div>{emptyLabel}</div>}
             >
               <div className="mailpoet-dataviews__toolbar">
                 <DataViews.Search
                   label={__('Search automations', 'mailpoet')}
                 />
+                <DataViews.FiltersToggle />
                 <div className="mailpoet-dataviews__toolbar-end">
                   <DataViews.ViewConfig />
                 </div>
               </div>
+              <DataViews.Filters />
               <DataViews.Layout />
               <DataViews.Footer />
             </DataViews>

--- a/mailpoet/assets/js/src/automation/listing/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/listing/store/reducer.ts
@@ -10,21 +10,22 @@ export function reducer(state: State, action): State {
     case 'ADD_AUTOMATION':
       return {
         ...state,
-        automations: [action.automation, ...state.automations],
+        automations: [action.automation, ...(state.automations ?? [])],
       };
     case 'UPDATE_AUTOMATION':
       return {
         ...state,
-        automations: state.automations.map((automation: AutomationItem) =>
-          automation.id === action.automation.id
-            ? action.automation
-            : automation,
+        automations: (state.automations ?? []).map(
+          (automation: AutomationItem) =>
+            automation.id === action.automation.id
+              ? action.automation
+              : automation,
         ),
       };
     case 'DELETE_AUTOMATION':
       return {
         ...state,
-        automations: state.automations.filter(
+        automations: (state.automations ?? []).filter(
           (automation: AutomationItem) =>
             automation.id !== action.automation.id,
         ),

--- a/mailpoet/changelog/2026-06-13-19-16-17-added-native-dataviews-filters-and-sorting-on-the-automa.md
+++ b/mailpoet/changelog/2026-06-13-19-16-17-added-native-dataviews-filters-and-sorting-on-the-automa.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Native DataViews filters and sorting on the automations listing for trigger, activity, and created or modified date

--- a/mailpoet/lib/AdminPages/Pages/Automation.php
+++ b/mailpoet/lib/AdminPages/Pages/Automation.php
@@ -91,6 +91,7 @@ class Automation {
         array_values($this->registry->getTemplateCategories())
       ),
       'registry' => $this->buildRegistry(),
+      'trigger_options' => $this->buildTriggerOptions(),
       'context' => $this->buildContext(),
       'segments' => $this->segmentsListRepository->getListWithSubscribedSubscribersCounts(),
       'roles' => $wp_roles->get_names() + ['mailpoet_all' => __('In any WordPress role', 'mailpoet')],
@@ -125,6 +126,24 @@ class Automation {
       'steps' => $steps,
       'subjects' => $subjects,
     ];
+  }
+
+  /**
+   * Filter options for the listing's "Trigger" filter: every trigger key
+   * actually used by an automation, mapped to its human-readable label.
+   *
+   * @return array<array{value: string, label: string}>
+   */
+  private function buildTriggerOptions(): array {
+    $options = [];
+    foreach ($this->automationStorage->getAllTriggerKeys() as $key) {
+      $trigger = $this->registry->getTrigger($key);
+      $options[] = [
+        'value' => $key,
+        'label' => $trigger ? $trigger->getName() : $key,
+      ];
+    }
+    return $options;
   }
 
   private function buildContext(): array {

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationsGetEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationsGetEndpoint.php
@@ -2,9 +2,12 @@
 
 namespace MailPoet\Automation\Engine\Endpoints\Automations;
 
+use DateTimeImmutable;
+use Exception;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Mappers\AutomationMapper;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Validator\Builder;
@@ -42,8 +45,32 @@ class AutomationsGetEndpoint extends Endpoint {
     $searchParam = $request->getParam('search');
     $search = is_string($searchParam) ? $searchParam : null;
 
-    $automations = $this->automationStorage->getAutomations($status, $orderBy, $order, $page, $perPage, $search);
-    $automationCount = $this->automationStorage->getAutomationCount($status, $search);
+    $filter = $this->parseFilter($request->getParam('filter'));
+
+    $automations = $this->automationStorage->getAutomations(
+      $status,
+      $orderBy,
+      $order,
+      $page,
+      $perPage,
+      $search,
+      $filter['triggerKeys'],
+      $filter['hasActivity'],
+      $filter['createdAfter'],
+      $filter['createdBefore'],
+      $filter['updatedAfter'],
+      $filter['updatedBefore']
+    );
+    $automationCount = $this->automationStorage->getAutomationCount(
+      $status,
+      $search,
+      $filter['triggerKeys'],
+      $filter['hasActivity'],
+      $filter['createdAfter'],
+      $filter['createdBefore'],
+      $filter['updatedAfter'],
+      $filter['updatedBefore']
+    );
 
     if ($automationCount === 0) {
       $pages = 0;
@@ -59,7 +86,80 @@ class AutomationsGetEndpoint extends Endpoint {
           'pages' => $pages,
           'count' => $automationCount,
         ],
+      'groups' => $this->buildGroups($search, $filter),
     ]);
+  }
+
+  /**
+   * Per-status counts for the listing tabs. Counts honor the active search and
+   * the trigger / activity / date filters, but not the status filter itself
+   * (each tab represents a status). "all" excludes the trash, matching the UI.
+   *
+   * @param array{triggerKeys: ?array, hasActivity: ?bool, createdAfter: ?DateTimeImmutable, createdBefore: ?DateTimeImmutable, updatedAfter: ?DateTimeImmutable, updatedBefore: ?DateTimeImmutable} $filter
+   * @return array<array{name: string, label: string, count: int}>
+   */
+  private function buildGroups(?string $search, array $filter): array {
+    $countFor = function (array $status) use ($search, $filter): int {
+      return $this->automationStorage->getAutomationCount(
+        $status,
+        $search,
+        $filter['triggerKeys'],
+        $filter['hasActivity'],
+        $filter['createdAfter'],
+        $filter['createdBefore'],
+        $filter['updatedAfter'],
+        $filter['updatedBefore']
+      );
+    };
+
+    return [
+      ['name' => 'all', 'label' => 'all', 'count' => $countFor([Automation::STATUS_ACTIVE, Automation::STATUS_DRAFT, Automation::STATUS_DEACTIVATING])],
+      ['name' => Automation::STATUS_ACTIVE, 'label' => Automation::STATUS_ACTIVE, 'count' => $countFor([Automation::STATUS_ACTIVE])],
+      ['name' => Automation::STATUS_DRAFT, 'label' => Automation::STATUS_DRAFT, 'count' => $countFor([Automation::STATUS_DRAFT])],
+      ['name' => Automation::STATUS_TRASH, 'label' => Automation::STATUS_TRASH, 'count' => $countFor([Automation::STATUS_TRASH])],
+    ];
+  }
+
+  /**
+   * Normalize the raw `filter` query param into typed storage arguments.
+   *
+   * @param mixed $rawFilter
+   * @return array{triggerKeys: ?array, hasActivity: ?bool, createdAfter: ?DateTimeImmutable, createdBefore: ?DateTimeImmutable, updatedAfter: ?DateTimeImmutable, updatedBefore: ?DateTimeImmutable}
+   */
+  private function parseFilter($rawFilter): array {
+    $filter = is_array($rawFilter) ? $rawFilter : [];
+
+    $triggerKeys = null;
+    if (isset($filter['trigger']) && is_array($filter['trigger']) && $filter['trigger'] !== []) {
+      $triggerKeys = array_values(array_filter($filter['trigger'], 'is_string'));
+      $triggerKeys = $triggerKeys === [] ? null : $triggerKeys;
+    }
+
+    $hasActivity = null;
+    if (isset($filter['activity']) && $filter['activity'] !== '') {
+      $hasActivity = in_array($filter['activity'], ['has', 'true', '1', true, 1], true);
+    }
+
+    return [
+      'triggerKeys' => $triggerKeys,
+      'hasActivity' => $hasActivity,
+      'createdAfter' => $this->parseDate($filter['created_after'] ?? null),
+      'createdBefore' => $this->parseDate($filter['created_before'] ?? null),
+      'updatedAfter' => $this->parseDate($filter['updated_after'] ?? null),
+      'updatedBefore' => $this->parseDate($filter['updated_before'] ?? null),
+    ];
+  }
+
+  /** @param mixed $value */
+  private function parseDate($value): ?DateTimeImmutable {
+    if (!is_string($value) || trim($value) === '') {
+      return null;
+    }
+    try {
+      return new DateTimeImmutable($value);
+    } catch (Exception $e) {
+      return null;
+    }
   }
 
   public static function getRequestSchema(): array {
@@ -70,6 +170,14 @@ class AutomationsGetEndpoint extends Endpoint {
       'page' => Builder::integer(),
       'per_page' => Builder::integer(),
       'search' => Builder::string(),
+      'filter' => Builder::object([
+        'trigger' => Builder::array(Builder::string()),
+        'activity' => Builder::string(),
+        'created_after' => Builder::string(),
+        'created_before' => Builder::string(),
+        'updated_after' => Builder::string(),
+        'updated_before' => Builder::string(),
+      ]),
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationStorage.php
@@ -159,7 +159,13 @@ class AutomationStorage {
     ?string $order = 'DESC',
     ?int $page = null,
     ?int $perPage = null,
-    ?string $search = null
+    ?string $search = null,
+    ?array $triggerKeys = null,
+    ?bool $hasActivity = null,
+    ?DateTimeImmutable $createdAfter = null,
+    ?DateTimeImmutable $createdBefore = null,
+    ?DateTimeImmutable $updatedAfter = null,
+    ?DateTimeImmutable $updatedBefore = null
   ): array {
     global $wpdb;
 
@@ -178,11 +184,27 @@ class AutomationStorage {
       $searchParams[] = '%' . $wpdb->esc_like($search) . '%';
     }
 
-    // Handle ordering
-    $validOrderByColumns = ['id', 'name', 'status', 'created_at', 'updated_at'];
-    $orderByColumn = $orderBy && in_array($orderBy, $validOrderByColumns, true) ? $orderBy : 'id';
+    // Trigger / activity / date filters are appended as self-contained,
+    // pre-prepared fragments so their placeholders don't have to be threaded
+    // through this query's positional argument list.
+    $extraFilter = $this->buildExtraFilterSql($triggerKeys, $hasActivity, $createdAfter, $createdBefore, $updatedAfter, $updatedBefore);
+
+    // Handle ordering. The synthetic `entered` column sorts by how many
+    // subscribers entered the automation, derived from the runs table.
+    $enteredJoin = '';
+    if ($orderBy === 'entered') {
+      $enteredJoin = $wpdb->prepare(
+        ' LEFT JOIN (SELECT automation_id, COUNT(*) AS entered_count FROM %i GROUP BY automation_id) AS rc ON rc.automation_id = a.id',
+        $this->runsTable
+      );
+      $orderColumnSql = 'COALESCE(rc.entered_count, 0)';
+    } else {
+      $validOrderByColumns = ['id', 'name', 'status', 'created_at', 'updated_at'];
+      $orderByColumn = $orderBy && in_array($orderBy, $validOrderByColumns, true) ? $orderBy : 'id';
+      $orderColumnSql = "a.{$orderByColumn}";
+    }
     $orderDirection = $order && strtoupper($order) === 'ASC' ? 'ASC' : 'DESC';
-    $orderClause = " ORDER BY a.{$orderByColumn} {$orderDirection}";
+    $orderClause = " ORDER BY {$orderColumnSql} {$orderDirection}";
 
     // Handle pagination
     $limitClause = '';
@@ -199,11 +221,13 @@ class AutomationStorage {
           SELECT a.*, v.id AS version_id, v.steps
           FROM %i AS a
           INNER JOIN %i as v ON (v.automation_id = a.id)
+          ' . $enteredJoin . /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The entered join is prepared. */ '
           WHERE v.id = (
             SELECT MAX(id) FROM %i WHERE automation_id = v.automation_id
           )
           ' . $statusFilter . /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The status filter uses placeholders. */ '
           ' . $searchFilter . /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The search filter uses placeholders. */ '
+          ' . $extraFilter . /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The extra filters are prepared. */ '
           ' . $orderClause . /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The order clause is sanitized. */ '
           ' . $limitClause, /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The limit clause is prepared. */
         array_merge(
@@ -222,6 +246,52 @@ class AutomationStorage {
       /** @var array $automationData - for PHPStan because it conflicts with expected callable(mixed): mixed)|null */
       return Automation::fromArray($automationData);
     }, (array)$data);
+  }
+
+  /**
+   * Build the self-contained, pre-prepared SQL fragment for the trigger /
+   * activity / date-range filters shared by getAutomations() and
+   * getAutomationCount(). Returns an empty string when no extra filter is set.
+   */
+  private function buildExtraFilterSql(
+    ?array $triggerKeys,
+    ?bool $hasActivity,
+    ?DateTimeImmutable $createdAfter,
+    ?DateTimeImmutable $createdBefore,
+    ?DateTimeImmutable $updatedAfter,
+    ?DateTimeImmutable $updatedBefore
+  ): string {
+    global $wpdb;
+    $sql = '';
+
+    if ($triggerKeys) {
+      $sql .= $wpdb->prepare(
+        // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- The number of replacements is dynamic.
+        ' AND a.id IN (SELECT automation_id FROM %i WHERE trigger_key IN (' . implode(',', array_fill(0, count($triggerKeys), '%s')) . '))',
+        array_merge([$this->triggersTable], $triggerKeys)
+      );
+    }
+
+    if ($hasActivity === true) {
+      $sql .= $wpdb->prepare(' AND a.id IN (SELECT DISTINCT automation_id FROM %i)', $this->runsTable);
+    } elseif ($hasActivity === false) {
+      $sql .= $wpdb->prepare(' AND a.id NOT IN (SELECT DISTINCT automation_id FROM %i)', $this->runsTable);
+    }
+
+    if ($createdAfter) {
+      $sql .= $wpdb->prepare(' AND a.created_at >= %s', $createdAfter->format('Y-m-d H:i:s'));
+    }
+    if ($createdBefore) {
+      $sql .= $wpdb->prepare(' AND a.created_at <= %s', $createdBefore->format('Y-m-d H:i:s'));
+    }
+    if ($updatedAfter) {
+      $sql .= $wpdb->prepare(' AND a.updated_at >= %s', $updatedAfter->format('Y-m-d H:i:s'));
+    }
+    if ($updatedBefore) {
+      $sql .= $wpdb->prepare(' AND a.updated_at <= %s', $updatedBefore->format('Y-m-d H:i:s'));
+    }
+
+    return $sql;
   }
 
   /** @return int[] */
@@ -259,7 +329,16 @@ class AutomationStorage {
     return array_map('intval', $result);
   }
 
-  public function getAutomationCount(?array $status = null, ?string $search = null): int {
+  public function getAutomationCount(
+    ?array $status = null,
+    ?string $search = null,
+    ?array $triggerKeys = null,
+    ?bool $hasActivity = null,
+    ?DateTimeImmutable $createdAfter = null,
+    ?DateTimeImmutable $createdBefore = null,
+    ?DateTimeImmutable $updatedAfter = null,
+    ?DateTimeImmutable $updatedBefore = null
+  ): int {
     global $wpdb;
 
     $statusFilter = '';
@@ -276,17 +355,28 @@ class AutomationStorage {
       $searchParams[] = '%' . $wpdb->esc_like($search) . '%';
     }
 
+    $extraFilter = $this->buildExtraFilterSql($triggerKeys, $hasActivity, $createdAfter, $createdBefore, $updatedAfter, $updatedBefore);
+
     return (int)$wpdb->get_var(
       $wpdb->prepare(
         'SELECT COUNT(*) FROM %i AS a WHERE 1=1'
         . $statusFilter /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The status filter uses placeholders. */
-        . $searchFilter, /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The search filter uses placeholders. */
+        . $searchFilter /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The search filter uses placeholders. */
+        . $extraFilter, /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The extra filters are prepared. */
         array_merge(
           [$this->automationsTable],
           $statusParams,
           $searchParams
         )
       )
+    );
+  }
+
+  /** @return string[] List of distinct trigger keys used across all automations. */
+  public function getAllTriggerKeys(): array {
+    global $wpdb;
+    return $wpdb->get_col(
+      $wpdb->prepare('SELECT DISTINCT trigger_key FROM %i ORDER BY trigger_key ASC', $this->triggersTable)
     );
   }
 

--- a/mailpoet/tests/acceptance/Automation/AutomationListingCest.php
+++ b/mailpoet/tests/acceptance/Automation/AutomationListingCest.php
@@ -220,6 +220,63 @@ class AutomationListingCest {
     $i->seeNoJSErrors();
   }
 
+  public function automationListingFiltersAndSorting(AcceptanceTester $i): void {
+    $i->wantTo('Filter and sort the automations listing');
+
+    $active = (new DataFactories\Automation())
+      ->withName('Aaa Active Automation')
+      ->withStatus(Automation::STATUS_ACTIVE)
+      ->create();
+    (new DataFactories\AutomationRun())
+      ->withAutomation($active)
+      ->withStatus(AutomationRun::STATUS_COMPLETE)
+      ->create();
+
+    (new DataFactories\Automation())
+      ->withName('Bbb Draft Automation')
+      ->create();
+
+    (new DataFactories\Automation())
+      ->withName('Ccc Active Automation')
+      ->withStatus(Automation::STATUS_ACTIVE)
+      ->create();
+
+    $i->login();
+
+    $i->wantTo('Land on the Active tab via the backwards-compatible ?status= deep link');
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-automation&status=active');
+    $i->waitForText('Aaa Active Automation', 20, '[data-automation-id="automation_listing"]');
+    $i->see('Ccc Active Automation', '[data-automation-id="automation_listing"]');
+    $i->dontSee('Bbb Draft Automation', '[data-automation-id="automation_listing"]');
+
+    $i->wantTo('Sort the listing by name ascending and descending');
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-automation&status=active&orderby=name&order=asc');
+    $i->waitForText('Aaa Active Automation', 20, '[data-automation-id="automation_listing"]');
+    $i->see('Aaa Active Automation', $this->getFirstRow());
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-automation&status=active&orderby=name&order=desc');
+    $i->waitForText('Ccc Active Automation', 20, '[data-automation-id="automation_listing"]');
+    $i->see('Ccc Active Automation', $this->getFirstRow());
+
+    $i->wantTo('Apply the native Activity filter to show only automations with entered subscribers');
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-automation&status=active');
+    $i->waitForText('Aaa Active Automation', 20, '[data-automation-id="automation_listing"]');
+    $i->click('.dataviews-filters__visibility-toggle');
+    $i->waitForElement('[aria-label="Add filter"]');
+    $i->click('[aria-label="Add filter"]');
+    $i->waitForText('Activity');
+    $i->click('//*[@role="menuitem"][contains(normalize-space(), "Activity")]');
+    $i->waitForText('Has subscribers entered');
+    $i->click('//*[@role="option"][contains(normalize-space(), "Has subscribers entered")]');
+    // The filter triggers a server refetch; wait for the non-matching row to drop.
+    $i->waitForElementNotVisible($this->getAutomationRow('Ccc Active Automation'), 20);
+    $i->see('Aaa Active Automation', '[data-automation-id="automation_listing"]');
+    $i->seeNoJSErrors();
+  }
+
+  private function getFirstRow(): string {
+    return '(//*[@data-automation-id="automation_listing"]//tbody//tr[contains(concat(" ", normalize-space(@class), " "), " dataviews-view-table__row ")])[1]';
+  }
+
   private function getAutomationRow(string $automationName): string {
     return sprintf(
       '//*[@data-automation-id="automation_listing"]//tr[contains(concat(" ", normalize-space(@class), " "), " dataviews-view-table__row ")][.//div[contains(concat(" ", normalize-space(@class), " "), " dataviews-title-field ")]//a[normalize-space()=%s]]',

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStorageTest.php
@@ -363,6 +363,154 @@ class AutomationStorageTest extends \MailPoetTest {
     verify($noResultsCount)->equals(0);
   }
 
+  public function testItCanFilterAutomationsByTriggerKey(): void {
+    $subscribesAutomation = $this->createAutomationWithTrigger('subscribes', SomeoneSubscribesTrigger::KEY);
+    $registersAutomation = $this->createAutomationWithTrigger('registers', UserRegistrationTrigger::KEY);
+    $this->createEmptyAutomation('no-trigger');
+
+    $bySubscribes = $this->testee->getAutomations(null, null, null, null, null, null, [SomeoneSubscribesTrigger::KEY]);
+    verify($bySubscribes)->arrayCount(1);
+    verify($bySubscribes[0]->getId())->equals($subscribesAutomation->getId());
+
+    $byEither = $this->testee->getAutomations(null, null, null, null, null, null, [SomeoneSubscribesTrigger::KEY, UserRegistrationTrigger::KEY]);
+    verify($byEither)->arrayCount(2);
+
+    verify($this->testee->getAutomationCount(null, null, [SomeoneSubscribesTrigger::KEY]))->equals(1);
+    verify($this->testee->getAutomationCount(null, null, ['nonexistent-key']))->equals(0);
+  }
+
+  public function testItCanFilterAutomationsByActivity(): void {
+    $withActivity = $this->createEmptyAutomation('with-activity');
+    $this->createRunFor($withActivity);
+    $withoutActivity = $this->createEmptyAutomation('without-activity');
+
+    $active = $this->testee->getAutomations(null, null, null, null, null, null, null, true);
+    verify($active)->arrayCount(1);
+    verify($active[0]->getId())->equals($withActivity->getId());
+
+    $inactive = $this->testee->getAutomations(null, null, null, null, null, null, null, false);
+    verify($inactive)->arrayCount(1);
+    verify($inactive[0]->getId())->equals($withoutActivity->getId());
+
+    verify($this->testee->getAutomationCount(null, null, null, true))->equals(1);
+    verify($this->testee->getAutomationCount(null, null, null, false))->equals(1);
+  }
+
+  public function testItCanFilterAutomationsByCreatedDate(): void {
+    $this->createEmptyAutomation('first');
+    $this->createEmptyAutomation('second');
+
+    $yesterday = new \DateTimeImmutable('-1 day');
+    $tomorrow = new \DateTimeImmutable('+1 day');
+
+    // Everything was created now, so a lower bound in the past matches all.
+    verify($this->testee->getAutomations(null, null, null, null, null, null, null, null, $yesterday))->arrayCount(2);
+    // A lower bound in the future excludes everything.
+    verify($this->testee->getAutomations(null, null, null, null, null, null, null, null, $tomorrow))->arrayCount(0);
+    // An upper bound in the future matches all.
+    verify($this->testee->getAutomations(null, null, null, null, null, null, null, null, null, $tomorrow))->arrayCount(2);
+    // An upper bound in the past excludes everything.
+    verify($this->testee->getAutomations(null, null, null, null, null, null, null, null, null, $yesterday))->arrayCount(0);
+
+    verify($this->testee->getAutomationCount(null, null, null, null, $yesterday))->equals(2);
+    verify($this->testee->getAutomationCount(null, null, null, null, $tomorrow))->equals(0);
+  }
+
+  public function testItCanFilterAutomationsByUpdatedDate(): void {
+    $this->createEmptyAutomation('first');
+    $this->createEmptyAutomation('second');
+
+    $yesterday = new \DateTimeImmutable('-1 day');
+    $tomorrow = new \DateTimeImmutable('+1 day');
+
+    verify($this->testee->getAutomations(null, null, null, null, null, null, null, null, null, null, $yesterday))->arrayCount(2);
+    verify($this->testee->getAutomations(null, null, null, null, null, null, null, null, null, null, $tomorrow))->arrayCount(0);
+    verify($this->testee->getAutomations(null, null, null, null, null, null, null, null, null, null, null, $tomorrow))->arrayCount(2);
+    verify($this->testee->getAutomations(null, null, null, null, null, null, null, null, null, null, null, $yesterday))->arrayCount(0);
+  }
+
+  public function testItCanOrderAutomationsByEnteredCount(): void {
+    $none = $this->createEmptyAutomation('none');
+    $one = $this->createEmptyAutomation('one');
+    $two = $this->createEmptyAutomation('two');
+    $this->createRunFor($one);
+    $this->createRunFor($two);
+    $this->createRunFor($two);
+
+    $desc = $this->testee->getAutomations(null, 'entered', 'DESC');
+    verify($desc[0]->getId())->equals($two->getId());
+    verify($desc[1]->getId())->equals($one->getId());
+    verify($desc[2]->getId())->equals($none->getId());
+
+    $asc = $this->testee->getAutomations(null, 'entered', 'ASC');
+    verify($asc[0]->getId())->equals($none->getId());
+    verify($asc[2]->getId())->equals($two->getId());
+  }
+
+  public function testItCombinesFiltersWhenCounting(): void {
+    $matching = $this->createAutomationWithTrigger('matching', SomeoneSubscribesTrigger::KEY);
+    $matching->setStatus(Automation::STATUS_ACTIVE);
+    $this->testee->updateAutomation($matching);
+    $this->createRunFor($matching);
+
+    $otherTrigger = $this->createAutomationWithTrigger('other', UserRegistrationTrigger::KEY);
+    $otherTrigger->setStatus(Automation::STATUS_ACTIVE);
+    $this->testee->updateAutomation($otherTrigger);
+
+    // Active + subscribes trigger + has activity => only the matching one.
+    $combined = $this->testee->getAutomationCount(
+      [Automation::STATUS_ACTIVE],
+      null,
+      [SomeoneSubscribesTrigger::KEY],
+      true
+    );
+    verify($combined)->equals(1);
+
+    // Same filters but requiring no activity yields nothing.
+    $empty = $this->testee->getAutomationCount(
+      [Automation::STATUS_ACTIVE],
+      null,
+      [SomeoneSubscribesTrigger::KEY],
+      false
+    );
+    verify($empty)->equals(0);
+  }
+
+  public function testItReturnsDistinctTriggerKeys(): void {
+    $this->createAutomationWithTrigger('a', SomeoneSubscribesTrigger::KEY);
+    $this->createAutomationWithTrigger('b', SomeoneSubscribesTrigger::KEY);
+    $this->createAutomationWithTrigger('c', UserRegistrationTrigger::KEY);
+
+    $keys = $this->testee->getAllTriggerKeys();
+    sort($keys);
+    $expected = [SomeoneSubscribesTrigger::KEY, UserRegistrationTrigger::KEY];
+    sort($expected);
+    verify($keys)->equals($expected);
+  }
+
+  private function createAutomationWithTrigger(string $name, string $triggerKey): Automation {
+    $automation = $this->createEmptyAutomation($name);
+    $trigger = new Step('trigger-id', Step::TYPE_TRIGGER, $triggerKey, [], []);
+    $automation->setSteps(['trigger-id' => $trigger]);
+    $this->testee->updateAutomation($automation);
+    $stored = $this->testee->getAutomation($automation->getId());
+    if (!$stored) {
+      throw new \RuntimeException("Automation not stored.");
+    }
+    return $stored;
+  }
+
+  private function createRunFor(Automation $automation): void {
+    $runStorage = $this->diContainer->get(AutomationRunStorage::class);
+    $run = new AutomationRun(
+      $automation->getId(),
+      $automation->getVersionId(),
+      'trigger-id',
+      []
+    );
+    $runStorage->createAutomationRun($run);
+  }
+
   private function createEmptyAutomation(string $name = "test"): Automation {
     $automation = new Automation($name, [], new \WP_User());
     $automationId = $this->testee->createAutomation($automation);

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsGetTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsGetTest.php
@@ -5,7 +5,9 @@ namespace MailPoet\REST\Automation\Automations;
 require_once __DIR__ . '/../AutomationTest.php';
 
 use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\REST\Automation\AutomationTest;
 
@@ -61,6 +63,12 @@ class AutomationsGetTest extends AutomationTest {
         'meta' => [
           'pages' => 0,
           'count' => 0,
+        ],
+        'groups' => [
+          ['name' => 'all', 'label' => 'all', 'count' => 0],
+          ['name' => Automation::STATUS_ACTIVE, 'label' => Automation::STATUS_ACTIVE, 'count' => 0],
+          ['name' => Automation::STATUS_DRAFT, 'label' => Automation::STATUS_DRAFT, 'count' => 0],
+          ['name' => Automation::STATUS_TRASH, 'label' => Automation::STATUS_TRASH, 'count' => 0],
         ],
       ],
     ], $data);
@@ -219,6 +227,135 @@ class AutomationsGetTest extends AutomationTest {
     $this->assertEquals(1, $result['meta']['count']);
     $this->assertEquals('Active Welcome', $result['items'][0]['name']);
     $this->assertEquals(Automation::STATUS_ACTIVE, $result['items'][0]['status']);
+  }
+
+  public function testTriggerFilterWorks(): void {
+    $subscribesId = $this->createNewAutomation([
+      'name' => 'Subscribes',
+      'steps' => [['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'mailpoet:someone-subscribes']],
+    ]);
+    $this->createNewAutomation([
+      'name' => 'Registers',
+      'steps' => [['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'wordpress:user-registered']],
+    ]);
+
+    $result = $this->get(self::ENDPOINT_PATH, [
+      'query' => ['filter' => ['trigger' => ['mailpoet:someone-subscribes']]],
+    ])['data'];
+
+    $this->assertCount(1, $result['items']);
+    $this->assertEquals(1, $result['meta']['count']);
+    $this->assertEquals($subscribesId, $result['items'][0]['id']);
+  }
+
+  public function testActivityFilterWorks(): void {
+    $withActivity = $this->createNewAutomation(['name' => 'With activity']);
+    $this->createRunFor($withActivity);
+    $withoutActivity = $this->createNewAutomation(['name' => 'Without activity']);
+
+    $hasResult = $this->get(self::ENDPOINT_PATH, [
+      'query' => ['filter' => ['activity' => 'has']],
+    ])['data'];
+    $this->assertCount(1, $hasResult['items']);
+    $this->assertEquals($withActivity, $hasResult['items'][0]['id']);
+
+    $noneResult = $this->get(self::ENDPOINT_PATH, [
+      'query' => ['filter' => ['activity' => 'none']],
+    ])['data'];
+    $this->assertCount(1, $noneResult['items']);
+    $this->assertEquals($withoutActivity, $noneResult['items'][0]['id']);
+  }
+
+  public function testDateFilterWorks(): void {
+    $this->createNewAutomation(['name' => 'First']);
+    $this->createNewAutomation(['name' => 'Second']);
+
+    $yesterday = (new \DateTimeImmutable('-1 day'))->format(\DateTimeImmutable::W3C);
+    $tomorrow = (new \DateTimeImmutable('+1 day'))->format(\DateTimeImmutable::W3C);
+
+    // Created after yesterday matches all, after tomorrow matches none.
+    $afterYesterday = $this->get(self::ENDPOINT_PATH, ['query' => ['filter' => ['created_after' => $yesterday]]])['data'];
+    $this->assertEquals(2, $afterYesterday['meta']['count']);
+    $afterTomorrow = $this->get(self::ENDPOINT_PATH, ['query' => ['filter' => ['created_after' => $tomorrow]]])['data'];
+    $this->assertEquals(0, $afterTomorrow['meta']['count']);
+
+    // Created before tomorrow matches all, before yesterday matches none.
+    $beforeTomorrow = $this->get(self::ENDPOINT_PATH, ['query' => ['filter' => ['created_before' => $tomorrow]]])['data'];
+    $this->assertEquals(2, $beforeTomorrow['meta']['count']);
+    $beforeYesterday = $this->get(self::ENDPOINT_PATH, ['query' => ['filter' => ['created_before' => $yesterday]]])['data'];
+    $this->assertEquals(0, $beforeYesterday['meta']['count']);
+  }
+
+  public function testEnteredSortWorks(): void {
+    $none = $this->createNewAutomation(['name' => 'None']);
+    $two = $this->createNewAutomation(['name' => 'Two']);
+    $this->createRunFor($two);
+    $this->createRunFor($two);
+    $one = $this->createNewAutomation(['name' => 'One']);
+    $this->createRunFor($one);
+
+    $desc = $this->get(self::ENDPOINT_PATH, ['query' => ['orderby' => 'entered', 'order' => 'DESC']])['data'];
+    $this->assertEquals($two, $desc['items'][0]['id']);
+    $this->assertEquals($one, $desc['items'][1]['id']);
+    $this->assertEquals($none, $desc['items'][2]['id']);
+
+    $asc = $this->get(self::ENDPOINT_PATH, ['query' => ['orderby' => 'entered', 'order' => 'ASC']])['data'];
+    $this->assertEquals($none, $asc['items'][0]['id']);
+    $this->assertEquals($two, $asc['items'][2]['id']);
+  }
+
+  public function testCombinedFilterAndStatusWork(): void {
+    $matchingId = $this->createNewAutomation([
+      'name' => 'Active subscribes',
+      'status' => Automation::STATUS_ACTIVE,
+      'steps' => [['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'mailpoet:someone-subscribes']],
+    ]);
+    $this->createRunFor($matchingId);
+    $this->createNewAutomation([
+      'name' => 'Draft subscribes',
+      'status' => Automation::STATUS_DRAFT,
+      'steps' => [['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'mailpoet:someone-subscribes']],
+    ]);
+
+    $result = $this->get(self::ENDPOINT_PATH, [
+      'query' => [
+        'status' => Automation::STATUS_ACTIVE,
+        'filter' => [
+          'trigger' => ['mailpoet:someone-subscribes'],
+          'activity' => 'has',
+        ],
+      ],
+    ])['data'];
+
+    $this->assertCount(1, $result['items']);
+    $this->assertEquals($matchingId, $result['items'][0]['id']);
+  }
+
+  public function testGroupsAreReturned(): void {
+    $this->createNewAutomation(['name' => 'Active', 'status' => Automation::STATUS_ACTIVE]);
+    $this->createNewAutomation(['name' => 'Draft', 'status' => Automation::STATUS_DRAFT]);
+    $this->createNewAutomation(['name' => 'Trashed', 'status' => Automation::STATUS_TRASH]);
+
+    $data = $this->get(self::ENDPOINT_PATH)['data'];
+    $this->assertArrayHasKey('groups', $data);
+
+    $counts = [];
+    foreach ($data['groups'] as $group) {
+      $counts[$group['name']] = $group['count'];
+    }
+    $this->assertEquals(2, $counts['all']); // active + draft, trash excluded
+    $this->assertEquals(1, $counts[Automation::STATUS_ACTIVE]);
+    $this->assertEquals(1, $counts[Automation::STATUS_DRAFT]);
+    $this->assertEquals(1, $counts[Automation::STATUS_TRASH]);
+  }
+
+  private function createRunFor(int $automationId): void {
+    $automation = $this->automationStorage->getAutomation($automationId);
+    $this->assertInstanceOf(Automation::class, $automation);
+    $runStorage = $this->diContainer->get(AutomationRunStorage::class);
+    $runStorage->createAutomationRun(
+      new AutomationRun($automationId, $automation->getVersionId(), 'trigger', [])
+    );
   }
 
   /**

--- a/mailpoet/tests/javascript/automation/listing/filters.spec.ts
+++ b/mailpoet/tests/javascript/automation/listing/filters.spec.ts
@@ -1,0 +1,95 @@
+import { filtersToParam } from '../../../../assets/js/src/automation/listing/filters';
+
+type Filter = {
+  field: string;
+  operator: string;
+  value: unknown;
+};
+
+const toParam = (filters: Filter[]) =>
+  filtersToParam(filters as never as Parameters<typeof filtersToParam>[0]);
+
+describe('automation listing filtersToParam', () => {
+  it('returns an empty object when there are no filters', () => {
+    expect(filtersToParam(undefined)).to.deep.equal({});
+    expect(toParam([])).to.deep.equal({});
+  });
+
+  it('drops filters with empty values', () => {
+    expect(
+      toParam([
+        { field: 'trigger', operator: 'isAny', value: [] },
+        { field: 'activity', operator: 'is', value: '' },
+      ]),
+    ).to.deep.equal({});
+  });
+
+  it('serializes the trigger multi-select filter', () => {
+    expect(
+      toParam([{ field: 'trigger', operator: 'isAny', value: ['a', 'b'] }]),
+    ).to.deep.equal({ trigger: ['a', 'b'] });
+  });
+
+  it('serializes the activity filter', () => {
+    expect(
+      toParam([{ field: 'activity', operator: 'is', value: 'has' }]),
+    ).to.deep.equal({ activity: 'has' });
+  });
+
+  it('maps created_at before/after operators to bounds', () => {
+    expect(
+      toParam([
+        { field: 'created_at', operator: 'before', value: '2026-01-01' },
+      ]),
+    ).to.deep.equal({ created_before: '2026-01-01' });
+    expect(
+      toParam([
+        { field: 'created_at', operator: 'after', value: '2026-01-01' },
+      ]),
+    ).to.deep.equal({ created_after: '2026-01-01' });
+  });
+
+  it('maps a created_at between range to both bounds', () => {
+    expect(
+      toParam([
+        {
+          field: 'created_at',
+          operator: 'between',
+          value: ['2026-01-01', '2026-02-01'],
+        },
+      ]),
+    ).to.deep.equal({
+      created_after: '2026-01-01',
+      created_before: '2026-02-01',
+    });
+  });
+
+  it('maps updated_at to its own bounds', () => {
+    expect(
+      toParam([
+        {
+          field: 'updated_at',
+          operator: 'between',
+          value: ['2026-01-01', '2026-02-01'],
+        },
+      ]),
+    ).to.deep.equal({
+      updated_after: '2026-01-01',
+      updated_before: '2026-02-01',
+    });
+  });
+
+  it('combines multiple filters', () => {
+    expect(
+      toParam([
+        { field: 'trigger', operator: 'isAny', value: ['x'] },
+        { field: 'activity', operator: 'is', value: 'none' },
+        { field: 'created_at', operator: 'after', value: '2026-01-01' },
+      ]),
+    ).to.deep.equal({
+      trigger: ['x'],
+      activity: 'none',
+      created_after: '2026-01-01',
+    });
+  });
+});

--- a/mailpoet/views/automation.html
+++ b/mailpoet/views/automation.html
@@ -11,6 +11,7 @@
   var mailpoet_automation_templates = <%= json_encode(templates) %>;
   var mailpoet_automation_template_categories = <%= json_encode(template_categories) %>;
   var mailpoet_automation_registry = <%= json_encode(registry) %>;
+  var mailpoet_automation_trigger_options = <%= json_encode(trigger_options) %>;
   var mailpoet_automation_context = <%= json_encode(context) %>;
   var mailpoet_segments = <%= json_encode(segments) %>;
   var mailpoet_roles = <%= json_encode(roles) %>;


### PR DESCRIPTION
## Description

Adds native DataViews filtering and sorting to the automations listing (STOMAIL-8171, part of STOMAIL-8166).

- **Filters:** trigger type (multi-select), activity (subscribers entered), created / modified date (before / after / between).
- **Sorting:** name, status, subscribers entered, created / modified date.
- **Server-side:** the `/automations` REST endpoint applies the new `filter[...]` params and `entered` order-by, and returns per-status group counts for the tabs. The listing now loads via `useDataViewsQuery`.

## Code review notes

- Automations are a merge of two heterogeneous sources: real automations (Automation Engine endpoint) and legacy automatic emails (newsletters endpoint). Only the former can be server-filtered, so legacy automatic emails are shown only in the default, unfiltered view and excluded once any filter / search / sort is active.
- The status tabs are kept (not migrated into a native filter) so the backwards-compatible `?status=` deep link and the trash workflow keep working.
- `entered` sort / activity filter add a runs-table subquery to the listing query — fine for a bounded admin listing; it is the heaviest part on installs with large run volume.
- Listing store reducer made null-safe: real automations no longer live in the store (they come from the query), so the bulk-action reducers must not assume `state.automations` is an array.

## QA notes

On the Automations listing: filter by trigger / activity / created or modified date, sort each column, and confirm `admin.php?page=mailpoet-automation&status=active` still lands on the Active tab filtered. Legacy automatic emails (WooCommerce) should appear in the default view and disappear when a filter is active.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8171

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed best practices for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8171-dataviews-native-filters-sorting-for-automations-listing)

_The latest successful build from `add/stomail-8171-dataviews-native-filters-sorting-for-automations-listing` will be used. If none is available, the link won't work._