### PR TITLE
Fix dark theme subscription page contrast

### DIFF
--- a/mailpoet/assets/css/src/components-public/_public.scss
+++ b/mailpoet/assets/css/src/components-public/_public.scss
@@ -580,7 +580,7 @@ h2.mailpoet-heading {
 
 .mailpoet-manage-subscription--modern {
   box-sizing: border-box;
-  color: #1f2933;
+  color: inherit;
   font-size: 16px;
   line-height: 1.5;
   margin: 0 auto;
@@ -605,7 +605,7 @@ h2.mailpoet-heading {
   }
 
   h2 {
-    color: #111827;
+    color: inherit;
     font-size: 24px;
     font-weight: 700;
     line-height: 1.25;
@@ -616,9 +616,8 @@ h2.mailpoet-heading {
   .mailpoet_field_description,
   .mailpoet-manage-subscription-lists-description,
   .mailpoet-manage-subscription-list-description,
-  .mailpoet-manage-subscription-no-lists,
   .mailpoet-change-email-info {
-    color: #52616f;
+    color: inherit;
     font-size: 15px;
     line-height: 1.5;
   }
@@ -643,7 +642,7 @@ h2.mailpoet-heading {
   .mailpoet_checkbox_label,
   .mailpoet_list_label,
   .mailpoet_date_label {
-    color: #111827;
+    color: inherit;
     font-size: 15px;
     font-weight: 700;
     line-height: 1.35;
@@ -680,6 +679,7 @@ h2.mailpoet-heading {
       background: #f6f8fa;
       border: 1px solid #d8dee4;
       border-radius: 6px;
+      color: #111827;
       display: block;
       font-weight: 600;
       margin-top: 6px;
@@ -700,7 +700,7 @@ h2.mailpoet-heading {
     padding: 0;
 
     > .mailpoet_segment_label {
-      color: #111827;
+      color: inherit;
       display: block;
       font-size: 24px;
       font-weight: 700;
@@ -728,7 +728,7 @@ h2.mailpoet-heading {
   }
 
   .mailpoet-manage-subscription-list-name {
-    color: #111827;
+    color: inherit;
     font-weight: 700;
     line-height: 1.4;
   }
@@ -796,6 +796,7 @@ h2.mailpoet-heading {
   .mailpoet-manage-subscription-no-lists {
     background: #f6f8fa;
     border-left: 4px solid #8c9aa8;
+    color: #52616f;
     margin: 8px 0 0;
     padding: 12px 14px;
   }

--- a/mailpoet/changelog/2026-06-14-12-53-40-fixed-modern-manage-subscription-page-text-contrast-on-d.md
+++ b/mailpoet/changelog/2026-06-14-12-53-40-fixed-modern-manage-subscription-page-text-contrast-on-d.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Modern Manage Subscription page text contrast on dark themes


### PR DESCRIPTION
## Description

Fixes Modern Manage Subscription page text contrast on dark theme backgrounds by inheriting theme text color for transparent form text while keeping explicit colors inside light controls and notices.

## Code review notes

_N/A_

## QA notes

1. Use dark theme
2. Go to **MailPoet > Settings > Basic** and click **Preview** on **Manage Subscription page** settings.
3. Verify, that the text is eligible.
4. Use light theme.
5. Verify the Manage subscription page still works. 

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8176

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

| Before | After | 
| ---- | ---- | 
|  <img width="728" height="1215" alt="Screenshot 2026-06-14 at 23 16 42" src="https://github.com/user-attachments/assets/cdeb53b9-b80d-4993-b814-2c124e89ef86" /> | <img width="745" height="1202" alt="Screenshot 2026-06-14 at 23 15 37" src="https://github.com/user-attachments/assets/b591ac23-ec8e-4926-9447-8dd137987f89" /> | 



## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8176-improve-modern-manage-subscription-page-contrast-on-dark)

_The latest successful build from `stomail-8176-improve-modern-manage-subscription-page-contrast-on-dark` will be used. If none is available, the link won't work._