### PR TITLE
Add automation email template content

### DIFF
--- a/mailpoet/changelog/2026-06-03-14-52-21-added-email-content-patterns-for-birthday-and-win-back-a.md
+++ b/mailpoet/changelog/2026-06-03-14-52-21-added-email-content-patterns-for-birthday-and-win-back-a.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Email content patterns for birthday and win-back automations

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -4,7 +4,6 @@ namespace MailPoet\Automation\Integrations\MailPoet\Templates;
 
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
-use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Templates\AutomationBuilder;
 use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
 use MailPoet\Config\Env;
@@ -58,7 +57,6 @@ class TemplatesFactory {
     if ($this->woocommerce->isWooCommerceActive()) {
       $templates[] = $this->createFirstPurchaseTemplate();
       $templates[] = $this->createThankLoyalCustomersTemplate();
-      $templates[] = $this->createWinBackCustomersTemplate();
       $templates[] = $this->createAbandonedCartTemplate();
       $templates[] = $this->createAbandonedCartCampaignTemplate();
       $templates[] = $this->createPurchasedProductTemplate();
@@ -360,103 +358,6 @@ class TemplatesFactory {
       },
       [
         'automationSteps' => 1, // trigger and all delay steps are excluded
-      ],
-      AutomationTemplate::TYPE_PREMIUM,
-      'people'
-    );
-  }
-
-  private function createWinBackCustomersTemplate(): AutomationTemplate {
-    return new AutomationTemplate(
-      'win-back-customers',
-      'purchase',
-      __('Win back customers', 'mailpoet'),
-      __(
-        'Rekindle the relationship with past customers by reminding them of their favorite products and showcasing what’s new, encouraging a return to your brand.',
-        'mailpoet'
-      ),
-      function (bool $preview = false): Automation {
-        $reminderEmailArgs = $this->createBlockEditorEmailArgs(
-          $preview,
-          'win-back-customer-reminder',
-          __('It’s been a while…', 'mailpoet'),
-          __('It’s been a while…', 'mailpoet'),
-          __('Products picked from their last order', 'mailpoet'),
-          'win-back-customers'
-        );
-        $finalNudgeEmailArgs = $this->createBlockEditorEmailArgs(
-          $preview,
-          'win-back-customer-final-nudge',
-          __('We’ve missed you', 'mailpoet'),
-          __('We’ve missed you', 'mailpoet'),
-          __('Recommended picks are waiting', 'mailpoet'),
-          'win-back-customers'
-        );
-
-        $automation = $this->builder->createFromSequence(
-          __('Win back customers', 'mailpoet'),
-          [
-            ['key' => 'woocommerce:order-completed'],
-            ['key' => 'core:delay', 'args' => ['delay' => 60, 'delay_type' => 'DAYS']],
-            [
-              'key' => 'core:if-else',
-              'filters' => [
-                'operator' => 'and',
-                'groups' => [
-                  [
-                    'operator' => 'and',
-                    'filters' => [
-                      [
-                        'field' => 'woocommerce:customer:order-count',
-                        'condition' => 'equals',
-                        'value' => 1,
-                        'params' => ['in_the_last' => ['number' => 60, 'unit' => 'days']],
-                      ],
-                    ],
-                  ],
-                ],
-              ],
-            ],
-            [
-              'key' => 'mailpoet:send-email',
-              'args' => $reminderEmailArgs,
-            ],
-            ['key' => 'core:delay', 'args' => ['delay' => 15, 'delay_type' => 'DAYS']],
-            [
-              'key' => 'core:if-else',
-              'filters' => [
-                'operator' => 'and',
-                'groups' => [
-                  [
-                    'operator' => 'and',
-                    'filters' => [
-                      [
-                        'field' => 'woocommerce:customer:order-count',
-                        'condition' => 'equals',
-                        'value' => 0,
-                        'params' => ['in_the_last' => ['number' => 15, 'unit' => 'days']],
-                      ],
-                    ],
-                  ],
-                ],
-              ],
-            ],
-            [
-              'key' => 'mailpoet:send-email',
-              'args' => $finalNudgeEmailArgs,
-            ],
-          ]
-        );
-
-        foreach ($automation->getSteps() as $step) {
-          if ($step->getKey() === 'core:if-else') {
-            $step->setNextSteps(array_merge($step->getNextSteps(), [new NextStep(null)]));
-          }
-        }
-        return $automation;
-      },
-      [
-        'automationSteps' => 4, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_PREMIUM,
       'people'

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -409,7 +409,7 @@ class TemplatesFactory {
                       [
                         'field' => 'woocommerce:customer:order-count',
                         'condition' => 'equals',
-                        'value' => 0,
+                        'value' => 1,
                         'params' => ['in_the_last' => ['number' => 60, 'unit' => 'days']],
                       ],
                     ],

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -12,6 +12,8 @@ use MailPoet\WooCommerce\WooCommerceBookings\Helper as WooCommerceBookingsHelper
 use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WooCommerceSubscriptions;
 
 class TemplatesFactory {
+  private const MIN_WOOCOMMERCE_VERSION_FOR_GENERATED_COUPON_BLOCK = '10.8.0';
+
   /** @var AutomationBuilder */
   private $builder;
 
@@ -91,18 +93,20 @@ class TemplatesFactory {
   }
 
   private function createBirthdayEmailTemplate(): AutomationTemplate {
+    $usesDiscountPattern = $this->woocommerce->isWooCommerceActive() && $this->supportsGeneratedCouponBlock();
+
     return new AutomationTemplate(
       'birthday-email',
       'celebrations',
       __('Birthday email', 'mailpoet'),
       __('Send a birthday email to your subscribers on their special day.', 'mailpoet'),
-      function (bool $preview = false): Automation {
+      function (bool $preview = false) use ($usesDiscountPattern): Automation {
         $emailArgs = $this->createBlockEditorEmailArgs(
           $preview,
-          'birthday-email-content',
-          __('Happy birthday!', 'mailpoet'),
-          __('Happy birthday!', 'mailpoet'),
-          __('A birthday note just for you', 'mailpoet'),
+          $usesDiscountPattern ? 'birthday-email-with-discount' : 'birthday-email-content',
+          $usesDiscountPattern ? __('A birthday treat from us', 'mailpoet') : __('Happy birthday!', 'mailpoet'),
+          $usesDiscountPattern ? __('A birthday treat from us', 'mailpoet') : __('Happy birthday!', 'mailpoet'),
+          $usesDiscountPattern ? __('Enjoy 10% off your next order', 'mailpoet') : __('Wishing you a wonderful day', 'mailpoet'),
           'birthday-email'
         );
 
@@ -888,6 +892,21 @@ class TemplatesFactory {
       AutomationTemplate::TYPE_PREMIUM,
       'calendar'
     );
+  }
+
+  private function supportsGeneratedCouponBlock(): bool {
+    $wooCommerceVersion = $this->woocommerceHelper->getWooCommerceVersion();
+    if (!$wooCommerceVersion) {
+      return false;
+    }
+
+    $numericVersionLength = strspn($wooCommerceVersion, '0123456789.');
+    $numericVersion = substr($wooCommerceVersion, 0, $numericVersionLength);
+    if ($numericVersion === '') {
+      return false;
+    }
+
+    return version_compare($numericVersion, self::MIN_WOOCOMMERCE_VERSION_FOR_GENERATED_COUPON_BLOCK, '>=');
   }
 
   /**

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -111,9 +111,6 @@ class TemplatesFactory {
           [
             ['key' => 'mailpoet:annual-date'],
             ['key' => 'mailpoet:send-email', 'args' => $emailArgs],
-          ],
-          [
-            'mailpoet:run-once-per-subscriber' => true,
           ]
         );
       },

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -4,6 +4,7 @@ namespace MailPoet\Automation\Integrations\MailPoet\Templates;
 
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
+use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Templates\AutomationBuilder;
 use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
 use MailPoet\Config\Env;
@@ -97,10 +98,25 @@ class TemplatesFactory {
       'celebrations',
       __('Birthday email', 'mailpoet'),
       __('Send a birthday email to your subscribers on their special day.', 'mailpoet'),
-      function (): Automation {
+      function (bool $preview = false): Automation {
+        $emailArgs = $this->createBlockEditorEmailArgs(
+          $preview,
+          'birthday-email-content',
+          __('Happy birthday!', 'mailpoet'),
+          __('Happy birthday!', 'mailpoet'),
+          __('A birthday note just for you', 'mailpoet'),
+          'birthday-email'
+        );
+
         return $this->builder->createFromSequence(
           __('Birthday email', 'mailpoet'),
-          []
+          [
+            ['key' => 'mailpoet:annual-date'],
+            ['key' => 'mailpoet:send-email', 'args' => $emailArgs],
+          ],
+          [
+            'mailpoet:run-once-per-subscriber' => true,
+          ]
         );
       },
       [
@@ -302,10 +318,44 @@ class TemplatesFactory {
         'These are your most important customers. Make them feel special by sending a thank you note for supporting your brand.',
         'mailpoet'
       ),
-      function (): Automation {
+      function (bool $preview = false): Automation {
+        $emailArgs = $this->createBlockEditorEmailArgs(
+          $preview,
+          'post-purchase-thank-you',
+          __('Thank you for your loyalty', 'mailpoet'),
+          __('Thank you for your loyalty', 'mailpoet'),
+          __('We appreciate your continued support', 'mailpoet'),
+          'thank-loyal-customers'
+        );
+
         return $this->builder->createFromSequence(
           __('Thank loyal customers', 'mailpoet'),
-          []
+          [
+            [
+              'key' => 'woocommerce:order-completed',
+              'filters' => [
+                'operator' => 'and',
+                'groups' => [
+                  [
+                    'operator' => 'and',
+                    'filters' => [
+                      [
+                        'field' => 'woocommerce:customer:order-count',
+                        'condition' => 'greater-than',
+                        'value' => 5,
+                        'params' => ['in_the_last' => ['number' => 365, 'unit' => 'days']],
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+            ['key' => 'core:delay', 'args' => ['delay' => 1, 'delay_type' => 'DAYS']],
+            [
+              'key' => 'mailpoet:send-email',
+              'args' => $emailArgs,
+            ],
+          ]
         );
       },
       [
@@ -325,11 +375,85 @@ class TemplatesFactory {
         'Rekindle the relationship with past customers by reminding them of their favorite products and showcasing what’s new, encouraging a return to your brand.',
         'mailpoet'
       ),
-      function (): Automation {
-        return $this->builder->createFromSequence(
-          __('Win back customers', 'mailpoet'),
-          []
+      function (bool $preview = false): Automation {
+        $reminderEmailArgs = $this->createBlockEditorEmailArgs(
+          $preview,
+          'win-back-customer-reminder',
+          __('It’s been a while…', 'mailpoet'),
+          __('It’s been a while…', 'mailpoet'),
+          __('Products picked from their last order', 'mailpoet'),
+          'win-back-customers'
         );
+        $finalNudgeEmailArgs = $this->createBlockEditorEmailArgs(
+          $preview,
+          'win-back-customer-final-nudge',
+          __('We’ve missed you', 'mailpoet'),
+          __('We’ve missed you', 'mailpoet'),
+          __('Recommended picks are waiting', 'mailpoet'),
+          'win-back-customers'
+        );
+
+        $automation = $this->builder->createFromSequence(
+          __('Win back customers', 'mailpoet'),
+          [
+            ['key' => 'woocommerce:order-completed'],
+            ['key' => 'core:delay', 'args' => ['delay' => 60, 'delay_type' => 'DAYS']],
+            [
+              'key' => 'core:if-else',
+              'filters' => [
+                'operator' => 'and',
+                'groups' => [
+                  [
+                    'operator' => 'and',
+                    'filters' => [
+                      [
+                        'field' => 'woocommerce:customer:order-count',
+                        'condition' => 'equals',
+                        'value' => 0,
+                        'params' => ['in_the_last' => ['number' => 60, 'unit' => 'days']],
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+            [
+              'key' => 'mailpoet:send-email',
+              'args' => $reminderEmailArgs,
+            ],
+            ['key' => 'core:delay', 'args' => ['delay' => 15, 'delay_type' => 'DAYS']],
+            [
+              'key' => 'core:if-else',
+              'filters' => [
+                'operator' => 'and',
+                'groups' => [
+                  [
+                    'operator' => 'and',
+                    'filters' => [
+                      [
+                        'field' => 'woocommerce:customer:order-count',
+                        'condition' => 'equals',
+                        'value' => 0,
+                        'params' => ['in_the_last' => ['number' => 15, 'unit' => 'days']],
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+            [
+              'key' => 'mailpoet:send-email',
+              'args' => $finalNudgeEmailArgs,
+            ],
+          ]
+        );
+
+        foreach ($automation->getSteps() as $step) {
+          if ($step->getKey() === 'core:if-else') {
+            $step->setNextSteps(array_merge($step->getNextSteps(), [new NextStep(null)]));
+          }
+        }
+        return $automation;
       },
       [
         'automationSteps' => 4, // trigger and all delay steps are excluded

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbandonedCartWithDiscountPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbandonedCartWithDiscountPattern.php
@@ -35,9 +35,7 @@ class AbandonedCartWithDiscountPattern extends AbstractAbandonedCartPattern {
       <p>' . __('Use this code at checkout to redeem your discount:', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
-      <!-- wp:woocommerce/coupon-code {"align":"left","source":"createNew","discountType":"percent","amount":10,"expiryDay":1} -->
-      <div class="wp-block-woocommerce-coupon-code alignleft"></div>
-      <!-- /wp:woocommerce/coupon-code -->
+      ' . $this->getGeneratedCouponBlock('left', 10, 1) . '
 
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
       <div class="wp-block-buttons">

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AskForReviewPostPurchasePattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AskForReviewPostPurchasePattern.php
@@ -157,9 +157,7 @@ class AskForReviewPostPurchasePattern extends Pattern {
       <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--20);font-size:16px">' . __('As a thank you, here’s a discount coupon for your next order:', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
-      <!-- wp:woocommerce/coupon-code {"align":"left","source":"createNew","discountType":"percent","amount":10,"expiryDay":10} -->
-      <div class="wp-block-woocommerce-coupon-code alignleft"></div>
-      <!-- /wp:woocommerce/coupon-code -->
+      ' . $this->getGeneratedCouponBlock('left', 10, 10) . '
 
       <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
       <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/BirthdayEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/BirthdayEmailPattern.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+use MailPoet\Util\CdnAssetUrl;
+
+/**
+ * Birthday email pattern.
+ */
+class BirthdayEmailPattern extends Pattern {
+  protected $name = 'birthday-email-content';
+  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $categories = ['celebrations'];
+  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+  /** @var bool */
+  private $withDiscount;
+
+  public function __construct(
+    CdnAssetUrl $cdnAssetUrl,
+    bool $withDiscount = false
+  ) {
+    parent::__construct($cdnAssetUrl);
+    $this->withDiscount = $withDiscount;
+
+    if ($withDiscount) {
+      $this->name = 'birthday-email-with-discount';
+    }
+  }
+
+  /**
+   * Get pattern content.
+   *
+   * @return string Pattern HTML content.
+   */
+  protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->withDiscount) {
+      return $this->getDiscountContent();
+    }
+
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"textAlign":"center","level":1} -->
+      <h1 class="wp-block-heading has-text-align-center">' . __('Happy birthday!', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p class="has-text-align-center" style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:18px">' . __('Wishing you a day filled with good things.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('We’re glad you’re part of our community. Here’s to another year of moments worth celebrating.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  private function getDiscountContent(): string {
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"textAlign":"center","level":1} -->
+      <h1 class="wp-block-heading has-text-align-center">' . __('Happy birthday - here’s 10% off', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p class="has-text-align-center" style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:18px">' . __('A little birthday treat for your next order.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|20"}}}} -->
+      <p style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--20);font-size:16px">' . __('We’re wishing you a wonderful day. Use this code for 10% off your next order:', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:woocommerce/coupon-code {"align":"center","source":"createNew","discountType":"percent","amount":10,"expiryDay":10} -->
+      <div class="wp-block-woocommerce-coupon-code aligncenter"></div>
+      <!-- /wp:woocommerce/coupon-code -->
+
+      <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|30"}}}} -->
+      <p class="has-text-align-center" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--30);font-size:14px">' . __('Valid for the next 10 days.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop birthday picks', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->withDiscount) {
+      /* translators: Name of a content pattern used as starting content of an email */
+      return __('Birthday Email with Discount', 'mailpoet');
+    }
+
+    /* translators: Name of a content pattern used as starting content of an email */
+    return __('Birthday Email', 'mailpoet');
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/BirthdayEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/BirthdayEmailPattern.php
@@ -76,9 +76,7 @@ class BirthdayEmailPattern extends Pattern {
       <p style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--20);font-size:16px">' . __('We’re wishing you a wonderful day. Use this code for 10% off your next order:', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
-      <!-- wp:woocommerce/coupon-code {"align":"center","source":"createNew","discountType":"percent","amount":10,"expiryDay":10} -->
-      <div class="wp-block-woocommerce-coupon-code aligncenter"></div>
-      <!-- /wp:woocommerce/coupon-code -->
+      ' . $this->getGeneratedCouponBlock('center', 10, 10) . '
 
       <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|30"}}}} -->
       <p class="has-text-align-center" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--30);font-size:14px">' . __('Valid for the next 10 days.', 'mailpoet') . '</p>

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/PostPurchaseThankYouPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/PostPurchaseThankYouPattern.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor;
 
 /**
  * Post purchase thank you email pattern.
@@ -30,7 +31,10 @@ class PostPurchaseThankYouPattern extends Pattern {
   }
 
   public function get_email_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    return $this->buildContent($this->getRecommendedProductCollectionBlock('new-arrivals'));
+    return $this->buildContent($this->getRecommendedProductCollectionBlock(
+      OrderProductCollectionProcessor::COLLECTION_ORDER_CROSS_SELLS,
+      'popularity'
+    ));
   }
 
   private function buildContent(string $productSection): string {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/PostPurchaseThankYouPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/PostPurchaseThankYouPattern.php
@@ -42,23 +42,17 @@ class PostPurchaseThankYouPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
       <!-- wp:heading {"level":1} -->
-      <h1 class="wp-block-heading">' .
-      /* translators: %s is a placeholder for the customer first name */
-      sprintf(__('%s, thank you for your order', 'mailpoet'), '<!--[woocommerce/customer-first-name]-->') . '</h1>
+      <h1 class="wp-block-heading">' . __('Thank you for your loyalty', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
       <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
-      __('Thanks for shopping with us. Your order is being processed, and we can’t wait for you to receive it.', 'mailpoet') . '</p>
+      __('Your continued support means a lot to us.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
-
-      <!-- wp:heading {"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}},"typography":{"fontSize":"24px"}}} -->
-      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('You might also like', 'mailpoet') . '</h2>
-      <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
       <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">
-      ' . __('While you wait, check out other items that pair perfectly with your order.', 'mailpoet') . '</p>
+      ' . __('Here are a few picks that pair well with your recent order.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       ' . $productSection . '

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
@@ -107,21 +107,18 @@ class WelcomeEmailPattern extends Pattern {
       <p class="has-text-align-center" style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:18px">' . __('Here’s to a day filled with good things.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
-      <!-- wp:image {"sizeSlug":"full"} -->
-      <figure class="wp-block-image size-full"><img src="' . esc_url($this->cdnAssetUrl->generateCdnUrl('email-editor/birthday-email.jpg')) . '" alt="' . esc_attr__('Birthday email image', 'mailpoet') . '"/></figure>
-      <!-- /wp:image -->
-
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
-      <p style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);font-size:16px">[subscriber:firstname | default:there], ' . __('we hope your birthday is as special as you are. Thank you for being part of our community.', 'mailpoet') . '</p>
+      <p style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
+      sprintf(
+        /* translators: %s: Subscriber first name personalization tag */
+        __('%s, we hope your birthday is as special as you are. Thank you for being part of our community.', 'mailpoet'),
+        sprintf(
+          '<!--[mailpoet/subscriber-firstname default="%s"]-->',
+          /* translators: Default placeholder used when no subscriber name is available in birthday emails */
+          esc_attr(_x('there', 'subscriber name placeholder', 'mailpoet'))
+        )
+      ) . '</p>
       <!-- /wp:paragraph -->
-
-      <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-      <div class="wp-block-buttons">
-      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Visit us today', 'mailpoet') . '</a></div>
-      <!-- /wp:button -->
-      </div>
-      <!-- /wp:buttons -->
     </div>
     <!-- /wp:group -->
     ';

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
@@ -4,7 +4,6 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
-use MailPoet\Util\CdnAssetUrl;
 
 /**
  * Welcome email pattern for new subscribers.
@@ -16,32 +15,12 @@ class WelcomeEmailPattern extends Pattern {
   protected $categories = ['welcome'];
   protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
-  /** @var bool */
-  private $isBirthday;
-
-  public function __construct(
-    CdnAssetUrl $cdnAssetUrl,
-    bool $isBirthday = false
-  ) {
-    parent::__construct($cdnAssetUrl);
-    $this->isBirthday = $isBirthday;
-
-    if ($isBirthday) {
-      $this->name = 'birthday-email-content';
-      $this->categories = ['celebrations'];
-    }
-  }
-
   /**
    * Get pattern content.
    *
    * @return string Pattern HTML content.
    */
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    if ($this->isBirthday) {
-      return $this->getBirthdayContent();
-    }
-
     return '
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
@@ -95,41 +74,7 @@ class WelcomeEmailPattern extends Pattern {
     ';
   }
 
-  private function getBirthdayContent(): string {
-    return '
-    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
-      <!-- wp:heading {"textAlign":"center","level":1} -->
-      <h1 class="wp-block-heading has-text-align-center">' . __('Happy Birthday!', 'mailpoet') . '</h1>
-      <!-- /wp:heading -->
-
-      <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
-      <p class="has-text-align-center" style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:18px">' . __('Here’s to a day filled with good things.', 'mailpoet') . '</p>
-      <!-- /wp:paragraph -->
-
-      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
-      <p style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
-      sprintf(
-        /* translators: %s: Subscriber first name personalization tag */
-        __('%s, we hope your birthday is as special as you are. Thank you for being part of our community.', 'mailpoet'),
-        sprintf(
-          '<!--[mailpoet/subscriber-firstname default="%s"]-->',
-          /* translators: Default placeholder used when no subscriber name is available in birthday emails */
-          esc_attr(_x('there', 'subscriber name placeholder', 'mailpoet'))
-        )
-      ) . '</p>
-      <!-- /wp:paragraph -->
-    </div>
-    <!-- /wp:group -->
-    ';
-  }
-
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    if ($this->isBirthday) {
-      /* translators: Name of a content pattern used as starting content of an email */
-      return __('Birthday Email', 'mailpoet');
-    }
-
     /* translators: Name of a content pattern used as starting content of an email */
     return __('Welcome Email', 'mailpoet');
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+use MailPoet\Util\CdnAssetUrl;
 
 /**
  * Welcome email pattern for new subscribers.
@@ -15,12 +16,32 @@ class WelcomeEmailPattern extends Pattern {
   protected $categories = ['welcome'];
   protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
+  /** @var bool */
+  private $isBirthday;
+
+  public function __construct(
+    CdnAssetUrl $cdnAssetUrl,
+    bool $isBirthday = false
+  ) {
+    parent::__construct($cdnAssetUrl);
+    $this->isBirthday = $isBirthday;
+
+    if ($isBirthday) {
+      $this->name = 'birthday-email-content';
+      $this->categories = ['celebrations'];
+    }
+  }
+
   /**
    * Get pattern content.
    *
    * @return string Pattern HTML content.
    */
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->isBirthday) {
+      return $this->getBirthdayContent();
+    }
+
     return '
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
@@ -74,7 +95,44 @@ class WelcomeEmailPattern extends Pattern {
     ';
   }
 
+  private function getBirthdayContent(): string {
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"textAlign":"center","level":1} -->
+      <h1 class="wp-block-heading has-text-align-center">' . __('Happy Birthday!', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p class="has-text-align-center" style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:18px">' . __('Here’s to a day filled with good things.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:image {"sizeSlug":"full"} -->
+      <figure class="wp-block-image size-full"><img src="' . esc_url($this->cdnAssetUrl->generateCdnUrl('email-editor/birthday-email.jpg')) . '" alt="' . esc_attr__('Birthday email image', 'mailpoet') . '"/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);font-size:16px">[subscriber:firstname | default:there], ' . __('we hope your birthday is as special as you are. Thank you for being part of our community.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Visit us today', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->isBirthday) {
+      /* translators: Name of a content pattern used as starting content of an email */
+      return __('Birthday Email', 'mailpoet');
+    }
+
     /* translators: Name of a content pattern used as starting content of an email */
     return __('Welcome Email', 'mailpoet');
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeWithDiscountEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeWithDiscountEmailPattern.php
@@ -40,9 +40,7 @@ class WelcomeWithDiscountEmailPattern extends Pattern {
       __('Use this code at checkout to redeem your discount:', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
-      <!-- wp:woocommerce/coupon-code {"align":"left","source":"createNew","discountType":"percent","amount":10,"expiryDay":10} -->
-      <div class="wp-block-woocommerce-coupon-code alignleft"></div>
-      <!-- /wp:woocommerce/coupon-code -->
+      ' . $this->getGeneratedCouponBlock('left', 10, 10) . '
 
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left"}} -->
       <div class="wp-block-buttons">

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeWithDiscountEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeWithDiscountEmailPattern.php
@@ -31,9 +31,7 @@ class WelcomeWithDiscountEmailPattern extends Pattern {
       <!-- /wp:heading -->
 
       <!-- wp:paragraph -->
-      <p>' .
-      /* translators: %s: Customer full name personalization tag */
-      sprintf(__('Hi %s, we are so glad to have you onboard. As a thank you, here is a 10%% discount for your first purchase.', 'mailpoet'), '<!--[woocommerce/customer-full-name]-->') . '</p>
+      <p>' . __('We are so glad to have you onboard. As a thank you, here is a 10% discount for your first purchase.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:paragraph -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeWithDiscountEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeWithDiscountEmailPattern.php
@@ -36,7 +36,6 @@ class WelcomeWithDiscountEmailPattern extends Pattern {
 
       <!-- wp:paragraph -->
       <p>' .
-      /* translators: %s: Site description personalization tag */
       __('Use this code at checkout to redeem your discount:', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
@@ -185,9 +185,7 @@ class WinBackCustomerPattern extends Pattern {
       __('Use this code at checkout to redeem your discount:', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
-      <!-- wp:woocommerce/coupon-code {"align":"left","source":"createNew","discountType":"percent","amount":15,"expiryDay":10} -->
-      <div class="wp-block-woocommerce-coupon-code alignleft"></div>
-      <!-- /wp:woocommerce/coupon-code -->
+      ' . $this->getGeneratedCouponBlock('left', 15, 10) . '
 
       <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
       <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
@@ -181,7 +181,6 @@ class WinBackCustomerPattern extends Pattern {
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
-      /* translators: %s: Site description personalization tag */
       __('Use this code at checkout to redeem your discount:', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
@@ -96,26 +96,12 @@ class WinBackCustomerPattern extends Pattern {
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
-      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
-      /* translators: %s is a placeholder for the first name */
-      sprintf(__('Hi %s, it’s been a little while since your last visit, and we’d love to welcome you back.', 'mailpoet'), '<!--[woocommerce/customer-first-name]-->') . '</p>
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('It’s been a little while since your last visit, and we’d love to welcome you back.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
       <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('New favorites may be waiting for you in the shop. We picked a few products that go well with your last order.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
-
-      <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
-      <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">
-      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
-      <!-- /wp:button -->
-      </div>
-      <!-- /wp:buttons -->
-
-      <!-- wp:heading {"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}},"typography":{"fontSize":"24px"}}} -->
-      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('You might also like', 'mailpoet') . '</h2>
-      <!-- /wp:heading -->
 
       ' . $productSection . '
 
@@ -144,9 +130,7 @@ class WinBackCustomerPattern extends Pattern {
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
-      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
-      /* translators: %s is a placeholder for the first name */
-      sprintf(__('Hi %s, there’s still time to find something you’ll love. These picks are based on what you bought last time.', 'mailpoet'), '<!--[woocommerce/customer-first-name]-->') . '</p>
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('There’s still time to find something you’ll love. These picks are based on what you bought last time.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
@@ -192,9 +176,7 @@ class WinBackCustomerPattern extends Pattern {
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
-      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
-      /* translators: %s is a placeholder for the first name */
-      sprintf(__('Hi %s, we’ve got an exclusive deal waiting just for you.', 'mailpoet'), '<!--[woocommerce/customer-first-name]-->') . '</p>
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('We’ve got an exclusive deal waiting just for you.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Pattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Pattern.php
@@ -3,6 +3,7 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns;
 
 use Automattic\WooCommerce\EmailEditor\Engine\Patterns\Abstract_Pattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlock;
 use MailPoet\Util\CdnAssetUrl;
 
 abstract class Pattern extends Abstract_Pattern {
@@ -97,6 +98,20 @@ abstract class Pattern extends Abstract_Pattern {
       <!-- /wp:woocommerce/product-template -->
       </div>
       <!-- /wp:woocommerce/product-collection -->
+    ';
+  }
+
+  protected function getGeneratedCouponBlock(string $align, int $amount, int $expiryDay): string {
+    $attributes = CouponBlock::withCreateNewDefaults([
+      'align' => $align,
+      'amount' => $amount,
+      'expiryDay' => $expiryDay,
+    ]);
+
+    return '
+      <!-- wp:woocommerce/coupon-code ' . wp_json_encode($attributes, JSON_UNESCAPED_SLASHES) . ' -->
+      <div class="wp-block-woocommerce-coupon-code align' . esc_attr($align) . '"><strong>' . CouponBlock::SAFE_PLACEHOLDER . '</strong></div>
+      <!-- /wp:woocommerce/coupon-code -->
     ';
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -104,6 +104,7 @@ class PatternsController {
       new ProductRestockNotificationPattern($this->cdnAssetUrl),
       new NewArrivalsAnnouncementPattern($this->cdnAssetUrl),
       new WelcomeEmailPattern($this->cdnAssetUrl),
+      new WelcomeEmailPattern($this->cdnAssetUrl, true),
     ];
 
     // WooCommerce-dependent patterns (uses product blocks or purchase/abandoned-cart categories)
@@ -261,6 +262,11 @@ class PatternsController {
         'name' => 'welcome',
         'label' => _x('Welcome', 'Block pattern category', 'mailpoet'),
         'description' => __('A collection of welcome email layouts.', 'mailpoet'),
+      ],
+      [
+        'name' => 'celebrations',
+        'label' => _x('Celebrations', 'Block pattern category', 'mailpoet'),
+        'description' => __('A collection of celebration email layouts.', 'mailpoet'),
       ],
     ];
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -6,6 +6,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartPat
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartReminderPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartWithDiscountPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AskForReviewPostPurchasePattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\BirthdayEmailPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\CategoryPurchaseFollowUpPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EducationalCampaignPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EventInvitationPattern;
@@ -104,7 +105,7 @@ class PatternsController {
       new ProductRestockNotificationPattern($this->cdnAssetUrl),
       new NewArrivalsAnnouncementPattern($this->cdnAssetUrl),
       new WelcomeEmailPattern($this->cdnAssetUrl),
-      new WelcomeEmailPattern($this->cdnAssetUrl, true),
+      new BirthdayEmailPattern($this->cdnAssetUrl),
     ];
 
     // WooCommerce-dependent patterns (uses product blocks or purchase/abandoned-cart categories)
@@ -134,6 +135,7 @@ class PatternsController {
       if ($wooCommerceVersion && version_compare($wooCommerceVersion, self::MIN_WOOCOMMERCE_VERSION_FOR_GENERATED_COUPON_BLOCK, '>=')) {
         $this->patterns = array_merge($this->patterns, [
           new WelcomeWithDiscountEmailPattern($this->cdnAssetUrl),
+          new BirthdayEmailPattern($this->cdnAssetUrl, true),
           new WinBackCustomerPattern($this->cdnAssetUrl),
           new AbandonedCartWithDiscountPattern($this->cdnAssetUrl),
           new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'reward-positive'),

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -355,7 +355,20 @@ class TemplatesFactoryTest extends MailPoetTest {
     $this->assertSame(789, $secondEmailArgs['email_id']);
     $this->assertSame(101, $secondEmailArgs['email_wp_post_id']);
 
-    foreach ($this->getStepsByKey($automation->getSteps(), 'core:if-else') as $ifElseStep) {
+    $ifElseSteps = $this->getStepsByKey($automation->getSteps(), 'core:if-else');
+    $this->assertCount(2, $ifElseSteps);
+
+    $firstFilters = $ifElseSteps[0]->getFilters();
+    $this->assertNotNull($firstFilters);
+    $firstOrderCountFilter = $firstFilters->getGroups()[0]->getFilters()[0];
+    $this->assertSame(1, $firstOrderCountFilter->getArgs()['value']);
+
+    $secondFilters = $ifElseSteps[1]->getFilters();
+    $this->assertNotNull($secondFilters);
+    $secondOrderCountFilter = $secondFilters->getGroups()[0]->getFilters()[0];
+    $this->assertSame(0, $secondOrderCountFilter->getArgs()['value']);
+
+    foreach ($ifElseSteps as $ifElseStep) {
       $this->assertCount(2, $ifElseStep->getNextSteps());
     }
   }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -4,6 +4,9 @@ namespace MailPoet\Test\Automation\Integrations\MailPoet\Templates;
 
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
+use MailPoet\Automation\Engine\Data\StepValidationArgs;
+use MailPoet\Automation\Engine\Integration\Trigger;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Templates\AutomationBuilder;
 use MailPoet\Automation\Integrations\MailPoet\Templates\EmailFactory;
@@ -14,6 +17,7 @@ use MailPoet\Automation\Integrations\WooCommerce\Triggers\BuysFromACategoryTrigg
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\BuysFromATagTrigger;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderCompletedTrigger;
 use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
+use MailPoet\Validator\Schema\ObjectSchema;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WooCommerce\WooCommerceBookings\Helper as WooCommerceBookingsHelper;
 use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WooCommerceSubscriptions;
@@ -238,6 +242,199 @@ class TemplatesFactoryTest extends MailPoetTest {
     ];
   }
 
+  /**
+   * @group woo
+   */
+  public function testThankLoyalCustomersTemplateCreatesBlockEditorEmail(): void {
+    $this->ensureWooCommerceTriggerRegistered('woocommerce:order-completed');
+    $this->emailFactory->expects($this->once())
+      ->method('createBlockEditorEmail')
+      ->with([
+        'pattern' => 'post-purchase-thank-you',
+        'subject' => 'Thank you for your loyalty',
+        'preheader' => 'We appreciate your continued support',
+      ])
+      ->willReturn([
+        'email_id' => 123,
+        'email_wp_post_id' => 456,
+      ]);
+
+    $factory = $this->createFactory();
+    $template = $this->findTemplateBySlug($factory->createTemplates(), 'thank-loyal-customers');
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation();
+
+    $this->assertNotNull($this->getFirstStepByKey($automation->getSteps(), 'woocommerce:order-completed'));
+    $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertInstanceOf(Step::class, $sendEmailStep);
+    $args = $sendEmailStep->getArgs();
+
+    $this->assertSame('Thank you for your loyalty', $args['name']);
+    $this->assertSame('Thank you for your loyalty', $args['subject']);
+    $this->assertSame('We appreciate your continued support', $args['preheader']);
+    $this->assertSame(123, $args['email_id']);
+    $this->assertSame(456, $args['email_wp_post_id']);
+  }
+
+  /**
+   * @group woo
+   */
+  public function testThankLoyalCustomersTemplatePreviewDoesNotCreatePersistentEmail(): void {
+    $this->ensureWooCommerceTriggerRegistered('woocommerce:order-completed');
+    $this->emailFactory->expects($this->never())->method('createBlockEditorEmail');
+
+    $factory = $this->createFactory();
+    $template = $this->findTemplateBySlug($factory->createTemplates(), 'thank-loyal-customers');
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation(true);
+
+    $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertInstanceOf(Step::class, $sendEmailStep);
+    $args = $sendEmailStep->getArgs();
+
+    $this->assertSame('Thank you for your loyalty', $args['name']);
+    $this->assertSame('Thank you for your loyalty', $args['subject']);
+    $this->assertSame('We appreciate your continued support', $args['preheader']);
+    $this->assertArrayNotHasKey('email_id', $args);
+    $this->assertArrayNotHasKey('email_wp_post_id', $args);
+  }
+
+  /**
+   * @group woo
+   */
+  public function testWinBackCustomersTemplateCreatesBlockEditorEmails(): void {
+    $this->ensureWooCommerceTriggerRegistered('woocommerce:order-completed');
+    $this->emailFactory->expects($this->exactly(2))
+      ->method('createBlockEditorEmail')
+      ->withConsecutive(
+        [[
+          'pattern' => 'win-back-customer-reminder',
+          'subject' => 'It’s been a while…',
+          'preheader' => 'Products picked from their last order',
+        ]],
+        [[
+          'pattern' => 'win-back-customer-final-nudge',
+          'subject' => 'We’ve missed you',
+          'preheader' => 'Recommended picks are waiting',
+        ]]
+      )
+      ->willReturnOnConsecutiveCalls(
+        [
+          'email_id' => 123,
+          'email_wp_post_id' => 456,
+        ],
+        [
+          'email_id' => 789,
+          'email_wp_post_id' => 101,
+        ]
+      );
+
+    $factory = $this->createFactory();
+    $template = $this->findTemplateBySlug($factory->createTemplates(), 'win-back-customers');
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation();
+
+    $this->assertNotNull($this->getFirstStepByKey($automation->getSteps(), 'woocommerce:order-completed'));
+    $sendEmailSteps = $this->getStepsByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertCount(2, $sendEmailSteps);
+
+    $firstEmailArgs = $sendEmailSteps[0]->getArgs();
+    $this->assertSame('It’s been a while…', $firstEmailArgs['name']);
+    $this->assertSame('It’s been a while…', $firstEmailArgs['subject']);
+    $this->assertSame('Products picked from their last order', $firstEmailArgs['preheader']);
+    $this->assertSame(123, $firstEmailArgs['email_id']);
+    $this->assertSame(456, $firstEmailArgs['email_wp_post_id']);
+
+    $secondEmailArgs = $sendEmailSteps[1]->getArgs();
+    $this->assertSame('We’ve missed you', $secondEmailArgs['name']);
+    $this->assertSame('We’ve missed you', $secondEmailArgs['subject']);
+    $this->assertSame('Recommended picks are waiting', $secondEmailArgs['preheader']);
+    $this->assertSame(789, $secondEmailArgs['email_id']);
+    $this->assertSame(101, $secondEmailArgs['email_wp_post_id']);
+
+    foreach ($this->getStepsByKey($automation->getSteps(), 'core:if-else') as $ifElseStep) {
+      $this->assertCount(2, $ifElseStep->getNextSteps());
+    }
+  }
+
+  /**
+   * @group woo
+   */
+  public function testWinBackCustomersTemplatePreviewDoesNotCreatePersistentEmails(): void {
+    $this->ensureWooCommerceTriggerRegistered('woocommerce:order-completed');
+    $this->emailFactory->expects($this->never())->method('createBlockEditorEmail');
+
+    $factory = $this->createFactory();
+    $template = $this->findTemplateBySlug($factory->createTemplates(), 'win-back-customers');
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation(true);
+    $sendEmailSteps = $this->getStepsByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertCount(2, $sendEmailSteps);
+
+    foreach ($sendEmailSteps as $sendEmailStep) {
+      $args = $sendEmailStep->getArgs();
+      $this->assertArrayNotHasKey('email_id', $args);
+      $this->assertArrayNotHasKey('email_wp_post_id', $args);
+    }
+  }
+
+  public function testBirthdayEmailTemplateCreatesBlockEditorEmail(): void {
+    $this->ensureAnnualDateTriggerRegistered();
+    $this->emailFactory->expects($this->once())
+      ->method('createBlockEditorEmail')
+      ->with([
+        'pattern' => 'birthday-email-content',
+        'subject' => 'Happy birthday!',
+        'preheader' => 'A birthday note just for you',
+      ])
+      ->willReturn([
+        'email_id' => 123,
+        'email_wp_post_id' => 456,
+      ]);
+
+    $factory = $this->createFactory();
+    $template = $this->findTemplateBySlug($factory->createTemplates(), 'birthday-email');
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation();
+
+    $this->assertNotNull($this->getFirstStepByKey($automation->getSteps(), 'mailpoet:annual-date'));
+    $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertInstanceOf(Step::class, $sendEmailStep);
+    $args = $sendEmailStep->getArgs();
+
+    $this->assertSame('Happy birthday!', $args['name']);
+    $this->assertSame('Happy birthday!', $args['subject']);
+    $this->assertSame('A birthday note just for you', $args['preheader']);
+    $this->assertSame(123, $args['email_id']);
+    $this->assertSame(456, $args['email_wp_post_id']);
+  }
+
+  public function testBirthdayEmailTemplatePreviewDoesNotCreatePersistentEmail(): void {
+    $this->ensureAnnualDateTriggerRegistered();
+    $this->emailFactory->expects($this->never())->method('createBlockEditorEmail');
+
+    $factory = $this->createFactory();
+    $template = $this->findTemplateBySlug($factory->createTemplates(), 'birthday-email');
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation(true);
+    $this->assertNotNull($this->getFirstStepByKey($automation->getSteps(), 'mailpoet:annual-date'));
+    $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertInstanceOf(Step::class, $sendEmailStep);
+    $args = $sendEmailStep->getArgs();
+
+    $this->assertSame('Happy birthday!', $args['name']);
+    $this->assertSame('Happy birthday!', $args['subject']);
+    $this->assertSame('A birthday note just for you', $args['preheader']);
+    $this->assertArrayNotHasKey('email_id', $args);
+    $this->assertArrayNotHasKey('email_wp_post_id', $args);
+  }
+
   public function testAbandonedCartTemplateCreatesBlockEditorEmail(): void {
     $this->ensureAbandonedCartTriggerRegistered();
     $this->emailFactory->expects($this->once())
@@ -313,6 +510,39 @@ class TemplatesFactoryTest extends MailPoetTest {
     }
   }
 
+  private function ensureAnnualDateTriggerRegistered(): void {
+    $registry = $this->diContainer->get(Registry::class);
+    if ($registry->getStep('mailpoet:annual-date') === null) {
+      $registry->addTrigger(new class implements Trigger {
+        public function getKey(): string {
+          return 'mailpoet:annual-date';
+        }
+
+        public function getName(): string {
+          return 'Annual date';
+        }
+
+        public function getArgsSchema(): ObjectSchema {
+          return new ObjectSchema();
+        }
+
+        public function getSubjectKeys(): array {
+          return [];
+        }
+
+        public function validate(StepValidationArgs $args): void {
+        }
+
+        public function registerHooks(): void {
+        }
+
+        public function isTriggeredBy(StepRunArgs $args): bool {
+          return true;
+        }
+      });
+    }
+  }
+
   private function createFactory(): TemplatesFactory {
     $woocommerce = $this->createMock(WooCommerce::class);
     $woocommerce->method('isWooCommerceActive')->willReturn(true);
@@ -351,5 +581,13 @@ class TemplatesFactoryTest extends MailPoetTest {
   private function getFirstStepByKey(array $steps, string $key): ?Step {
     $matches = array_values(array_filter($steps, fn(Step $step) => $step->getKey() === $key));
     return $matches[0] ?? null;
+  }
+
+  /**
+   * @param Step[] $steps
+   * @return Step[]
+   */
+  private function getStepsByKey(array $steps, string $key): array {
+    return array_values(array_filter($steps, fn(Step $step) => $step->getKey() === $key));
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -126,6 +126,12 @@ class TemplatesFactoryTest extends MailPoetTest {
     ];
   }
 
+  public function testWinBackCustomersTemplateIsNotReturned(): void {
+    $factory = $this->createFactory();
+
+    $this->assertNull($this->findTemplateBySlug($factory->createTemplates(), 'win-back-customers'));
+  }
+
   /**
    * The first purchase template filters on WooCommerce order fields, which can
    * only be built with an active WooCommerce, so these tests run in the woo jobs.
@@ -299,100 +305,6 @@ class TemplatesFactoryTest extends MailPoetTest {
     $this->assertSame('We appreciate your continued support', $args['preheader']);
     $this->assertArrayNotHasKey('email_id', $args);
     $this->assertArrayNotHasKey('email_wp_post_id', $args);
-  }
-
-  /**
-   * @group woo
-   */
-  public function testWinBackCustomersTemplateCreatesBlockEditorEmails(): void {
-    $this->ensureWooCommerceTriggerRegistered('woocommerce:order-completed');
-    $this->emailFactory->expects($this->exactly(2))
-      ->method('createBlockEditorEmail')
-      ->withConsecutive(
-        [[
-          'pattern' => 'win-back-customer-reminder',
-          'subject' => 'It’s been a while…',
-          'preheader' => 'Products picked from their last order',
-        ]],
-        [[
-          'pattern' => 'win-back-customer-final-nudge',
-          'subject' => 'We’ve missed you',
-          'preheader' => 'Recommended picks are waiting',
-        ]]
-      )
-      ->willReturnOnConsecutiveCalls(
-        [
-          'email_id' => 123,
-          'email_wp_post_id' => 456,
-        ],
-        [
-          'email_id' => 789,
-          'email_wp_post_id' => 101,
-        ]
-      );
-
-    $factory = $this->createFactory();
-    $template = $this->findTemplateBySlug($factory->createTemplates(), 'win-back-customers');
-    $this->assertInstanceOf(AutomationTemplate::class, $template);
-
-    $automation = $template->createAutomation();
-
-    $this->assertNotNull($this->getFirstStepByKey($automation->getSteps(), 'woocommerce:order-completed'));
-    $sendEmailSteps = $this->getStepsByKey($automation->getSteps(), 'mailpoet:send-email');
-    $this->assertCount(2, $sendEmailSteps);
-
-    $firstEmailArgs = $sendEmailSteps[0]->getArgs();
-    $this->assertSame('It’s been a while…', $firstEmailArgs['name']);
-    $this->assertSame('It’s been a while…', $firstEmailArgs['subject']);
-    $this->assertSame('Products picked from their last order', $firstEmailArgs['preheader']);
-    $this->assertSame(123, $firstEmailArgs['email_id']);
-    $this->assertSame(456, $firstEmailArgs['email_wp_post_id']);
-
-    $secondEmailArgs = $sendEmailSteps[1]->getArgs();
-    $this->assertSame('We’ve missed you', $secondEmailArgs['name']);
-    $this->assertSame('We’ve missed you', $secondEmailArgs['subject']);
-    $this->assertSame('Recommended picks are waiting', $secondEmailArgs['preheader']);
-    $this->assertSame(789, $secondEmailArgs['email_id']);
-    $this->assertSame(101, $secondEmailArgs['email_wp_post_id']);
-
-    $ifElseSteps = $this->getStepsByKey($automation->getSteps(), 'core:if-else');
-    $this->assertCount(2, $ifElseSteps);
-
-    $firstFilters = $ifElseSteps[0]->getFilters();
-    $this->assertNotNull($firstFilters);
-    $firstOrderCountFilter = $firstFilters->getGroups()[0]->getFilters()[0];
-    $this->assertSame(1, $firstOrderCountFilter->getArgs()['value']);
-
-    $secondFilters = $ifElseSteps[1]->getFilters();
-    $this->assertNotNull($secondFilters);
-    $secondOrderCountFilter = $secondFilters->getGroups()[0]->getFilters()[0];
-    $this->assertSame(0, $secondOrderCountFilter->getArgs()['value']);
-
-    foreach ($ifElseSteps as $ifElseStep) {
-      $this->assertCount(2, $ifElseStep->getNextSteps());
-    }
-  }
-
-  /**
-   * @group woo
-   */
-  public function testWinBackCustomersTemplatePreviewDoesNotCreatePersistentEmails(): void {
-    $this->ensureWooCommerceTriggerRegistered('woocommerce:order-completed');
-    $this->emailFactory->expects($this->never())->method('createBlockEditorEmail');
-
-    $factory = $this->createFactory();
-    $template = $this->findTemplateBySlug($factory->createTemplates(), 'win-back-customers');
-    $this->assertInstanceOf(AutomationTemplate::class, $template);
-
-    $automation = $template->createAutomation(true);
-    $sendEmailSteps = $this->getStepsByKey($automation->getSteps(), 'mailpoet:send-email');
-    $this->assertCount(2, $sendEmailSteps);
-
-    foreach ($sendEmailSteps as $sendEmailStep) {
-      $args = $sendEmailStep->getArgs();
-      $this->assertArrayNotHasKey('email_id', $args);
-      $this->assertArrayNotHasKey('email_wp_post_id', $args);
-    }
   }
 
   public function testBirthdayEmailTemplateCreatesBlockEditorEmail(): void {
@@ -594,13 +506,5 @@ class TemplatesFactoryTest extends MailPoetTest {
   private function getFirstStepByKey(array $steps, string $key): ?Step {
     $matches = array_values(array_filter($steps, fn(Step $step) => $step->getKey() === $key));
     return $matches[0] ?? null;
-  }
-
-  /**
-   * @param Step[] $steps
-   * @return Step[]
-   */
-  private function getStepsByKey(array $steps, string $key): array {
-    return array_values(array_filter($steps, fn(Step $step) => $step->getKey() === $key));
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -328,6 +328,7 @@ class TemplatesFactoryTest extends MailPoetTest {
     $automation = $template->createAutomation();
 
     $this->assertNotNull($this->getFirstStepByKey($automation->getSteps(), 'mailpoet:annual-date'));
+    $this->assertNull($automation->getMeta('mailpoet:run-once-per-subscriber'));
     $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
     $this->assertInstanceOf(Step::class, $sendEmailStep);
     $args = $sendEmailStep->getArgs();
@@ -349,6 +350,7 @@ class TemplatesFactoryTest extends MailPoetTest {
 
     $automation = $template->createAutomation(true);
     $this->assertNotNull($this->getFirstStepByKey($automation->getSteps(), 'mailpoet:annual-date'));
+    $this->assertNull($automation->getMeta('mailpoet:run-once-per-subscriber'));
     $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
     $this->assertInstanceOf(Step::class, $sendEmailStep);
     $args = $sendEmailStep->getArgs();

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplatesFactoryTest.php
@@ -312,9 +312,9 @@ class TemplatesFactoryTest extends MailPoetTest {
     $this->emailFactory->expects($this->once())
       ->method('createBlockEditorEmail')
       ->with([
-        'pattern' => 'birthday-email-content',
-        'subject' => 'Happy birthday!',
-        'preheader' => 'A birthday note just for you',
+        'pattern' => 'birthday-email-with-discount',
+        'subject' => 'A birthday treat from us',
+        'preheader' => 'Enjoy 10% off your next order',
       ])
       ->willReturn([
         'email_id' => 123,
@@ -333,9 +333,39 @@ class TemplatesFactoryTest extends MailPoetTest {
     $this->assertInstanceOf(Step::class, $sendEmailStep);
     $args = $sendEmailStep->getArgs();
 
+    $this->assertSame('A birthday treat from us', $args['name']);
+    $this->assertSame('A birthday treat from us', $args['subject']);
+    $this->assertSame('Enjoy 10% off your next order', $args['preheader']);
+    $this->assertSame(123, $args['email_id']);
+    $this->assertSame(456, $args['email_wp_post_id']);
+  }
+
+  public function testBirthdayEmailTemplateUsesPlainPatternWithoutGeneratedCouponSupport(): void {
+    $this->ensureAnnualDateTriggerRegistered();
+    $this->emailFactory->expects($this->once())
+      ->method('createBlockEditorEmail')
+      ->with([
+        'pattern' => 'birthday-email-content',
+        'subject' => 'Happy birthday!',
+        'preheader' => 'Wishing you a wonderful day',
+      ])
+      ->willReturn([
+        'email_id' => 123,
+        'email_wp_post_id' => 456,
+      ]);
+
+    $factory = $this->createFactory(true, '10.7.0');
+    $template = $this->findTemplateBySlug($factory->createTemplates(), 'birthday-email');
+    $this->assertInstanceOf(AutomationTemplate::class, $template);
+
+    $automation = $template->createAutomation();
+    $sendEmailStep = $this->getFirstStepByKey($automation->getSteps(), 'mailpoet:send-email');
+    $this->assertInstanceOf(Step::class, $sendEmailStep);
+    $args = $sendEmailStep->getArgs();
+
     $this->assertSame('Happy birthday!', $args['name']);
     $this->assertSame('Happy birthday!', $args['subject']);
-    $this->assertSame('A birthday note just for you', $args['preheader']);
+    $this->assertSame('Wishing you a wonderful day', $args['preheader']);
     $this->assertSame(123, $args['email_id']);
     $this->assertSame(456, $args['email_wp_post_id']);
   }
@@ -355,9 +385,9 @@ class TemplatesFactoryTest extends MailPoetTest {
     $this->assertInstanceOf(Step::class, $sendEmailStep);
     $args = $sendEmailStep->getArgs();
 
-    $this->assertSame('Happy birthday!', $args['name']);
-    $this->assertSame('Happy birthday!', $args['subject']);
-    $this->assertSame('A birthday note just for you', $args['preheader']);
+    $this->assertSame('A birthday treat from us', $args['name']);
+    $this->assertSame('A birthday treat from us', $args['subject']);
+    $this->assertSame('Enjoy 10% off your next order', $args['preheader']);
     $this->assertArrayNotHasKey('email_id', $args);
     $this->assertArrayNotHasKey('email_wp_post_id', $args);
   }
@@ -470,15 +500,16 @@ class TemplatesFactoryTest extends MailPoetTest {
     }
   }
 
-  private function createFactory(): TemplatesFactory {
+  private function createFactory(bool $woocommerceActive = true, string $wooCommerceVersion = '10.8.0'): TemplatesFactory {
     $woocommerce = $this->createMock(WooCommerce::class);
-    $woocommerce->method('isWooCommerceActive')->willReturn(true);
+    $woocommerce->method('isWooCommerceActive')->willReturn($woocommerceActive);
     $woocommerceSubscriptions = $this->createMock(WooCommerceSubscriptions::class);
     $woocommerceSubscriptions->method('isWooCommerceSubscriptionsActive')->willReturn(false);
     $bookingsHelper = $this->createMock(WooCommerceBookingsHelper::class);
     $bookingsHelper->method('isWooCommerceBookingsActive')->willReturn(false);
     $woocommerceHelper = $this->createMock(WooCommerceHelper::class);
     $woocommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(false);
+    $woocommerceHelper->method('getWooCommerceVersion')->willReturn($wooCommerceVersion);
 
     return new TemplatesFactory(
       $this->builder,

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns;
 
+use MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlock;
 use MailPoet\Util\CdnAssetUrl;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
@@ -226,14 +227,31 @@ class PatternsControllerTest extends \MailPoetTest {
     $blockPatterns = \WP_Block_Patterns_Registry::get_instance()->get_all_registered();
     $patternsByName = array_column($blockPatterns, null, 'name');
 
-    $this->assertStringContainsString('"source":"createNew"', $patternsByName['mailpoet/welcome-with-discount-email-content']['content']);
-    $this->assertStringContainsString('"amount":10', $patternsByName['mailpoet/welcome-with-discount-email-content']['content']);
-    $this->assertStringContainsString('"expiryDay":10', $patternsByName['mailpoet/welcome-with-discount-email-content']['content']);
-    $this->assertStringContainsString('"source":"createNew"', $patternsByName['mailpoet/birthday-email-with-discount']['content']);
-    $this->assertStringContainsString('"amount":10', $patternsByName['mailpoet/birthday-email-with-discount']['content']);
-    $this->assertStringContainsString('"expiryDay":10', $patternsByName['mailpoet/birthday-email-with-discount']['content']);
-    $this->assertStringContainsString('"amount":15', $patternsByName['mailpoet/win-back-customer']['content']);
-    $this->assertStringContainsString('"expiryDay":1', $patternsByName['mailpoet/abandoned-cart-with-discount-content']['content']);
+    $this->assertGeneratedCouponPattern($patternsByName['mailpoet/welcome-with-discount-email-content']['content'], [
+      'align' => 'left',
+      'amount' => 10,
+      'expiryDay' => 10,
+    ]);
+    $this->assertGeneratedCouponPattern($patternsByName['mailpoet/birthday-email-with-discount']['content'], [
+      'align' => 'center',
+      'amount' => 10,
+      'expiryDay' => 10,
+    ]);
+    $this->assertGeneratedCouponPattern($patternsByName['mailpoet/win-back-customer']['content'], [
+      'align' => 'left',
+      'amount' => 15,
+      'expiryDay' => 10,
+    ]);
+    $this->assertGeneratedCouponPattern($patternsByName['mailpoet/abandoned-cart-with-discount-content']['content'], [
+      'align' => 'left',
+      'amount' => 10,
+      'expiryDay' => 1,
+    ]);
+    $this->assertGeneratedCouponPattern($patternsByName['mailpoet/reward-positive-reviewer']['content'], [
+      'align' => 'left',
+      'amount' => 10,
+      'expiryDay' => 10,
+    ]);
 
     $winBackEmailContent = $patterns->getPatternContent('win-back-customer');
     $this->assertIsString($winBackEmailContent);
@@ -592,6 +610,34 @@ class PatternsControllerTest extends \MailPoetTest {
       $this->diContainer->get(WPFunctions::class),
       $wooCommerceHelper
     );
+  }
+
+  private function assertGeneratedCouponPattern(string $content, array $expectedAttributes): void {
+    $couponBlock = $this->findBlockByName(parse_blocks($content), CouponBlock::NAME);
+    $this->assertIsArray($couponBlock);
+
+    $this->assertSame(CouponBlock::withCreateNewDefaults($expectedAttributes), $couponBlock['attrs']);
+    $this->assertStringContainsString(CouponBlock::SAFE_PLACEHOLDER, (string)$couponBlock['innerHTML']);
+  }
+
+  private function findBlockByName(array $blocks, string $blockName): ?array {
+    foreach ($blocks as $block) {
+      if (!is_array($block)) {
+        continue;
+      }
+
+      if (($block['blockName'] ?? null) === $blockName) {
+        return $block;
+      }
+
+      $innerBlocks = isset($block['innerBlocks']) && is_array($block['innerBlocks']) ? $block['innerBlocks'] : [];
+      $foundBlock = $this->findBlockByName($innerBlocks, $blockName);
+      if ($foundBlock !== null) {
+        return $foundBlock;
+      }
+    }
+
+    return null;
   }
 
   private function cleanupPatterns(): void {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -38,6 +38,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/product-restock-notification', $patternNames);
     $this->assertContains('mailpoet/new-arrivals-announcement', $patternNames);
     $this->assertContains('mailpoet/welcome-email-content', $patternNames);
+    $this->assertContains('mailpoet/birthday-email-content', $patternNames);
 
     // WooCommerce-dependent patterns (uses product blocks or purchase/abandoned-cart categories)
     $this->assertContains('mailpoet/first-purchase-thank-you', $patternNames);
@@ -60,7 +61,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(24, $blockPatterns);
+    $this->assertCount(25, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
@@ -102,6 +103,11 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertEquals('welcome', $welcomeCategory['name']);
     $this->assertNotEmpty($welcomeCategory['label']);
 
+    $celebrationsCategory = $registry->get_registered('celebrations');
+    $this->assertIsArray($celebrationsCategory);
+    $this->assertEquals('celebrations', $celebrationsCategory['name']);
+    $this->assertNotEmpty($celebrationsCategory['label']);
+
     $purchaseCategory = $registry->get_registered('purchase');
     $this->assertIsArray($purchaseCategory);
     $this->assertEquals('purchase', $purchaseCategory['name']);
@@ -137,6 +143,7 @@ class PatternsControllerTest extends \MailPoetTest {
     // Should include non-WooCommerce patterns
     $this->assertContains('mailpoet/newsletter-content', $patternNames);
     $this->assertContains('mailpoet/welcome-email-content', $patternNames);
+    $this->assertContains('mailpoet/birthday-email-content', $patternNames);
 
     // Should include WooCommerce patterns that don't require coupon block
     $this->assertContains('mailpoet/first-purchase-thank-you', $patternNames);
@@ -159,7 +166,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/reward-positive-reviewer', $patternNames);
 
     // Verify total count (all patterns except 4 coupon patterns)
-    $this->assertCount(20, $blockPatterns);
+    $this->assertCount(21, $blockPatterns);
   }
 
   /**
@@ -390,6 +397,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/newsletter-content', $patternNames);
     $this->assertContains('mailpoet/sale-announcement', $patternNames);
     $this->assertContains('mailpoet/welcome-email-content', $patternNames);
+    $this->assertContains('mailpoet/birthday-email-content', $patternNames);
 
     // Should NOT include WooCommerce-dependent patterns
     $this->assertNotContains('mailpoet/welcome-with-discount-email-content', $patternNames);
@@ -408,7 +416,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count (only non-WooCommerce patterns)
-    $this->assertCount(8, $blockPatterns);
+    $this->assertCount(9, $blockPatterns);
   }
 
   public function testItDoesNotRegisterWooCommerceCategoriesWhenWooCommerceIsInactive(): void {
@@ -430,6 +438,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertIsArray($registry->get_registered('event'));
     $this->assertIsArray($registry->get_registered('newsletter'));
     $this->assertIsArray($registry->get_registered('welcome'));
+    $this->assertIsArray($registry->get_registered('celebrations'));
 
     // Should NOT include WooCommerce-dependent categories
     $purchaseCategory = $registry->get_registered('purchase');

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -57,11 +57,12 @@ class PatternsControllerTest extends \MailPoetTest {
 
     // WooCommerce 10.8.0+ patterns (uses generated coupon block)
     $this->assertContains('mailpoet/welcome-with-discount-email-content', $patternNames);
+    $this->assertContains('mailpoet/birthday-email-with-discount', $patternNames);
     $this->assertContains('mailpoet/win-back-customer', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(25, $blockPatterns);
+    $this->assertCount(26, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
@@ -161,11 +162,12 @@ class PatternsControllerTest extends \MailPoetTest {
 
     // Should NOT include generated coupon block patterns (require WooCommerce 10.8.0+)
     $this->assertNotContains('mailpoet/welcome-with-discount-email-content', $patternNames);
+    $this->assertNotContains('mailpoet/birthday-email-with-discount', $patternNames);
     $this->assertNotContains('mailpoet/win-back-customer', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
     $this->assertNotContains('mailpoet/reward-positive-reviewer', $patternNames);
 
-    // Verify total count (all patterns except 4 coupon patterns)
+    // Verify total count (all patterns except 5 coupon patterns)
     $this->assertCount(21, $blockPatterns);
   }
 
@@ -190,6 +192,7 @@ class PatternsControllerTest extends \MailPoetTest {
 
     // Generated coupon block patterns should be registered for WooCommerce 10.8.0+ (including RC/beta)
     $this->assertContains('mailpoet/welcome-with-discount-email-content', $patternNames);
+    $this->assertContains('mailpoet/birthday-email-with-discount', $patternNames);
     $this->assertContains('mailpoet/win-back-customer', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
     $this->assertContains('mailpoet/reward-positive-reviewer', $patternNames);
@@ -226,6 +229,9 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertStringContainsString('"source":"createNew"', $patternsByName['mailpoet/welcome-with-discount-email-content']['content']);
     $this->assertStringContainsString('"amount":10', $patternsByName['mailpoet/welcome-with-discount-email-content']['content']);
     $this->assertStringContainsString('"expiryDay":10', $patternsByName['mailpoet/welcome-with-discount-email-content']['content']);
+    $this->assertStringContainsString('"source":"createNew"', $patternsByName['mailpoet/birthday-email-with-discount']['content']);
+    $this->assertStringContainsString('"amount":10', $patternsByName['mailpoet/birthday-email-with-discount']['content']);
+    $this->assertStringContainsString('"expiryDay":10', $patternsByName['mailpoet/birthday-email-with-discount']['content']);
     $this->assertStringContainsString('"amount":15', $patternsByName['mailpoet/win-back-customer']['content']);
     $this->assertStringContainsString('"expiryDay":1', $patternsByName['mailpoet/abandoned-cart-with-discount-content']['content']);
 
@@ -251,8 +257,10 @@ class PatternsControllerTest extends \MailPoetTest {
 
     $this->assertIsString($content);
     $this->assertStringContainsString('We miss you', $content);
-    $this->assertStringContainsString('wp:button', $content);
+    $this->assertStringContainsString('New favorites may be waiting for you in the shop.', $content);
     $this->assertStringContainsString('mailpoet/product-collection/order-cross-sells', $content);
+    $this->assertStringNotContainsString('wp:button', $content);
+    $this->assertStringNotContainsString('You might also like', $content);
     $this->assertStringNotContainsString('wp:woocommerce/coupon-code', $content);
   }
 
@@ -272,7 +280,8 @@ class PatternsControllerTest extends \MailPoetTest {
 
     $this->assertIsString($content);
     $this->assertStringContainsString('mailpoet/product-collection/order-cross-sells', $content);
-    $this->assertStringContainsString('While you wait, check out other items that pair perfectly with your order.', $content);
+    $this->assertStringContainsString('Here are a few picks that pair well with your recent order.', $content);
+    $this->assertStringNotContainsString('You might also like', $content);
   }
 
   public function testWinBackFinalNudgePatternDoesNotUseGeneratedCouponBlock(): void {
@@ -420,6 +429,7 @@ class PatternsControllerTest extends \MailPoetTest {
 
     // Should NOT include WooCommerce-dependent patterns
     $this->assertNotContains('mailpoet/welcome-with-discount-email-content', $patternNames);
+    $this->assertNotContains('mailpoet/birthday-email-with-discount', $patternNames);
     $this->assertNotContains('mailpoet/first-purchase-thank-you', $patternNames);
     $this->assertNotContains('mailpoet/post-purchase-thank-you', $patternNames);
     $this->assertNotContains('mailpoet/product-purchase-follow-up', $patternNames);

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -256,6 +256,25 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertStringNotContainsString('wp:woocommerce/coupon-code', $content);
   }
 
+  public function testPostPurchaseThankYouPatternUsesOrderAwareProducts(): void {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
+
+    $patterns = new PatternsController(
+      $this->diContainer->get(CdnAssetUrl::class),
+      $this->diContainer->get(WPFunctions::class),
+      $wooCommerceHelper
+    );
+
+    $content = $patterns->getPatternContent('post-purchase-thank-you');
+
+    $this->assertIsString($content);
+    $this->assertStringContainsString('mailpoet/product-collection/order-cross-sells', $content);
+    $this->assertStringContainsString('While you wait, check out other items that pair perfectly with your order.', $content);
+  }
+
   public function testWinBackFinalNudgePatternDoesNotUseGeneratedCouponBlock(): void {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
@@ -107,7 +107,6 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
       // Purchase - customer relationship
       'first-purchase' => 'people',
       'thank-loyal-customers' => 'people',
-      'win-back-customers' => 'people',
       // Purchase - product focused
       'purchased-product' => 'store',
       'purchased-product-with-tag' => 'store',

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
@@ -59,7 +59,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
         'category' => 'purchase',
       ],
     ]);
-    $this->assertCount(6, $result['data']);
+    $this->assertCount(5, $result['data']);
 
     $result = $this->get(self::ENDPOINT_PATH, [
       'json' => [
@@ -177,7 +177,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
   }
 
   private function getExpectedTemplateCount(): int {
-    return $this->isOrderReviewUrlSupported() ? 22 : 21;
+    return $this->isOrderReviewUrlSupported() ? 21 : 20;
   }
 
   private function isOrderReviewUrlSupported(): bool {


### PR DESCRIPTION
## Description

Adds block-editor email content for birthday and loyalty automations, improves dynamic product content, and removes the simulated `win-back-customers` template so customer win-back is handled only by the premium explicit trigger template.

## Code review notes

Premium keeps the single customer win-back automation via `woocommerce:customer-win-back`; see the linked premium PR.

## QA notes

_N/A_

## Linked PRs

Premium: https://github.com/mailpoet/mailpoet-premium/pull/1096

## Linked tickets

[STOMAIL-8123](https://linear.app/a8c/issue/STOMAIL-8123/add-email-templates-for-loyalty-and-win-back-automations)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8123-add-email-templates-for-loyalty-and-win-back-automations)

_The latest successful build from `stomail-8123-add-email-templates-for-loyalty-and-win-back-automations` will be used. If none is available, the link will not work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->