### PR TITLE
Add Woo attribution compatibility tests

### DIFF
--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -61,6 +61,16 @@ class Helper {
     return WC();
   }
 
+  public function isWooCommerceRestApiRequest(): bool {
+    $wc = $this->WC();
+    return $wc instanceof \WooCommerce && $wc->is_rest_api_request();
+  }
+
+  public function isWooCommerceStoreApiRequest(): bool {
+    $wc = $this->WC();
+    return $wc instanceof \WooCommerce && $wc->is_store_api_request();
+  }
+
   public function wcGetCustomerOrderCount($userId) {
     return wc_get_customer_order_count($userId);
   }

--- a/mailpoet/lib/WooCommerce/OrderAttributionFields.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionFields.php
@@ -5,6 +5,9 @@ namespace MailPoet\WooCommerce;
 use MailPoet\WP\Functions as WPFunctions;
 
 class OrderAttributionFields {
+  // Pinned by STOMAIL-8135; Woo's filterable field prefix is intentionally not applied.
+  const META_PREFIX = '_wc_order_attribution_';
+
   const FIELD_CLICK_ID = 'mailpoet_click_id';
   const FIELD_NEWSLETTER_ID = 'mailpoet_newsletter_id';
   const FIELD_QUEUE_ID = 'mailpoet_queue_id';
@@ -16,6 +19,20 @@ class OrderAttributionFields {
     self::FIELD_QUEUE_ID,
     self::FIELD_SUBSCRIBER_ID,
   ];
+
+  public static function getMetaKey(string $fieldName): string {
+    return self::META_PREFIX . $fieldName;
+  }
+
+  /**
+   * @param string[] $fieldNames
+   * @return string[]
+   */
+  public static function getMetaKeys(array $fieldNames): array {
+    return array_map(function(string $fieldName): string {
+      return self::getMetaKey($fieldName);
+    }, $fieldNames);
+  }
 
   /** @var WPFunctions */
   private $wp;

--- a/mailpoet/lib/WooCommerce/OrderAttributionPrivacy.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionPrivacy.php
@@ -92,7 +92,7 @@ class OrderAttributionPrivacy {
       return;
     }
     foreach (self::PERSONAL_FIELD_NAMES as $fieldName) {
-      $order->delete_meta_data(OrderAttributionWriter::META_PREFIX . $fieldName);
+      $order->delete_meta_data(OrderAttributionFields::getMetaKey($fieldName));
     }
     // The reconciliation record (STOMAIL-8136) embeds the same click identifiers.
     $order->delete_meta_data(OrderAttributionReconciler::RECONCILIATION_META_KEY);
@@ -121,7 +121,7 @@ class OrderAttributionPrivacy {
     if ($this->wooHelper->isWooCommerceCustomOrdersTableEnabled()) {
       $args['meta_query'] = [
         [
-          'key' => OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_SUBSCRIBER_ID,
+          'key' => OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID),
           'value' => $subscriberId,
         ],
       ];
@@ -171,7 +171,7 @@ class OrderAttributionPrivacy {
     }
     $metaQuery = isset($query['meta_query']) && is_array($query['meta_query']) ? $query['meta_query'] : [];
     $metaQuery[] = [
-      'key' => OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_SUBSCRIBER_ID,
+      'key' => OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID),
       'value' => (string)$subscriberId,
     ];
     $query['meta_query'] = $metaQuery;
@@ -192,7 +192,7 @@ class OrderAttributionPrivacy {
       ],
     ];
     foreach ($fieldLabels as $fieldName => $label) {
-      $value = $order->get_meta(OrderAttributionWriter::META_PREFIX . $fieldName);
+      $value = $order->get_meta(OrderAttributionFields::getMetaKey($fieldName));
       if (!is_scalar($value) || (string)$value === '') {
         continue;
       }

--- a/mailpoet/lib/WooCommerce/OrderAttributionReconciler.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionReconciler.php
@@ -138,7 +138,7 @@ class OrderAttributionReconciler {
   }
 
   private function getWooClickId(WC_Order $order): ?int {
-    $value = $order->get_meta(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_CLICK_ID);
+    $value = $order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID));
     if (!is_scalar($value) || (string)$value === '') {
       return null;
     }
@@ -348,8 +348,8 @@ class OrderAttributionReconciler {
     if ($wooClickId === null) {
       return false;
     }
-    $sourceType = $order->get_meta(OrderAttributionWriter::META_PREFIX . 'source_type');
-    $utmSource = $order->get_meta(OrderAttributionWriter::META_PREFIX . 'utm_source');
+    $sourceType = $order->get_meta(OrderAttributionFields::getMetaKey('source_type'));
+    $utmSource = $order->get_meta(OrderAttributionFields::getMetaKey('utm_source'));
     $sourceType = is_scalar($sourceType) ? (string)$sourceType : '';
     $utmSource = is_scalar($utmSource) ? (string)$utmSource : '';
     $isOverwritable = in_array($sourceType, OrderAttributionWriter::OVERWRITABLE_SOURCE_TYPES, true)

--- a/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
@@ -529,12 +529,12 @@ class OrderAttributionRevenueReader {
     $typeSql = $orderLookup['type_column'] !== null ? ' AND woo_order.' . $orderLookup['type_column'] . ' = %s' : '';
     $typeParams = $orderLookup['type_column'] !== null ? ['shop_order'] : [];
     $meta = $this->getOrderMetaTable();
-    $metaKeys = [
-      OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_CLICK_ID,
-      OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_NEWSLETTER_ID,
-      OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_SUBSCRIBER_ID,
-      OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_QUEUE_ID,
-    ];
+    $metaKeys = OrderAttributionFields::getMetaKeys([
+      OrderAttributionFields::FIELD_CLICK_ID,
+      OrderAttributionFields::FIELD_NEWSLETTER_ID,
+      OrderAttributionFields::FIELD_SUBSCRIBER_ID,
+      OrderAttributionFields::FIELD_QUEUE_ID,
+    ]);
 
     $having = 'click_id IS NOT NULL AND click_id <> \'\' AND newsletter_id IS NOT NULL AND newsletter_id <> \'\'';
     $havingParams = [];
@@ -728,7 +728,7 @@ class OrderAttributionRevenueReader {
       $exists[] = 'EXISTS (SELECT 1 FROM %i woo_meta WHERE woo_meta.%i = ' . $orderIdExpression . ' AND woo_meta.meta_key = %s AND woo_meta.meta_value <> \'\')';
       $params[] = $meta['table'];
       $params[] = $meta['order_id_column'];
-      $params[] = OrderAttributionWriter::META_PREFIX . $fieldName;
+      $params[] = OrderAttributionFields::getMetaKey($fieldName);
     }
 
     return ' AND NOT (' . implode(' AND ', $exists) . ')';

--- a/mailpoet/lib/WooCommerce/OrderAttributionWriter.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionWriter.php
@@ -17,9 +17,7 @@ use WC_Order;
 class OrderAttributionWriter {
   const WRITES_STARTED_AT_OPTION = 'mailpoet_woo_attribution_writes_started_at';
 
-  // The meta key names are pinned by the migration contract (STOMAIL-8135), so Woo's
-  // filterable wc_order_attribution_tracking_field_prefix is intentionally not applied.
-  const META_PREFIX = '_wc_order_attribution_';
+  const META_PREFIX = OrderAttributionFields::META_PREFIX;
 
   // 'typein' is Woo's source type for direct traffic. A clear non-MailPoet source
   // (organic, referral, non-MailPoet utm, admin, mobile_app) is never overwritten.
@@ -115,11 +113,7 @@ class OrderAttributionWriter {
     if ($this->wp->isAdmin()) {
       return true;
     }
-    $wc = $this->wooHelper->WC();
-    if (!$wc instanceof \WooCommerce) {
-      return false;
-    }
-    return $wc->is_rest_api_request() && !$wc->is_store_api_request();
+    return $this->wooHelper->isWooCommerceRestApiRequest() && !$this->wooHelper->isWooCommerceStoreApiRequest();
   }
 
   /**
@@ -234,13 +228,13 @@ class OrderAttributionWriter {
         $this->removeEmptyPlaceholder($order, $fieldName);
         continue;
       }
-      $order->update_meta_data(self::META_PREFIX . $fieldName, $value);
+      $order->update_meta_data(OrderAttributionFields::getMetaKey($fieldName), $value);
     }
   }
 
   private function writeStandardSourceFields(WC_Order $order, StatisticsClickEntity $click): void {
-    $sourceType = $this->getMetaString($order, self::META_PREFIX . 'source_type');
-    $utmSource = $this->getMetaString($order, self::META_PREFIX . 'utm_source');
+    $sourceType = $this->getMetaString($order, OrderAttributionFields::getMetaKey('source_type'));
+    $utmSource = $this->getMetaString($order, OrderAttributionFields::getMetaKey('utm_source'));
     $isOverwritable = in_array($sourceType, self::OVERWRITABLE_SOURCE_TYPES, true) || $utmSource === 'mailpoet';
     if (!$isOverwritable) {
       return;
@@ -257,7 +251,7 @@ class OrderAttributionWriter {
       $values['utm_campaign'] = $subject !== '' ? $subject : 'newsletter-' . $newsletter->getId();
     }
     foreach ($values as $fieldName => $value) {
-      $order->update_meta_data(self::META_PREFIX . $fieldName, $this->wp->sanitizeTextField($value));
+      $order->update_meta_data(OrderAttributionFields::getMetaKey($fieldName), $this->wp->sanitizeTextField($value));
     }
   }
 
@@ -274,7 +268,7 @@ class OrderAttributionWriter {
   }
 
   private function removeEmptyPlaceholder(WC_Order $order, string $fieldName): void {
-    $metaKey = self::META_PREFIX . $fieldName;
+    $metaKey = OrderAttributionFields::getMetaKey($fieldName);
     if ($order->meta_exists($metaKey) && $this->getMetaString($order, $metaKey) === '') {
       $order->delete_meta_data($metaKey);
     }

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
@@ -196,10 +196,10 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
     $order->set_total((string)$total);
     $order->set_status('completed');
     $order->save();
-    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_CLICK_ID, (string)$click->getId());
-    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_NEWSLETTER_ID, (string)$this->newsletter->getId());
-    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_QUEUE_ID, (string)$queue->getId());
-    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_SUBSCRIBER_ID, (string)$this->subscriber->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID), (string)$click->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID), (string)$this->newsletter->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_QUEUE_ID), (string)$queue->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID), (string)$this->subscriber->getId());
     $order->save_meta_data();
     return $order;
   }

--- a/mailpoet/tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php
@@ -294,9 +294,9 @@ class SubscriberStatisticsRepositoryTest extends \MailPoetTest {
     $order->set_total('40');
     $order->set_status('completed');
     $order->save();
-    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_CLICK_ID, (string)$click->getId());
-    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_NEWSLETTER_ID, (string)$newsletter->getId());
-    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_QUEUE_ID, (string)$queue->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID), (string)$click->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID), (string)$newsletter->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_QUEUE_ID), (string)$queue->getId());
     $order->save_meta_data();
 
     (new StatisticsWooCommercePurchases($click, [
@@ -335,10 +335,10 @@ class SubscriberStatisticsRepositoryTest extends \MailPoetTest {
     $order->set_total((string)$total);
     $order->set_status('completed');
     $order->save();
-    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_CLICK_ID, (string)$click->getId());
-    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_NEWSLETTER_ID, (string)$newsletter->getId());
-    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_QUEUE_ID, (string)$queue->getId());
-    $order->update_meta_data(OrderAttributionWriter::META_PREFIX . OrderAttributionFields::FIELD_SUBSCRIBER_ID, (string)$subscriber->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID), (string)$click->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID), (string)$newsletter->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_QUEUE_ID), (string)$queue->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID), (string)$subscriber->getId());
     $order->save_meta_data();
     return $order;
   }

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionCompatibilityTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionCompatibilityTest.php
@@ -1,0 +1,322 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use Codeception\Stub;
+use DateTime;
+use DateTimeImmutable;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Features\FeaturesController;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\TrackingConfig;
+use MailPoet\Statistics\StatisticsClicksRepository;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Test\DataFactories\Features;
+use MailPoet\Util\Cookies;
+use MailPoet\WP\Functions as WPFunctions;
+use WC_Order;
+
+/**
+ * STOMAIL-8144 compatibility matrix for the MailPoet <-> Woo attribution write + read paths.
+ *
+ * Each data set is one matrix cell: a write context crossed with a consent state and a
+ * customer type. The test writes through that context, then reads back through the
+ * Woo-backed read model, so every cell exercises the full write -> read round trip and
+ * reports an independent pass/fail.
+ *
+ * Two matrix axes are environment-level in this repo and are covered by re-running this
+ * test under each environment rather than by an in-process toggle:
+ *   - HPOS on/off: flipped at container boot via ENABLE_HPOS / DISABLE_HPOS
+ *     (tests_env/docker/codeception/docker-entrypoint.sh).
+ *   - WooCommerce 10.7 vs trunk: run the suite against each version.
+ * Express-payment buttons and headless checkouts reach the same server-side write path as
+ * Block checkout (woocommerce_order_save_attribution_data) and are covered by equivalence.
+ *
+ * @phpstan-import-type OrderRow from OrderAttributionRevenueReader
+ * @group woo
+ */
+class OrderAttributionCompatibilityTest extends \MailPoetTest {
+  private const CONTEXT_CLASSIC_BLOCK_CHECKOUT = 'classic_block_checkout';
+  private const CONTEXT_ORDER_STATUS_CHANGE = 'order_status_change';
+  private const CONTEXT_ADMIN_ORDER = 'admin_order';
+  private const CONTEXT_REST_API_ORDER = 'rest_api_order';
+  private const CONTEXT_STORE_API_ORDER = 'store_api_order';
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var SubscriberEntity */
+  private $subscriber;
+
+  /** @var NewsletterEntity */
+  private $newsletter;
+
+  /** @var SendingQueueEntity */
+  private $queue;
+
+  /** @var NewsletterLinkEntity */
+  private $link;
+
+  public function _before() {
+    parent::_before();
+    delete_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
+    unset($_COOKIE['mailpoet_revenue_tracking']);
+    $this->settings = SettingsController::getInstance();
+    $this->subscriber = $this->createSubscriber('matrix@example.com');
+    $this->newsletter = $this->createNewsletter('Matrix Campaign');
+    $this->queue = $this->createQueue($this->newsletter, $this->subscriber);
+    $this->link = $this->createLink($this->newsletter, $this->queue);
+  }
+
+  /**
+   * @dataProvider matrixProvider
+   */
+  public function testAttributionWriteReadMatrix(
+    string $context,
+    bool $consentGranted,
+    bool $loggedIn,
+    bool $expectWrite
+  ): void {
+    $this->settings->set('tracking.level', $consentGranted ? TrackingConfig::LEVEL_FULL : TrackingConfig::LEVEL_BASIC);
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+
+    $order = $this->createOrder($this->subscriber->getEmail(), $loggedIn);
+    $this->writeThroughContext($context, $order);
+
+    $order = $this->reloadOrder($order);
+    $clickIdKey = OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID);
+
+    if (!$expectWrite) {
+      verify($order->meta_exists($clickIdKey))->false();
+      $this->assertArrayNotHasKey($order->get_id(), $this->readNewsletterOrderIds());
+      return;
+    }
+
+    verify($order->get_meta($clickIdKey))->equals((string)$click->getId());
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID)))
+      ->equals((string)$this->newsletter->getId());
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID)))
+      ->equals((string)$this->subscriber->getId());
+
+    $row = $this->readNewsletterOrderRow($order->get_id());
+    $this->assertNotNull($row);
+    verify($row['newsletter_id'])->equals((int)$this->newsletter->getId());
+    verify($row['subscriber_id'])->equals((int)$this->subscriber->getId());
+  }
+
+  /**
+   * @return array<string, array{0: string, 1: bool, 2: bool, 3: bool}>
+   */
+  public function matrixProvider(): array {
+    return [
+      'classic/Block checkout, consent granted, logged-in' => [self::CONTEXT_CLASSIC_BLOCK_CHECKOUT, true, true, true],
+      'classic/Block checkout, consent granted, guest' => [self::CONTEXT_CLASSIC_BLOCK_CHECKOUT, true, false, true],
+      'classic/Block checkout, consent denied, logged-in' => [self::CONTEXT_CLASSIC_BLOCK_CHECKOUT, false, true, false],
+      'order status change, consent granted, logged-in' => [self::CONTEXT_ORDER_STATUS_CHANGE, true, true, true],
+      'admin order, consent granted, guest' => [self::CONTEXT_ADMIN_ORDER, true, false, true],
+      'admin order, consent denied, guest' => [self::CONTEXT_ADMIN_ORDER, false, false, false],
+      'REST-API order, consent granted, logged-in' => [self::CONTEXT_REST_API_ORDER, true, true, true],
+      'REST-API order, consent granted, guest' => [self::CONTEXT_REST_API_ORDER, true, false, true],
+      'Store-API order, consent granted, logged-in' => [self::CONTEXT_STORE_API_ORDER, true, true, false],
+    ];
+  }
+
+  private function writeThroughContext(string $context, WC_Order $order): void {
+    switch ($context) {
+      case self::CONTEXT_CLASSIC_BLOCK_CHECKOUT:
+        do_action('woocommerce_order_save_attribution_data', $order, $this->checkoutAttributionParams());
+        return;
+      case self::CONTEXT_ORDER_STATUS_CHANGE:
+        $order->set_status('processing');
+        $order->save();
+        return;
+      case self::CONTEXT_ADMIN_ORDER:
+        $this->createWriterForRequestContext(true, false, false)->writeForNewOrder($order->get_id());
+        return;
+      case self::CONTEXT_REST_API_ORDER:
+        $this->createWriterForRequestContext(false, true, false)->writeForNewOrder($order->get_id());
+        return;
+      case self::CONTEXT_STORE_API_ORDER:
+        $this->createWriterForRequestContext(false, true, true)->writeForNewOrder($order->get_id());
+        return;
+    }
+  }
+
+  /**
+   * Mirrors Woo's classic/Block checkout payload: Woo's priority-10 handler persists the
+   * registered MailPoet fields as empty placeholders, which the MailPoet handler overwrites.
+   *
+   * @return array<string, string>
+   */
+  private function checkoutAttributionParams(): array {
+    $params = array_fill_keys([
+      'source_type', 'referrer', 'utm_campaign', 'utm_source', 'utm_medium', 'utm_content',
+      'utm_id', 'utm_term', 'utm_source_platform', 'utm_creative_format', 'utm_marketing_tactic',
+      'session_entry', 'session_start_time', 'session_pages', 'session_count', 'user_agent',
+    ], '(none)');
+    foreach (OrderAttributionFields::FIELD_NAMES as $fieldName) {
+      $params[$fieldName] = '';
+    }
+    return $params;
+  }
+
+  /**
+   * @return array<int, int> map of order id => order id, for membership assertions
+   */
+  private function readNewsletterOrderIds(): array {
+    $ids = [];
+    foreach ($this->readNewsletterOrderRows() as $row) {
+      $ids[$row['order_id']] = $row['order_id'];
+    }
+    return $ids;
+  }
+
+  /**
+   * @return OrderRow|null
+   */
+  private function readNewsletterOrderRow(int $orderId): ?array {
+    foreach ($this->readNewsletterOrderRows() as $row) {
+      if ($row['order_id'] === $orderId) {
+        return $row;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @return OrderRow[]
+   */
+  private function readNewsletterOrderRows(): array {
+    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
+    $this->diContainer->get(FeaturesController::class)->resetCache();
+    update_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION, '2000-01-01 00:00:00');
+
+    $reader = $this->diContainer->get(OrderAttributionRevenueReader::class);
+    $rows = $reader->getNewsletterOrderRows(
+      [(int)$this->newsletter->getId()],
+      new DateTimeImmutable('@0'),
+      new DateTimeImmutable('+1 day')
+    );
+    return $rows ?? [];
+  }
+
+  private function createOrder(string $billingEmail, bool $loggedIn): WC_Order {
+    $order = wc_create_order();
+    $this->assertInstanceOf(WC_Order::class, $order);
+    $order->set_billing_email($billingEmail);
+    $order->set_total('15');
+    if ($loggedIn) {
+      $order->set_customer_id($this->ensureWpUser($billingEmail));
+    }
+    $order->save();
+    return $order;
+  }
+
+  private function ensureWpUser(string $email): int {
+    $existing = get_user_by('email', $email);
+    if ($existing) {
+      return (int)$existing->ID;
+    }
+    $userId = wp_insert_user([
+      'user_login' => 'matrix_' . md5($email),
+      'user_email' => $email,
+      'user_pass' => 'password',
+    ]);
+    $this->assertIsInt($userId);
+    return $userId;
+  }
+
+  private function reloadOrder(WC_Order $order): WC_Order {
+    $reloaded = wc_get_order($order->get_id());
+    $this->assertInstanceOf(WC_Order::class, $reloaded);
+    return $reloaded;
+  }
+
+  private function createWriterForRequestContext(
+    bool $isAdmin,
+    bool $isRestApiRequest,
+    bool $isStoreApiRequest
+  ): OrderAttributionWriter {
+    $wooHelper = Stub::make(Helper::class, [
+      'isWooCommerceActive' => true,
+      'wcGetOrder' => function($order) {
+        return wc_get_order($order);
+      },
+      'isWooCommerceRestApiRequest' => $isRestApiRequest,
+      'isWooCommerceStoreApiRequest' => $isStoreApiRequest,
+    ], $this);
+
+    return new OrderAttributionWriter(
+      Stub::make(WPFunctions::class, ['isAdmin' => $isAdmin]),
+      $wooHelper,
+      $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(StatisticsClicksRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
+      new Cookies()
+    );
+  }
+
+  private function createNewsletter(string $subject): NewsletterEntity {
+    $newsletter = new NewsletterEntity();
+    $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
+    $newsletter->setSubject($subject);
+    $this->entityManager->persist($newsletter);
+    return $newsletter;
+  }
+
+  private function createQueue(NewsletterEntity $newsletter, SubscriberEntity $subscriber): SendingQueueEntity {
+    $task = new ScheduledTaskEntity();
+    $this->entityManager->persist($task);
+    $queue = new SendingQueueEntity();
+    $queue->setNewsletter($newsletter);
+    $queue->setTask($task);
+    $this->entityManager->persist($queue);
+    $sendingTaskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber, 1);
+    $this->entityManager->persist($sendingTaskSubscriber);
+    return $queue;
+  }
+
+  private function createSubscriber(string $email): SubscriberEntity {
+    $subscriber = new SubscriberEntity();
+    $subscriber->setEmail($email);
+    $subscriber->setFirstName('First');
+    $subscriber->setLastName('Last');
+    $this->entityManager->persist($subscriber);
+    return $subscriber;
+  }
+
+  private function createLink(NewsletterEntity $newsletter, SendingQueueEntity $queue): NewsletterLinkEntity {
+    $link = new NewsletterLinkEntity($newsletter, $queue, 'url', 'hash');
+    $this->entityManager->persist($link);
+    return $link;
+  }
+
+  private function createClick(NewsletterLinkEntity $link, SubscriberEntity $subscriber): StatisticsClickEntity {
+    $newsletter = $link->getNewsletter();
+    $queue = $link->getQueue();
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
+    $click = new StatisticsClickEntity($newsletter, $queue, $subscriber, $link, 1);
+    $this->entityManager->persist($click);
+    $timestamp = new DateTime('-5 days');
+    $click->setCreatedAt($timestamp);
+    $click->setUpdatedAt($timestamp);
+    return $click;
+  }
+
+  public function _after() {
+    parent::_after();
+    delete_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
+    $orders = (array)wc_get_orders(['limit' => -1]);
+    foreach ($orders as $order) {
+      $order->delete(true);
+    }
+  }
+}

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionPrivacyTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionPrivacyTest.php
@@ -62,11 +62,11 @@ class OrderAttributionPrivacyTest extends \MailPoetTest {
     verify($result['items_removed'])->true();
     verify($result['done'])->true();
     $order = $this->reloadOrder($order);
-    verify($order->meta_exists('_wc_order_attribution_mailpoet_subscriber_id'))->false();
-    verify($order->meta_exists('_wc_order_attribution_mailpoet_click_id'))->false();
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID)))->false();
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->false();
     verify($order->meta_exists(OrderAttributionReconciler::RECONCILIATION_META_KEY))->false();
-    verify($order->get_meta('_wc_order_attribution_mailpoet_newsletter_id'))->equals('22');
-    verify($order->get_meta('_wc_order_attribution_mailpoet_queue_id'))->equals('33');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID)))->equals('22');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_QUEUE_ID)))->equals('33');
   }
 
   public function testEraseLeavesOrdersOfOtherSubscribersUntouched(): void {
@@ -78,8 +78,8 @@ class OrderAttributionPrivacyTest extends \MailPoetTest {
     $this->privacy->erase($this->subscriber->getEmail());
 
     $otherOrder = $this->reloadOrder($otherOrder);
-    verify($otherOrder->get_meta('_wc_order_attribution_mailpoet_subscriber_id'))->equals((string)$otherSubscriber->getId());
-    verify($otherOrder->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals('11');
+    verify($otherOrder->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID)))->equals((string)$otherSubscriber->getId());
+    verify($otherOrder->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals('11');
   }
 
   public function testEraseReportsNothingRemovedForAnUnknownEmail(): void {
@@ -108,8 +108,8 @@ class OrderAttributionPrivacyTest extends \MailPoetTest {
     }
 
     $order = $this->reloadOrder($order);
-    verify($order->meta_exists('_wc_order_attribution_mailpoet_subscriber_id'))->false();
-    verify($order->meta_exists('_wc_order_attribution_mailpoet_click_id'))->false();
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID)))->false();
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->false();
     $this->entityManager->refresh($this->subscriber);
     verify($this->subscriber->getEmail())->stringNotContainsString($email);
   }
@@ -134,11 +134,11 @@ class OrderAttributionPrivacyTest extends \MailPoetTest {
     do_action('woocommerce_privacy_remove_order_personal_data', $order);
 
     $order = $this->reloadOrder($order);
-    verify($order->meta_exists('_wc_order_attribution_mailpoet_subscriber_id'))->false();
-    verify($order->meta_exists('_wc_order_attribution_mailpoet_click_id'))->false();
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID)))->false();
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->false();
     verify($order->meta_exists(OrderAttributionReconciler::RECONCILIATION_META_KEY))->false();
-    verify($order->get_meta('_wc_order_attribution_mailpoet_newsletter_id'))->equals('22');
-    verify($order->get_meta('_wc_order_attribution_mailpoet_queue_id'))->equals('33');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID)))->equals('22');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_QUEUE_ID)))->equals('33');
   }
 
   private function createAttributedOrder(SubscriberEntity $subscriber): WC_Order {
@@ -146,10 +146,10 @@ class OrderAttributionPrivacyTest extends \MailPoetTest {
     $this->assertInstanceOf(WC_Order::class, $order);
     $order->set_billing_email($subscriber->getEmail());
     $order->set_total('15');
-    $order->update_meta_data('_wc_order_attribution_mailpoet_click_id', '11');
-    $order->update_meta_data('_wc_order_attribution_mailpoet_newsletter_id', '22');
-    $order->update_meta_data('_wc_order_attribution_mailpoet_queue_id', '33');
-    $order->update_meta_data('_wc_order_attribution_mailpoet_subscriber_id', (string)$subscriber->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID), '11');
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID), '22');
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_QUEUE_ID), '33');
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID), (string)$subscriber->getId());
     $order->save();
     return $order;
   }

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionReconcilerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionReconcilerTest.php
@@ -107,8 +107,8 @@ class OrderAttributionReconcilerTest extends \MailPoetTest {
     $this->entityManager->flush();
 
     $order = $this->createOrder($this->subscriber->getEmail());
-    $order->update_meta_data('_wc_order_attribution_source_type', 'referral');
-    $order->update_meta_data('_wc_order_attribution_utm_source', 'google');
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('source_type'), 'referral');
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('utm_source'), 'google');
     $order->save_meta_data();
 
     $this->completeOrder($order);
@@ -130,7 +130,7 @@ class OrderAttributionReconcilerTest extends \MailPoetTest {
     $this->completeOrder($order);
 
     $order = $this->reloadOrder($order);
-    $order->delete_meta_data('_wc_order_attribution_mailpoet_click_id');
+    $order->delete_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID));
     $order->save_meta_data();
 
     $this->reconciler->reconcileForOrder($order->get_id());
@@ -174,7 +174,7 @@ class OrderAttributionReconcilerTest extends \MailPoetTest {
     $this->completeOrder($order);
 
     $order = $this->reloadOrder($order);
-    $order->update_meta_data('_wc_order_attribution_mailpoet_click_id', (string)((int)$click->getId() + 999));
+    $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID), (string)((int)$click->getId() + 999));
     $order->save_meta_data();
 
     $this->reconciler->reconcileForOrder($order->get_id());

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionWriterTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionWriterTest.php
@@ -64,15 +64,15 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     $this->writer->writeForOrder($order->get_id());
 
     $order = $this->reloadOrder($order);
-    verify($order->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$click->getId());
-    verify($order->get_meta('_wc_order_attribution_mailpoet_newsletter_id'))->equals((string)$this->newsletter->getId());
-    verify($order->get_meta('_wc_order_attribution_mailpoet_queue_id'))->equals((string)$this->queue->getId());
-    verify($order->get_meta('_wc_order_attribution_mailpoet_subscriber_id'))->equals((string)$this->subscriber->getId());
-    verify($order->get_meta('_wc_order_attribution_source_type'))->equals('utm');
-    verify($order->get_meta('_wc_order_attribution_utm_source'))->equals('mailpoet');
-    verify($order->get_meta('_wc_order_attribution_utm_medium'))->equals('email');
-    verify($order->get_meta('_wc_order_attribution_utm_source_platform'))->equals('mailpoet');
-    verify($order->get_meta('_wc_order_attribution_utm_campaign'))->equals('First Campaign');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$click->getId());
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID)))->equals((string)$this->newsletter->getId());
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_QUEUE_ID)))->equals((string)$this->queue->getId());
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID)))->equals((string)$this->subscriber->getId());
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('source_type')))->equals('utm');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_source')))->equals('mailpoet');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_medium')))->equals('email');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_source_platform')))->equals('mailpoet');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_campaign')))->equals('First Campaign');
     verify(get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION))->notEmpty();
   }
 
@@ -95,9 +95,9 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     $this->writer->writeForOrder($order->get_id());
 
     $order = $this->reloadOrder($order);
-    verify($order->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$cookieClick->getId());
-    verify($order->get_meta('_wc_order_attribution_mailpoet_newsletter_id'))->equals((string)$cookieNewsletter->getId());
-    verify($order->get_meta('_wc_order_attribution_utm_campaign'))->equals('Cookie Campaign');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$cookieClick->getId());
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID)))->equals((string)$cookieNewsletter->getId());
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_campaign')))->equals('Cookie Campaign');
   }
 
   public function testLastClickWinsAcrossNewslettersForTheSameSubscriber(): void {
@@ -113,8 +113,8 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     $this->writer->writeForOrder($order->get_id());
 
     $order = $this->reloadOrder($order);
-    verify($order->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$newerClick->getId());
-    verify($order->get_meta('_wc_order_attribution_mailpoet_newsletter_id'))->equals((string)$newerNewsletter->getId());
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$newerClick->getId());
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID)))->equals((string)$newerNewsletter->getId());
   }
 
   public function testItPreservesExistingNonMailPoetSource(): void {
@@ -122,17 +122,17 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     $this->entityManager->flush();
 
     $order = $this->createOrder($this->subscriber->getEmail());
-    $order->update_meta_data('_wc_order_attribution_source_type', 'referral');
-    $order->update_meta_data('_wc_order_attribution_utm_source', 'google');
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('source_type'), 'referral');
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('utm_source'), 'google');
     $order->save_meta_data();
 
     $this->writer->writeForOrder($order->get_id());
 
     $order = $this->reloadOrder($order);
-    verify($order->get_meta('_wc_order_attribution_source_type'))->equals('referral');
-    verify($order->get_meta('_wc_order_attribution_utm_source'))->equals('google');
-    verify($order->meta_exists('_wc_order_attribution_utm_medium'))->false();
-    verify($order->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$click->getId());
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('source_type')))->equals('referral');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_source')))->equals('google');
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey('utm_medium')))->false();
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$click->getId());
   }
 
   public function testItIsIdempotent(): void {
@@ -145,8 +145,8 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     $this->writer->writeForOrder($order->get_id());
 
     $order = $this->reloadOrder($order);
-    verify($this->getMetaValues($order, '_wc_order_attribution_mailpoet_click_id'))->equals([(string)$click->getId()]);
-    verify($this->getMetaValues($order, '_wc_order_attribution_utm_source'))->equals(['mailpoet']);
+    verify($this->getMetaValues($order, OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals([(string)$click->getId()]);
+    verify($this->getMetaValues($order, OrderAttributionFields::getMetaKey('utm_source')))->equals(['mailpoet']);
     verify(get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION))->equals($writesStartedAt);
   }
 
@@ -179,8 +179,8 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     $this->writer->writeForOrder($order->get_id());
 
     $order = $this->reloadOrder($order);
-    verify($order->meta_exists('_wc_order_attribution_mailpoet_click_id'))->false();
-    verify($order->meta_exists('_wc_order_attribution_utm_source'))->false();
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->false();
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey('utm_source')))->false();
     verify(get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION))->false();
   }
 
@@ -197,14 +197,14 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     }
 
     $order = $this->reloadOrder($order);
-    verify($order->meta_exists('_wc_order_attribution_mailpoet_click_id'))->false();
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->false();
     verify(get_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION))->false();
   }
 
   public function testItRemovesEmptyPlaceholdersWhenNoClickResolves(): void {
     $order = $this->createOrder('no-clicks@example.com');
     foreach (OrderAttributionFields::FIELD_NAMES as $fieldName) {
-      $order->update_meta_data('_wc_order_attribution_' . $fieldName, '');
+      $order->update_meta_data(OrderAttributionFields::getMetaKey($fieldName), '');
     }
     $order->save_meta_data();
 
@@ -212,9 +212,9 @@ class OrderAttributionWriterTest extends \MailPoetTest {
 
     $order = $this->reloadOrder($order);
     foreach (OrderAttributionFields::FIELD_NAMES as $fieldName) {
-      verify($order->meta_exists('_wc_order_attribution_' . $fieldName))->false();
+      verify($order->meta_exists(OrderAttributionFields::getMetaKey($fieldName)))->false();
     }
-    verify($order->meta_exists('_wc_order_attribution_utm_source'))->false();
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey('utm_source')))->false();
   }
 
   public function testItWritesViaWooAttributionDataAction(): void {
@@ -250,8 +250,8 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     do_action('woocommerce_order_save_attribution_data', $order, $params);
 
     $order = $this->reloadOrder($order);
-    verify($order->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$click->getId());
-    verify($this->getMetaValues($order, '_wc_order_attribution_mailpoet_click_id'))->equals([(string)$click->getId()]);
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$click->getId());
+    verify($this->getMetaValues($order, OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals([(string)$click->getId()]);
   }
 
   public function testItWritesWhenOrderStatusChanges(): void {
@@ -263,7 +263,7 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     $order->save();
 
     $order = $this->reloadOrder($order);
-    verify($order->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$click->getId());
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$click->getId());
   }
 
   public function testNewOrderPathRunsOnlyInAdminOrRestContext(): void {
@@ -274,19 +274,24 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     // neither admin nor REST here, so the new-order path must not write
     $this->writer->writeForNewOrder($order->get_id());
     $reloaded = $this->reloadOrder($order);
-    verify($reloaded->meta_exists('_wc_order_attribution_mailpoet_click_id'))->false();
+    verify($reloaded->meta_exists(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->false();
 
-    $adminWriter = new OrderAttributionWriter(
-      Stub::make(WPFunctions::class, ['isAdmin' => true]),
-      $this->diContainer->get(Helper::class),
-      $this->diContainer->get(TrackingConfig::class),
-      $this->diContainer->get(StatisticsClicksRepository::class),
-      $this->diContainer->get(SubscribersRepository::class),
-      new Cookies()
-    );
+    $storeApiOrder = $this->createOrder($this->subscriber->getEmail());
+    $storeApiWriter = $this->createWriterForRequestContext(false, true, true);
+    $storeApiWriter->writeForNewOrder($storeApiOrder->get_id());
+    $reloadedStoreApiOrder = $this->reloadOrder($storeApiOrder);
+    verify($reloadedStoreApiOrder->meta_exists(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->false();
+
+    $restApiOrder = $this->createOrder($this->subscriber->getEmail());
+    $restApiWriter = $this->createWriterForRequestContext(false, true, false);
+    $restApiWriter->writeForNewOrder($restApiOrder->get_id());
+    $reloadedRestApiOrder = $this->reloadOrder($restApiOrder);
+    verify($reloadedRestApiOrder->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$click->getId());
+
+    $adminWriter = $this->createWriterForRequestContext(true, false, false);
     $adminWriter->writeForNewOrder($order->get_id());
     $reloaded = $this->reloadOrder($order);
-    verify($reloaded->get_meta('_wc_order_attribution_mailpoet_click_id'))->equals((string)$click->getId());
+    verify($reloaded->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$click->getId());
   }
 
   private function createOrder(string $billingEmail): WC_Order {
@@ -302,6 +307,30 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     $reloaded = wc_get_order($order->get_id());
     $this->assertInstanceOf(WC_Order::class, $reloaded);
     return $reloaded;
+  }
+
+  private function createWriterForRequestContext(
+    bool $isAdmin,
+    bool $isRestApiRequest,
+    bool $isStoreApiRequest
+  ): OrderAttributionWriter {
+    $wooHelper = Stub::make(Helper::class, [
+      'isWooCommerceActive' => true,
+      'wcGetOrder' => function($order) {
+        return wc_get_order($order);
+      },
+      'isWooCommerceRestApiRequest' => $isRestApiRequest,
+      'isWooCommerceStoreApiRequest' => $isStoreApiRequest,
+    ], $this);
+
+    return new OrderAttributionWriter(
+      Stub::make(WPFunctions::class, ['isAdmin' => $isAdmin]),
+      $wooHelper,
+      $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(StatisticsClicksRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
+      new Cookies()
+    );
   }
 
   /**

--- a/mailpoet/tests/unit/WooCommerce/OrderAttributionFieldsTest.php
+++ b/mailpoet/tests/unit/WooCommerce/OrderAttributionFieldsTest.php
@@ -42,6 +42,22 @@ class OrderAttributionFieldsTest extends \MailPoetUnitTest {
     verify($fields)->arrayCount(count(self::WOO_DEFAULT_FIELDS) + count(OrderAttributionFields::FIELD_NAMES));
   }
 
+  public function testItBuildsWooAttributionMetaKeys(): void {
+    verify(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID))
+      ->equals('_wc_order_attribution_mailpoet_click_id');
+    verify(OrderAttributionFields::getMetaKey('utm_source'))->equals('_wc_order_attribution_utm_source');
+  }
+
+  public function testItBuildsMultipleWooAttributionMetaKeys(): void {
+    verify(OrderAttributionFields::getMetaKeys([
+      OrderAttributionFields::FIELD_NEWSLETTER_ID,
+      OrderAttributionFields::FIELD_SUBSCRIBER_ID,
+    ]))->equals([
+      '_wc_order_attribution_mailpoet_newsletter_id',
+      '_wc_order_attribution_mailpoet_subscriber_id',
+    ]);
+  }
+
   public function testItDoesNotAddFieldsWhenWooCommerceIsNotActive(): void {
     $orderAttributionFields = $this->createOrderAttributionFields(false);
 

--- a/mailpoet/tests/unit/WooCommerce/OrderAttributionFieldsTest.php
+++ b/mailpoet/tests/unit/WooCommerce/OrderAttributionFieldsTest.php
@@ -76,12 +76,17 @@ class OrderAttributionFieldsTest extends \MailPoetUnitTest {
    */
   public function testWooMetaPrefixLiteralIsSingleSourced(): void {
     $libDir = __DIR__ . '/../../../lib/WooCommerce';
-    $quotedLiteral = "'" . OrderAttributionFields::META_PREFIX;
+    $singleQuotedLiteral = "'" . OrderAttributionFields::META_PREFIX;
+    $doubleQuotedLiteral = '"' . OrderAttributionFields::META_PREFIX;
     $filesWithLiteral = [];
-    foreach ((array)glob($libDir . '/*.php') as $file) {
-      $contents = (string)file_get_contents((string)$file);
-      if (strpos($contents, $quotedLiteral) !== false) {
-        $filesWithLiteral[] = basename((string)$file);
+    $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($libDir, \FilesystemIterator::SKIP_DOTS));
+    foreach ($iterator as $fileInfo) {
+      if (!$fileInfo instanceof \SplFileInfo || !$fileInfo->isFile() || $fileInfo->getExtension() !== 'php') {
+        continue;
+      }
+      $contents = (string)file_get_contents($fileInfo->getPathname());
+      if (strpos($contents, $singleQuotedLiteral) !== false || strpos($contents, $doubleQuotedLiteral) !== false) {
+        $filesWithLiteral[] = $fileInfo->getFilename();
       }
     }
     verify($filesWithLiteral)->equals(['OrderAttributionFields.php']);

--- a/mailpoet/tests/unit/WooCommerce/OrderAttributionFieldsTest.php
+++ b/mailpoet/tests/unit/WooCommerce/OrderAttributionFieldsTest.php
@@ -58,6 +58,35 @@ class OrderAttributionFieldsTest extends \MailPoetUnitTest {
     ]);
   }
 
+  public function testAllMetaKeysDeriveFromTheSinglePrefixConstant(): void {
+    $prefix = OrderAttributionFields::META_PREFIX;
+    $fieldNames = array_merge(OrderAttributionFields::FIELD_NAMES, ['source_type', 'utm_source', 'utm_campaign']);
+    foreach ($fieldNames as $fieldName) {
+      verify(OrderAttributionFields::getMetaKey($fieldName))->equals($prefix . $fieldName);
+    }
+  }
+
+  /**
+   * STOMAIL-8144 acceptance: a Woo meta-key change must break one place, not many. The
+   * prefix literal may live only in OrderAttributionFields::META_PREFIX; every other
+   * consumer must derive its keys through getMetaKey(). This guard fails if a raw
+   * '_wc_order_attribution_' string literal is reintroduced anywhere else in the
+   * WooCommerce library. Doc comments referencing the prefix are not quoted literals and
+   * are intentionally not matched.
+   */
+  public function testWooMetaPrefixLiteralIsSingleSourced(): void {
+    $libDir = __DIR__ . '/../../../lib/WooCommerce';
+    $quotedLiteral = "'" . OrderAttributionFields::META_PREFIX;
+    $filesWithLiteral = [];
+    foreach ((array)glob($libDir . '/*.php') as $file) {
+      $contents = (string)file_get_contents((string)$file);
+      if (strpos($contents, $quotedLiteral) !== false) {
+        $filesWithLiteral[] = basename((string)$file);
+      }
+    }
+    verify($filesWithLiteral)->equals(['OrderAttributionFields.php']);
+  }
+
   public function testItDoesNotAddFieldsWhenWooCommerceIsNotActive(): void {
     $orderAttributionFields = $this->createOrderAttributionFields(false);
 


### PR DESCRIPTION
## Description

Adds automated coverage around Woo order attribution compatibility and centralizes MailPoet attribution meta-key construction.

## Code review notes

Store API requests are kept out of the new-order write path because block checkout goes through Woo's attribution save action.

## QA notes

_N/A_


## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1097

## Linked tickets

STOMAIL-8144

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8144-compatibility-test-matrix)

_The latest successful build from `add/stomail-8144-compatibility-test-matrix` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->