### PR TITLE
Add wp mailpoet import WP-CLI command

### DIFF
--- a/mailpoet/changelog/2026-06-15-05-04-53-added-wp-cli-command-wp-mailpoet-import-to-import-subscr.md
+++ b/mailpoet/changelog/2026-06-15-05-04-53-added-wp-cli-command-wp-mailpoet-import-to-import-subscr.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+WP-CLI command "wp mailpoet import" to import subscribers from a CSV file

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -31,6 +31,7 @@ use MailPoet\Router;
 use MailPoet\Segments\RestApi\Api as SegmentsRestApi;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Statistics\Track\SubscriberActivityTracker;
+use MailPoet\Subscribers\ImportExport\Import\Cli as ImportCli;
 use MailPoet\Subscribers\RestApi\Api as SubscribersRestApi;
 use MailPoet\Tags\RestApi\Api as TagsRestApi;
 use MailPoet\Util\ConflictResolver;
@@ -66,6 +67,9 @@ class Initializer {
 
   /** @var MigratorCli */
   private $migratorCli;
+
+  /** @var ImportCli */
+  private $importCli;
 
   /** @var Router\Router */
   private $router;
@@ -179,6 +183,7 @@ class Initializer {
     Activator $activator,
     SettingsController $settings,
     MigratorCli $migratorCli,
+    ImportCli $importCli,
     Router\Router $router,
     Hooks $hooks,
     Changelog $changelog,
@@ -219,6 +224,7 @@ class Initializer {
     $this->activator = $activator;
     $this->settings = $settings;
     $this->migratorCli = $migratorCli;
+    $this->importCli = $importCli;
     $this->router = $router;
     $this->hooks = $hooks;
     $this->changelog = $changelog;
@@ -401,6 +407,7 @@ class Initializer {
   public function initialize() {
     try {
       $this->migratorCli->initialize();
+      $this->importCli->initialize();
       $this->setupInstaller();
       $this->setupUpdater();
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -299,6 +299,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\PostEditorBlocks\SubscriptionFormBlock::class);
     $container->autowire(\MailPoet\PostEditorBlocks\NewsletterBlock::class)->setPublic(true);
     $container->autowire(\MailPoet\PostEditorBlocks\WooCommerceBlocksIntegration::class);
+    // Subscribers import CLI
+    $container->autowire(\MailPoet\Subscribers\ImportExport\Import\Cli::class)->setPublic(true);
     // Migrations
     $container->autowire(\MailPoet\Migrator\Cli::class)->setPublic(true);
     $container->autowire(\MailPoet\Migrator\Migrator::class)->setPublic(true);

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
@@ -1,0 +1,416 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscribers\ImportExport\Import;
+
+use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\Entities\CustomFieldEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
+use MailPoet\Segments\SegmentSaveController;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Segments\WP as SegmentsWP;
+use MailPoet\Services\Validator;
+use MailPoet\Subscribers\ImportExport\ImportExportRepository;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Tags\TagRepository;
+use WP_CLI;
+
+class Cli {
+  /** Subscriber fields that can appear as CSV columns, matched by their canonical name. */
+  private const BASE_FIELDS = [
+    'email',
+    'first_name',
+    'last_name',
+    'subscribed_ip',
+    'created_at',
+    'confirmed_at',
+    'confirmed_ip',
+  ];
+
+  private const NEW_SUBSCRIBER_STATUSES = [
+    SubscriberEntity::STATUS_SUBSCRIBED,
+    SubscriberEntity::STATUS_UNCONFIRMED,
+    SubscriberEntity::STATUS_UNSUBSCRIBED,
+    SubscriberEntity::STATUS_INACTIVE,
+  ];
+
+  private const EXISTING_SUBSCRIBER_STATUSES = [
+    Import::STATUS_DONT_UPDATE,
+    SubscriberEntity::STATUS_SUBSCRIBED,
+    SubscriberEntity::STATUS_UNSUBSCRIBED,
+    SubscriberEntity::STATUS_INACTIVE,
+  ];
+
+  private const DEFAULT_BATCH_SIZE = 2000;
+
+  /** @var SegmentsWP */
+  private $wpSegment;
+
+  /** @var CustomFieldsRepository */
+  private $customFieldsRepository;
+
+  /** @var ImportExportRepository */
+  private $importExportRepository;
+
+  /** @var NewsletterOptionsRepository */
+  private $newsletterOptionsRepository;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var TagRepository */
+  private $tagRepository;
+
+  /** @var Validator */
+  private $validator;
+
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
+  /** @var SegmentSaveController */
+  private $segmentSaveController;
+
+  public function __construct(
+    SegmentsWP $wpSegment,
+    CustomFieldsRepository $customFieldsRepository,
+    ImportExportRepository $importExportRepository,
+    NewsletterOptionsRepository $newsletterOptionsRepository,
+    SubscribersRepository $subscribersRepository,
+    TagRepository $tagRepository,
+    Validator $validator,
+    SegmentsRepository $segmentsRepository,
+    SegmentSaveController $segmentSaveController
+  ) {
+    $this->wpSegment = $wpSegment;
+    $this->customFieldsRepository = $customFieldsRepository;
+    $this->importExportRepository = $importExportRepository;
+    $this->newsletterOptionsRepository = $newsletterOptionsRepository;
+    $this->subscribersRepository = $subscribersRepository;
+    $this->tagRepository = $tagRepository;
+    $this->validator = $validator;
+    $this->segmentsRepository = $segmentsRepository;
+    $this->segmentSaveController = $segmentSaveController;
+  }
+
+  public function initialize(): void {
+    if (!class_exists(WP_CLI::class)) {
+      return;
+    }
+
+    WP_CLI::add_command('mailpoet import', [$this, 'import'], [
+      'shortdesc' => 'Imports subscribers into MailPoet from a CSV file',
+      'synopsis' => [
+        [
+          'type' => 'positional',
+          'name' => 'file',
+          'description' => 'Path to the CSV file. The header row must use MailPoet field names (email, first_name, last_name, subscribed_ip, created_at, confirmed_at, confirmed_ip) or existing custom field names. An "email" column is required.',
+          'optional' => false,
+        ],
+        [
+          'type' => 'assoc',
+          'name' => 'segments',
+          'description' => 'Comma-separated segment IDs or names to add subscribers to. Names that do not exist are created.',
+          'optional' => true,
+        ],
+        [
+          'type' => 'assoc',
+          'name' => 'status',
+          'description' => 'Status for newly created subscribers.',
+          'optional' => true,
+          'default' => SubscriberEntity::STATUS_SUBSCRIBED,
+          'options' => self::NEW_SUBSCRIBER_STATUSES,
+        ],
+        [
+          'type' => 'flag',
+          'name' => 'update-existing',
+          'description' => 'Update the details of subscribers that already exist.',
+          'optional' => true,
+        ],
+        [
+          'type' => 'assoc',
+          'name' => 'existing-status',
+          'description' => 'Status to set on existing subscribers.',
+          'optional' => true,
+          'default' => Import::STATUS_DONT_UPDATE,
+          'options' => self::EXISTING_SUBSCRIBER_STATUSES,
+        ],
+        [
+          'type' => 'assoc',
+          'name' => 'tags',
+          'description' => 'Comma-separated tag names to assign to imported subscribers. Tags are created if they do not exist.',
+          'optional' => true,
+        ],
+        [
+          'type' => 'assoc',
+          'name' => 'batch-size',
+          'description' => 'Number of subscribers to process per batch.',
+          'optional' => true,
+          'default' => self::DEFAULT_BATCH_SIZE,
+        ],
+        [
+          'type' => 'flag',
+          'name' => 'dry-run',
+          'description' => 'Parse and validate the file and report what would be imported without writing anything.',
+          'optional' => true,
+        ],
+      ],
+    ]);
+  }
+
+  /**
+   * WP-CLI entry point. Translates CLI input/output; the work happens in run().
+   *
+   * @param string[] $args
+   * @param array<string, string> $assocArgs
+   */
+  public function import(array $args, array $assocArgs): void {
+    $options = [
+      'segments' => $this->parseList((string)($assocArgs['segments'] ?? '')),
+      'status' => (string)($assocArgs['status'] ?? SubscriberEntity::STATUS_SUBSCRIBED),
+      'existing_status' => (string)($assocArgs['existing-status'] ?? Import::STATUS_DONT_UPDATE),
+      'update_existing' => !empty($assocArgs['update-existing']),
+      'tags' => $this->parseList((string)($assocArgs['tags'] ?? '')),
+      'batch_size' => (int)($assocArgs['batch-size'] ?? self::DEFAULT_BATCH_SIZE),
+      'dry_run' => !empty($assocArgs['dry-run']),
+    ];
+
+    try {
+      $totals = $this->run((string)($args[0] ?? ''), $options, function (string $message): void {
+        WP_CLI::log($message);
+      });
+    } catch (\Exception $e) {
+      WP_CLI::error($e->getMessage());
+      return;
+    }
+
+    if ($options['dry_run']) {
+      WP_CLI::success(sprintf(
+        'Dry run: %d rows read, %d subscribers with a valid email. Nothing was written.',
+        $totals['rows'],
+        $totals['valid']
+      ));
+      return;
+    }
+
+    WP_CLI::success(sprintf(
+      'Import finished: %d created, %d updated (out of %d rows).',
+      $totals['created'],
+      $totals['updated'],
+      $totals['rows']
+    ));
+  }
+
+  /**
+   * Parses the CSV file and imports the subscribers. Throws on invalid input.
+   * Free of any WP-CLI dependency so it can be unit/integration tested.
+   *
+   * @param array{segments: string[], status: string, existing_status: string, update_existing: bool, tags: string[], batch_size: int, dry_run: bool} $options
+   * @param callable(string): void|null $logger
+   * @return array{created: int, updated: int, valid: int, rows: int}
+   * @throws \RuntimeException
+   */
+  public function run(string $file, array $options, ?callable $logger = null): array {
+    $log = $logger ?? function (string $message): void {
+    };
+
+    if (!is_readable($file)) {
+      throw new \RuntimeException(sprintf('File "%s" does not exist or is not readable.', $file));
+    }
+    if (!in_array($options['status'], self::NEW_SUBSCRIBER_STATUSES, true)) {
+      throw new \RuntimeException(sprintf('Invalid status "%s". Allowed: %s.', $options['status'], implode(', ', self::NEW_SUBSCRIBER_STATUSES)));
+    }
+    if (!in_array($options['existing_status'], self::EXISTING_SUBSCRIBER_STATUSES, true)) {
+      throw new \RuntimeException(sprintf('Invalid existing status "%s". Allowed: %s.', $options['existing_status'], implode(', ', self::EXISTING_SUBSCRIBER_STATUSES)));
+    }
+    if ($options['batch_size'] < 1) {
+      throw new \RuntimeException('Batch size must be a positive integer.');
+    }
+
+    $segmentIds = $this->resolveSegments($options['segments'], $options['dry_run'], $log);
+
+    $handle = fopen($file, 'r');
+    if ($handle === false) {
+      throw new \RuntimeException(sprintf('Unable to open file "%s".', $file));
+    }
+
+    try {
+      $header = fgetcsv($handle, 0, ',', '"', '\\');
+      if (!is_array($header)) {
+        throw new \RuntimeException('The CSV file is empty or has no header row.');
+      }
+      $columns = $this->buildColumns($header);
+
+      $totals = ['created' => 0, 'updated' => 0, 'valid' => 0, 'rows' => 0];
+      $batch = [];
+      while (is_array($row = fgetcsv($handle, 0, ',', '"', '\\'))) {
+        if ($row === [null]) {
+          continue; // skip blank lines
+        }
+        $totals['rows']++;
+        $batch[] = $row;
+        if (count($batch) >= $options['batch_size']) {
+          $this->processBatch($batch, $columns, $segmentIds, $options, $totals, $log);
+          $batch = [];
+        }
+      }
+      if ($batch) {
+        $this->processBatch($batch, $columns, $segmentIds, $options, $totals, $log);
+      }
+    } finally {
+      fclose($handle);
+    }
+
+    return $totals;
+  }
+
+  /**
+   * @param array<int, array<int, string|null>> $batch
+   * @param array<string|int, array{index: int}> $columns
+   * @param int[] $segmentIds
+   * @param array{segments: string[], status: string, existing_status: string, update_existing: bool, tags: string[], batch_size: int, dry_run: bool} $options
+   * @param array{created: int, updated: int, valid: int, rows: int} $totals
+   * @param callable(string): void $log
+   */
+  private function processBatch(
+    array $batch,
+    array $columns,
+    array $segmentIds,
+    array $options,
+    array &$totals,
+    callable $log
+  ): void {
+    $data = [
+      'subscribers' => $batch,
+      'columns' => $columns,
+      'segments' => $segmentIds,
+      'tags' => $options['tags'],
+      'timestamp' => time(),
+      'newSubscribersStatus' => $options['status'],
+      'existingSubscribersStatus' => $options['existing_status'],
+      'updateSubscribers' => $options['update_existing'],
+    ];
+
+    $import = new Import(
+      $this->wpSegment,
+      $this->customFieldsRepository,
+      $this->importExportRepository,
+      $this->newsletterOptionsRepository,
+      $this->subscribersRepository,
+      $this->tagRepository,
+      $this->validator,
+      $data
+    );
+
+    if ($options['dry_run']) {
+      $valid = $import->validateSubscribersData($import->subscribersData);
+      $emails = is_array($valid) && isset($valid['email']) ? $valid['email'] : [];
+      $totals['valid'] += count($emails);
+      return;
+    }
+
+    $result = $import->process();
+    $totals['created'] += (int)$result['created'];
+    $totals['updated'] += (int)$result['updated'];
+    $log(sprintf('  Batch of %d rows: %d created, %d updated.', count($batch), $result['created'], $result['updated']));
+  }
+
+  /**
+   * Maps each CSV header to a subscriber field or custom field id.
+   *
+   * @param array<int, string|null> $header
+   * @return array<string|int, array{index: int}>
+   * @throws \RuntimeException
+   */
+  private function buildColumns(array $header): array {
+    $columns = [];
+    $unknown = [];
+    foreach ($header as $index => $name) {
+      $name = trim((string)$name);
+      if ($name === '') {
+        continue;
+      }
+      $field = $this->resolveField($name);
+      if ($field === null) {
+        $unknown[] = $name;
+        continue;
+      }
+      $columns[$field] = ['index' => $index];
+    }
+
+    if ($unknown) {
+      throw new \RuntimeException(sprintf(
+        'Unrecognized CSV column(s): %s. Use MailPoet field names (%s) or an existing custom field name.',
+        implode(', ', $unknown),
+        implode(', ', self::BASE_FIELDS)
+      ));
+    }
+
+    if (!isset($columns['email'])) {
+      throw new \RuntimeException('The CSV file must contain an "email" column.');
+    }
+
+    return $columns;
+  }
+
+  /**
+   * @return string|int|null Field name, custom field id, or null when unrecognized.
+   */
+  private function resolveField(string $header) {
+    if (in_array(strtolower($header), self::BASE_FIELDS, true)) {
+      return strtolower($header);
+    }
+    $customField = $this->customFieldsRepository->findOneBy(['name' => $header]);
+    if ($customField instanceof CustomFieldEntity) {
+      return $customField->getId();
+    }
+    return null;
+  }
+
+  /**
+   * Resolves segment IDs/names to IDs. Unknown names are created unless this is a dry run.
+   *
+   * @param string[] $segments
+   * @param callable(string): void $log
+   * @return int[]
+   * @throws \RuntimeException
+   */
+  private function resolveSegments(array $segments, bool $dryRun, callable $log): array {
+    $ids = [];
+    foreach ($segments as $segment) {
+      if (ctype_digit($segment)) {
+        $entity = $this->segmentsRepository->findOneById((int)$segment);
+        if (!$entity instanceof SegmentEntity) {
+          throw new \RuntimeException(sprintf('Segment with ID "%s" does not exist.', $segment));
+        }
+        $ids[] = (int)$segment;
+        continue;
+      }
+      $entity = $this->segmentsRepository->findOneBy(['name' => $segment, 'type' => SegmentEntity::TYPE_DEFAULT]);
+      if ($entity instanceof SegmentEntity) {
+        $ids[] = (int)$entity->getId();
+        continue;
+      }
+      if ($dryRun) {
+        $log(sprintf('Segment "%s" would be created.', $segment));
+        continue;
+      }
+      $entity = $this->segmentSaveController->save(['name' => $segment]);
+      $log(sprintf('Created segment "%s" (ID %d).', $segment, (int)$entity->getId()));
+      $ids[] = (int)$entity->getId();
+    }
+    return array_values(array_unique($ids));
+  }
+
+  /**
+   * @return string[]
+   */
+  private function parseList(string $value): array {
+    if (trim($value) === '') {
+      return [];
+    }
+    return array_values(array_filter(array_map('trim', explode(',', $value)), function (string $item): bool {
+      return $item !== '';
+    }));
+  }
+}

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
@@ -371,6 +371,7 @@ class Cli {
    * Resolves segment IDs/names to IDs. Unknown names are created unless this is a dry run.
    *
    * @param string[] $segments
+   * @param bool $dryRun
    * @param callable(string): void $log
    * @return int[]
    * @throws \RuntimeException

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/CliTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/CliTest.php
@@ -1,0 +1,201 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscribers\ImportExport\Import;
+
+use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\Entities\CustomFieldEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Subscribers\SubscriberCustomFieldRepository;
+use MailPoet\Subscribers\SubscribersRepository;
+
+class CliTest extends \MailPoetTest {
+  /** @var Cli */
+  private $cli;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
+  /** @var CustomFieldsRepository */
+  private $customFieldsRepository;
+
+  /** @var SubscriberCustomFieldRepository */
+  private $subscriberCustomFieldRepository;
+
+  /** @var string[] */
+  private $tempFiles = [];
+
+  private const DEFAULT_OPTIONS = [
+    'segments' => [],
+    'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+    'existing_status' => Import::STATUS_DONT_UPDATE,
+    'update_existing' => false,
+    'tags' => [],
+    'batch_size' => 2000,
+    'dry_run' => false,
+  ];
+
+  public function _before(): void {
+    parent::_before();
+    $this->cli = $this->diContainer->get(Cli::class);
+    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+    $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
+    $this->customFieldsRepository = $this->diContainer->get(CustomFieldsRepository::class);
+    $this->subscriberCustomFieldRepository = $this->diContainer->get(SubscriberCustomFieldRepository::class);
+  }
+
+  public function testItImportsNewSubscribersAndCreatesSegment(): void {
+    $file = $this->writeCsv([
+      ['email', 'first_name', 'last_name'],
+      ['Adam@Example.com', 'Adam', 'Smith'],
+      ['mary@example.com', 'Mary', 'Jane'],
+    ]);
+
+    $totals = $this->cli->run($file, ['segments' => ['CLI Import List']] + self::DEFAULT_OPTIONS);
+
+    $this->assertSame(2, $totals['created']);
+    $this->assertSame(0, $totals['updated']);
+
+    $adam = $this->subscribersRepository->findOneBy(['email' => 'adam@example.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $adam);
+    $this->assertSame('Adam', $adam->getFirstName());
+    $this->assertSame(SubscriberEntity::STATUS_SUBSCRIBED, $adam->getStatus());
+
+    $segment = $this->segmentsRepository->findOneBy(['name' => 'CLI Import List', 'type' => SegmentEntity::TYPE_DEFAULT]);
+    $this->assertInstanceOf(SegmentEntity::class, $segment);
+    $this->assertCount(1, array_filter($adam->getSegments()->toArray(), function (SegmentEntity $s) use ($segment): bool {
+      return $s->getId() === $segment->getId();
+    }));
+  }
+
+  public function testItImportsIntoExistingSegmentById(): void {
+    $segment = $this->segmentsRepository->createOrUpdate('Existing CLI List');
+    $file = $this->writeCsv([
+      ['email'],
+      ['solo@example.com'],
+    ]);
+
+    $totals = $this->cli->run($file, ['segments' => [(string)$segment->getId()]] + self::DEFAULT_OPTIONS);
+
+    $this->assertSame(1, $totals['created']);
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => 'solo@example.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+  }
+
+  public function testItMapsCustomFieldByName(): void {
+    $customField = $this->customFieldsRepository->createOrUpdate([
+      'name' => 'Country',
+      'type' => CustomFieldEntity::TYPE_TEXT,
+    ]);
+    $this->assertInstanceOf(CustomFieldEntity::class, $customField);
+
+    $file = $this->writeCsv([
+      ['email', 'Country'],
+      ['traveler@example.com', 'France'],
+    ]);
+
+    $this->cli->run($file, self::DEFAULT_OPTIONS);
+
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => 'traveler@example.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $value = $this->subscriberCustomFieldRepository->findOneBy([
+      'subscriber' => $subscriber,
+      'customField' => $customField,
+    ]);
+    $this->assertNotNull($value);
+    $this->assertSame('France', $value->getValue());
+  }
+
+  public function testItUpdatesExistingSubscribersWhenFlagIsSet(): void {
+    $this->cli->run($this->writeCsv([
+      ['email', 'first_name'],
+      ['repeat@example.com', 'Original'],
+    ]), self::DEFAULT_OPTIONS);
+
+    $totals = $this->cli->run($this->writeCsv([
+      ['email', 'first_name'],
+      ['repeat@example.com', 'Updated'],
+    ]), ['update_existing' => true] + self::DEFAULT_OPTIONS);
+
+    $this->assertSame(0, $totals['created']);
+    $this->assertSame(1, $totals['updated']);
+    $this->subscribersRepository->refreshAll();
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => 'repeat@example.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->assertSame('Updated', $subscriber->getFirstName());
+  }
+
+  public function testDryRunDoesNotWriteAnything(): void {
+    $file = $this->writeCsv([
+      ['email'],
+      ['ghost@example.com'],
+      ['invalid-email'],
+    ]);
+
+    $totals = $this->cli->run($file, ['dry_run' => true, 'segments' => ['Phantom List']] + self::DEFAULT_OPTIONS);
+
+    $this->assertSame(2, $totals['rows']);
+    $this->assertSame(1, $totals['valid']);
+    $this->assertSame(0, $totals['created']);
+    $this->assertNull($this->subscribersRepository->findOneBy(['email' => 'ghost@example.com']));
+    $this->assertNull($this->segmentsRepository->findOneBy(['name' => 'Phantom List', 'type' => SegmentEntity::TYPE_DEFAULT]));
+  }
+
+  public function testItThrowsWhenEmailColumnMissing(): void {
+    $file = $this->writeCsv([
+      ['first_name', 'last_name'],
+      ['No', 'Email'],
+    ]);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('must contain an "email" column');
+    $this->cli->run($file, self::DEFAULT_OPTIONS);
+  }
+
+  public function testItThrowsOnUnrecognizedColumn(): void {
+    $file = $this->writeCsv([
+      ['email', 'favourite_colour'],
+      ['picky@example.com', 'blue'],
+    ]);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Unrecognized CSV column(s): favourite_colour');
+    $this->cli->run($file, self::DEFAULT_OPTIONS);
+  }
+
+  public function testItThrowsForMissingFile(): void {
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('does not exist or is not readable');
+    $this->cli->run('/tmp/does-not-exist-' . bin2hex(random_bytes(6)) . '.csv', self::DEFAULT_OPTIONS); // phpcs:ignore
+  }
+
+  /**
+   * @param array<int, array<int, string>> $rows
+   */
+  private function writeCsv(array $rows): string {
+    $path = tempnam(sys_get_temp_dir(), 'mailpoet-import-');
+    $this->assertIsString($path);
+    $this->tempFiles[] = $path;
+    $handle = fopen($path, 'w');
+    $this->assertNotFalse($handle);
+    foreach ($rows as $row) {
+      fputcsv($handle, $row, ',', '"', '\\');
+    }
+    fclose($handle);
+    return $path;
+  }
+
+  public function _after(): void {
+    parent::_after();
+    foreach ($this->tempFiles as $file) {
+      if (is_file($file)) {
+        unlink($file);
+      }
+    }
+    $this->tempFiles = [];
+  }
+}


### PR DESCRIPTION
## Description

Adds a `wp mailpoet import` WP-CLI command for importing subscribers from a CSV file, reusing the existing `Import` service so all validation, deduplication, WP-user sync, and welcome-email handling stay identical to the UI import.

```
wp mailpoet import <file.csv>
    [--segments=<ids-or-names>]   # names auto-created if missing
    [--status=<status>]           # new subscribers; default subscribed
    [--update-existing]           # update matched existing subscribers
    [--existing-status=<status>]  # default dont_update
    [--tags=<names>]
    [--batch-size=<n>]            # default 2000
    [--dry-run]
```

The CSV header row must use MailPoet field names (`email`, `first_name`, `last_name`, `subscribed_ip`, `created_at`, `confirmed_at`, `confirmed_ip`) or an existing custom field name. There is intentionally **no column mapping** — `email` is required and unrecognized headers fail loudly rather than being silently dropped.

## Code review notes

- The command is a thin WP-CLI wrapper (`import()`) over a `public run()` method that is free of any `WP_CLI` dependency and throws `\RuntimeException` on bad input. This is what makes it integration-testable, since `WP_CLI` is not available in the test env (and `WP_CLI::error` exits the process in production).
- `Import` is constructed per batch with the injected services, mirroring `API\JSON1\ImportExport::processImport()` — same wiring, so behaviour matches the existing endpoint.
- `fgetcsv`/`fputcsv` calls pass explicit `$escape` args to avoid the PHP 8.1+ deprecation while staying PHP 7.4 compatible.
- Registration follows the existing `Migrator\Cli` pattern (autowired `setPublic(true)`, `initialize()` called from `Initializer`, guarded by `class_exists(WP_CLI::class)`).

## QA notes

Manual check from the wp-env container:

```
wp mailpoet import subscribers.csv --segments="My List" --dry-run
wp mailpoet import subscribers.csv --segments="My List" --status=subscribed
```

Automated: `tests/integration/Subscribers/ImportExport/Import/CliTest.php` — 8 tests / 44 assertions, all passing (new import + segment auto-create, import by segment ID, custom-field-by-name, `--update-existing`, `--dry-run` writes nothing, and the no-email-column / unrecognized-column / missing-file error paths).

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/MPI-433/add-wp-mailpoet-import-command

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/wp-cli-import-subscribers-command)

_The latest successful build from `add/wp-cli-import-subscribers-command` will be used. If none is available, the link won't work._