### PR TITLE
Disable WooCommerce transactional email log in acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1074,6 +1074,18 @@ workflows:
           blockbased_theme: 1
           requires:
             - build
+      # TEMPORARY: verify the WooCommerce email-log fix against the latest WC beta on this PR.
+      # The real beta job lives only in the `nightly` workflow, which is schedule-driven and
+      # trunk-only, so a PR cannot trigger it. This duplicate runs the full acceptance suite
+      # against the WC beta on the branch instead. REMOVE this job before merging once the run
+      # is green.
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_tests_woocommerce_beta_TEMP
+          enable_hpos: 1
+          use_woocommerce_beta: true
+          requires:
+            - build
       - js_tests:
           <<: *slack-fail-post-step
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1074,18 +1074,6 @@ workflows:
           blockbased_theme: 1
           requires:
             - build
-      # TEMPORARY: verify the WooCommerce email-log fix against the latest WC beta on this PR.
-      # The real beta job lives only in the `nightly` workflow, which is schedule-driven and
-      # trunk-only, so a PR cannot trigger it. This duplicate runs the full acceptance suite
-      # against the WC beta on the branch instead. REMOVE this job before merging once the run
-      # is green.
-      - acceptance_tests:
-          <<: *slack-fail-post-step
-          name: acceptance_tests_woocommerce_beta_TEMP
-          enable_hpos: 1
-          use_woocommerce_beta: true
-          requires:
-            - build
       - js_tests:
           <<: *slack-fail-post-step
           requires:

--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -148,6 +148,16 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     echo "<?php add_filter('site_transient_woocommerce_blocks_patterns', '__return_false');" > "/wp-core/wp-content/mu-plugins/woo-cache-disable.php"
   fi
 
+  # Install MU plugin that disables WooCommerce's transactional email log (WC 10.9.0+, log source: transactional-emails)
+  # It writes a wc-logs file on every order email sent during checkout. Here wp-cli runs as root and Apache as www-data
+  # on a shared volume, so that log file can be owned by a different user than the web request; PHP touch() then fails
+  # with "Utime failed: Operation not permitted" and the warning fails acceptance tests. The log is irrelevant to the
+  # assertions. See WooCommerce PR #64491.
+  if [[ ! -f "/wp-core/wp-content/mu-plugins/woo-email-log-disable.php" ]]; then
+    mkdir -p /wp-core/wp-content/mu-plugins
+    echo "<?php add_filter('woocommerce_email_log_enabled', '__return_false');" > "/wp-core/wp-content/mu-plugins/woo-email-log-disable.php"
+  fi
+
   ACTIVATION_CONTEXT=$HTTP_HOST
   # For integration tests in multisite environment we need to activate the plugin for correct site that is loaded in tests
   # The acceptance tests activate/deactivate plugins using a helper.


### PR DESCRIPTION
## Description

The [nightly acceptance_tests_woocommerce_beta job](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/23792/workflows/f3a2d492-6c52-4e0b-84fc-e1dd5ca24298/jobs/418256/parallel-runs/6) failed on `WooCheckoutAutomateWooSubscriptionsCest` (`checkoutOptInChecked` / `checkoutOptInUnchecked`). The scenarios themselves pass; the suite fails on a PHP warning captured during the Store API checkout request:

```
Warning: touch(): Utime failed: Operation not permitted
in .../wp-includes/class-wp-filesystem-direct.php:548
@ http://test.local/wp-json/wc/store/v1/checkout
```

The root cause is an interaction of three things, not a single fault:

1. **Trigger (new):** WooCommerce 10.9.0 adds a native transactional email log (`EmailLogger`, `@since 10.9.0`) that writes a `wc-logs` entry under the `transactional-emails` source for every order email. Placing an order during checkout now writes that log inside the web request.
2. **Enabling condition (test env):** In the acceptance stack, wp-cli runs as `root` and Apache as `www-data` on a shared volume, so the daily log file can be owned by a different user than the web request. `WP_Filesystem_Direct::touch()` passes an explicit timestamp, which needs file ownership (not just write permission), so the `www-data` request gets `EPERM`.
3. **Amplifier:** `WP_DEBUG_DISPLAY` renders the warning, and the acceptance suite treats any PHP warning as a failure.

This is not a MailPoet defect (MailPoet never calls `touch()` / `WP_Filesystem`) and not an `EmailLogger` bug (it behaves as designed).

The fix disables the transactional email log in the test environment via WooCommerce's official `woocommerce_email_log_enabled` filter, installed as a mu-plugin from the test entry point. The log is not used by any assertion. Removing the write removes the `touch()` trigger entirely, regardless of file ownership.

## Code review notes

- Disabling is global (a mu-plugin) rather than per-test because the Codeception test process and the Apache request that handles checkout are separate processes, so a `_before` filter in the Cest cannot affect the web request. The filter must be loaded by WordPress itself. This matches `woo-cache-disable.php`, added for the same shape of problem (test-run vs wp-cli path differences producing notices).
- The official filter was chosen over chowning / clearing the log files because those do not reliably fix it: `touch()`'s `utime()` needs ownership (chmod/ACL/setgid do not help), and clearing is ordering-dependent. The filter removes the write outright.
- The temporary commit cd5a949968f373d798f18f65c99251ae050e09cd verified on CI that this change prevents these test failures.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="1328" height="670" alt="image" src="https://github.com/user-attachments/assets/a3b5fca2-48b5-4c21-8dac-37410664be35" /> | <img width="1334" height="1040" alt="image" src="https://github.com/user-attachments/assets/d431726a-dd97-4bfb-8fe5-23cfa4fbaecc" /> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
   - Not applicable: test-environment / CI only, no user-facing change
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/wc-beta-acceptance-disable-transactional-email-log)

_The latest successful build from `fix/wc-beta-acceptance-disable-transactional-email-log` will be used. If none is available, the link won't work._