### PR TITLE
Add recurring cleanup for completed bounce task subscribers

### DIFF
--- a/mailpoet/changelog/2026-06-15-11-52-06-added-recurring-cleanup-task-that-removes-leftover-subsc.md
+++ b/mailpoet/changelog/2026-06-15-11-52-06-added-recurring-cleanup-task-that-removes-leftover-subsc.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Recurring cleanup task that removes leftover subscriber rows from completed bounce tasks

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -99,6 +99,7 @@ class Daemon {
     yield $this->workersFactory->createExportFilesCleanupWorker();
     yield $this->workersFactory->createLogCleanupWorker();
     yield $this->workersFactory->createSendingTaskSubscribersCleanupWorker();
+    yield $this->workersFactory->createBounceTaskSubscribersCleanupWorker();
     yield $this->workersFactory->createSendingQueueBodyCleanupWorker();
     yield $this->workersFactory->createSubscribersEmailCountsWorker();
     yield $this->workersFactory->createInactiveSubscribersWorker();

--- a/mailpoet/lib/Cron/Workers/BounceTaskSubscribersCleanup.php
+++ b/mailpoet/lib/Cron/Workers/BounceTaskSubscribersCleanup.php
@@ -14,12 +14,12 @@ use MailPoetVendor\Carbon\Carbon;
  * period — every completed, non-deleted bounce task that still has rows is
  * eligible.
  *
- * Runs 4 times per day in random 6-hour slots (0–5h, 6–11h, 12–17h, 18–23h).
- * Each run loops in batches: first selects up to TASK_BATCH_SIZE completed
- * bounce tasks that still have subscriber rows, then deletes up to
- * ROW_BATCH_SIZE rows per iteration. The loop continues until fewer rows are
- * deleted than the limit or MAX_EXECUTION_TIME is exceeded. A 100ms pause
- * between iterations throttles I/O on shared hosting.
+ * Runs once an hour at a random minute past the hour (to spread DB load
+ * across sites). Each run loops in batches: first selects up to
+ * TASK_BATCH_SIZE completed bounce tasks that still have subscriber rows, then
+ * deletes up to ROW_BATCH_SIZE rows per iteration. The loop continues until
+ * fewer rows are deleted than the limit or MAX_EXECUTION_TIME is exceeded. A
+ * 100ms pause between iterations throttles I/O on shared hosting.
  *
  * This is kept separate from the bounce task itself, which is expected to be
  * replaced by a more efficient one. Once that lands, the cleanup can stop as
@@ -66,37 +66,11 @@ class BounceTaskSubscribersCleanup extends SimpleWorker {
     return true;
   }
 
-  public function schedule() {
-    $baseDate = Carbon::now()->millisecond(0)->startOfDay();
-
-    for ($slot = 0; $slot < 4; $slot++) {
-      $hour = $slot * 6 + mt_rand(0, 5);
-      $minute = mt_rand(0, 59);
-      $second = mt_rand(0, 59);
-
-      $scheduleDate = clone $baseDate;
-      $scheduleDate->setTime($hour, $minute, $second);
-
-      if ($scheduleDate->isPast()) {
-        $scheduleDate->addDay();
-      }
-
-      $this->cronWorkerScheduler->scheduleMultiple(static::TASK_TYPE, $scheduleDate);
-    }
-  }
-
   public function getNextRunDate() {
-    $date = Carbon::now()->millisecond(0);
-    $timeSlot = mt_rand(0, 3);
-    $hour = $timeSlot * 6 + mt_rand(0, 5);
-    $minute = mt_rand(0, 59);
-
-    $date->setTime($hour, $minute, mt_rand(0, 59));
-
-    if ($date->isPast()) {
-      $date->addDay();
-    }
-
-    return $date;
+    return Carbon::now()->millisecond(0)
+      ->startOfHour()
+      ->addHour()
+      ->addMinutes(mt_rand(0, 59))
+      ->addSeconds(mt_rand(0, 59));
   }
 }

--- a/mailpoet/lib/Cron/Workers/BounceTaskSubscribersCleanup.php
+++ b/mailpoet/lib/Cron/Workers/BounceTaskSubscribersCleanup.php
@@ -29,7 +29,7 @@ class BounceTaskSubscribersCleanup extends SimpleWorker {
   const TASK_TYPE = 'bounce_task_subscribers_cleanup';
   const TASK_BATCH_SIZE = 200;
   const ROW_BATCH_SIZE = 10000;
-  const MAX_EXECUTION_TIME = 30;
+  const MAX_EXECUTION_TIME = 10;
   const SUPPORT_MULTIPLE_INSTANCES = false;
 
   /** @var ScheduledTaskSubscribersRepository */

--- a/mailpoet/lib/Cron/Workers/BounceTaskSubscribersCleanup.php
+++ b/mailpoet/lib/Cron/Workers/BounceTaskSubscribersCleanup.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoetVendor\Carbon\Carbon;
+
+/**
+ * Purges leftover rows from scheduled_task_subscribers for completed bounce tasks.
+ *
+ * Bounce tasks are recurring and no longer need their subscriber rows once
+ * completed, so unlike SendingTaskSubscribersCleanup there is no retention
+ * period — every completed, non-deleted bounce task that still has rows is
+ * eligible.
+ *
+ * Runs 4 times per day in random 6-hour slots (0–5h, 6–11h, 12–17h, 18–23h).
+ * Each run loops in batches: first selects up to TASK_BATCH_SIZE completed
+ * bounce tasks that still have subscriber rows, then deletes up to
+ * ROW_BATCH_SIZE rows per iteration. The loop continues until fewer rows are
+ * deleted than the limit or MAX_EXECUTION_TIME is exceeded. A 100ms pause
+ * between iterations throttles I/O on shared hosting.
+ *
+ * This is kept separate from the bounce task itself, which is expected to be
+ * replaced by a more efficient one. Once that lands, the cleanup can stop as
+ * soon as no bounce rows are found — which the batch loop already does.
+ */
+class BounceTaskSubscribersCleanup extends SimpleWorker {
+  const TASK_TYPE = 'bounce_task_subscribers_cleanup';
+  const TASK_BATCH_SIZE = 200;
+  const ROW_BATCH_SIZE = 10000;
+  const MAX_EXECUTION_TIME = 30;
+  const SUPPORT_MULTIPLE_INSTANCES = false;
+
+  /** @var ScheduledTaskSubscribersRepository */
+  private $scheduledTaskSubscribersRepository;
+
+  public function __construct(
+    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository
+  ) {
+    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    parent::__construct();
+  }
+
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+    $startTime = microtime(true);
+
+    do {
+      $this->cronHelper->enforceExecutionLimit($timer);
+
+      $deleted = $this->scheduledTaskSubscribersRepository->purgeCompletedBounceTaskSubscribers(
+        self::TASK_BATCH_SIZE,
+        self::ROW_BATCH_SIZE
+      );
+
+      if (
+        $deleted === 0 ||
+          (microtime(true) - $startTime) > self::MAX_EXECUTION_TIME
+      ) {
+        break;
+      }
+
+      usleep(100000);
+    } while (true);
+
+    return true;
+  }
+
+  public function schedule() {
+    $baseDate = Carbon::now()->millisecond(0)->startOfDay();
+
+    for ($slot = 0; $slot < 4; $slot++) {
+      $hour = $slot * 6 + mt_rand(0, 5);
+      $minute = mt_rand(0, 59);
+      $second = mt_rand(0, 59);
+
+      $scheduleDate = clone $baseDate;
+      $scheduleDate->setTime($hour, $minute, $second);
+
+      if ($scheduleDate->isPast()) {
+        $scheduleDate->addDay();
+      }
+
+      $this->cronWorkerScheduler->scheduleMultiple(static::TASK_TYPE, $scheduleDate);
+    }
+  }
+
+  public function getNextRunDate() {
+    $date = Carbon::now()->millisecond(0);
+    $timeSlot = mt_rand(0, 3);
+    $hour = $timeSlot * 6 + mt_rand(0, 5);
+    $minute = mt_rand(0, 59);
+
+    $date->setTime($hour, $minute, mt_rand(0, 59));
+
+    if ($date->isPast()) {
+      $date->addDay();
+    }
+
+    return $date;
+  }
+}

--- a/mailpoet/lib/Cron/Workers/WorkersFactory.php
+++ b/mailpoet/lib/Cron/Workers/WorkersFactory.php
@@ -35,6 +35,7 @@ class WorkersFactory {
     AbandonedCartWorker::TASK_TYPE,
     LogCleanup::TASK_TYPE,
     SendingTaskSubscribersCleanup::TASK_TYPE,
+    BounceTaskSubscribersCleanup::TASK_TYPE,
     SendingQueueBodyCleanup::TASK_TYPE,
     Tracks::TASK_TYPE,
     StatisticsExport::TASK_TYPE,
@@ -104,6 +105,11 @@ class WorkersFactory {
   /** @return SendingTaskSubscribersCleanup */
   public function createSendingTaskSubscribersCleanupWorker() {
     return $this->container->get(SendingTaskSubscribersCleanup::class);
+  }
+
+  /** @return BounceTaskSubscribersCleanup */
+  public function createBounceTaskSubscribersCleanupWorker() {
+    return $this->container->get(BounceTaskSubscribersCleanup::class);
   }
 
   /** @return SendingQueueBodyCleanup */

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -340,6 +340,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\Workers\ExportFilesCleanup::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\LogCleanup::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SendingTaskSubscribersCleanup::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\Workers\BounceTaskSubscribersCleanup::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SendingQueueBodyCleanup::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SubscribersEmailCount::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\InactiveSubscribers::class)->setPublic(true);

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
@@ -289,6 +289,52 @@ class ScheduledTaskSubscribersRepository extends Repository {
     return (int)$deleted;
   }
 
+  public function purgeCompletedBounceTaskSubscribers(int $taskBatchSize, int $rowLimit): int {
+    $stTable = $this->entityManager->getClassMetadata(ScheduledTaskEntity::class)->getTableName();
+    $stsTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+
+    $taskIds = $this->entityManager->getConnection()->executeQuery(
+      "SELECT DISTINCT st.`id`
+       FROM `{$stTable}` st
+       INNER JOIN `{$stsTable}` sts ON sts.`task_id` = st.`id`
+       WHERE st.`type` = :type
+         AND st.`status` = :status
+         AND st.`deleted_at` IS NULL
+       LIMIT :taskBatchSize",
+      [
+        'type' => 'bounce',
+        'status' => ScheduledTaskEntity::STATUS_COMPLETED,
+        'taskBatchSize' => $taskBatchSize,
+      ],
+      [
+        'type' => ParameterType::STRING,
+        'status' => ParameterType::STRING,
+        'taskBatchSize' => ParameterType::INTEGER,
+      ]
+    )->fetchFirstColumn();
+
+    if (!$taskIds) {
+      return 0;
+    }
+
+    /** @var int[] $taskIds */
+    $taskIdsList = implode(',', array_map('intval', $taskIds));
+
+    $deleted = $this->entityManager->getConnection()->executeStatement(
+      "DELETE FROM `{$stsTable}`
+       WHERE `task_id` IN ({$taskIdsList})
+       LIMIT :rowLimit",
+      [
+        'rowLimit' => $rowLimit,
+      ],
+      [
+        'rowLimit' => ParameterType::INTEGER,
+      ]
+    );
+
+    return (int)$deleted;
+  }
+
   private function checkCompleted(ScheduledTaskEntity $task): void {
     $count = $this->countUnprocessed($task);
     if ($count === 0) {

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -307,6 +307,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'createExportFilesCleanupWorker' => $worker,
       'createLogCleanupWorker' => $worker,
       'createSendingTaskSubscribersCleanupWorker' => $worker,
+      'createBounceTaskSubscribersCleanupWorker' => $worker,
       'createSendingQueueBodyCleanupWorker' => $worker,
       'createSubscribersEmailCountsWorker' => $worker,
       'createInactiveSubscribersWorker' => $worker,

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -107,6 +107,7 @@ class DaemonTest extends \MailPoetTest {
       'createExportFilesCleanupWorker' => $this->createSimpleWorkerMock(),
       'createLogCleanupWorker' => $this->createSimpleWorkerMock(),
       'createSendingTaskSubscribersCleanupWorker' => $this->createSimpleWorkerMock(),
+      'createBounceTaskSubscribersCleanupWorker' => $this->createSimpleWorkerMock(),
       'createSendingQueueBodyCleanupWorker' => $this->createSimpleWorkerMock(),
       'createSubscribersEmailCountsWorker' => $this->createSimpleWorkerMock(),
       'createInactiveSubscribersWorker' => $this->createSimpleWorkerMock(),

--- a/mailpoet/tests/integration/Cron/Workers/BounceTaskSubscribersCleanupTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/BounceTaskSubscribersCleanupTest.php
@@ -175,12 +175,16 @@ class BounceTaskSubscribersCleanupTest extends \MailPoetTest {
     verify((int)$afterResult)->equals(0);
   }
 
-  public function testItSchedulesInTheFuture() {
+  public function testItSchedulesWithinTheNextHour() {
+    $now = Carbon::now();
+    Carbon::setTestNow($now);
+
     $nextRunDate = $this->worker->getNextRunDate();
     verify($nextRunDate)->notNull();
-    verify($nextRunDate->getTimestamp())->greaterThan(Carbon::now()->getTimestamp());
+    verify($nextRunDate->getTimestamp())->greaterThan($now->getTimestamp());
 
-    $tomorrow = Carbon::now()->addDay();
-    verify($nextRunDate->getTimestamp())->lessThan($tomorrow->getTimestamp());
+    $nextHour = $now->copy()->startOfHour()->addHour();
+    verify($nextRunDate->getTimestamp())->greaterThanOrEqual($nextHour->getTimestamp());
+    verify($nextRunDate->getTimestamp())->lessThan($nextHour->copy()->addHour()->getTimestamp());
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/BounceTaskSubscribersCleanupTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/BounceTaskSubscribersCleanupTest.php
@@ -1,0 +1,186 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\Workers;
+
+use MailPoet\Cron\Workers\Bounce;
+use MailPoet\Cron\Workers\BounceTaskSubscribersCleanup;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as ScheduledTaskSubscriberFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+class BounceTaskSubscribersCleanupTest extends \MailPoetTest {
+  /** @var BounceTaskSubscribersCleanup */
+  private $worker;
+
+  /** @var ScheduledTaskFactory */
+  private $taskFactory;
+
+  /** @var ScheduledTaskSubscriberFactory */
+  private $taskSubscriberFactory;
+
+  /** @var SubscriberFactory */
+  private $subscriberFactory;
+
+  public function _before() {
+    parent::_before();
+    $this->worker = $this->diContainer->get(BounceTaskSubscribersCleanup::class);
+    $this->taskFactory = new ScheduledTaskFactory();
+    $this->taskSubscriberFactory = new ScheduledTaskSubscriberFactory();
+    $this->subscriberFactory = new SubscriberFactory();
+  }
+
+  public function _after() {
+    Carbon::setTestNow();
+    parent::_after();
+  }
+
+  public function testItDeletesCompletedBounceTaskSubscribers() {
+    $subscriber = $this->subscriberFactory->create();
+    $completedTask = $this->taskFactory->create(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->taskSubscriberFactory->createProcessed($completedTask, $subscriber);
+
+    $task = new ScheduledTaskEntity();
+    $this->worker->processTaskStrategy($task, microtime(true));
+
+    $remaining = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->findAll();
+    verify(count($remaining))->equals(0);
+  }
+
+  public function testItKeepsNonCompletedBounceTaskSubscribers() {
+    $subscriber = $this->subscriberFactory->create();
+    $scheduledTask = $this->taskFactory->create(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->taskSubscriberFactory->createUnprocessed($scheduledTask, $subscriber);
+
+    $task = new ScheduledTaskEntity();
+    $this->worker->processTaskStrategy($task, microtime(true));
+
+    $remaining = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->findAll();
+    verify(count($remaining))->equals(1);
+  }
+
+  public function testItKeepsNonBounceTaskSubscribers() {
+    $subscriber = $this->subscriberFactory->create();
+    $sendingTask = $this->taskFactory->create('sending', ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->taskSubscriberFactory->createProcessed($sendingTask, $subscriber);
+
+    $task = new ScheduledTaskEntity();
+    $this->worker->processTaskStrategy($task, microtime(true));
+
+    $remaining = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->findAll();
+    verify(count($remaining))->equals(1);
+  }
+
+  public function testItExcludesSoftDeletedTasks() {
+    $now = Carbon::now();
+    Carbon::setTestNow($now);
+
+    $subscriber = $this->subscriberFactory->create();
+    $softDeletedTask = $this->taskFactory->create(
+      Bounce::TASK_TYPE,
+      ScheduledTaskEntity::STATUS_COMPLETED,
+      null,
+      $now->copy()->subDays(1)
+    );
+    $this->taskSubscriberFactory->createProcessed($softDeletedTask, $subscriber);
+
+    $task = new ScheduledTaskEntity();
+    $this->worker->processTaskStrategy($task, microtime(true));
+
+    $remaining = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->findAll();
+    verify(count($remaining))->equals(1);
+  }
+
+  public function testItDeletesOnlyEligibleTasksInMixedState() {
+    $subscriber1 = (new SubscriberFactory())->create();
+    $subscriber2 = (new SubscriberFactory())->create();
+    $subscriber3 = (new SubscriberFactory())->create();
+
+    $completedBounce = $this->taskFactory->create(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->taskSubscriberFactory->createProcessed($completedBounce, $subscriber1);
+
+    $scheduledBounce = $this->taskFactory->create(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->taskSubscriberFactory->createUnprocessed($scheduledBounce, $subscriber2);
+
+    $completedSending = $this->taskFactory->create('sending', ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->taskSubscriberFactory->createProcessed($completedSending, $subscriber3);
+
+    $task = new ScheduledTaskEntity();
+    $this->worker->processTaskStrategy($task, microtime(true));
+
+    $remaining = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->findAll();
+    verify(count($remaining))->equals(2);
+  }
+
+  public function testItRespectsRowBatchSize() {
+    $completedTask = $this->taskFactory->create(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED);
+
+    $total = BounceTaskSubscribersCleanup::ROW_BATCH_SIZE + 5;
+    $stsTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    $taskId = $completedTask->getId();
+
+    for ($i = 1; $i <= $total; $i++) {
+      $this->entityManager->getConnection()->executeStatement(
+        "INSERT INTO `{$stsTable}` (task_id, subscriber_id, processed) VALUES (:taskId, :subscriberId, 1)",
+        ['taskId' => $taskId, 'subscriberId' => $i]
+      );
+    }
+
+    $repository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
+    $deleted = $repository->purgeCompletedBounceTaskSubscribers(
+      BounceTaskSubscribersCleanup::TASK_BATCH_SIZE,
+      BounceTaskSubscribersCleanup::ROW_BATCH_SIZE
+    );
+
+    verify($deleted)->equals(BounceTaskSubscribersCleanup::ROW_BATCH_SIZE);
+
+    /** @var string|false $remainingResult */
+    $remainingResult = $this->entityManager->getConnection()->executeQuery(
+      "SELECT COUNT(*) FROM `{$stsTable}` WHERE task_id = :taskId",
+      ['taskId' => $taskId]
+    )->fetchOne();
+
+    verify((int)$remainingResult)->equals(5);
+  }
+
+  public function testItProcessesMultipleBatchesAcrossIterations() {
+    $stsTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+
+    // Create more eligible tasks than TASK_BATCH_SIZE (200), each with 1 subscriber
+    $taskCount = BounceTaskSubscribersCleanup::TASK_BATCH_SIZE + 50;
+    for ($i = 0; $i < $taskCount; $i++) {
+      $completedTask = $this->taskFactory->create(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED);
+      $this->entityManager->getConnection()->executeStatement(
+        "INSERT INTO `{$stsTable}` (task_id, subscriber_id, processed) VALUES (:taskId, :subscriberId, 1)",
+        ['taskId' => $completedTask->getId(), 'subscriberId' => $i + 1]
+      );
+    }
+
+    /** @var string|false $beforeResult */
+    $beforeResult = $this->entityManager->getConnection()->executeQuery(
+      "SELECT COUNT(*) FROM `{$stsTable}`"
+    )->fetchOne();
+    verify((int)$beforeResult)->equals($taskCount);
+
+    $task = new ScheduledTaskEntity();
+    $this->worker->processTaskStrategy($task, microtime(true));
+
+    /** @var string|false $afterResult */
+    $afterResult = $this->entityManager->getConnection()->executeQuery(
+      "SELECT COUNT(*) FROM `{$stsTable}`"
+    )->fetchOne();
+    verify((int)$afterResult)->equals(0);
+  }
+
+  public function testItSchedulesInTheFuture() {
+    $nextRunDate = $this->worker->getNextRunDate();
+    verify($nextRunDate)->notNull();
+    verify($nextRunDate->getTimestamp())->greaterThan(Carbon::now()->getTimestamp());
+
+    $tomorrow = Carbon::now()->addDay();
+    verify($nextRunDate->getTimestamp())->lessThan($tomorrow->getTimestamp());
+  }
+}


### PR DESCRIPTION
## Description

Bounce tasks are recurring and keep accumulating rows in `scheduled_task_subscribers` that are no longer needed once the task completes. This adds a new `SimpleWorker` (`BounceTaskSubscribersCleanup`, task type `bounce_task_subscribers_cleanup`) that purges those rows in batches.

It mirrors `SendingTaskSubscribersCleanup` (batched delete with a 100ms throttle pause between iterations), but with two differences:

- **No retention period** — bounce subscriber rows carry no user-facing status, so every completed, non-deleted bounce task that still has rows is eligible immediately.
- **Runs hourly** at a random minute past the hour (rather than 4×/day in fixed slots), so sites don't all hit the database at the same time.

Kept deliberately separate from the bounce task itself, which is expected to be replaced by a more efficient one. Once that lands, the cleanup can stop as soon as no bounce rows are found — which the batch loop already does.

## Code review notes

- **`MAX_EXECUTION_TIME` is 10s, intentionally below the 20s daemon limit (`CronHelper::DAEMON_EXECUTION_LIMIT`).** The daemon runs all workers serially in one pass, sharing a single 20s timer; bounce cleanup sits after the sending queue worker (so sending is never blocked) but before other maintenance workers. If the loop ran until the daemon limit, a large backlog would let it drain the remaining budget every pass and starve the downstream workers. Capping at 10s makes the worker `break` and complete gracefully, yielding its slot. Trade-off: slower drain (~10s of deletes per hour), acceptable for a one-time accumulated backlog.
- The new repository method `purgeCompletedBounceTaskSubscribers()` hardcodes the `'bounce'` task type in SQL rather than referencing `Bounce::TASK_TYPE`, matching the existing `purgeOldTaskSubscribers()` which hardcodes `'sending'`. This keeps the repository free of a dependency on the Cron worker layer. Happy to switch to the constant if preferred.
- Registered in `WorkersFactory::SIMPLE_WORKER_TYPES` so the WordPress cron trigger (`Cron/Triggers/WordPress.php`) activates the daemon when eligible tasks exist.

## QA notes

Automated coverage in `BounceTaskSubscribersCleanupTest` (8 tests): deletes completed bounce rows; keeps scheduled, non-bounce, and soft-deleted task rows; mixed-state selectivity; respects row batch size; processes multiple task batches across iterations; schedules within the next hour. Daemon wiring covered by updated `DaemonTest` / `DaemonHttpRunnerTest`.

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/MPI-430/add-recurring-cleanup-task-for-completed-bounce-rows

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I added sufficient test coverage

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/mpi-430-recurring-cleanup-task-for-completed-bounce-rows)

_The latest successful build from `add/mpi-430-recurring-cleanup-task-for-completed-bounce-rows` will be used. If none is available, the link won't work._