### PR TITLE
Fix Woo system status QIT failures

### DIFF
--- a/mailpoet/lib/WooCommerce/WooSystemInfo.php
+++ b/mailpoet/lib/WooCommerce/WooSystemInfo.php
@@ -38,7 +38,11 @@ class WooSystemInfo {
   }
 
   public function cronPingUrl(): string {
-    return $this->cronHelper->getCronUrl(CronDaemon::ACTION_PING);
+    try {
+      return $this->cronHelper->getCronUrl(CronDaemon::ACTION_PING);
+    } catch (\Exception $e) {
+      return __('Can‘t generate cron URL.', 'mailpoet') . ' (' . $e->getMessage() . ')';
+    }
   }
 
   public function toArray(): array {

--- a/mailpoet/lib/WooCommerce/WooSystemInfo.php
+++ b/mailpoet/lib/WooCommerce/WooSystemInfo.php
@@ -40,7 +40,7 @@ class WooSystemInfo {
   public function cronPingUrl(): string {
     try {
       return $this->cronHelper->getCronUrl(CronDaemon::ACTION_PING);
-    } catch (\Exception $e) {
+    } catch (\Throwable $e) {
       return __('Can‘t generate cron URL.', 'mailpoet') . ' (' . $e->getMessage() . ')';
     }
   }

--- a/mailpoet/tests/unit/WooCommerce/WooSystemInfoTest.php
+++ b/mailpoet/tests/unit/WooCommerce/WooSystemInfoTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use Codeception\Stub;
+use MailPoet\Cron\CronHelper;
+use MailPoet\Router\Endpoints\CronDaemon;
+use MailPoet\Settings\SettingsController;
+
+class WooSystemInfoTest extends \MailPoetUnitTest {
+  public function testItDoesNotThrowWhenCronUrlCannotBeGenerated(): void {
+    $systemInfo = new WooSystemInfo(
+      Stub::make(CronHelper::class, [
+        'getCronUrl' => function($action) {
+          verify($action)->equals(CronDaemon::ACTION_PING);
+          throw new \Exception('Site URL is unreachable.');
+        },
+      ]),
+      Stub::make(SettingsController::class, [
+        'get' => function($setting) {
+          $settings = [
+            'mta.method' => 'MailPoet',
+            'send_transactional_emails' => true,
+            'cron_trigger.method' => 'WordPress',
+          ];
+          return $settings[$setting];
+        },
+      ])
+    );
+
+    verify($systemInfo->toArray())->equals([
+      'sending_method' => 'MailPoet',
+      'transactional_emails' => 'Current sending method',
+      'task_scheduler_method' => 'WordPress',
+      'cron_ping_url' => 'Can‘t generate cron URL. (Site URL is unreachable.)',
+    ]);
+  }
+}

--- a/mailpoet/tests/unit/WooCommerce/WooSystemInfoTest.php
+++ b/mailpoet/tests/unit/WooCommerce/WooSystemInfoTest.php
@@ -9,11 +9,33 @@ use MailPoet\Settings\SettingsController;
 
 class WooSystemInfoTest extends \MailPoetUnitTest {
   public function testItDoesNotThrowWhenCronUrlCannotBeGenerated(): void {
-    $systemInfo = new WooSystemInfo(
+    $systemInfo = $this->createWooSystemInfoThrowing(new \Exception('Site URL is unreachable.'));
+
+    verify($systemInfo->toArray())->equals([
+      'sending_method' => 'MailPoet',
+      'transactional_emails' => 'Current sending method',
+      'task_scheduler_method' => 'WordPress',
+      'cron_ping_url' => 'Can‘t generate cron URL. (Site URL is unreachable.)',
+    ]);
+  }
+
+  public function testItDoesNotThrowWhenCronUrlGenerationCausesAnError(): void {
+    $systemInfo = $this->createWooSystemInfoThrowing(new \TypeError('Cron URL type error.'));
+
+    verify($systemInfo->toArray())->equals([
+      'sending_method' => 'MailPoet',
+      'transactional_emails' => 'Current sending method',
+      'task_scheduler_method' => 'WordPress',
+      'cron_ping_url' => 'Can‘t generate cron URL. (Cron URL type error.)',
+    ]);
+  }
+
+  private function createWooSystemInfoThrowing(\Throwable $throwable): WooSystemInfo {
+    return new WooSystemInfo(
       Stub::make(CronHelper::class, [
-        'getCronUrl' => function($action) {
+        'getCronUrl' => function($action) use ($throwable) {
           verify($action)->equals(CronDaemon::ACTION_PING);
-          throw new \Exception('Site URL is unreachable.');
+          throw $throwable;
         },
       ]),
       Stub::make(SettingsController::class, [
@@ -27,12 +49,5 @@ class WooSystemInfoTest extends \MailPoetUnitTest {
         },
       ])
     );
-
-    verify($systemInfo->toArray())->equals([
-      'sending_method' => 'MailPoet',
-      'transactional_emails' => 'Current sending method',
-      'task_scheduler_method' => 'WordPress',
-      'cron_ping_url' => 'Can‘t generate cron URL. (Site URL is unreachable.)',
-    ]);
   }
 }


### PR DESCRIPTION
## Description

Fixes WooCommerce QIT failures caused by MailPoet throwing while adding Woo system status data.

## Code review notes

Temporary CI change enables Woo QIT jobs on this branch for verification; remove before merge.

## QA notes

Passing CI https://app.circleci.com/pipelines/github/mailpoet/mailpoet/23809/workflows/4ccc23f4-d95e-41df-b8da-dc76c4a865a5

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8185

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (pnpm changelog:add --type=<type> --description=<description>)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8185-fix-qit-failures-in-woocommerce-system-status)

_The latest successful build from `stomail-8185-fix-qit-failures-in-woocommerce-system-status` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**2 issues found:**

1. **Suggestion**: Incomplete translation context - The error message concatenates a translatable string with an untranslated exception message. The exception text in parentheses is not passed through the translation function, which may create translation inconsistencies and make it harder for translators to handle the complete message.

2. **Suggestion**: Incomplete test coverage - The test only validates the error path where `getCronUrl()` throws an exception. The test does not cover the happy path where the method successfully returns a cron URL, which limits verification that the fix doesn't break the normal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->