### PR TITLE
Restrict subscribers listing sorting to created_at

### DIFF
--- a/mailpoet/assets/js/src/subscribers/fields.tsx
+++ b/mailpoet/assets/js/src/subscribers/fields.tsx
@@ -86,7 +86,7 @@ export function getSubscriberFields(
       ]
     : [];
 
-  return [
+  const fields: Field<Subscriber>[] = [
     {
       id: 'email',
       label: __('Subscriber', 'mailpoet'),
@@ -157,4 +157,10 @@ export function getSubscriberFields(
       render: ({ item }) => <span>{dateTime(item.created_at)}</span>,
     },
   ];
+
+  // This listing filters through its own toolbar (segments, tags, status, …),
+  // so DataViews' built-in per-column filters are unused. Every field type
+  // defaults to a non-empty operator set, which would otherwise surface a dead
+  // "Add filter" entry in each column header menu; disable it explicitly.
+  return fields.map((field) => ({ ...field, filterBy: false }));
 }

--- a/mailpoet/assets/js/src/subscribers/fields.tsx
+++ b/mailpoet/assets/js/src/subscribers/fields.tsx
@@ -91,7 +91,7 @@ export function getSubscriberFields(
       id: 'email',
       label: __('Subscriber', 'mailpoet'),
       type: 'text',
-      enableSorting: true,
+      enableSorting: false,
       enableGlobalSearch: true,
       render: ({ item }) => (
         <div>
@@ -113,7 +113,7 @@ export function getSubscriberFields(
       id: 'status',
       label: __('Status', 'mailpoet'),
       type: 'text',
-      enableSorting: true,
+      enableSorting: false,
       enableGlobalSearch: false,
       render: ({ item }) => <span>{statusLabel(item.status)}</span>,
     },
@@ -144,7 +144,7 @@ export function getSubscriberFields(
       id: 'last_subscribed_at',
       label: __('Subscribed on', 'mailpoet'),
       type: 'datetime',
-      enableSorting: true,
+      enableSorting: false,
       enableGlobalSearch: false,
       render: ({ item }) => <span>{dateTime(item.last_subscribed_at)}</span>,
     },

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -78,11 +78,17 @@ const bulkConfirmationResendLimit =
 const bulkConfirmationCheckboxId = 'bulk-resend-confirmation-checkbox-input';
 const listingPerPage = Number(window.mailpoet_listing_per_page);
 
+// `created_at` is the only sortable column (STOMAIL-8162): the backend can't
+// efficiently serve sorts on other columns at scale, so we pin the sort field
+// here and never let a stale URL hash or persisted preference ask the listing
+// to sort on anything else. Only the direction (asc/desc) varies.
+const SORT_FIELD = 'created_at';
+
 const DEFAULT_VIEW: View = {
   type: 'table',
   perPage: listingPerPage,
   page: 1,
-  sort: { field: 'created_at', direction: 'desc' },
+  sort: { field: SORT_FIELD, direction: 'desc' },
   fields: [
     'status',
     'segments',
@@ -116,7 +122,6 @@ function parseHash(): Partial<{
   group: Group;
   page: number;
   perPage: number;
-  orderby: string;
   order: 'asc' | 'desc';
   search: string;
   filter: Record<string, string>;
@@ -145,9 +150,6 @@ function parseHash(): Partial<{
       }
       if ((key === 'per_page' || key === 'limit') && Number(value) > 0) {
         return { ...params, perPage: Number(value) };
-      }
-      if (key === 'sort_by' || key === 'orderby') {
-        return { ...params, orderby: value };
       }
       if (
         (key === 'sort_order' || key === 'order') &&
@@ -185,13 +187,6 @@ function getListingPath(
       'limit',
       view.perPage && view.perPage !== (defaults.perPage ?? listingPerPage)
         ? view.perPage
-        : undefined,
-    ],
-    [
-      'sort_by',
-      view.sort?.field &&
-      view.sort.field !== (defaults.sort?.field ?? 'created_at')
-        ? view.sort.field
         : undefined,
     ],
     [
@@ -772,7 +767,7 @@ function SubscriberList() {
     perPage: hashState.perPage ?? preferredView.perPage,
     search: hashState.search,
     sort: {
-      field: hashState.orderby ?? preferredView.sort?.field ?? 'created_at',
+      field: SORT_FIELD,
       direction: hashState.order ?? preferredView.sort?.direction ?? 'desc',
     },
   }));
@@ -843,7 +838,7 @@ function SubscriberList() {
         perPage: next.perPage ?? preferredDefaults.perPage,
         search: next.search ?? '',
         sort: {
-          field: next.orderby ?? preferredDefaults.sort?.field ?? 'created_at',
+          field: SORT_FIELD,
           direction: next.order ?? preferredDefaults.sort?.direction ?? 'desc',
         },
       }));

--- a/mailpoet/changelog/2026-06-15-14-33-54-changed-subscribers-list-sorting-to-the-created-on-column-.md
+++ b/mailpoet/changelog/2026-06-15-14-33-54-changed-subscribers-list-sorting-to-the-created-on-column-.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+Subscribers list sorting to the Created on column only for faster performance on large lists

--- a/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -51,16 +51,16 @@ class ManageSegmentsCest {
     // config; the listing also reads it from the URL, so drive it from there.
     $i->amOnPage('/wp-admin/admin.php?page=mailpoet-subscribers#/group[all]/filter[segment=' . $segment->getId() . ']/limit[1]');
     $i->reloadPage(); // to avoid flakyness we reload page manually
-    $i->wantTo('Reorder subscribers by email and check if correct subscribes are present');
-    // DataViews wraps sortable column labels in a button that opens a sort
-    // popover (Sort ascending / descending), and exposes pagination via
-    // aria-labelled icon buttons in `.dataviews-pagination`. Pick "Sort
-    // ascending" explicitly, then page forward.
+    $i->wantTo('Reorder subscribers by the Created on column and check if correct subscribers are present');
+    // Created on is the only sortable column; its header button opens the sort
+    // popover (Sort ascending / descending). Pagination is exposed via
+    // aria-labelled icon buttons in `.dataviews-pagination`. Sort ascending so
+    // the earliest-created editor lands on the first page, then page forward.
     $nextPageButton = ['xpath' => '//*[contains(@class, "dataviews-pagination")]//button[@aria-label="Next page"]'];
-    $subscriberHeaderButton = ['xpath' => '//th//button[normalize-space(.)="Subscriber"]'];
+    $createdOnHeaderButton = ['xpath' => '//th//button[contains(@class, "dataviews-view-table-header-button")][contains(normalize-space(.), "Created on")]'];
     $sortAscendingItem = ['xpath' => '//*[@role="menuitem" or @role="menuitemradio"][contains(normalize-space(.), "Sort ascending")]'];
     $i->waitForElementClickable($nextPageButton);
-    $i->click($subscriberHeaderButton);
+    $i->click($createdOnHeaderButton);
     $i->waitForElementClickable($sortAscendingItem);
     $i->click($sortAscendingItem);
     $i->waitForText($wpEditorEmail, 20);

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -553,6 +553,48 @@ class SubscribersListingCest {
     $i->seeInCurrentURL(urlencode('group[trash]'));
   }
 
+  public function sortingIsRestrictedToCreatedAt(\AcceptanceTester $i) {
+    $i->wantTo('Restrict subscribers listing sorting to the Created on column');
+
+    (new Subscriber())
+      ->withEmail('sortable@example.com')
+      ->withStatus('subscribed')
+      ->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('Subscribers');
+    $i->waitForListingItemsToLoad();
+
+    $headerButton = function (string $contains): array {
+      return ['xpath' =>
+        '//thead//button[contains(concat(" ", normalize-space(@class), " "), " dataviews-view-table-header-button ")]' .
+        '[contains(., ' . \AcceptanceTester::xpathString($contains) . ')]',
+      ];
+    };
+
+    $i->wantTo('Confirm Created on is sorted descending by default');
+    $i->seeElement(['xpath' => '//thead//th[@aria-sort="descending"][contains(., "Created on")]']);
+
+    $i->wantTo('Confirm the Subscriber column header offers no sort control');
+    $i->click($headerButton('Subscriber'));
+    $i->waitForText('Hide column'); // the column menu is open
+    $i->dontSee('Sort ascending');
+    $i->pressKey('body', WebDriverKeys::ESCAPE);
+
+    $i->wantTo('Confirm the Created on column header offers a sort control');
+    $i->click($headerButton('Created on'));
+    $i->waitForText('Sort ascending');
+    $i->pressKey('body', WebDriverKeys::ESCAPE);
+
+    $i->wantTo('Restore an old hash that sorts by a now-unsortable column');
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-subscribers#/group[all]/sort_by[email]/sort_order[asc]');
+    $i->waitForListingItemsToLoad();
+
+    $i->wantTo('Confirm the stale sort field is dropped and Created on is sorted instead');
+    $i->dontSeeInCurrentUrl('sort_by');
+    $i->seeElement(['xpath' => '//thead//th[@aria-sort="ascending"][contains(., "Created on")]']);
+  }
+
   private function selectSubscriberForBulkAction(\AcceptanceTester $i, $subscriber): void {
     $i->waitForText($subscriber->getEmail());
     $i->checkWooTableCheckboxForItemName($subscriber->getEmail());

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -575,15 +575,17 @@ class SubscribersListingCest {
     $i->wantTo('Confirm Created on is sorted descending by default');
     $i->seeElement(['xpath' => '//thead//th[@aria-sort="descending"][contains(., "Created on")]']);
 
-    $i->wantTo('Confirm the Subscriber column header offers no sort control');
+    $i->wantTo('Confirm the Subscriber column header offers no sort or filter control');
     $i->click($headerButton('Subscriber'));
     $i->waitForText('Hide column'); // the column menu is open
     $i->dontSee('Sort ascending');
+    $i->dontSee('Add filter');
     $i->pressKey('body', WebDriverKeys::ESCAPE);
 
-    $i->wantTo('Confirm the Created on column header offers a sort control');
+    $i->wantTo('Confirm the Created on column header offers sorting but no filter');
     $i->click($headerButton('Created on'));
     $i->waitForText('Sort ascending');
+    $i->dontSee('Add filter');
     $i->pressKey('body', WebDriverKeys::ESCAPE);
 
     $i->wantTo('Restore an old hash that sorts by a now-unsortable column');


### PR DESCRIPTION
## Description

We're scaling the subscribers listing to millions of rows. Supporting sorting on multiple columns would mean maintaining a DB index per column, which is too costly at that scale, so the backend efficiently serves sorting by `created_at` only. 

### Changes 
- Disable sorting on **Subscriber**, **Status**, and **Subscribed on**; keep **Created on** sortable (default, descending).
- Pin the sort field to `created_at` when building the view, so a stale URL hash or a persisted view preference referencing a now-unsortable column can't ask the backend for an unindexed sort — it falls back to `created_at` and the hash self-heals.

Complements the backend `created_at` index in #6834 and the preference persistence in #6842.

While testing this I also fixed an unrelated DataViews quirk in the same listing: every column header menu offered a dead **Add filter** item. This listing filters through its own toolbar, so DataViews' built-in per-column filters are never wired up — clicking "Add filter" added an empty, optionless filter that did nothing. 

<img width="318" height="350" alt="Screenshot 2026-06-15 at 17 04 55" src="https://github.com/user-attachments/assets/2b31e091-e83a-4b93-8712-847cd02d31ca" />


## Code review notes

The field-pinning isn't just defensive: `getPreferredSort` (added in #6842) validates that a persisted sort field _exists_, not that it's _sortable_. So a user who sorted by `email` before this change could have that persisted, and an old bookmarked hash can carry `sort_by[email]`. Both flow through the same `field: SORT_FIELD` pin in `initialView`/`applyHash`, so neither reaches the backend.

## QA notes

On the Subscribers listing (verified locally against a 100k-subscriber list, and covered by the acceptance test):

- Only **Created on** offers a sort control; Subscriber / Status / Subscribed on do not. Default sort is Created on descending.
- Toggle Created on asc → URL hash gets `sort_order[asc]`; back to desc → hash drops it. Reload restores the sort.
- Load `#/group[all]/sort_by[email]/sort_order[asc]` → listing sorts by Created on ascending (not email) and the hash self-heals to `sort_order[asc]`.
- No **Add filter** entry in any column header menu.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8162](https://linear.app/a8c/issue/STOMAIL-8162/subscribers-listing-restrict-sorting-to-created-at-only)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/stomail-8162-restrict-subscriber-sorting)

_The latest successful build from `update/stomail-8162-restrict-subscriber-sorting` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Issues Addressed

**2 issues found**

1. **Performance**: Restricts the Subscribers listing sorting to `created_at` only to support scaling to millions of rows. This pins the sort field during view initialization and falls back to `created_at` when stale URL/persisted preferences reference previously sortable columns, preventing unindexed sorts.

2. **Bug**: Removes/disables the non-functional **Add filter** option in column header menus. Since this listing uses its own toolbar-based filtering, per-column filter UI produced dead/empty filters; this is disabled by turning off per-field DataViews filtering (`filterBy: false` for subscriber fields).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->