### PR TITLE
Add WP-CLI commands for MailPoet cron jobs

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -70,3 +70,10 @@ Class `\MailPoet\API\API` becomes available once MailPoet plugin is loaded by Wo
 ### Usage examples
 
 You can check some basic examples [here](UsageExamples.md).
+
+## WP-CLI commands
+
+MailPoet ships [WP-CLI](https://wp-cli.org/) commands for inspecting and running its background (cron)
+tasks from the command line — useful for debugging a site or running the queue from system cron.
+
+- [`wp mailpoet cron` cron task commands](wp-cli-cron-commands.md)

--- a/doc/wp-cli-cron-commands.md
+++ b/doc/wp-cli-cron-commands.md
@@ -1,0 +1,236 @@
+# MailPoet – WP-CLI cron commands
+
+`wp mailpoet cron` is a set of [WP-CLI](https://wp-cli.org/) commands for inspecting and running
+MailPoet's background (cron) tasks from the command line. They are aimed at developers and support
+engineers debugging a site, and at operators who want to run MailPoet's queue from system cron
+instead of (or alongside) the default web-request-driven runner.
+
+Run `wp help mailpoet cron <command>` on any site for the same synopsis the commands below document —
+the in-terminal help is generated from the command definitions and is always authoritative for the
+exact options.
+
+> In local `wp-env` development, prefix commands with `pnpm wp` (e.g. `pnpm wp mailpoet cron list`).
+
+## Background: how MailPoet runs background work
+
+MailPoet stores background work as rows in the `scheduled_tasks` table, each with a `type` (the worker
+that handles it) and a `status`. A site-side runner (Action Scheduler by default, or WordPress cron)
+periodically wakes a **daemon** that runs each worker over its due tasks. See
+[`wp mailpoet cron types`](#wp-mailpoet-cron-types) for the list of worker types.
+
+Task statuses:
+
+| Status      | Meaning                                                                                                                                         |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scheduled` | Waiting to run at or after its scheduled time.                                                                                                  |
+| `running`   | Being processed by the site daemon. Stored as `NULL` in the database; shown as `running`.                                                       |
+| `cli`       | Claimed and being processed by a `wp mailpoet cron` process. Invisible to the site daemon (see [CLI execution](#cli-execution-the-cli-status)). |
+| `completed` | Finished.                                                                                                                                       |
+| `paused`    | On hold.                                                                                                                                        |
+| `cancelled` | Cancelled.                                                                                                                                      |
+| `invalid`   | Could not be processed.                                                                                                                         |
+
+## Command reference
+
+| Command                                      | Purpose                                             |
+| -------------------------------------------- | --------------------------------------------------- |
+| [`list`](#wp-mailpoet-cron-list)             | List scheduled tasks.                               |
+| [`types`](#wp-mailpoet-cron-types)           | List known worker task types and their attributes.  |
+| [`trigger`](#wp-mailpoet-cron-trigger)       | Mark a task due so the site's own cron picks it up. |
+| [`run`](#wp-mailpoet-cron-run)               | Run a worker to completion inside the CLI process.  |
+| [`run-daemon`](#wp-mailpoet-cron-run-daemon) | Run one full daemon pass inside the CLI process.    |
+| [`add`](#wp-mailpoet-cron-add)               | Add a new task, optionally running it immediately.  |
+| [`cancel`](#wp-mailpoet-cron-cancel)         | Cancel a scheduled, paused, or CLI task.            |
+
+### `wp mailpoet cron list`
+
+Lists scheduled tasks. By default shows only actionable tasks (`scheduled`, `running`, and `cli`),
+newest first.
+
+| Option                                  | Description                                                                                                                               |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `--status=<status>`                     | Filter by status: `scheduled`, `running`, `cli`, `completed`, `cancelled`, `paused`, `invalid`, or `all`. Defaults to the actionable set. |
+| `--type=<type>`                         | Filter by task type.                                                                                                                      |
+| `--limit=<n>`                           | Maximum number of tasks. Default 50.                                                                                                      |
+| `--field=<field>` / `--fields=<fields>` | Output a single field / a comma-separated subset.                                                                                         |
+| `--format=<format>`                     | `table` (default), `csv`, `json`, `ids`, `count`.                                                                                         |
+
+Columns: `id`, `type`, `status`, `scheduled_at`, `priority`, `updated_at`.
+
+```bash
+wp mailpoet cron list
+wp mailpoet cron list --status=running
+wp mailpoet cron list --status=all --format=json
+wp mailpoet cron list --type=sending --limit=10
+```
+
+### `wp mailpoet cron types`
+
+Lists every known worker task type with its attributes: whether it is `addable` (see
+[`add`](#wp-mailpoet-cron-add)), whether it `schedule_automatically`, whether it
+`supports_multiple_instances`, and whether it is a `mailing` worker (the `sending` and
+`stats_notification` jobs, which run their own mailer-driven flow instead of the standard worker
+model). This is the authoritative list of valid `<type>` values for `trigger`, `run`, and `add`.
+
+| Option                                  | Description                                        |
+| --------------------------------------- | -------------------------------------------------- |
+| `--field=<field>` / `--fields=<fields>` | Output a single field / a comma-separated subset.  |
+| `--format=<format>`                     | `table` (default), `csv`, `json`, `yaml`, `count`. |
+
+```bash
+wp mailpoet cron types
+wp mailpoet cron types --format=json
+wp mailpoet cron types --fields=type,addable
+```
+
+### `wp mailpoet cron trigger`
+
+Marks a task due **now** so the site's own cron processor picks it up. It does **not** kick the cron
+pipeline itself — the MailPoet cron runner runs the task on its next tick. Use this when you want the
+normal site runner to do the work; use [`run`](#wp-mailpoet-cron-run) to do it immediately in the CLI
+process instead.
+
+By type, it targets the soonest-due scheduled task of that type. `cli` tasks are rejected (a task an
+active CLI process owns must not be yanked away).
+
+| Argument / option | Description                                                                                                  |
+| ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| `<type>`          | The task type to trigger.                                                                                    |
+| `--task-id=<id>`  | Trigger an exact task by ID (also re-schedules a paused one) instead of the next scheduled task of the type. |
+
+```bash
+wp mailpoet cron trigger sending
+wp mailpoet cron trigger bounce --task-id=42
+```
+
+### `wp mailpoet cron run`
+
+Runs a worker **inside this WP-CLI process** (see [CLI execution](#cli-execution-the-cli-status)).
+
+Without `--task-id`, it snapshots the currently-due tasks of the given type and runs each one once,
+**atomically claiming each as `cli`** (a single guarded status update, hidden from the web daemon)
+before processing. The claim is the safeguard against double-processing: a row another process already
+took is skipped, so neither a concurrently running web daemon nor a second overlapping CLI run can pick
+up the same task. A task that completes is marked `completed`; one that does not finish (or whose worker
+fails) is handed back to the site cron. Self-rescheduling batched workers
+(e.g. `subscribers_engagement_score`) process one batch per due task and schedule a continuation; that
+continuation is created after the snapshot, so it is left for the site cron — run the command again, or
+`trigger` it, to process the rest. Mailing workers run via their own process step; `run sending` runs
+the Scheduler and then the SendingQueue.
+
+With `--task-id`, it claims that one exact row (status `cli`, hidden from the web daemon) and runs
+just that task.
+
+The 20-second daemon execution limit is lifted by default so jobs run to completion; `--timeout`
+restores a cap.
+
+| Argument / option     | Description                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `<type>`              | The task type to run.                                                                |
+| `--task-id=<id>`      | Run this exact task in-process. Only `scheduled` or `paused` tasks can be run by ID. |
+| `--timeout=<seconds>` | Cap the run at this many seconds. Omit to run to completion.                         |
+
+```bash
+wp mailpoet cron run log_cleanup
+wp mailpoet cron run sending
+wp mailpoet cron run bounce --task-id=42
+wp mailpoet cron run sending --timeout=30
+```
+
+### `wp mailpoet cron run-daemon`
+
+Runs one full daemon pass over **all** workers inside this WP-CLI process. Each worker runs once,
+processing the tasks that are due. This is a single pass, not a backlog drain — a worker with many due
+tasks may need several passes, or use [`run <type>`](#wp-mailpoet-cron-run) to drain one type.
+
+Per-worker errors collected during the pass are printed and make the command exit non-zero.
+
+| Option                | Description                                                                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--timeout=<seconds>` | Cap the pass at this many seconds. Omit to run to completion. Unlike `run`, hitting `--timeout` mid-pass surfaces as a worker error and exits non-zero. |
+
+```bash
+wp mailpoet cron run-daemon
+wp mailpoet cron run-daemon --timeout=30
+```
+
+### `wp mailpoet cron add`
+
+Adds a new task to the schedule, optionally running it immediately in the CLI process.
+
+Only standard (addable) worker types can be added — see [`types`](#wp-mailpoet-cron-types). The mailing
+`sending` and `stats_notification` types are created by app flows (scheduling a newsletter, etc.) and
+are rejected.
+
+By default the task is due now at low priority. If a task of the type is already scheduled, the
+command reports the existing task and does nothing unless `--force` is given.
+
+With `--run`, the task is created already claimed (status `cli`, hidden from the web daemon) and
+processed in-CLI immediately. `--run` bypasses the duplicate check (the claimed row is independent)
+and cannot be combined with `--at`/`--in`.
+
+| Argument / option       | Description                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------------- |
+| `<type>`                | The (addable) task type to add.                                                             |
+| `--at=<datetime>`       | Schedule for this date/time (e.g. `'2026-01-01 09:00'`, `'tomorrow 8am'`). Defaults to now. |
+| `--in=<seconds>`        | Schedule this many seconds from now. Cannot be combined with `--at`.                        |
+| `--priority=<priority>` | `high`, `medium`, or `low` (default). Lower runs sooner.                                    |
+| `--force`               | Add the task even if one of the type is already scheduled.                                  |
+| `--run`                 | Claim and run the task in this process now. Cannot be combined with `--at`/`--in`.          |
+
+```bash
+wp mailpoet cron add log_cleanup
+wp mailpoet cron add bounce --in=3600 --priority=high
+wp mailpoet cron add bounce --at='tomorrow 8am'
+wp mailpoet cron add log_cleanup --force
+wp mailpoet cron add subscribers_count_cache_recalculation --run
+```
+
+### `wp mailpoet cron cancel`
+
+Cancels a task by setting its status to `cancelled`. Only `scheduled`, `paused`, and `cli` tasks can
+be cancelled — running tasks are owned by the site daemon and completed ones are history. Cancelling a
+`cli` task is the recovery path for a stuck CLI claim (see [Zombie CLI tasks](#zombie-cli-tasks)).
+
+| Argument    | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| `<task-id>` | The ID of the task to cancel (from `wp mailpoet cron list`). |
+
+```bash
+wp mailpoet cron cancel 42
+```
+
+## CLI execution: the `cli` status
+
+`run`, `run-daemon`, and `add --run` all execute work **inside the WP-CLI process** rather than the
+site's web-request daemon. The 20-second execution limit that bounds web-triggered runs is lifted by
+default, so a long job runs to completion in one invocation (use `--timeout` to restore a cap).
+
+When a task is run individually (`run --task-id`, `add --run`), it is **claimed** by giving it a
+dedicated `cli` status. Every daemon-side query selects only known statuses (`null`/running and
+`scheduled`), so a `cli` row is naturally invisible to the site daemon: it can neither pick the task
+up nor reschedule it out from under the CLI run. This is what prevents two workers (CLI and web)
+processing the same task at once.
+
+> **Why a dedicated status rather than the in-progress flag?** An earlier design claimed a task by
+> setting it to `running` (`NULL`) with an in-progress flag. That left two holes: the daemon's
+> stuck-task rescue would steal a long-running CLI task after 120 minutes, and workers that support
+> multiple instances skipped the in-progress guard entirely and would run the claimed task in
+> parallel. A distinct status closes both with no changes to the daemon.
+
+Outcomes of a claimed run:
+
+- **Completed** → status `completed`, and a `meta.cli` breadcrumb (`pid`, `started_at`) is recorded so
+  you can see the task was run from the CLI. The breadcrumb is written at completion (after the
+  worker's own writes), so workers that rewrite their task meta mid-run can't clobber it.
+- **Partial, or the worker throws** → the task is handed back to the site cron (status `scheduled`,
+  due now) so the daemon continues or retries it. A `cli` row must never be left behind when the CLI
+  isn't going to finish it.
+- **Requirements not met** → the task is removed, exactly as the daemon does for such tasks.
+
+### Zombie CLI tasks
+
+If a CLI process is hard-killed (e.g. `kill -9`) mid-run, its task stays in `cli` status. This is
+deliberate — there is no automatic cleanup. The stuck `cli` row is harmless (it is invisible to the
+daemon, so it blocks nothing) and serves as evidence that a CLI run died. Recover it manually with
+`wp mailpoet cron cancel <id>`, then re-add the work if needed.

--- a/mailpoet/changelog/2026-06-11-14-13-26-added-wp-cli-commands-for-managing-mailpoet-cron-tasks-w.md
+++ b/mailpoet/changelog/2026-06-11-14-13-26-added-wp-cli-commands-for-managing-mailpoet-cron-tasks-w.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+WP-CLI commands for managing MailPoet cron tasks (wp mailpoet cron)

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -13,6 +13,7 @@ use MailPoet\Automation\Engine\Engine;
 use MailPoet\Automation\Engine\Hooks as AutomationHooks;
 use MailPoet\Automation\Integrations\MailPoet\MailPoetIntegration;
 use MailPoet\Automation\Integrations\WooCommerce\WooCommerceIntegration;
+use MailPoet\Cron\CliCommands\Cli as CronCli;
 use MailPoet\Cron\CronTrigger;
 use MailPoet\Cron\DaemonActionSchedulerRunner;
 use MailPoet\CustomFields\RestApi\Api as CustomFieldsRestApi;
@@ -70,6 +71,9 @@ class Initializer {
 
   /** @var ImportCli */
   private $importCli;
+
+  /** @var CronCli */
+  private $cronCli;
 
   /** @var Router\Router */
   private $router;
@@ -184,6 +188,7 @@ class Initializer {
     SettingsController $settings,
     MigratorCli $migratorCli,
     ImportCli $importCli,
+    CronCli $cronCli,
     Router\Router $router,
     Hooks $hooks,
     Changelog $changelog,
@@ -225,6 +230,7 @@ class Initializer {
     $this->settings = $settings;
     $this->migratorCli = $migratorCli;
     $this->importCli = $importCli;
+    $this->cronCli = $cronCli;
     $this->router = $router;
     $this->hooks = $hooks;
     $this->changelog = $changelog;
@@ -408,6 +414,7 @@ class Initializer {
     try {
       $this->migratorCli->initialize();
       $this->importCli->initialize();
+      $this->cronCli->initialize();
       $this->setupInstaller();
       $this->setupUpdater();
 

--- a/mailpoet/lib/Cron/CliCommands/ClaimedTaskRunner.php
+++ b/mailpoet/lib/Cron/CliCommands/ClaimedTaskRunner.php
@@ -1,0 +1,170 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\CliCommands;
+
+use MailPoet\Cron\CronHelper;
+use MailPoet\Cron\CronWorkerInterface;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoetVendor\Carbon\Carbon;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Claims a single scheduled-task row for a WP-CLI process and drives it through one worker run.
+ *
+ * A claimed row carries status = STATUS_CLI, which is invisible to every daemon-side query, so the web
+ * daemon can neither pick it up nor reschedule it while the CLI run owns it. On success the row is
+ * completed (with a meta.cli breadcrumb merged after the worker's last write); on a partial run or
+ * failure it is handed back to the site cron (scheduled, due now); if requirements are not met it is
+ * removed.
+ *
+ * See doc/wp-cli-cron-commands.md ("CLI execution: the cli status") for the full rationale — why a
+ * dedicated status, the meta/inProgress placement, and how hard-killed (zombie) claims are handled.
+ */
+class ClaimedTaskRunner {
+  private ScheduledTasksRepository $scheduledTasksRepository;
+
+  private ExecutionLimitOverride $executionLimitOverride;
+
+  public function __construct(
+    ScheduledTasksRepository $scheduledTasksRepository,
+    ExecutionLimitOverride $executionLimitOverride
+  ) {
+    $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->executionLimitOverride = $executionLimitOverride;
+  }
+
+  /**
+   * Creates a fresh row already claimed (status STATUS_CLI), due now, and flushes it. No meta and no
+   * inProgress: the status alone hides the row, and workers may overwrite meta mid-run (see the doc).
+   * Public so a test can inspect the DB state after the claim.
+   */
+  public function claimNew(string $type, int $priority = ScheduledTaskEntity::PRIORITY_LOW): ScheduledTaskEntity {
+    $task = new ScheduledTaskEntity();
+    $task->setType($type);
+    $task->setStatus(ScheduledTaskEntity::STATUS_CLI);
+    $task->setPriority($priority);
+    $task->setScheduledAt(Carbon::now()->millisecond(0));
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+    return $task;
+  }
+
+  /**
+   * Atomically claims an EXISTING row (scheduled/paused, already resolved by the caller) by transitioning
+   * it to STATUS_CLI in a single guarded UPDATE. The row's meta is preserved; only the status changes.
+   * Returns false when the row was no longer claimable (a concurrent CLI run or the site daemon got it
+   * first), so the caller can skip it instead of double-processing.
+   */
+  public function claimExisting(ScheduledTaskEntity $task): bool {
+    return $this->scheduledTasksRepository->claimAsCli($task);
+  }
+
+  /**
+   * Drives one already-claimed row through a single worker run. The claim is always resolved on a
+   * non-completing path so the row never stays in 'cli' unless the process dies: on success it is
+   * completed; on partial work, a failed prepare, a hit execution limit, or an error it is handed back to
+   * the site cron; when requirements are not met it is removed. Public so a test can drive a fake worker
+   * through each path directly.
+   *
+   * $timeout caps the worker's own execution-limit checks (in seconds); null lifts the cap so the worker
+   * runs to completion. A worker that hits the cap is handed back gracefully and reported via
+   * limit_reached rather than as a failure.
+   *
+   * @return array{completed: bool, limit_reached: bool, message: string}
+   */
+  public function run(CronWorkerInterface $worker, ScheduledTaskEntity $task, ?int $timeout = null): array {
+    // Capture the claim marker at the start of the run. Claim and run always happen back-to-back on
+    // the same instance, so this is the pid/started_at of the run that owns the row.
+    $marker = [
+      'pid' => getmypid(),
+      'started_at' => Carbon::now()->toIso8601String(),
+    ];
+
+    $requirementsMet = false;
+    try {
+      $requirementsMet = $worker->checkProcessingRequirements();
+    } catch (Throwable $e) {
+      $this->handBack($task);
+      throw new RuntimeException(sprintf("Task %d (%s) failed while running: %s. It was handed back to the site cron to retry.", $task->getId(), $worker->getTaskType(), $e->getMessage()), 0, $e);
+    }
+
+    if (!$requirementsMet) {
+      // Requirements not met: the claimed row would never run, so drop it rather than leave a stuck
+      // 'cli' task. Mirrors CronWorkerRunner, which removes such tasks.
+      $this->scheduledTasksRepository->remove($task);
+      $this->scheduledTasksRepository->flush();
+      throw new RuntimeException(sprintf("Requirements for '%s' are not met; the claimed task was removed and nothing ran.", $worker->getTaskType()));
+    }
+
+    $completed = false;
+    try {
+      $worker->init();
+
+      $this->executionLimitOverride->overrideDuring($timeout, function () use ($worker, $task, &$completed): void {
+        // Mirror CronWorkerRunner: a task is only processed after prepare succeeds. Bounce is the one
+        // standard worker that overrides prepare (it builds subscriber rows and returns false when there
+        // is nothing to do); when prepare returns false we leave $completed false and hand the row back.
+        if (!$worker->prepareTaskStrategy($task, microtime(true))) {
+          return;
+        }
+        $completed = (bool)$worker->processTaskStrategy($task, microtime(true));
+      });
+    } catch (Throwable $e) {
+      $this->handBack($task);
+      // A worker that hit the execution limit (when $timeout caps the run) is yielding, not failing:
+      // hand it back so the site cron continues it, and report it as limit_reached rather than an error.
+      if ($e->getCode() === CronHelper::DAEMON_EXECUTION_LIMIT_REACHED) {
+        return [
+          'completed' => false,
+          'limit_reached' => true,
+          'message' => sprintf('Task %d hit the execution limit; it was handed back to the site cron to continue.', $task->getId()),
+        ];
+      }
+      throw new RuntimeException(sprintf("Task %d (%s) failed while running: %s. It was handed back to the site cron to retry.", $task->getId(), $worker->getTaskType(), $e->getMessage()), 0, $e);
+    }
+
+    if ($completed) {
+      $this->complete($task, $marker);
+      return [
+        'completed' => true,
+        'limit_reached' => false,
+        'message' => sprintf('Task %d completed.', $task->getId()),
+      ];
+    }
+
+    $this->handBack($task);
+    return [
+      'completed' => false,
+      'limit_reached' => false,
+      'message' => sprintf('Task %d processed partially; it was handed back to the site cron to continue.', $task->getId()),
+    ];
+  }
+
+  /**
+   * Marks the row completed (STATUS_COMPLETED + processedAt) and stamps meta.cli as the permanent
+   * "done by CLI" breadcrumb. The merge happens AFTER the worker's last write, so a worker that
+   * overwrote meta wholesale mid-run cannot clobber the breadcrumb.
+   *
+   * @param array{pid: int|false, started_at: string} $marker
+   */
+  private function complete(ScheduledTaskEntity $task, array $marker): void {
+    $task->setProcessedAt(Carbon::now()->millisecond(0));
+    $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+    $task->setMeta(array_merge($task->getMeta() ?? [], ['cli' => $marker]));
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+  }
+
+  /**
+   * Hands a not-finished row back to the site cron: STATUS_SCHEDULED, due now. No meta.cli is written
+   * — the breadcrumb is only for tasks the CLI actually completed.
+   */
+  private function handBack(ScheduledTaskEntity $task): void {
+    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $task->setScheduledAt(Carbon::now()->millisecond(0));
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+  }
+}

--- a/mailpoet/lib/Cron/CliCommands/Cli.php
+++ b/mailpoet/lib/Cron/CliCommands/Cli.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\CliCommands;
+
+use WP_CLI;
+
+class Cli {
+  private CronCommand $cronCommand;
+
+  public function __construct(
+    CronCommand $cronCommand
+  ) {
+    $this->cronCommand = $cronCommand;
+  }
+
+  public function initialize(): void {
+    if (!class_exists(WP_CLI::class)) {
+      return;
+    }
+
+    WP_CLI::add_command('mailpoet cron', $this->cronCommand, [
+      'shortdesc' => 'Manages MailPoet cron tasks',
+    ]);
+  }
+}

--- a/mailpoet/lib/Cron/CliCommands/CronCommand.php
+++ b/mailpoet/lib/Cron/CliCommands/CronCommand.php
@@ -11,12 +11,16 @@ class CronCommand {
 
   private WorkerTypesCatalog $workerTypesCatalog;
 
+  private TaskTrigger $taskTrigger;
+
   public function __construct(
     ScheduledTasksLister $scheduledTasksLister,
-    WorkerTypesCatalog $workerTypesCatalog
+    WorkerTypesCatalog $workerTypesCatalog,
+    TaskTrigger $taskTrigger
   ) {
     $this->scheduledTasksLister = $scheduledTasksLister;
     $this->workerTypesCatalog = $workerTypesCatalog;
+    $this->taskTrigger = $taskTrigger;
   }
 
   /**
@@ -136,5 +140,48 @@ class CronCommand {
 
     $formatter = new Formatter($assocArgs, WorkerTypesCatalog::FIELDS);
     $formatter->display_items($rows);
+  }
+
+  /**
+   * Marks a MailPoet cron task as due now so the site's own cron processor picks it up.
+   *
+   * This does not kick the cron pipeline; the MailPoet cron runner runs the task on its next tick.
+   * By type it targets the next scheduled task of that type; with --task-id it targets an exact row
+   * and also re-schedules a paused one.
+   *
+   * ## OPTIONS
+   *
+   * <type>
+   * : The task type to trigger. See `wp mailpoet cron types` for valid values.
+   *
+   * [--task-id=<id>]
+   * : Trigger an exact task by ID instead of the next scheduled task of the type.
+   *
+   * ## EXAMPLES
+   *
+   *     wp mailpoet cron trigger sending
+   *     wp mailpoet cron trigger bounce --task-id=42
+   *
+   * @subcommand trigger
+   *
+   * @param array $args
+   * @param array $assocArgs
+   */
+  public function trigger(array $args, array $assocArgs): void {
+    $type = (string)$args[0];
+    $taskId = array_key_exists('task-id', $assocArgs) ? (int)$assocArgs['task-id'] : null;
+
+    try {
+      $triggered = $this->taskTrigger->trigger($type, $taskId);
+    } catch (Throwable $e) {
+      WP_CLI::error($e->getMessage());
+      return;
+    }
+
+    WP_CLI::success(sprintf(
+      "Task %d (%s) is now due. The MailPoet cron runner will pick it up on its next tick.",
+      $triggered['id'],
+      $triggered['type']
+    ));
   }
 }

--- a/mailpoet/lib/Cron/CliCommands/CronCommand.php
+++ b/mailpoet/lib/Cron/CliCommands/CronCommand.php
@@ -15,20 +15,28 @@ class CronCommand {
 
   private TaskRunner $taskRunner;
 
+  private TaskCanceller $taskCanceller;
+
   private DaemonRunner $daemonRunner;
+
+  private TaskAdder $taskAdder;
 
   public function __construct(
     ScheduledTasksLister $scheduledTasksLister,
     WorkerTypesCatalog $workerTypesCatalog,
     TaskTrigger $taskTrigger,
     TaskRunner $taskRunner,
-    DaemonRunner $daemonRunner
+    TaskCanceller $taskCanceller,
+    DaemonRunner $daemonRunner,
+    TaskAdder $taskAdder
   ) {
     $this->scheduledTasksLister = $scheduledTasksLister;
     $this->workerTypesCatalog = $workerTypesCatalog;
     $this->taskTrigger = $taskTrigger;
     $this->taskRunner = $taskRunner;
+    $this->taskCanceller = $taskCanceller;
     $this->daemonRunner = $daemonRunner;
+    $this->taskAdder = $taskAdder;
   }
 
   /**
@@ -294,5 +302,124 @@ class CronCommand {
       WP_CLI::warning(sprintf('%s: %s', $error['worker'], $error['message']));
     }
     WP_CLI::error(sprintf('Daemon pass finished with %d worker error(s).', count($errors)));
+  }
+
+  /**
+   * Adds a new MailPoet cron task to the schedule, optionally running it immediately in this process.
+   *
+   * Only standard worker types are addable; see `wp mailpoet cron types` (the mailing 'sending' and
+   * 'stats_notification' rows are created by app flows and are rejected). By default the task is due
+   * now at low priority. If a task of the type is already scheduled the command reports it and does
+   * nothing unless --force is given. With --run the task is created already claimed (status 'cli',
+   * hidden from the web daemon) and processed in-CLI, bypassing the web daemon and the duplicate check.
+   *
+   * ## OPTIONS
+   *
+   * <type>
+   * : The task type to add. See `wp mailpoet cron types` for addable values.
+   *
+   * [--at=<datetime>]
+   * : Schedule for this date/time (e.g. '2026-01-01 09:00', 'tomorrow 8am'). Defaults to now.
+   *
+   * [--in=<seconds>]
+   * : Schedule this many seconds from now. Cannot be combined with --at.
+   *
+   * [--priority=<priority>]
+   * : Task priority. Lower runs sooner.
+   * ---
+   * default: low
+   * options:
+   *   - high
+   *   - medium
+   *   - low
+   * ---
+   *
+   * [--force]
+   * : Add the task even if one of the type is already scheduled.
+   *
+   * [--run]
+   * : Claim the task (status 'cli', hidden from the web daemon) and run it in this process now. Cannot
+   * be combined with --at/--in.
+   *
+   * ## EXAMPLES
+   *
+   *     wp mailpoet cron add log_cleanup
+   *     wp mailpoet cron add bounce --in=3600 --priority=high
+   *     wp mailpoet cron add bounce --at='tomorrow 8am'
+   *     wp mailpoet cron add log_cleanup --force
+   *     wp mailpoet cron add subscribers_count_cache_recalculation --run
+   *
+   * @subcommand add
+   *
+   * @param array $args
+   * @param array $assocArgs
+   */
+  public function add(array $args, array $assocArgs): void {
+    $type = (string)$args[0];
+    $at = array_key_exists('at', $assocArgs) ? (string)$assocArgs['at'] : null;
+    $in = array_key_exists('in', $assocArgs) ? (int)$assocArgs['in'] : null;
+    $priority = array_key_exists('priority', $assocArgs) ? (string)$assocArgs['priority'] : 'low';
+    $force = (bool)($assocArgs['force'] ?? false);
+    $run = (bool)($assocArgs['run'] ?? false);
+
+    try {
+      $result = $this->taskAdder->add($type, $at, $in, $priority, $force, $run);
+    } catch (Throwable $e) {
+      WP_CLI::error($e->getMessage());
+      return;
+    }
+
+    if ($result['action'] === 'duplicate') {
+      WP_CLI::warning($result['message']);
+      return;
+    }
+
+    WP_CLI::success($result['message']);
+
+    if ($result['run'] !== null) {
+      if ($result['run']['completed']) {
+        WP_CLI::success($result['run']['message']);
+      } else {
+        WP_CLI::warning($result['run']['message']);
+      }
+    }
+  }
+
+  /**
+   * Cancels a MailPoet cron task by setting its status to cancelled.
+   *
+   * Scheduled, paused, and cli tasks can be cancelled; cancelling a cli task recovers a stuck CLI
+   * claim. Running tasks are owned by their executor and completed ones are history, so both are
+   * rejected.
+   *
+   * ## OPTIONS
+   *
+   * <task-id>
+   * : The ID of the task to cancel. See `wp mailpoet cron list` for task IDs.
+   *
+   * ## EXAMPLES
+   *
+   *     wp mailpoet cron cancel 42
+   *
+   * @subcommand cancel
+   *
+   * @param array $args
+   * @param array $assocArgs
+   */
+  public function cancel(array $args, array $assocArgs): void {
+    $taskId = (int)$args[0];
+
+    try {
+      $cancelled = $this->taskCanceller->cancel($taskId);
+    } catch (Throwable $e) {
+      WP_CLI::error($e->getMessage());
+      return;
+    }
+
+    WP_CLI::success(sprintf(
+      "Task %d (%s) cancelled.",
+      $cancelled['id'],
+      $cancelled['type']
+    ));
   }
 }

--- a/mailpoet/lib/Cron/CliCommands/CronCommand.php
+++ b/mailpoet/lib/Cron/CliCommands/CronCommand.php
@@ -9,10 +9,14 @@ use WP_CLI\Formatter;
 class CronCommand {
   private ScheduledTasksLister $scheduledTasksLister;
 
+  private WorkerTypesCatalog $workerTypesCatalog;
+
   public function __construct(
-    ScheduledTasksLister $scheduledTasksLister
+    ScheduledTasksLister $scheduledTasksLister,
+    WorkerTypesCatalog $workerTypesCatalog
   ) {
     $this->scheduledTasksLister = $scheduledTasksLister;
+    $this->workerTypesCatalog = $workerTypesCatalog;
   }
 
   /**
@@ -90,6 +94,47 @@ class CronCommand {
       $formatter->display_items(array_column($rows, 'id'));
       return;
     }
+    $formatter->display_items($rows);
+  }
+
+  /**
+   * Lists all known MailPoet cron worker task types and their attributes.
+   *
+   * ## OPTIONS
+   *
+   * [--fields=<fields>]
+   * : Limit the output to specific fields. Comma-separated.
+   *
+   * [--field=<field>]
+   * : Print the value of a single field for each type.
+   *
+   * [--format=<format>]
+   * : Render output in a particular format.
+   * ---
+   * default: table
+   * options:
+   *   - table
+   *   - csv
+   *   - json
+   *   - yaml
+   *   - count
+   * ---
+   *
+   * ## EXAMPLES
+   *
+   *     wp mailpoet cron types
+   *     wp mailpoet cron types --format=json
+   *     wp mailpoet cron types --fields=type,addable
+   *
+   * @subcommand types
+   *
+   * @param array $args
+   * @param array $assocArgs
+   */
+  public function types(array $args, array $assocArgs): void {
+    $rows = $this->workerTypesCatalog->getRows();
+
+    $formatter = new Formatter($assocArgs, WorkerTypesCatalog::FIELDS);
     $formatter->display_items($rows);
   }
 }

--- a/mailpoet/lib/Cron/CliCommands/CronCommand.php
+++ b/mailpoet/lib/Cron/CliCommands/CronCommand.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\CliCommands;
+
+use Throwable;
+use WP_CLI;
+use WP_CLI\Formatter;
+
+class CronCommand {
+  private ScheduledTasksLister $scheduledTasksLister;
+
+  public function __construct(
+    ScheduledTasksLister $scheduledTasksLister
+  ) {
+    $this->scheduledTasksLister = $scheduledTasksLister;
+  }
+
+  /**
+   * Lists MailPoet scheduled tasks.
+   *
+   * ## OPTIONS
+   *
+   * [--status=<status>]
+   * : Filter tasks by status. Defaults to actionable tasks (scheduled, running, and cli).
+   * ---
+   * options:
+   *   - scheduled
+   *   - running
+   *   - cli
+   *   - completed
+   *   - cancelled
+   *   - paused
+   *   - invalid
+   *   - all
+   * ---
+   *
+   * [--type=<type>]
+   * : Filter tasks by type.
+   *
+   * [--limit=<n>]
+   * : Maximum number of tasks to return. Default 50.
+   *
+   * [--field=<field>]
+   * : Print the value of a single field for each task.
+   *
+   * [--fields=<fields>]
+   * : Limit the output to specific fields. Comma-separated.
+   *
+   * [--format=<format>]
+   * : Render output in a particular format.
+   * ---
+   * default: table
+   * options:
+   *   - table
+   *   - csv
+   *   - json
+   *   - ids
+   *   - count
+   * ---
+   *
+   * ## EXAMPLES
+   *
+   *     wp mailpoet cron list
+   *     wp mailpoet cron list --status=running
+   *     wp mailpoet cron list --status=all --format=json
+   *     wp mailpoet cron list --type=sending --limit=10
+   *
+   * @subcommand list
+   *
+   * @param array $args
+   * @param array $assocArgs
+   */
+  public function list(array $args, array $assocArgs): void {
+    $status = isset($assocArgs['status']) ? (string)$assocArgs['status'] : null;
+    $type = isset($assocArgs['type']) ? (string)$assocArgs['type'] : null;
+    $limit = array_key_exists('limit', $assocArgs) ? (int)$assocArgs['limit'] : ScheduledTasksLister::DEFAULT_LIMIT;
+    $format = $assocArgs['format'] ?? 'table';
+
+    try {
+      $rows = $this->scheduledTasksLister->getRows($status, $type, $limit);
+    } catch (Throwable $e) {
+      WP_CLI::error($e->getMessage());
+      return;
+    }
+
+    // The Formatter constructor consumes the format/fields keys from $assocArgs (by reference),
+    // so read the format before constructing it.
+    $formatter = new Formatter($assocArgs, ScheduledTasksLister::FIELDS);
+    if ($format === 'ids') {
+      $formatter->display_items(array_column($rows, 'id'));
+      return;
+    }
+    $formatter->display_items($rows);
+  }
+}

--- a/mailpoet/lib/Cron/CliCommands/CronCommand.php
+++ b/mailpoet/lib/Cron/CliCommands/CronCommand.php
@@ -13,14 +13,22 @@ class CronCommand {
 
   private TaskTrigger $taskTrigger;
 
+  private TaskRunner $taskRunner;
+
+  private DaemonRunner $daemonRunner;
+
   public function __construct(
     ScheduledTasksLister $scheduledTasksLister,
     WorkerTypesCatalog $workerTypesCatalog,
-    TaskTrigger $taskTrigger
+    TaskTrigger $taskTrigger,
+    TaskRunner $taskRunner,
+    DaemonRunner $daemonRunner
   ) {
     $this->scheduledTasksLister = $scheduledTasksLister;
     $this->workerTypesCatalog = $workerTypesCatalog;
     $this->taskTrigger = $taskTrigger;
+    $this->taskRunner = $taskRunner;
+    $this->daemonRunner = $daemonRunner;
   }
 
   /**
@@ -183,5 +191,108 @@ class CronCommand {
       $triggered['id'],
       $triggered['type']
     ));
+  }
+
+  /**
+   * Runs a MailPoet cron worker inside this WP-CLI process.
+   *
+   * Without --task-id, it snapshots the currently-due tasks of the given type and runs each once,
+   * claiming it as 'cli' (invisible to the site daemon) so the daemon never double-processes it.
+   * Self-rescheduling batched workers (e.g. subscribers_engagement_score) process one batch per due
+   * task and leave a continuation for the site cron, so run again (or `trigger`) to process the rest.
+   * The 20-second execution limit is lifted by default; pass --timeout to cap it.
+   *
+   * ## OPTIONS
+   *
+   * <type>
+   * : The task type to run. See `wp mailpoet cron types` for valid values.
+   *
+   * [--task-id=<id>]
+   * : Run this exact task in-process: it is claimed (status 'cli', hidden from the web daemon) and run
+   * here, so the daemon never double-processes it. Only scheduled or paused tasks can be run by ID.
+   *
+   * [--timeout=<seconds>]
+   * : Cap the run at this many seconds (restores an execution limit). Omit to run to completion.
+   *
+   * ## EXAMPLES
+   *
+   *     wp mailpoet cron run log_cleanup
+   *     wp mailpoet cron run sending
+   *     wp mailpoet cron run bounce --task-id=42
+   *     wp mailpoet cron run sending --timeout=30
+   *
+   * @subcommand run
+   *
+   * @param array $args
+   * @param array $assocArgs
+   */
+  public function run(array $args, array $assocArgs): void {
+    $type = (string)$args[0];
+    $taskId = array_key_exists('task-id', $assocArgs) ? (int)$assocArgs['task-id'] : null;
+    $timeout = array_key_exists('timeout', $assocArgs) ? (int)$assocArgs['timeout'] : null;
+
+    try {
+      $result = $this->taskRunner->run($type, $taskId, $timeout);
+    } catch (Throwable $e) {
+      WP_CLI::error($e->getMessage());
+      return;
+    }
+
+    // limit_reached and an un-drained backlog are both non-fatal partial outcomes (still exit 0):
+    // warn so the operator sees that not everything ran. A fully drained backlog is a success.
+    if ($result['limit_reached'] || !$result['backlog_drained']) {
+      WP_CLI::warning($result['message']);
+      return;
+    }
+
+    WP_CLI::success($result['message']);
+  }
+
+  /**
+   * Runs one full MailPoet daemon pass over all cron workers inside this WP-CLI process.
+   *
+   * Each worker runs once, processing the tasks that are due. This is a single daemon pass, not a
+   * backlog drain: a worker with many due tasks may need several passes, or use
+   * `wp mailpoet cron run <type>` to drain one type. The 20-second execution limit is lifted by
+   * default; pass --timeout to cap it. Per-worker errors collected during the pass are printed and
+   * make the command exit non-zero.
+   *
+   * ## OPTIONS
+   *
+   * [--timeout=<seconds>]
+   * : Cap the pass at this many seconds (restores an execution limit). Omit to run to completion.
+   * Unlike `run`, hitting --timeout mid-pass surfaces as a worker error and exits non-zero.
+   *
+   * ## EXAMPLES
+   *
+   *     wp mailpoet cron run-daemon
+   *     wp mailpoet cron run-daemon --timeout=30
+   *
+   * @subcommand run-daemon
+   *
+   * @param array $args
+   * @param array $assocArgs
+   */
+  // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- WP-CLI maps the run_daemon method to the run-daemon subcommand; the underscore is required.
+  public function run_daemon(array $args, array $assocArgs): void {
+    $timeout = array_key_exists('timeout', $assocArgs) ? (int)$assocArgs['timeout'] : null;
+
+    try {
+      $result = $this->daemonRunner->run($timeout);
+    } catch (Throwable $e) {
+      WP_CLI::error($e->getMessage());
+      return;
+    }
+
+    $errors = $result['errors'];
+    if (empty($errors)) {
+      WP_CLI::success('Daemon pass finished. Note: large backlogs may need multiple passes or `wp mailpoet cron run <type>`.');
+      return;
+    }
+
+    foreach ($errors as $error) {
+      WP_CLI::warning(sprintf('%s: %s', $error['worker'], $error['message']));
+    }
+    WP_CLI::error(sprintf('Daemon pass finished with %d worker error(s).', count($errors)));
   }
 }

--- a/mailpoet/lib/Cron/CliCommands/DaemonRunner.php
+++ b/mailpoet/lib/Cron/CliCommands/DaemonRunner.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\CliCommands;
+
+use MailPoet\Cron\CronHelper;
+use MailPoet\Cron\CronWorkerRunner;
+use MailPoet\Cron\CronWorkerScheduler;
+use MailPoet\Cron\Daemon;
+use MailPoet\Cron\Workers\WorkersFactory;
+use MailPoet\Logging\LoggerFactory;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+/**
+ * Runs one full MailPoet daemon pass over all workers inside the current process.
+ *
+ * This is a single Daemon::run() pass: each worker runs once, processing its due tasks (a standard
+ * worker processes at most TASK_BATCH_SIZE tasks per run). It is not a backlog drain — large
+ * backlogs may need several passes or a targeted `wp mailpoet cron run <type>`. The daemon's own
+ * maintenance-mode early exit is preserved. The 20-second execution limit is lifted by default (or
+ * capped via $timeout); because the daemon sets its timer at construction, the cap applies to the
+ * whole pass with no extra tracking.
+ */
+class DaemonRunner {
+  private ExecutionLimitOverride $executionLimitOverride;
+
+  private CronHelper $cronHelper;
+
+  private CronWorkerScheduler $cronWorkerScheduler;
+
+  private ScheduledTasksRepository $scheduledTasksRepository;
+
+  private EntityManager $entityManager;
+
+  private LoggerFactory $loggerFactory;
+
+  private WorkersFactory $workersFactory;
+
+  public function __construct(
+    ExecutionLimitOverride $executionLimitOverride,
+    CronHelper $cronHelper,
+    CronWorkerScheduler $cronWorkerScheduler,
+    ScheduledTasksRepository $scheduledTasksRepository,
+    EntityManager $entityManager,
+    LoggerFactory $loggerFactory,
+    WorkersFactory $workersFactory
+  ) {
+    $this->executionLimitOverride = $executionLimitOverride;
+    $this->cronHelper = $cronHelper;
+    $this->cronWorkerScheduler = $cronWorkerScheduler;
+    $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->entityManager = $entityManager;
+    $this->loggerFactory = $loggerFactory;
+    $this->workersFactory = $workersFactory;
+  }
+
+  /**
+   * @return array{errors: array<array{worker: string, message: string}>}
+   */
+  public function run(?int $timeout = null): array {
+    // createDaemon() resets last_error to null, so any last_error read back after the run is from
+    // this pass alone. Mirrors how the web cron (DaemonRun::process) builds its settings data.
+    $settingsDaemonData = $this->cronHelper->createDaemon($this->cronHelper->createToken());
+
+    $this->executionLimitOverride->overrideDuring($timeout, function () use ($settingsDaemonData): void {
+      $this->makeDaemon()->run($settingsDaemonData);
+    });
+
+    return [
+      'errors' => $this->readErrors(),
+    ];
+  }
+
+  /**
+   * @return array<array{worker: string, message: string}>
+   */
+  private function readErrors(): array {
+    $daemon = $this->cronHelper->getDaemon();
+    $errors = is_array($daemon) ? ($daemon['last_error'] ?? null) : null;
+    if (!is_array($errors)) {
+      return [];
+    }
+
+    // last_error is persisted untyped; normalise to the worker/message shape callers expect.
+    $normalised = [];
+    foreach ($errors as $error) {
+      $worker = is_array($error) ? ($error['worker'] ?? '') : '';
+      $message = is_array($error) ? ($error['message'] ?? '') : '';
+      $normalised[] = [
+        'worker' => is_string($worker) ? $worker : '',
+        'message' => is_string($message) ? $message : '',
+      ];
+    }
+    return $normalised;
+  }
+
+  /**
+   * A fresh Daemon (and a fresh CronWorkerRunner) per invocation so both execution timers start at
+   * the run, not at container build. Otherwise the shared instances would carry a stale timer and a
+   * --timeout cap would be measured from the wrong moment. Protected so a test can substitute a
+   * daemon that persists a worker error and assert the error-retrieval path surfaces it.
+   */
+  protected function makeDaemon(): Daemon {
+    $cronWorkerRunner = new CronWorkerRunner(
+      $this->cronHelper,
+      $this->cronWorkerScheduler,
+      $this->scheduledTasksRepository,
+      $this->loggerFactory
+    );
+
+    return new Daemon(
+      $this->cronHelper,
+      $cronWorkerRunner,
+      $this->entityManager,
+      $this->workersFactory,
+      $this->loggerFactory
+    );
+  }
+}

--- a/mailpoet/lib/Cron/CliCommands/ExecutionLimitOverride.php
+++ b/mailpoet/lib/Cron/CliCommands/ExecutionLimitOverride.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\WP\Functions as WPFunctions;
+
+/**
+ * Overrides MailPoet's cron execution limit for the duration of a callback.
+ *
+ * The cron machinery enforces a 20-second limit via the `mailpoet_cron_get_execution_limit`
+ * filter. When running a worker from WP-CLI we usually want it to run to completion, so the
+ * default is to lift the cap entirely; a caller may instead pass a number of seconds to cap it.
+ * The filter is always removed afterwards (including on exceptions) so global state never leaks.
+ */
+class ExecutionLimitOverride {
+  private WPFunctions $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  /**
+   * @template T
+   * @param int|null $seconds Cap in seconds, or null to lift the limit entirely.
+   * @param callable():T $fn
+   * @return T
+   */
+  public function overrideDuring(?int $seconds, callable $fn) {
+    if ($seconds !== null && $seconds < 0) {
+      throw new InvalidArgumentException(sprintf('Execution limit must be a non-negative number of seconds, got %d.', $seconds));
+    }
+    $limit = $seconds ?? PHP_INT_MAX;
+    $filter = function () use ($limit) {
+      return $limit;
+    };
+
+    $this->wp->addFilter('mailpoet_cron_get_execution_limit', $filter, PHP_INT_MAX);
+    try {
+      return $fn();
+    } finally {
+      $this->wp->removeFilter('mailpoet_cron_get_execution_limit', $filter, PHP_INT_MAX);
+    }
+  }
+}

--- a/mailpoet/lib/Cron/CliCommands/ScheduledTaskResolver.php
+++ b/mailpoet/lib/Cron/CliCommands/ScheduledTaskResolver.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+
+class ScheduledTaskResolver {
+  private ScheduledTasksRepository $scheduledTasksRepository;
+
+  public function __construct(
+    ScheduledTasksRepository $scheduledTasksRepository
+  ) {
+    $this->scheduledTasksRepository = $scheduledTasksRepository;
+  }
+
+  /**
+   * Finds a task by ID, treating soft-deleted rows as missing. When $expectedType is given the row
+   * must match it. The status whitelist stays with each caller.
+   */
+  public function resolveById(int $taskId, ?string $expectedType = null): ScheduledTaskEntity {
+    $task = $this->scheduledTasksRepository->findOneById($taskId);
+    if (!$task instanceof ScheduledTaskEntity || $task->getDeletedAt() !== null) {
+      throw new InvalidArgumentException("No task with ID {$taskId} found.");
+    }
+
+    if ($expectedType !== null && $task->getType() !== $expectedType) {
+      $actualType = (string)$task->getType();
+      throw new InvalidArgumentException("Task {$taskId} is of type '{$actualType}', not '{$expectedType}'.");
+    }
+
+    return $task;
+  }
+
+  /**
+   * The displayable status, mapping the NULL "running" placeholder to its virtual name.
+   */
+  public function nameStatus(ScheduledTaskEntity $task): string {
+    return $task->getStatus() ?? ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING;
+  }
+}

--- a/mailpoet/lib/Cron/CliCommands/ScheduledTasksLister.php
+++ b/mailpoet/lib/Cron/CliCommands/ScheduledTasksLister.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+
+class ScheduledTasksLister {
+  const DEFAULT_LIMIT = 50;
+
+  const DEFAULT_STATUSES = [
+    ScheduledTaskEntity::STATUS_SCHEDULED,
+    ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING,
+    ScheduledTaskEntity::STATUS_CLI,
+  ];
+
+  const ALLOWED_STATUSES = [
+    ScheduledTaskEntity::STATUS_SCHEDULED,
+    ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING,
+    ScheduledTaskEntity::STATUS_CLI,
+    ScheduledTaskEntity::STATUS_COMPLETED,
+    ScheduledTaskEntity::STATUS_CANCELLED,
+    ScheduledTaskEntity::STATUS_PAUSED,
+    ScheduledTaskEntity::STATUS_INVALID,
+  ];
+
+  const FIELDS = ['id', 'type', 'status', 'scheduled_at', 'priority', 'updated_at'];
+
+  private ScheduledTasksRepository $scheduledTasksRepository;
+
+  public function __construct(
+    ScheduledTasksRepository $scheduledTasksRepository
+  ) {
+    $this->scheduledTasksRepository = $scheduledTasksRepository;
+  }
+
+  /**
+   * @param string|null $status One of ALLOWED_STATUSES, 'all', or null for the default actionable statuses.
+   * @return array<int, array{id: int|null, type: string|null, status: string, scheduled_at: string, priority: int, updated_at: string}>
+   */
+  public function getRows(?string $status = null, ?string $type = null, int $limit = self::DEFAULT_LIMIT): array {
+    if ($limit < 1) {
+      throw new InvalidArgumentException("Invalid limit '{$limit}'. It must be a positive integer.");
+    }
+
+    $statuses = $this->resolveStatuses($status);
+    $tasks = $this->scheduledTasksRepository->getLatestTasks($type, $statuses, $limit);
+
+    $rows = array_map([$this, 'mapTaskToRow'], $tasks);
+
+    usort($rows, function (array $a, array $b): int {
+      return ($b['id'] ?? 0) <=> ($a['id'] ?? 0);
+    });
+
+    return array_slice($rows, 0, $limit);
+  }
+
+  /**
+   * @return string[]
+   */
+  private function resolveStatuses(?string $status): array {
+    if ($status === null) {
+      return self::DEFAULT_STATUSES;
+    }
+
+    if ($status === 'all') {
+      return self::ALLOWED_STATUSES;
+    }
+
+    if (!in_array($status, self::ALLOWED_STATUSES, true)) {
+      $allowed = implode(', ', array_merge(self::ALLOWED_STATUSES, ['all']));
+      throw new InvalidArgumentException("Invalid status '{$status}'. Allowed values: {$allowed}.");
+    }
+
+    return [$status];
+  }
+
+  /**
+   * @return array{id: int|null, type: string|null, status: string, scheduled_at: string, priority: int, updated_at: string}
+   */
+  private function mapTaskToRow(ScheduledTaskEntity $task): array {
+    $status = $this->renderStatus($task);
+    $scheduledAt = $task->getScheduledAt();
+    $updatedAt = $task->getUpdatedAt();
+
+    return [
+      'id' => $task->getId(),
+      'type' => $task->getType(),
+      'status' => $status,
+      'scheduled_at' => $scheduledAt ? $scheduledAt->format('Y-m-d H:i:s') : '',
+      'priority' => $task->getPriority(),
+      'updated_at' => $updatedAt ? $updatedAt->format('Y-m-d H:i:s') : '',
+    ];
+  }
+
+  /**
+   * Maps the NULL "running" placeholder to its virtual name. A CLI-claimed task carries the literal
+   * 'cli' status, so it renders as 'cli' through the regular branch with no special handling here.
+   */
+  private function renderStatus(ScheduledTaskEntity $task): string {
+    return $task->getStatus() ?? ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING;
+  }
+}

--- a/mailpoet/lib/Cron/CliCommands/TaskAdder.php
+++ b/mailpoet/lib/Cron/CliCommands/TaskAdder.php
@@ -1,0 +1,151 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\CliCommands;
+
+use Exception;
+use InvalidArgumentException;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoetVendor\Carbon\Carbon;
+
+/**
+ * Adds a new scheduled task for a standard cron worker, optionally claiming and running it in-process.
+ *
+ * Only standard CronWorkerInterface workers are addable (see WorkerTypesCatalog::getAddableTypes());
+ * mailing 'sending'/'stats_notification' rows are created by app flows and are rejected. --run drives a
+ * freshly claimed row through ClaimedTaskRunner, shared with `cron run --task-id`.
+ *
+ * See doc/wp-cli-cron-commands.md for command behaviour.
+ */
+class TaskAdder {
+  const PRIORITY_MAP = [
+    'high' => ScheduledTaskEntity::PRIORITY_HIGH,
+    'medium' => ScheduledTaskEntity::PRIORITY_MEDIUM,
+    'low' => ScheduledTaskEntity::PRIORITY_LOW,
+  ];
+
+  private WorkerTypesCatalog $workerTypesCatalog;
+
+  private ScheduledTasksRepository $scheduledTasksRepository;
+
+  private ClaimedTaskRunner $claimedTaskRunner;
+
+  public function __construct(
+    WorkerTypesCatalog $workerTypesCatalog,
+    ScheduledTasksRepository $scheduledTasksRepository,
+    ClaimedTaskRunner $claimedTaskRunner
+  ) {
+    $this->workerTypesCatalog = $workerTypesCatalog;
+    $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->claimedTaskRunner = $claimedTaskRunner;
+  }
+
+  /**
+   * @return array{id: int, type: string, action: string, message: string, run: array{completed: bool, limit_reached: bool, message: string}|null}
+   */
+  public function add(string $type, ?string $at, ?int $in, string $priority, bool $force, bool $run): array {
+    $this->workerTypesCatalog->assertAddableType($type);
+    $priorityValue = $this->resolvePriority($priority);
+
+    if ($run && ($at !== null || $in !== null)) {
+      throw new InvalidArgumentException('--run cannot be combined with --at or --in. A claimed task runs immediately.');
+    }
+
+    if ($run) {
+      return $this->claimAndRun($type, $priorityValue);
+    }
+
+    $scheduledAt = $this->resolveScheduledAt($at, $in);
+
+    if (!$force) {
+      $existing = $this->scheduledTasksRepository->findScheduledTask($type);
+      if ($existing instanceof ScheduledTaskEntity) {
+        $existingId = (int)$existing->getId();
+        return [
+          'id' => $existingId,
+          'type' => $type,
+          'action' => 'duplicate',
+          'message' => sprintf("A task of type '%s' is already scheduled as task %d. Use --force to add another.", $type, $existingId),
+          'run' => null,
+        ];
+      }
+    }
+
+    $task = $this->createTask($type, $priorityValue, $scheduledAt);
+
+    return [
+      'id' => (int)$task->getId(),
+      'type' => $type,
+      'action' => 'created',
+      'message' => sprintf("Added task %d (%s), scheduled for %s, priority %s.", $task->getId(), $type, $scheduledAt->format('Y-m-d H:i:s'), $priority),
+      'run' => null,
+    ];
+  }
+
+  private function createTask(string $type, int $priority, Carbon $scheduledAt): ScheduledTaskEntity {
+    $task = new ScheduledTaskEntity();
+    $task->setType($type);
+    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $task->setPriority($priority);
+    $task->setScheduledAt($scheduledAt);
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+    return $task;
+  }
+
+  /**
+   * Claims a fresh row (status STATUS_CLI) and processes exactly that one task. The duplicate check is
+   * intentionally skipped: the claim is a fresh, independently-owned row, never a "scheduled
+   * duplicate", so --run ignores --force entirely.
+   *
+   * @return array{id: int, type: string, action: string, message: string, run: array{completed: bool, limit_reached: bool, message: string}}
+   */
+  private function claimAndRun(string $type, int $priority): array {
+    $worker = $this->workerTypesCatalog->getWorkerByType($type);
+    if ($worker === null) {
+      // Unreachable: assertAddableType already restricts to types with a standard worker.
+      throw new InvalidArgumentException("Task type '{$type}' has no runnable worker.");
+    }
+
+    $task = $this->claimedTaskRunner->claimNew($type, $priority);
+    $taskId = (int)$task->getId();
+
+    $runResult = $this->claimedTaskRunner->run($worker, $task);
+
+    return [
+      'id' => $taskId,
+      'type' => $type,
+      'action' => 'claimed',
+      'message' => sprintf("Claimed task %d (%s) and ran it in this process.", $taskId, $type),
+      'run' => $runResult,
+    ];
+  }
+
+  private function resolveScheduledAt(?string $at, ?int $in): Carbon {
+    if ($at !== null && $in !== null) {
+      throw new InvalidArgumentException('--at and --in cannot be used together. Pick one.');
+    }
+
+    if ($at !== null) {
+      try {
+        return Carbon::parse($at)->millisecond(0);
+      } catch (Exception $e) {
+        throw new InvalidArgumentException("Could not parse --at value '{$at}'. Use a date/time like '2026-01-01 09:00' or 'tomorrow 8am'.");
+      }
+    }
+
+    if ($in !== null) {
+      return Carbon::now()->millisecond(0)->addSeconds($in);
+    }
+
+    return Carbon::now()->millisecond(0);
+  }
+
+  private function resolvePriority(string $priority): int {
+    if (!isset(self::PRIORITY_MAP[$priority])) {
+      $valid = implode(', ', array_keys(self::PRIORITY_MAP));
+      throw new InvalidArgumentException("Invalid priority '{$priority}'. Valid values: {$valid}.");
+    }
+    return self::PRIORITY_MAP[$priority];
+  }
+}

--- a/mailpoet/lib/Cron/CliCommands/TaskCanceller.php
+++ b/mailpoet/lib/Cron/CliCommands/TaskCanceller.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoetVendor\Carbon\Carbon;
+
+class TaskCanceller {
+  private ScheduledTasksRepository $scheduledTasksRepository;
+
+  private ScheduledTaskResolver $taskResolver;
+
+  public function __construct(
+    ScheduledTasksRepository $scheduledTasksRepository,
+    ScheduledTaskResolver $taskResolver
+  ) {
+    $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->taskResolver = $taskResolver;
+  }
+
+  /**
+   * Cancels a scheduled, paused, or 'cli' task. Running tasks are owned by their executor and completed
+   * ones are history, so both are rejected. A 'cli' task is cancellable as the recovery path for a
+   * zombie left behind by a hard-killed CLI run (cancel, then re-add).
+   *
+   * @return array{id: int, type: string}
+   */
+  public function cancel(int $taskId): array {
+    $task = $this->taskResolver->resolveById($taskId);
+
+    $status = $task->getStatus();
+    if (!in_array($status, [ScheduledTaskEntity::STATUS_SCHEDULED, ScheduledTaskEntity::STATUS_PAUSED, ScheduledTaskEntity::STATUS_CLI], true)) {
+      $current = $this->taskResolver->nameStatus($task);
+      throw new InvalidArgumentException("Task {$taskId} is '{$current}' and cannot be cancelled. Only scheduled, paused, or cli tasks can be cancelled.");
+    }
+
+    $task->setStatus(ScheduledTaskEntity::STATUS_CANCELLED);
+    $task->setCancelledAt(Carbon::now()->millisecond(0));
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+
+    return [
+      'id' => (int)$task->getId(),
+      'type' => (string)$task->getType(),
+    ];
+  }
+}

--- a/mailpoet/lib/Cron/CliCommands/TaskRunner.php
+++ b/mailpoet/lib/Cron/CliCommands/TaskRunner.php
@@ -1,0 +1,284 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\Cron\CronHelper;
+use MailPoet\Cron\CronWorkerInterface;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
+use MailPoet\Cron\Workers\StatsNotifications\Worker as StatsNotificationsWorker;
+use MailPoet\Cron\Workers\WorkersFactory;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\InvalidStateException;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Runs a MailPoet cron worker inside the current process.
+ *
+ * Bulk `run <type>` snapshots the type's currently-due tasks, then claims each as a CLI row (status
+ * 'cli', invisible to the site daemon) and runs it once through the shared ClaimedTaskRunner — the same
+ * claim model as `run --task-id`. This closes the concurrency hole (the daemon can never double-process
+ * a row the CLI owns) and stops self-rescheduling batched workers from running away: continuations they
+ * create mid-run are not in the snapshot, so each due task processes one batch and the continuation is
+ * left for the site cron. Mailing workers run via process(), and 'sending' runs the Scheduler then the
+ * SendingQueue. `run --task-id` claims one exact row through ClaimedTaskRunner. The 20-second execution
+ * limit is lifted by default (or capped via $timeout).
+ *
+ * See doc/wp-cli-cron-commands.md for command behaviour and the cli-claim rationale.
+ */
+class TaskRunner {
+  private WorkerTypesCatalog $workerTypesCatalog;
+
+  private WorkersFactory $workersFactory;
+
+  private ExecutionLimitOverride $executionLimitOverride;
+
+  private ScheduledTasksRepository $scheduledTasksRepository;
+
+  private ScheduledTaskResolver $taskResolver;
+
+  private ClaimedTaskRunner $claimedTaskRunner;
+
+  public function __construct(
+    WorkerTypesCatalog $workerTypesCatalog,
+    WorkersFactory $workersFactory,
+    ExecutionLimitOverride $executionLimitOverride,
+    ScheduledTasksRepository $scheduledTasksRepository,
+    ScheduledTaskResolver $taskResolver,
+    ClaimedTaskRunner $claimedTaskRunner
+  ) {
+    $this->workerTypesCatalog = $workerTypesCatalog;
+    $this->workersFactory = $workersFactory;
+    $this->executionLimitOverride = $executionLimitOverride;
+    $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->taskResolver = $taskResolver;
+    $this->claimedTaskRunner = $claimedTaskRunner;
+  }
+
+  /**
+   * @return array{completed: int, message: string, limit_reached: bool, backlog_drained: bool}
+   */
+  public function run(string $type, ?int $taskId = null, ?int $timeout = null): array {
+    $this->workerTypesCatalog->assertValidType($type);
+
+    if ($taskId !== null) {
+      return $this->runClaimedTask($type, $taskId, $timeout);
+    }
+
+    if ($type === SendingQueueWorker::TASK_TYPE || $type === StatsNotificationsWorker::TASK_TYPE) {
+      return $this->runMailing($type, $timeout);
+    }
+
+    return $this->runDueTasks($type, $timeout);
+  }
+
+  /**
+   * --task-id: resolve the exact row (scheduled/paused only, type must match), claim it as a CLI row
+   * preserving its meta, and run it through the shared ClaimedTaskRunner. The shared CronWorkerRunner
+   * cannot see a STATUS_CLI row, so claiming is the only way the exact row is processed in-CLI.
+   *
+   * @return array{completed: int, message: string, limit_reached: bool, backlog_drained: bool}
+   */
+  private function runClaimedTask(string $type, int $taskId, ?int $timeout): array {
+    $worker = $this->workerTypesCatalog->getWorkerByType($type);
+    if ($worker === null) {
+      throw new InvalidArgumentException("Task type '{$type}' has no runnable worker, so --task-id cannot run it in-process. Use `wp mailpoet cron trigger` for mailing types.");
+    }
+
+    $task = $this->taskResolver->resolveById($taskId, $type);
+    $status = $task->getStatus();
+    if (!in_array($status, [ScheduledTaskEntity::STATUS_SCHEDULED, ScheduledTaskEntity::STATUS_PAUSED], true)) {
+      $current = $this->taskResolver->nameStatus($task);
+      throw new InvalidArgumentException("Task {$taskId} is '{$current}' and cannot be run. Only scheduled or paused tasks can be run by ID.");
+    }
+
+    if (!$this->claimedTaskRunner->claimExisting($task)) {
+      throw new RuntimeException(sprintf('Task %d was claimed by another process; nothing ran.', $taskId));
+    }
+
+    // ClaimedTaskRunner installs the execution-limit override itself, so the timeout is passed through
+    // rather than wrapped here — wrapping would be defeated by its own (inner) override.
+    $runResult = $this->claimedTaskRunner->run($worker, $task, $timeout);
+
+    return [
+      'completed' => $runResult['completed'] ? 1 : 0,
+      'limit_reached' => $runResult['limit_reached'],
+      'backlog_drained' => $runResult['completed'],
+      'message' => $runResult['message'],
+    ];
+  }
+
+  /**
+   * Bulk `run <type>` for standard workers: snapshot the currently-due tasks, then claim and run each one
+   * exactly once through the shared ClaimedTaskRunner. Tasks are claimed as 'cli' so the site daemon
+   * cannot double-process them, and continuations created during the run (e.g. self-rescheduling batched
+   * workers) are not in the snapshot, so they are left for the site cron instead of being chased.
+   *
+   * @return array{completed: int, message: string, limit_reached: bool, backlog_drained: bool}
+   */
+  private function runDueTasks(string $type, ?int $timeout): array {
+    $worker = $this->resolveWorker($type);
+    if ($worker === null) {
+      // Should be unreachable: assertValidType allows only mailing + standard types, and mailing types
+      // are handled before this method is called.
+      throw new InvalidArgumentException("Task type '{$type}' has no runnable worker.");
+    }
+
+    // Pre-check requirements once so we never claim a task only to remove it on the requirements path.
+    try {
+      $requirementsMet = $worker->checkProcessingRequirements();
+    } catch (Throwable $e) {
+      throw new RuntimeException(sprintf("Requirements check for '%s' failed: %s. Nothing ran.", $type, $e->getMessage()), 0, $e);
+    }
+    if (!$requirementsMet) {
+      // Nothing ran and the due tasks are left scheduled, so the backlog is not drained: surface a
+      // warning rather than a green success.
+      return [
+        'completed' => 0,
+        'limit_reached' => false,
+        'backlog_drained' => false,
+        'message' => sprintf("Ran '%s': requirements not met, nothing ran.", $type),
+      ];
+    }
+
+    $dueTasks = $this->scheduledTasksRepository->findDueByType($type);
+
+    $completed = 0;
+    $handedBack = 0;
+    $limitReached = false;
+    $start = microtime(true);
+
+    foreach ($dueTasks as $task) {
+      // With --timeout, each task gets the run's remaining budget (capping the worker's own execution
+      // limit too, not just the gap between tasks); once it is spent we stop starting new tasks.
+      $remaining = null;
+      if ($timeout !== null) {
+        $remaining = $timeout - (microtime(true) - $start);
+        if ($remaining <= 0) {
+          $limitReached = true;
+          break;
+        }
+      }
+
+      // Atomic claim: another CLI run (or the daemon) may have taken this row since the snapshot, so a
+      // lost claim is skipped rather than double-processed.
+      if (!$this->claimedTaskRunner->claimExisting($task)) {
+        continue;
+      }
+
+      // A worker failure aborts the bulk run: already-processed tasks stay done, the failing one is
+      // handed back by ClaimedTaskRunner, and the RuntimeException propagates to the caller.
+      $result = $this->claimedTaskRunner->run($worker, $task, $remaining === null ? null : (int)ceil($remaining));
+      if ($result['limit_reached']) {
+        // The task hit the cap and was handed back; stop the run so it is not counted as completed.
+        $limitReached = true;
+        break;
+      }
+      $result['completed'] ? $completed++ : $handedBack++;
+    }
+
+    // Handed-back tasks (partial work, not ready, or a failed worker) are not "drained" — the command
+    // surfaces this as a warning so it is visible to operators and scripts.
+    $backlogDrained = !$limitReached && $handedBack === 0;
+
+    return [
+      'completed' => $completed,
+      'limit_reached' => $limitReached,
+      'backlog_drained' => $backlogDrained,
+      'message' => $this->buildMessage($type, $completed, $handedBack, $limitReached, $timeout),
+    ];
+  }
+
+  /**
+   * Mailing types ('sending', 'stats_notification') run their own mailer-driven flow instead of
+   * CronWorkerInterface, via their own process step under the execution-limit override, surfacing a hit
+   * limit as limit_reached.
+   *
+   * @return array{completed: int, message: string, limit_reached: bool, backlog_drained: bool}
+   */
+  private function runMailing(string $type, ?int $timeout): array {
+    $limitReached = false;
+
+    try {
+      $this->executionLimitOverride->overrideDuring($timeout, function () use ($type): void {
+        if ($type === SendingQueueWorker::TASK_TYPE) {
+          $this->runSending();
+          return;
+        }
+        $this->workersFactory->createStatsNotificationsWorker()->process();
+      });
+    } catch (\Exception $e) {
+      if ($e->getCode() === CronHelper::DAEMON_EXECUTION_LIMIT_REACHED) {
+        $limitReached = true;
+      } else {
+        throw $e;
+      }
+    }
+
+    if ($limitReached) {
+      return [
+        'completed' => 0,
+        'limit_reached' => true,
+        'backlog_drained' => false,
+        'message' => sprintf("Execution limit of %d seconds reached while running '%s'.", (int)$timeout, $type),
+      ];
+    }
+
+    return [
+      'completed' => 0,
+      'limit_reached' => false,
+      'backlog_drained' => true,
+      'message' => sprintf("Ran '%s'.", $type),
+    ];
+  }
+
+  /**
+   * Seam over the catalog lookup so tests can drive the run with a stub worker.
+   */
+  protected function resolveWorker(string $type): ?CronWorkerInterface {
+    return $this->workerTypesCatalog->getWorkerByType($type);
+  }
+
+  private function runSending(): void {
+    // Scheduling first, then sending: the Scheduler turns scheduled newsletters into running sending
+    // tasks the SendingQueue then picks up. Instantiated lazily because the queue worker resolves the
+    // mailer eagerly and throws on a site with no sender configured.
+    try {
+      $scheduler = $this->workersFactory->createScheduleWorker();
+      $queue = $this->workersFactory->createQueueWorker();
+    } catch (InvalidStateException $e) {
+      throw new RuntimeException('Sending is not configured on this site: ' . $e->getMessage());
+    }
+
+    $scheduler->process();
+    $queue->process();
+  }
+
+  private function buildMessage(string $type, int $completed, int $handedBack, bool $limitReached, ?int $timeout): string {
+    if ($limitReached) {
+      return sprintf(
+        "Execution limit of %d seconds reached while running '%s'. %d task(s) completed; remaining due tasks will run on the next invocation.",
+        (int)$timeout,
+        $type,
+        $completed
+      );
+    }
+
+    if ($handedBack > 0) {
+      return sprintf(
+        "Ran '%s': %d task(s) completed; %d task(s) handed back to the site cron (not ready or failed).",
+        $type,
+        $completed,
+        $handedBack
+      );
+    }
+
+    if ($completed > 0) {
+      return sprintf("Ran '%s': %d task(s) completed.", $type, $completed);
+    }
+
+    return sprintf("Ran '%s': no tasks completed (nothing was due).", $type);
+  }
+}

--- a/mailpoet/lib/Cron/CliCommands/TaskTrigger.php
+++ b/mailpoet/lib/Cron/CliCommands/TaskTrigger.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoetVendor\Carbon\Carbon;
+
+class TaskTrigger {
+  private ScheduledTasksRepository $scheduledTasksRepository;
+
+  private WorkerTypesCatalog $workerTypesCatalog;
+
+  private ScheduledTaskResolver $taskResolver;
+
+  public function __construct(
+    ScheduledTasksRepository $scheduledTasksRepository,
+    WorkerTypesCatalog $workerTypesCatalog,
+    ScheduledTaskResolver $taskResolver
+  ) {
+    $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->workerTypesCatalog = $workerTypesCatalog;
+    $this->taskResolver = $taskResolver;
+  }
+
+  /**
+   * Marks a task as due now so the site's own cron processor picks it up. Does not kick the pipeline.
+   *
+   * @return array{id: int, type: string}
+   */
+  public function trigger(string $type, ?int $taskId = null): array {
+    $this->workerTypesCatalog->assertValidType($type);
+
+    $task = $taskId !== null
+      ? $this->resolveTaskById($taskId, $type)
+      : $this->resolveTaskByType($type);
+
+    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $task->setScheduledAt(Carbon::now()->millisecond(0));
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+
+    return [
+      'id' => (int)$task->getId(),
+      'type' => (string)$task->getType(),
+    ];
+  }
+
+  private function resolveTaskByType(string $type): ScheduledTaskEntity {
+    $task = $this->scheduledTasksRepository->findSoonestScheduledTaskByType($type);
+    if (!$task instanceof ScheduledTaskEntity) {
+      throw new InvalidArgumentException("No scheduled task of type '{$type}' found. Run `wp mailpoet cron list` to see existing tasks.");
+    }
+    return $task;
+  }
+
+  private function resolveTaskById(int $taskId, string $type): ScheduledTaskEntity {
+    $task = $this->taskResolver->resolveById($taskId, $type);
+
+    $status = $task->getStatus();
+    if (!in_array($status, [ScheduledTaskEntity::STATUS_SCHEDULED, ScheduledTaskEntity::STATUS_PAUSED], true)) {
+      $current = $this->taskResolver->nameStatus($task);
+      throw new InvalidArgumentException("Task {$taskId} is '{$current}' and cannot be triggered. Only scheduled or paused tasks can be triggered.");
+    }
+
+    return $task;
+  }
+}

--- a/mailpoet/lib/Cron/CliCommands/WorkerTypesCatalog.php
+++ b/mailpoet/lib/Cron/CliCommands/WorkerTypesCatalog.php
@@ -1,0 +1,169 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\Cron\CronWorkerInterface;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
+use MailPoet\Cron\Workers\StatsNotifications\Worker as StatsNotificationsWorker;
+use MailPoet\Cron\Workers\WorkersFactory;
+use ReflectionMethod;
+
+class WorkerTypesCatalog {
+  const FIELDS = ['type', 'addable', 'schedule_automatically', 'supports_multiple_instances', 'mailing'];
+
+  /**
+   * Mailing worker task types: workers that run their own mailer-driven flow instead of
+   * CronWorkerInterface and cannot be created standalone. 'sending' covers both the Scheduler and
+   * SendingQueue workers.
+   */
+  const MAILING_TYPES = [
+    SendingQueueWorker::TASK_TYPE,
+    StatsNotificationsWorker::TASK_TYPE,
+  ];
+
+  /**
+   * Factory methods that build mailing workers. They are skipped during introspection: their attributes
+   * are static (see MAILING_TYPES) and instantiating the queue worker eagerly resolves the mailer, which
+   * fails on an unconfigured site. Mirrors the mailing workers Daemon::getWorkers() lists explicitly.
+   */
+  const MAILING_FACTORY_METHODS = [
+    'createScheduleWorker',
+    'createQueueWorker',
+    'createStatsNotificationsWorker',
+  ];
+
+  private WorkersFactory $workersFactory;
+
+  public function __construct(
+    WorkersFactory $workersFactory
+  ) {
+    $this->workersFactory = $workersFactory;
+  }
+
+  /**
+   * @return array<int, array{type: string, addable: bool, schedule_automatically: bool, supports_multiple_instances: bool, mailing: bool}>
+   */
+  public function getRows(): array {
+    $rows = [];
+
+    foreach ($this->getStandardWorkers() as $worker) {
+      $rows[$worker->getTaskType()] = [
+        'type' => $worker->getTaskType(),
+        'addable' => true,
+        'schedule_automatically' => $worker->scheduleAutomatically(),
+        'supports_multiple_instances' => $worker->supportsMultipleInstances(),
+        'mailing' => false,
+      ];
+    }
+
+    foreach (self::MAILING_TYPES as $type) {
+      $rows[$type] = [
+        'type' => $type,
+        'addable' => false,
+        'schedule_automatically' => false,
+        'supports_multiple_instances' => false,
+        'mailing' => true,
+      ];
+    }
+
+    ksort($rows);
+
+    return array_values($rows);
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getTypes(): array {
+    return array_column($this->getRows(), 'type');
+  }
+
+  /**
+   * Task types a user may add from the CLI: the standard CronWorkerInterface workers only. Mailing rows
+   * ('sending', 'stats_notification') are created by app flows (a newsletter being sent, a digest
+   * scheduling) and have no standalone factory, so they are deliberately excluded. Derived from the
+   * standard workers, not WorkersFactory::SIMPLE_WORKER_TYPES (which misleadingly lists the mailing
+   * 'stats_notification').
+   *
+   * @return string[]
+   */
+  public function getAddableTypes(): array {
+    $types = [];
+    foreach ($this->getStandardWorkers() as $worker) {
+      $types[] = $worker->getTaskType();
+    }
+    sort($types);
+    return $types;
+  }
+
+  /**
+   * Throws unless $type is a known task type (standard or mailing). Shared by the trigger and run
+   * commands, which accept any existing type.
+   */
+  public function assertValidType(string $type): void {
+    $validTypes = $this->getTypes();
+    if (!in_array($type, $validTypes, true)) {
+      $valid = implode(', ', $validTypes);
+      throw new InvalidArgumentException("Unknown task type '{$type}'. Valid types: {$valid}.");
+    }
+  }
+
+  /**
+   * Throws unless $type can be added from the CLI. A known-but-mailing type gets a richer message
+   * explaining it is created by app flows; an entirely unknown type is reported as such. Used by the
+   * add command, which only accepts standard types.
+   */
+  public function assertAddableType(string $type): void {
+    $addable = $this->getAddableTypes();
+    if (in_array($type, $addable, true)) {
+      return;
+    }
+
+    $allTypes = $this->getTypes();
+    if (in_array($type, $allTypes, true)) {
+      throw new InvalidArgumentException("Task type '{$type}' cannot be added from the CLI. It is a mailing type created by app flows (a newsletter being sent, a digest scheduling). Addable types: " . implode(', ', $addable) . '.');
+    }
+
+    throw new InvalidArgumentException("Unknown task type '{$type}'. Addable types: " . implode(', ', $addable) . '.');
+  }
+
+  /**
+   * Returns the standard worker instance for a task type, or null for mailing/unknown types.
+   * Keeps the run command in lockstep with the factory: it resolves the same instances the
+   * catalog introspects, so a new create*Worker() method is runnable without touching this code.
+   */
+  public function getWorkerByType(string $type): ?CronWorkerInterface {
+    foreach ($this->getStandardWorkers() as $worker) {
+      if ($worker->getTaskType() === $type) {
+        return $worker;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Instantiates every standalone worker the factory can build, skipping the mailing ones.
+   * This keeps the catalog in lockstep with the factory: a new create*Worker() method appears
+   * here automatically. The instanceof check guards against a future non-standard worker slipping in.
+   *
+   * @return iterable<CronWorkerInterface>
+   */
+  private function getStandardWorkers(): iterable {
+    foreach (get_class_methods($this->workersFactory) as $method) {
+      if (strpos($method, 'create') !== 0) {
+        continue;
+      }
+      if (in_array($method, self::MAILING_FACTORY_METHODS, true)) {
+        continue;
+      }
+      if ((new ReflectionMethod($this->workersFactory, $method))->getNumberOfRequiredParameters() > 0) {
+        continue;
+      }
+      $worker = $this->workersFactory->{$method}();
+      if ($worker instanceof CronWorkerInterface) {
+        yield $worker;
+      }
+    }
+  }
+}

--- a/mailpoet/lib/Cron/Workers/WorkersFactory.php
+++ b/mailpoet/lib/Cron/Workers/WorkersFactory.php
@@ -13,6 +13,16 @@ use MailPoet\Cron\Workers\StatsNotifications\Worker as StatsNotificationsWorker;
 use MailPoet\Cron\Workers\WooCommerceSync as WooCommerceSyncWorker;
 use MailPoet\DI\ContainerWrapper;
 
+/**
+ * Builds cron worker instances for the daemon.
+ *
+ * The CLI cron commands auto-discover workers by reflecting over this factory (see
+ * MailPoet\Cron\CliCommands\WorkerTypesCatalog): every argument-less create*() method that returns a
+ * CronWorkerInterface becomes listable and runnable via `wp mailpoet cron`. Keep the `create` prefix
+ * and the no-required-arguments shape when adding a worker; mailing workers that are not
+ * CronWorkerInterface (Scheduler, SendingQueue, StatsNotifications) must be excluded there via
+ * WorkerTypesCatalog::MAILING_FACTORY_METHODS.
+ */
 class WorkersFactory {
   public const SIMPLE_WORKER_TYPES = [
     SubscribersCountCacheRecalculation::TASK_TYPE,

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -315,6 +315,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\CliCommands\ExecutionLimitOverride::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\ScheduledTaskResolver::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\ScheduledTasksLister::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\CliCommands\TaskAdder::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\CliCommands\TaskCanceller::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\TaskRunner::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\TaskTrigger::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\WorkerTypesCatalog::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -311,6 +311,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\CliCommands\Cli::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\CronCommand::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\ScheduledTasksLister::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\CliCommands\WorkerTypesCatalog::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CronHelper::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CronTrigger::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CronWorkerRunner::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -308,10 +308,14 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Migrator\Runner::class)->setPublic(true);
     $container->autowire(\MailPoet\Migrator\Store::class)->setPublic(true);
     // Cron
+    $container->autowire(\MailPoet\Cron\CliCommands\ClaimedTaskRunner::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\Cli::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\CronCommand::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\CliCommands\DaemonRunner::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\CliCommands\ExecutionLimitOverride::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\ScheduledTaskResolver::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\ScheduledTasksLister::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\CliCommands\TaskRunner::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\TaskTrigger::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\WorkerTypesCatalog::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CronHelper::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -308,6 +308,9 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Migrator\Runner::class)->setPublic(true);
     $container->autowire(\MailPoet\Migrator\Store::class)->setPublic(true);
     // Cron
+    $container->autowire(\MailPoet\Cron\CliCommands\Cli::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\CliCommands\CronCommand::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\CliCommands\ScheduledTasksLister::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CronHelper::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CronTrigger::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CronWorkerRunner::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -310,7 +310,9 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Cron
     $container->autowire(\MailPoet\Cron\CliCommands\Cli::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\CronCommand::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\CliCommands\ScheduledTaskResolver::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\ScheduledTasksLister::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\CliCommands\TaskTrigger::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CliCommands\WorkerTypesCatalog::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CronHelper::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\CronTrigger::class)->setPublic(true);

--- a/mailpoet/lib/Entities/ScheduledTaskEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskEntity.php
@@ -23,6 +23,7 @@ class ScheduledTaskEntity {
   const STATUS_CANCELLED = 'cancelled';
   const STATUS_PAUSED = 'paused';
   const STATUS_INVALID = 'invalid';
+  const STATUS_CLI = 'cli'; // A task claimed and run by a WP-CLI process; hidden from the web daemon, which only queries known statuses (null, scheduled).
   const VIRTUAL_STATUS_RUNNING = 'running'; // For historical reasons this is stored as null in DB
   const PRIORITY_HIGH = 1;
   const PRIORITY_MEDIUM = 5;

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -175,6 +175,33 @@ class ScheduledTasksRepository extends Repository {
       ->getOneOrNullResult();
   }
 
+  /**
+   * Atomically claims a scheduled/paused row for a CLI run by flipping it to STATUS_CLI in a single
+   * guarded UPDATE. Returns false when no row was changed (another process already claimed or ran it),
+   * so concurrent CLI runs never both process the same task.
+   */
+  public function claimAsCli(ScheduledTaskEntity $task): bool {
+    $updated = (int)$this->entityManager->createQuery(
+      'UPDATE ' . ScheduledTaskEntity::class . ' st ' .
+      'SET st.status = :cli ' .
+      'WHERE st.id = :id AND st.status IN (:claimable) AND st.deletedAt IS NULL'
+    )
+      ->setParameter('cli', ScheduledTaskEntity::STATUS_CLI)
+      ->setParameter('id', $task->getId())
+      ->setParameter('claimable', [ScheduledTaskEntity::STATUS_SCHEDULED, ScheduledTaskEntity::STATUS_PAUSED])
+      ->execute();
+
+    if ($updated === 0) {
+      return false;
+    }
+
+    // The DQL UPDATE bypasses the entity manager, so refresh the in-memory entity to the claimed state.
+    // Otherwise its status snapshot stays 'scheduled' and a later hand-back to 'scheduled' is seen as a
+    // no-op change, leaving the row stuck as 'cli'.
+    $this->entityManager->refresh($task);
+    return true;
+  }
+
   public function findPreviousTask(ScheduledTaskEntity $task): ?ScheduledTaskEntity {
     return $this->doctrineRepository->createQueryBuilder('st')
       ->select('st')

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -161,6 +161,20 @@ class ScheduledTasksRepository extends Repository {
     return $queryBuilder->getQuery()->getOneOrNullResult();
   }
 
+  public function findSoonestScheduledTaskByType(string $type): ?ScheduledTaskEntity {
+    return $this->doctrineRepository->createQueryBuilder('st')
+      ->select('st')
+      ->where('st.status = :scheduledStatus')
+      ->andWhere('st.type = :type')
+      ->andWhere('st.deletedAt IS NULL')
+      ->setParameter('scheduledStatus', ScheduledTaskEntity::STATUS_SCHEDULED)
+      ->setParameter('type', $type)
+      ->setMaxResults(1)
+      ->orderBy('st.scheduledAt', 'ASC')
+      ->getQuery()
+      ->getOneOrNullResult();
+  }
+
   public function findPreviousTask(ScheduledTaskEntity $task): ?ScheduledTaskEntity {
     return $this->doctrineRepository->createQueryBuilder('st')
       ->select('st')

--- a/mailpoet/tests/integration/Cron/CliCommands/ClaimedTaskRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/CliCommands/ClaimedTaskRunnerTest.php
@@ -1,0 +1,361 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\CliCommands;
+
+use MailPoet\Cron\CliCommands\ClaimedTaskRunner;
+use MailPoet\Cron\CronHelper;
+use MailPoet\Cron\CronWorkerInterface;
+use MailPoet\Cron\Triggers\WordPress as WordPressTrigger;
+use MailPoet\Cron\Workers\SubscribersCountCacheRecalculation;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Services\Bridge;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Carbon\Carbon;
+use RuntimeException;
+
+class ClaimedTaskRunnerTest extends \MailPoetTest {
+  /** @var ClaimedTaskRunner */
+  private $claimedTaskRunner;
+
+  /** @var ScheduledTasksRepository */
+  private $scheduledTasksRepository;
+
+  /** @var ScheduledTaskFactory */
+  private $taskFactory;
+
+  public function _before() {
+    parent::_before();
+    $this->claimedTaskRunner = $this->diContainer->get(ClaimedTaskRunner::class);
+    $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    $this->taskFactory = new ScheduledTaskFactory();
+  }
+
+  public function testClaimNewCreatesACliRowWithoutMetaOrInProgress() {
+    $task = $this->claimedTaskRunner->claimNew(SubscribersCountCacheRecalculation::TASK_TYPE);
+
+    // Re-read from the DB to assert the state was actually flushed.
+    $this->entityManager->clear();
+    $persisted = $this->scheduledTasksRepository->findOneById((int)$task->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $persisted);
+
+    verify($persisted->getStatus())->same(ScheduledTaskEntity::STATUS_CLI);
+    // No inProgress and no meta at claim time: the status alone hides the row from the daemon, and
+    // a claim-time meta.cli would be clobbered by workers that overwrite meta mid-run.
+    verify($persisted->getInProgress())->null();
+    verify($persisted->getMeta())->null();
+  }
+
+  public function testClaimExistingTransitionsToCliPreservingMeta() {
+    $existing = $this->taskFactory->create('typeExisting', ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+    $existing->setMeta(['kept' => 'yes']);
+    $this->entityManager->flush();
+
+    verify($this->claimedTaskRunner->claimExisting($existing))->true();
+
+    $this->entityManager->clear();
+    $persisted = $this->scheduledTasksRepository->findOneById((int)$existing->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $persisted);
+    verify($persisted->getStatus())->same(ScheduledTaskEntity::STATUS_CLI);
+    // Existing meta is preserved by the claim.
+    $meta = $persisted->getMeta();
+    $this->assertIsArray($meta);
+    verify($meta['kept'])->same('yes');
+  }
+
+  public function testClaimExistingIsAtomicAndLosesToAConcurrentClaim() {
+    $task = $this->taskFactory->create('typeRace', ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    // First claim wins and flips the row to cli; a second claim of the now-cli row loses, so two CLI
+    // processes that snapshotted the same scheduled row never both process it.
+    verify($this->claimedTaskRunner->claimExisting($task))->true();
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_CLI);
+    verify($this->claimedTaskRunner->claimExisting($task))->false();
+  }
+
+  public function testRunCompletesAndMergesCliMetaWithWorkerWrittenMeta() {
+    $task = $this->claimedTaskRunner->claimNew('typeComplete');
+    // The worker writes its own meta during processing; the cli breadcrumb must merge with it, not
+    // clobber it (and must survive the worker's wholesale meta write).
+    $worker = $this->makeWorker('typeComplete', true, false, true, false, ['x' => 1]);
+
+    $result = $this->claimedTaskRunner->run($worker, $task);
+
+    verify($result['completed'])->true();
+
+    $this->entityManager->clear();
+    $persisted = $this->scheduledTasksRepository->findOneById((int)$task->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $persisted);
+    verify($persisted->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
+    verify($persisted->getProcessedAt())->notNull();
+
+    $meta = $persisted->getMeta();
+    $this->assertIsArray($meta);
+    // Worker-written key and the cli breadcrumb both present.
+    $this->assertArrayHasKey('x', $meta);
+    verify($meta['x'])->same(1);
+    $this->assertArrayHasKey('cli', $meta);
+    verify($meta['cli']['pid'])->same(getmypid());
+    $this->assertIsString($meta['cli']['started_at']);
+  }
+
+  public function testRunHandsBackAndRethrowsWhenWorkerThrows() {
+    $task = $this->claimedTaskRunner->claimNew('typeThrow');
+    $worker = $this->makeWorker('typeThrow', true, true, false);
+
+    try {
+      $this->claimedTaskRunner->run($worker, $task);
+      $this->fail('Expected a RuntimeException.');
+    } catch (RuntimeException $e) {
+      verify($e->getMessage())->stringContainsString('failed while running');
+      verify($e->getMessage())->stringContainsString('handed back');
+    }
+
+    $this->entityManager->clear();
+    $persisted = $this->scheduledTasksRepository->findOneById((int)$task->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $persisted);
+    verify($persisted->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->assertScheduledNow($persisted);
+  }
+
+  public function testRunHandsBackWhenRequirementsCheckThrows() {
+    $task = $this->claimedTaskRunner->claimNew('typeReqThrow');
+    // checkProcessingRequirements() itself throws, before any processing happens.
+    $worker = $this->makeWorker('typeReqThrow', true, false, false, true);
+
+    try {
+      $this->claimedTaskRunner->run($worker, $task);
+      $this->fail('Expected a RuntimeException.');
+    } catch (RuntimeException $e) {
+      verify($e->getMessage())->stringContainsString('failed while running');
+    }
+
+    $this->entityManager->clear();
+    $persisted = $this->scheduledTasksRepository->findOneById((int)$task->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $persisted);
+    verify($persisted->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->assertScheduledNow($persisted);
+  }
+
+  public function testRunHandsBackWithoutProcessingWhenPrepareReturnsFalse() {
+    $task = $this->claimedTaskRunner->claimNew('typePrepareFalse');
+    // Mirrors Bounce: prepareTaskStrategy returns false (nothing to do), so the task is never processed.
+    $worker = $this->makeWorker('typePrepareFalse', true, false, true, false, null, false);
+
+    $result = $this->claimedTaskRunner->run($worker, $task);
+
+    verify($result['completed'])->false();
+    verify($result['message'])->stringContainsString('handed back');
+    // processTaskStrategy must not have run when prepare returns false.
+    verify($worker->processCalled)->false();
+
+    $this->entityManager->clear();
+    $persisted = $this->scheduledTasksRepository->findOneById((int)$task->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $persisted);
+    // Handed back to the site cron: scheduled, due now, no cli breadcrumb left behind.
+    verify($persisted->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->assertScheduledNow($persisted);
+    $meta = $persisted->getMeta();
+    verify($meta === null || !isset($meta['cli']))->true();
+  }
+
+  public function testRunProcessesWhenPrepareReturnsTrue() {
+    $task = $this->claimedTaskRunner->claimNew('typePrepareTrue');
+    $worker = $this->makeWorker('typePrepareTrue', true, false, true, false, null, true);
+
+    $result = $this->claimedTaskRunner->run($worker, $task);
+
+    verify($result['completed'])->true();
+    verify($worker->processCalled)->true();
+
+    $this->entityManager->clear();
+    $persisted = $this->scheduledTasksRepository->findOneById((int)$task->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $persisted);
+    verify($persisted->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
+  }
+
+  public function testRunRemovesTheClaimedTaskWhenRequirementsNotMet() {
+    $task = $this->claimedTaskRunner->claimNew('typeNoReq');
+    $taskId = (int)$task->getId();
+    $worker = $this->makeWorker('typeNoReq', false, false, true);
+
+    try {
+      $this->claimedTaskRunner->run($worker, $task);
+      $this->fail('Expected a RuntimeException.');
+    } catch (RuntimeException $e) {
+      verify($e->getMessage())->stringContainsString('Requirements');
+    }
+
+    $this->entityManager->clear();
+    verify($this->scheduledTasksRepository->findOneById($taskId))->null();
+  }
+
+  public function testRunHandsBackGracefullyWhenWorkerHitsExecutionLimit() {
+    $task = $this->claimedTaskRunner->claimNew('typeLimit');
+    // requirements met, processes, but hits the execution limit (the worker yields rather than fails).
+    $worker = $this->makeWorker('typeLimit', true, false, false, false, null, true, true);
+
+    // No exception: a hit limit is a graceful yield, surfaced via limit_reached.
+    $result = $this->claimedTaskRunner->run($worker, $task, 5);
+
+    verify($result['completed'])->false();
+    verify($result['limit_reached'])->true();
+    verify($result['message'])->stringContainsString('execution limit');
+
+    $this->entityManager->clear();
+    $persisted = $this->scheduledTasksRepository->findOneById((int)$task->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $persisted);
+    // Handed back to the site cron to continue: scheduled, due now, no cli breadcrumb.
+    verify($persisted->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->assertScheduledNow($persisted);
+    $meta = $persisted->getMeta();
+    verify($meta === null || !isset($meta['cli']))->true();
+  }
+
+  public function testACliRowIsInvisibleToDaemonDueAndRunningQueries() {
+    // The two confirmed holes: a long CLI run must not be findable by the daemon's due/running
+    // queries for its type, so the daemon can neither pick it up nor reschedule it.
+    $type = 'typeHidden';
+    $this->claimedTaskRunner->claimNew($type);
+
+    verify($this->scheduledTasksRepository->findDueByType($type))->arrayCount(0);
+    verify($this->scheduledTasksRepository->findRunningByType($type))->arrayCount(0);
+  }
+
+  public function testACliRowIsNotCountedAsPendingWorkByCheckExecutionRequirements() {
+    // Mirrors the WordPressTest baseline: with cron disabled, no sending keys, and only a future
+    // stats-report task, checkExecutionRequirements() is false. A DUE cli row of a simple-worker type
+    // must keep it false (it is invisible), whereas the same row as 'scheduled' flips it to true —
+    // proving the cli status, not the row's presence, is what hides it.
+    $settings = SettingsController::getInstance();
+    $settings->set('cron_trigger', ['method' => 'none']);
+    $settings->set(Bridge::API_KEY_SETTING_NAME, null);
+    $settings->set(Bridge::PREMIUM_KEY_SETTING_NAME, null);
+
+    $future = Carbon::createFromTimestamp(WPFunctions::get()->currentTime('timestamp', true) + 600);
+    $this->taskFactory->create(\MailPoet\Cron\Workers\SubscribersStatsReport::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, $future);
+
+    $trigger = $this->diContainer->get(WordPressTrigger::class);
+    verify($trigger->checkExecutionRequirements())->false();
+
+    $cliRow = $this->taskFactory->create(SubscribersCountCacheRecalculation::TASK_TYPE, ScheduledTaskEntity::STATUS_CLI, Carbon::now());
+    verify($trigger->checkExecutionRequirements())->false();
+
+    // Flip the very same row to scheduled: now it IS pending work and the daemon wakes up.
+    $cliRow->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->entityManager->flush();
+    verify($trigger->checkExecutionRequirements())->true();
+  }
+
+  private function assertScheduledNow(ScheduledTaskEntity $task): void {
+    $scheduledAt = $task->getScheduledAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $scheduledAt);
+    verify(abs(Carbon::now()->getTimestamp() - $scheduledAt->getTimestamp()))->lessThan(120);
+  }
+
+  /**
+   * @param array<string, mixed>|null $metaToWrite Meta the worker writes wholesale during processing.
+   *
+   * The return type is left off so callers can read the public processCalled flag on the anonymous
+   * class.
+   */
+  private function makeWorker(
+    string $type,
+    bool $requirementsMet,
+    bool $throws,
+    bool $completed,
+    bool $requirementsThrows = false,
+    ?array $metaToWrite = null,
+    bool $prepareReturns = true,
+    bool $throwsExecutionLimit = false
+  ) {
+    return new class($type, $requirementsMet, $throws, $completed, $requirementsThrows, $metaToWrite, $prepareReturns, $throwsExecutionLimit) implements CronWorkerInterface {
+      /** @var string */
+      private $type;
+      /** @var bool */
+      private $requirementsMet;
+      /** @var bool */
+      private $throws;
+      /** @var bool */
+      private $completed;
+      /** @var bool */
+      private $requirementsThrows;
+      /** @var array<string, mixed>|null */
+      private $metaToWrite;
+      /** @var bool */
+      private $prepareReturns;
+      /** @var bool */
+      private $throwsExecutionLimit;
+      /** @var bool */
+      public $processCalled = false;
+
+      public function __construct(
+        string $type,
+        bool $requirementsMet,
+        bool $throws,
+        bool $completed,
+        bool $requirementsThrows,
+        ?array $metaToWrite,
+        bool $prepareReturns,
+        bool $throwsExecutionLimit
+      ) {
+        $this->type = $type;
+        $this->requirementsMet = $requirementsMet;
+        $this->throws = $throws;
+        $this->completed = $completed;
+        $this->requirementsThrows = $requirementsThrows;
+        $this->metaToWrite = $metaToWrite;
+        $this->prepareReturns = $prepareReturns;
+        $this->throwsExecutionLimit = $throwsExecutionLimit;
+      }
+
+      public function getTaskType() {
+        return $this->type;
+      }
+
+      public function scheduleAutomatically() {
+        return false;
+      }
+
+      public function supportsMultipleInstances() {
+        return false;
+      }
+
+      public function checkProcessingRequirements() {
+        if ($this->requirementsThrows) {
+          throw new \RuntimeException('requirements boom');
+        }
+        return $this->requirementsMet;
+      }
+
+      public function init() {
+      }
+
+      public function prepareTaskStrategy(ScheduledTaskEntity $task, $timer) {
+        return $this->prepareReturns;
+      }
+
+      public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+        $this->processCalled = true;
+        if ($this->metaToWrite !== null) {
+          // Workers like InactiveSubscribers overwrite meta wholesale mid-run.
+          $task->setMeta($this->metaToWrite);
+        }
+        if ($this->throwsExecutionLimit) {
+          // Mirrors CronHelper::enforceExecutionLimit when a worker exhausts its time budget.
+          throw new \Exception('execution limit reached', CronHelper::DAEMON_EXECUTION_LIMIT_REACHED);
+        }
+        if ($this->throws) {
+          throw new \RuntimeException('boom');
+        }
+        return $this->completed;
+      }
+
+      public function getNextRunDate() {
+        return Carbon::now();
+      }
+    };
+  }
+}

--- a/mailpoet/tests/integration/Cron/CliCommands/DaemonRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/CliCommands/DaemonRunnerTest.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\CliCommands;
+
+use MailPoet\Cron\CliCommands\DaemonRunner;
+use MailPoet\Cron\CliCommands\ExecutionLimitOverride;
+use MailPoet\Cron\CronHelper;
+use MailPoet\Cron\CronWorkerScheduler;
+use MailPoet\Cron\Daemon;
+use MailPoet\Cron\Workers\UnsubscribeTokens;
+use MailPoet\Cron\Workers\WorkersFactory;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Logging\LoggerFactory;
+use MailPoet\Mailer\Mailer;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class DaemonRunnerTest extends \MailPoetTest {
+  /** @var DaemonRunner */
+  private $daemonRunner;
+
+  /** @var ScheduledTaskFactory */
+  private $taskFactory;
+
+  public function _before() {
+    parent::_before();
+    $this->daemonRunner = $this->diContainer->get(DaemonRunner::class);
+    $this->taskFactory = new ScheduledTaskFactory();
+    // A full daemon pass instantiates the SendingQueue worker, which resolves the mailer eagerly and
+    // throws on a site with no sender configured (a configured site is the realistic case).
+    $settings = $this->diContainer->get(SettingsController::class);
+    $settings->set(Mailer::MAILER_CONFIG_SETTING_NAME, ['method' => Mailer::METHOD_PHPMAIL]);
+    $settings->set('sender', ['name' => 'Sender', 'address' => 'sender@example.com']);
+  }
+
+  public function testItCompletesADueTaskInOnePassWithoutErrors() {
+    $task = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+    $taskId = (int)$task->getId();
+
+    $result = $this->daemonRunner->run();
+
+    verify($result['errors'])->equals([]);
+
+    // The daemon clears the entity manager during its pass, so re-fetch the task by ID.
+    $scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    $processed = $scheduledTasksRepository->findOneById($taskId);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $processed);
+    verify($processed->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
+  }
+
+  public function testItSurfacesWorkerErrorsCollectedDuringThePass() {
+    // Forcing a real worker to throw mid-pass is brittle, and createDaemon() resets last_error so
+    // pre-seeding it would be wiped. Instead substitute a daemon that persists an error exactly the
+    // way Daemon::run does (saveDaemonLastError) and assert the real retrieval path surfaces it.
+    $persistedError = [['worker' => 'BounceWorker', 'message' => 'Boom']];
+
+    $result = $this->makeDaemonRunnerPersisting($persistedError)->run();
+
+    verify($result['errors'])->equals($persistedError);
+  }
+
+  public function testItNormalisesMalformedPersistedErrors() {
+    // last_error is persisted untyped, so readErrors() must coerce unexpected shapes. A non-string
+    // worker plus a missing message must normalise to empty strings rather than leak raw values.
+    $malformedError = [['worker' => 123, 'unexpected' => 'x']];
+
+    $result = $this->makeDaemonRunnerPersisting($malformedError)->run();
+
+    verify($result['errors'])->equals([['worker' => '', 'message' => '']]);
+  }
+
+  private function makeDaemonRunnerPersisting(array $persistedError): DaemonRunner {
+    $cronHelper = $this->diContainer->get(CronHelper::class);
+
+    return new class(
+      $this->diContainer->get(ExecutionLimitOverride::class),
+      $cronHelper,
+      $this->diContainer->get(CronWorkerScheduler::class),
+      $this->diContainer->get(ScheduledTasksRepository::class),
+      $this->diContainer->get(EntityManager::class),
+      $this->diContainer->get(LoggerFactory::class),
+      $this->diContainer->get(WorkersFactory::class),
+      $persistedError
+    ) extends DaemonRunner {
+      /** @var CronHelper */
+      private $stubCronHelper;
+
+      /** @var array */
+      private $persistedError;
+
+      public function __construct(
+        ExecutionLimitOverride $executionLimitOverride,
+        CronHelper $cronHelper,
+        CronWorkerScheduler $cronWorkerScheduler,
+        ScheduledTasksRepository $scheduledTasksRepository,
+        EntityManager $entityManager,
+        LoggerFactory $loggerFactory,
+        WorkersFactory $workersFactory,
+        array $persistedError
+      ) {
+        parent::__construct(
+          $executionLimitOverride,
+          $cronHelper,
+          $cronWorkerScheduler,
+          $scheduledTasksRepository,
+          $entityManager,
+          $loggerFactory,
+          $workersFactory
+        );
+        $this->stubCronHelper = $cronHelper;
+        $this->persistedError = $persistedError;
+      }
+
+      protected function makeDaemon(): Daemon {
+        $cronHelper = $this->stubCronHelper;
+        $persistedError = $this->persistedError;
+        return new class($cronHelper, $persistedError) extends Daemon {
+          /** @var CronHelper */
+          private $cronHelper;
+
+          /** @var array */
+          private $persistedError;
+
+          // Intentionally bypasses the parent Daemon constructor; this stub only persists an error.
+          public function __construct(
+            CronHelper $cronHelper,
+            array $persistedError
+          ) {
+            $this->cronHelper = $cronHelper;
+            $this->persistedError = $persistedError;
+          }
+
+          public function run($settingsDaemonData) {
+            $this->cronHelper->saveDaemonLastError($this->persistedError);
+          }
+        };
+      }
+    };
+  }
+}

--- a/mailpoet/tests/integration/Cron/CliCommands/ExecutionLimitOverrideTest.php
+++ b/mailpoet/tests/integration/Cron/CliCommands/ExecutionLimitOverrideTest.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\Cron\CliCommands\ExecutionLimitOverride;
+use MailPoet\Cron\CronHelper;
+use RuntimeException;
+
+class ExecutionLimitOverrideTest extends \MailPoetTest {
+  /** @var ExecutionLimitOverride */
+  private $override;
+
+  /** @var CronHelper */
+  private $cronHelper;
+
+  public function _before() {
+    parent::_before();
+    $this->override = $this->diContainer->get(ExecutionLimitOverride::class);
+    $this->cronHelper = $this->diContainer->get(CronHelper::class);
+  }
+
+  public function testItLiftsTheExecutionLimitInsideTheCallback() {
+    $defaultLimit = $this->cronHelper->getDaemonExecutionLimit();
+    verify($defaultLimit)->equals(CronHelper::DAEMON_EXECUTION_LIMIT);
+
+    $insideLimit = $this->override->overrideDuring(null, function () {
+      return $this->cronHelper->getDaemonExecutionLimit();
+    });
+
+    verify($insideLimit)->equals(PHP_INT_MAX);
+  }
+
+  public function testItCapsTheExecutionLimitWhenSecondsGiven() {
+    $insideLimit = $this->override->overrideDuring(3, function () {
+      return $this->cronHelper->getDaemonExecutionLimit();
+    });
+
+    verify($insideLimit)->equals(3);
+  }
+
+  public function testItRestoresTheLimitAfterTheCallback() {
+    $this->override->overrideDuring(1, function () {
+      return null;
+    });
+
+    verify($this->cronHelper->getDaemonExecutionLimit())->equals(CronHelper::DAEMON_EXECUTION_LIMIT);
+  }
+
+  public function testItRestoresTheLimitEvenWhenTheCallbackThrows() {
+    $caught = null;
+    try {
+      $this->override->overrideDuring(1, function (): void {
+        throw new RuntimeException('boom');
+      });
+    } catch (RuntimeException $e) {
+      $caught = $e;
+    }
+
+    verify($caught)->notNull();
+    verify($caught->getMessage())->equals('boom');
+    verify($this->cronHelper->getDaemonExecutionLimit())->equals(CronHelper::DAEMON_EXECUTION_LIMIT);
+  }
+
+  public function testItRejectsANegativeLimitWithoutTouchingTheFilter() {
+    $callbackRan = false;
+    try {
+      $this->override->overrideDuring(-1, function () use (&$callbackRan) {
+        $callbackRan = true;
+        return null;
+      });
+      $this->fail('Expected an InvalidArgumentException.');
+    } catch (InvalidArgumentException $e) {
+      verify($e->getMessage())->stringContainsString('non-negative');
+    }
+
+    // The guard fires before the callback runs and before the filter is touched.
+    verify($callbackRan)->false();
+    verify($this->cronHelper->getDaemonExecutionLimit())->equals(CronHelper::DAEMON_EXECUTION_LIMIT);
+  }
+
+  public function testItAllowsAZeroLimit() {
+    $insideLimit = $this->override->overrideDuring(0, function () {
+      return $this->cronHelper->getDaemonExecutionLimit();
+    });
+
+    verify($insideLimit)->equals(0);
+  }
+
+  public function testItReturnsTheCallbackResult() {
+    $result = $this->override->overrideDuring(null, function () {
+      return 'value';
+    });
+
+    verify($result)->equals('value');
+  }
+}

--- a/mailpoet/tests/integration/Cron/CliCommands/ScheduledTasksListerTest.php
+++ b/mailpoet/tests/integration/Cron/CliCommands/ScheduledTasksListerTest.php
@@ -1,0 +1,152 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\Cron\CliCommands\ScheduledTasksLister;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+class ScheduledTasksListerTest extends \MailPoetTest {
+  /** @var ScheduledTasksLister */
+  private $lister;
+
+  /** @var ScheduledTaskFactory */
+  private $taskFactory;
+
+  public function _before() {
+    parent::_before();
+    $this->lister = $this->diContainer->get(ScheduledTasksLister::class);
+    $this->taskFactory = new ScheduledTaskFactory();
+  }
+
+  public function testItListsScheduledAndRunningTasksByDefault() {
+    $scheduled = $this->createTask('typeA', ScheduledTaskEntity::STATUS_SCHEDULED);
+    $running = $this->createTask('typeB', null);
+    $this->createTask('typeC', ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->createTask('typeD', ScheduledTaskEntity::STATUS_CANCELLED);
+    $this->createTask('typeE', ScheduledTaskEntity::STATUS_PAUSED);
+    $this->createTask('typeF', ScheduledTaskEntity::STATUS_INVALID);
+
+    $rows = $this->lister->getRows();
+
+    $ids = array_column($rows, 'id');
+    verify($ids)->arrayCount(2);
+    verify(in_array($scheduled->getId(), $ids, true))->true();
+    verify(in_array($running->getId(), $ids, true))->true();
+  }
+
+  public function testItSortsNewestFirst() {
+    $first = $this->createTask('typeA', ScheduledTaskEntity::STATUS_SCHEDULED);
+    $second = $this->createTask('typeB', ScheduledTaskEntity::STATUS_SCHEDULED);
+    $third = $this->createTask('typeC', ScheduledTaskEntity::STATUS_SCHEDULED);
+
+    $rows = $this->lister->getRows();
+
+    $ids = array_column($rows, 'id');
+    verify($ids)->same([$third->getId(), $second->getId(), $first->getId()]);
+  }
+
+  public function testItIncludesCliInTheDefaultActionableSet() {
+    $cli = $this->createTask('typeA', ScheduledTaskEntity::STATUS_CLI);
+    $this->createTask('typeB', ScheduledTaskEntity::STATUS_COMPLETED);
+
+    $rows = $this->lister->getRows();
+
+    $ids = array_column($rows, 'id');
+    verify(in_array($cli->getId(), $ids, true))->true();
+  }
+
+  /**
+   * @dataProvider dataForSingleStatusFilter
+   */
+  public function testItFiltersAndRendersBySingleStatus(string $key, string $filterValue, string $expectedStatus) {
+    $tasks = $this->createOneTaskPerStatus();
+
+    $rows = $this->lister->getRows($filterValue);
+
+    verify($rows)->arrayCount(1);
+    verify($rows[0]['id'])->equals($tasks[$key]->getId());
+    verify($rows[0]['status'])->same($expectedStatus);
+  }
+
+  public function dataForSingleStatusFilter(): array {
+    return [
+      'scheduled' => ['scheduled', ScheduledTaskEntity::STATUS_SCHEDULED, ScheduledTaskEntity::STATUS_SCHEDULED],
+      'running' => ['running', ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING, ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING],
+      'cli' => ['cli', ScheduledTaskEntity::STATUS_CLI, ScheduledTaskEntity::STATUS_CLI],
+      'completed' => ['completed', ScheduledTaskEntity::STATUS_COMPLETED, ScheduledTaskEntity::STATUS_COMPLETED],
+    ];
+  }
+
+  public function testItListsAllStatuses() {
+    $this->createTask('typeA', ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->createTask('typeB', null);
+    $this->createTask('typeC', ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->createTask('typeD', ScheduledTaskEntity::STATUS_CANCELLED);
+    $this->createTask('typeE', ScheduledTaskEntity::STATUS_PAUSED);
+    $this->createTask('typeF', ScheduledTaskEntity::STATUS_INVALID);
+    $this->createTask('typeG', ScheduledTaskEntity::STATUS_CLI);
+
+    $rows = $this->lister->getRows('all');
+
+    verify($rows)->arrayCount(7);
+  }
+
+  public function testItFiltersByType() {
+    $matching = $this->createTask('sending', ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->createTask('bounce', ScheduledTaskEntity::STATUS_SCHEDULED);
+
+    $rows = $this->lister->getRows(null, 'sending');
+
+    verify($rows)->arrayCount(1);
+    verify($rows[0]['id'])->equals($matching->getId());
+    verify($rows[0]['type'])->same('sending');
+  }
+
+  public function testItRespectsLimit() {
+    foreach (range(1, 5) as $i) {
+      $this->createTask("type{$i}", ScheduledTaskEntity::STATUS_SCHEDULED);
+    }
+
+    $rows = $this->lister->getRows(null, null, 3);
+
+    verify($rows)->arrayCount(3);
+  }
+
+  public function testItReturnsTheConfiguredColumns() {
+    $this->createTask('typeA', ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    $rows = $this->lister->getRows();
+
+    verify(array_keys($rows[0]))->same(ScheduledTasksLister::FIELDS);
+  }
+
+  public function testItThrowsOnInvalidStatus() {
+    $this->expectException(InvalidArgumentException::class);
+    $this->lister->getRows('bogus');
+  }
+
+  public function testItThrowsOnInvalidLimit() {
+    $this->expectException(InvalidArgumentException::class);
+    $this->lister->getRows(null, null, 0);
+  }
+
+  /** @return array<string, ScheduledTaskEntity> */
+  private function createOneTaskPerStatus(): array {
+    return [
+      'scheduled' => $this->createTask('typeScheduled', ScheduledTaskEntity::STATUS_SCHEDULED),
+      'running' => $this->createTask('typeRunning', null),
+      'cli' => $this->createTask('typeCli', ScheduledTaskEntity::STATUS_CLI),
+      'completed' => $this->createTask('typeCompleted', ScheduledTaskEntity::STATUS_COMPLETED),
+      'cancelled' => $this->createTask('typeCancelled', ScheduledTaskEntity::STATUS_CANCELLED),
+      'paused' => $this->createTask('typePaused', ScheduledTaskEntity::STATUS_PAUSED),
+      'invalid' => $this->createTask('typeInvalid', ScheduledTaskEntity::STATUS_INVALID),
+    ];
+  }
+
+  private function createTask(string $type, ?string $status, ?Carbon $scheduledAt = null): ScheduledTaskEntity {
+    return $this->taskFactory->create($type, $status, $scheduledAt ?? Carbon::now());
+  }
+}

--- a/mailpoet/tests/integration/Cron/CliCommands/TaskAdderTest.php
+++ b/mailpoet/tests/integration/Cron/CliCommands/TaskAdderTest.php
@@ -1,0 +1,193 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\Cron\CliCommands\TaskAdder;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
+use MailPoet\Cron\Workers\StatsNotifications\Worker as StatsNotificationsWorker;
+use MailPoet\Cron\Workers\SubscribersCountCacheRecalculation;
+use MailPoet\Cron\Workers\UnsubscribeTokens;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+class TaskAdderTest extends \MailPoetTest {
+  /** @var TaskAdder */
+  private $adder;
+
+  /** @var ScheduledTasksRepository */
+  private $scheduledTasksRepository;
+
+  /** @var ScheduledTaskFactory */
+  private $taskFactory;
+
+  public function _before() {
+    parent::_before();
+    $this->adder = $this->diContainer->get(TaskAdder::class);
+    $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    $this->taskFactory = new ScheduledTaskFactory();
+  }
+
+  public function testItAddsADueNowLowPriorityScheduledTaskByDefault() {
+    $before = Carbon::now()->subSecond();
+
+    $result = $this->adder->add(UnsubscribeTokens::TASK_TYPE, null, null, 'low', false, false);
+
+    verify($result['action'])->same('created');
+    verify($result['id'])->greaterThan(0);
+
+    $task = $this->scheduledTasksRepository->findOneById($result['id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+    verify($task->getPriority())->same(ScheduledTaskEntity::PRIORITY_LOW);
+    $scheduledAt = $task->getScheduledAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $scheduledAt);
+    verify($scheduledAt->getTimestamp())->greaterThanOrEqual($before->getTimestamp());
+  }
+
+  public function testItRespectsPriority() {
+    $result = $this->adder->add(UnsubscribeTokens::TASK_TYPE, null, null, 'high', false, false);
+
+    $task = $this->scheduledTasksRepository->findOneById($result['id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    verify($task->getPriority())->same(ScheduledTaskEntity::PRIORITY_HIGH);
+  }
+
+  public function testItRespectsAtDatetime() {
+    $result = $this->adder->add(UnsubscribeTokens::TASK_TYPE, '2030-01-01 09:00:00', null, 'low', false, false);
+
+    $task = $this->scheduledTasksRepository->findOneById($result['id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    $scheduledAt = $task->getScheduledAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $scheduledAt);
+    verify($scheduledAt->format('Y-m-d H:i:s'))->same('2030-01-01 09:00:00');
+  }
+
+  public function testItRespectsInSeconds() {
+    $result = $this->adder->add(UnsubscribeTokens::TASK_TYPE, null, 3600, 'low', false, false);
+
+    $task = $this->scheduledTasksRepository->findOneById($result['id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    $scheduledAt = $task->getScheduledAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $scheduledAt);
+    $expected = Carbon::now()->addSeconds(3600);
+    // Within a minute of "now + 3600s", tolerant of test execution time.
+    verify(abs($scheduledAt->getTimestamp() - $expected->getTimestamp()))->lessThan(60);
+  }
+
+  public function testItRejectsAtAndInTogether() {
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/--at and --in/');
+    $this->adder->add(UnsubscribeTokens::TASK_TYPE, '2030-01-01', 60, 'low', false, false);
+  }
+
+  public function testItRejectsUnparseableAt() {
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/Could not parse --at/');
+    $this->adder->add(UnsubscribeTokens::TASK_TYPE, 'not a date at all', null, 'low', false, false);
+  }
+
+  public function testItRejectsInvalidPriority() {
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/Invalid priority/');
+    $this->adder->add(UnsubscribeTokens::TASK_TYPE, null, null, 'urgent', false, false);
+  }
+
+  public function testItRejectsSendingAsMailingType() {
+    try {
+      $this->adder->add(SendingQueueWorker::TASK_TYPE, null, null, 'low', false, false);
+      $this->fail('Expected an InvalidArgumentException.');
+    } catch (InvalidArgumentException $e) {
+      verify($e->getMessage())->stringContainsString('mailing type');
+      verify($e->getMessage())->stringContainsString(UnsubscribeTokens::TASK_TYPE);
+    }
+  }
+
+  public function testItRejectsStatsNotificationAsMailingType() {
+    try {
+      $this->adder->add(StatsNotificationsWorker::TASK_TYPE, null, null, 'low', false, false);
+      $this->fail('Expected an InvalidArgumentException.');
+    } catch (InvalidArgumentException $e) {
+      verify($e->getMessage())->stringContainsString('mailing type');
+    }
+  }
+
+  public function testItRejectsUnknownTypeListingAddableTypes() {
+    try {
+      $this->adder->add('totally_bogus_type', null, null, 'low', false, false);
+      $this->fail('Expected an InvalidArgumentException.');
+    } catch (InvalidArgumentException $e) {
+      verify($e->getMessage())->stringContainsString("Unknown task type 'totally_bogus_type'");
+      verify($e->getMessage())->stringContainsString(UnsubscribeTokens::TASK_TYPE);
+    }
+  }
+
+  public function testItReportsAnExistingScheduledTaskWithoutCreating() {
+    $existing = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    $result = $this->adder->add(UnsubscribeTokens::TASK_TYPE, null, null, 'low', false, false);
+
+    verify($result['action'])->same('duplicate');
+    verify($result['id'])->same((int)$existing->getId());
+    verify($result['message'])->stringContainsString('already scheduled');
+
+    $all = $this->scheduledTasksRepository->findBy(['type' => UnsubscribeTokens::TASK_TYPE]);
+    verify($all)->arrayCount(1);
+  }
+
+  public function testItForcesADuplicateWithForce() {
+    $existing = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    $result = $this->adder->add(UnsubscribeTokens::TASK_TYPE, null, null, 'low', true, false);
+
+    verify($result['action'])->same('created');
+    verify($result['id'])->notEquals((int)$existing->getId());
+
+    $all = $this->scheduledTasksRepository->findBy(['type' => UnsubscribeTokens::TASK_TYPE]);
+    verify($all)->arrayCount(2);
+  }
+
+  public function testItClaimsAndRunsToCompletion() {
+    $result = $this->adder->add(SubscribersCountCacheRecalculation::TASK_TYPE, null, null, 'low', false, true);
+
+    verify($result['action'])->same('claimed');
+    $this->assertIsArray($result['run']);
+    verify($result['run']['completed'])->true();
+
+    $this->entityManager->clear();
+    $task = $this->scheduledTasksRepository->findOneById($result['id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
+    verify($task->getProcessedAt())->notNull();
+    // meta.cli is stamped on completion as the permanent "done by CLI" breadcrumb.
+    $meta = $task->getMeta();
+    $this->assertIsArray($meta);
+    $this->assertArrayHasKey('cli', $meta);
+    verify($meta['cli']['pid'])->same(getmypid());
+    $this->assertArrayHasKey('started_at', $meta['cli']);
+  }
+
+  public function testItIgnoresAnExistingScheduledTaskWhenRunning() {
+    // A scheduled duplicate must not block --run: the claim is an independent row.
+    $existing = $this->taskFactory->create(SubscribersCountCacheRecalculation::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    $result = $this->adder->add(SubscribersCountCacheRecalculation::TASK_TYPE, null, null, 'low', false, true);
+
+    verify($result['action'])->same('claimed');
+    verify($result['id'])->notEquals((int)$existing->getId());
+  }
+
+  public function testItRejectsRunCombinedWithAt() {
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/--run cannot be combined/');
+    $this->adder->add(UnsubscribeTokens::TASK_TYPE, '2030-01-01', null, 'low', false, true);
+  }
+
+  public function testItRejectsRunCombinedWithIn() {
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/--run cannot be combined/');
+    $this->adder->add(UnsubscribeTokens::TASK_TYPE, null, 60, 'low', false, true);
+  }
+}

--- a/mailpoet/tests/integration/Cron/CliCommands/TaskCancellerTest.php
+++ b/mailpoet/tests/integration/Cron/CliCommands/TaskCancellerTest.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\Cron\CliCommands\TaskCanceller;
+use MailPoet\Cron\Workers\Bounce;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+class TaskCancellerTest extends \MailPoetTest {
+  /** @var TaskCanceller */
+  private $canceller;
+
+  /** @var ScheduledTaskFactory */
+  private $taskFactory;
+
+  public function _before() {
+    parent::_before();
+    $this->canceller = $this->diContainer->get(TaskCanceller::class);
+    $this->taskFactory = new ScheduledTaskFactory();
+  }
+
+  public function testItCancelsAScheduledTask() {
+    $task = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+
+    $result = $this->canceller->cancel((int)$task->getId());
+
+    verify($result['id'])->equals($task->getId());
+    verify($result['type'])->same(Bounce::TASK_TYPE);
+    $this->entityManager->refresh($task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_CANCELLED);
+    verify($task->getCancelledAt())->notNull();
+  }
+
+  public function testItCancelsAPausedTask() {
+    $task = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_PAUSED);
+
+    $result = $this->canceller->cancel((int)$task->getId());
+
+    verify($result['id'])->equals($task->getId());
+    $this->entityManager->refresh($task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_CANCELLED);
+  }
+
+  public function testItCancelsACliTask() {
+    // Recovery path for a zombie left by a hard-killed CLI run: cancel, then re-add.
+    $task = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_CLI);
+
+    $result = $this->canceller->cancel((int)$task->getId());
+
+    verify($result['id'])->equals($task->getId());
+    $this->entityManager->refresh($task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_CANCELLED);
+    verify($task->getCancelledAt())->notNull();
+  }
+
+  public function testItThrowsWhenCancellingARunningTask() {
+    $task = $this->createTask(Bounce::TASK_TYPE, null);
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/running.*cannot be cancelled/');
+    $this->canceller->cancel((int)$task->getId());
+  }
+
+  public function testItThrowsWhenCancellingACompletedTask() {
+    $task = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED);
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/cannot be cancelled/');
+    $this->canceller->cancel((int)$task->getId());
+  }
+
+  public function testItThrowsWhenCancellingAnAlreadyCancelledTask() {
+    $task = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_CANCELLED);
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/cannot be cancelled/');
+    $this->canceller->cancel((int)$task->getId());
+  }
+
+  public function testItThrowsWhenCancellingAnInvalidTask() {
+    $task = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_INVALID);
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/cannot be cancelled/');
+    $this->canceller->cancel((int)$task->getId());
+  }
+
+  public function testItThrowsWhenTaskIdDoesNotExist() {
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/No task with ID/');
+    $this->canceller->cancel(999999);
+  }
+
+  public function testItThrowsWhenTaskIsSoftDeleted() {
+    $task = $this->taskFactory->create(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now(), Carbon::now());
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/No task with ID/');
+    $this->canceller->cancel((int)$task->getId());
+  }
+
+  private function createTask(string $type, ?string $status): ScheduledTaskEntity {
+    return $this->taskFactory->create($type, $status, Carbon::now());
+  }
+}

--- a/mailpoet/tests/integration/Cron/CliCommands/TaskRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/CliCommands/TaskRunnerTest.php
@@ -1,0 +1,695 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\Cron\CliCommands\ClaimedTaskRunner;
+use MailPoet\Cron\CliCommands\ExecutionLimitOverride;
+use MailPoet\Cron\CliCommands\ScheduledTaskResolver;
+use MailPoet\Cron\CliCommands\TaskRunner;
+use MailPoet\Cron\CliCommands\WorkerTypesCatalog;
+use MailPoet\Cron\CronHelper;
+use MailPoet\Cron\CronWorkerInterface;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
+use MailPoet\Cron\Workers\SendingQueue\Tasks\Mailer as MailerTask;
+use MailPoet\Cron\Workers\StatsNotifications\Worker as StatsNotificationsWorker;
+use MailPoet\Cron\Workers\UnsubscribeTokens;
+use MailPoet\Cron\Workers\WorkersFactory;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\MailerFactory;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
+use MailPoetVendor\Carbon\Carbon;
+use RuntimeException;
+
+class TaskRunnerTest extends \MailPoetTest {
+  /** @var TaskRunner */
+  private $runner;
+
+  /** @var ScheduledTaskFactory */
+  private $taskFactory;
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var ScheduledTasksRepository */
+  private $scheduledTasksRepository;
+
+  public function _before() {
+    parent::_before();
+    $this->runner = $this->diContainer->get(TaskRunner::class);
+    $this->settings = $this->diContainer->get(SettingsController::class);
+    $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    $this->taskFactory = new ScheduledTaskFactory();
+  }
+
+  public function testItRunsAStandardWorkerDueTaskToCompletion() {
+    $task = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    $result = $this->runner->run(UnsubscribeTokens::TASK_TYPE);
+
+    verify($result['completed'])->equals(1);
+    verify($result['limit_reached'])->false();
+    verify($result['message'])->stringContainsString('1 task(s) completed');
+
+    $this->entityManager->refresh($task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
+  }
+
+  public function testItReportsWhenNothingIsDue() {
+    $result = $this->runner->run(UnsubscribeTokens::TASK_TYPE);
+
+    verify($result['completed'])->equals(0);
+    verify($result['limit_reached'])->false();
+    verify($result['message'])->stringContainsString('no tasks completed');
+  }
+
+  public function testItRunsExactlyTheTaskGivenByTaskId() {
+    // Scheduled in the future so it would not be due on its own; --task-id claims and runs it now.
+    $task = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->addDays(5));
+
+    $result = $this->runner->run(UnsubscribeTokens::TASK_TYPE, (int)$task->getId());
+
+    verify($result['completed'])->equals(1);
+    $this->entityManager->clear();
+    $persisted = $this->scheduledTasksRepository->findOneById((int)$task->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $persisted);
+    verify($persisted->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
+    // Completed via the claim path: the cli breadcrumb is stamped.
+    $meta = $persisted->getMeta();
+    $this->assertIsArray($meta);
+    $this->assertArrayHasKey('cli', $meta);
+  }
+
+  public function testItClaimsAnExistingScheduledRowPreservingItsMetaWhenRunByTaskId() {
+    $task = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->addDays(5));
+    $task->setMeta(['kept' => 'yes']);
+    $this->entityManager->flush();
+
+    $result = $this->runner->run(UnsubscribeTokens::TASK_TYPE, (int)$task->getId());
+
+    verify($result['completed'])->equals(1);
+    $this->entityManager->clear();
+    $persisted = $this->scheduledTasksRepository->findOneById((int)$task->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $persisted);
+    verify($persisted->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
+    $meta = $persisted->getMeta();
+    $this->assertIsArray($meta);
+    // The pre-existing meta survives the claim and merges with the cli breadcrumb.
+    verify($meta['kept'])->same('yes');
+    $this->assertArrayHasKey('cli', $meta);
+  }
+
+  public function testItRunsAPausedTaskByTaskId() {
+    $task = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_PAUSED, Carbon::now());
+
+    $result = $this->runner->run(UnsubscribeTokens::TASK_TYPE, (int)$task->getId());
+
+    verify($result['completed'])->equals(1);
+    $this->entityManager->clear();
+    $persisted = $this->scheduledTasksRepository->findOneById((int)$task->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $persisted);
+    verify($persisted->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
+  }
+
+  public function testItRejectsRunningACompletedTaskByTaskId() {
+    $task = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now());
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/cannot be run/');
+    $this->runner->run(UnsubscribeTokens::TASK_TYPE, (int)$task->getId());
+  }
+
+  public function testItRejectsRunningARunningTaskByTaskId() {
+    $task = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, null, Carbon::now());
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/running.*cannot be run/');
+    $this->runner->run(UnsubscribeTokens::TASK_TYPE, (int)$task->getId());
+  }
+
+  public function testItRejectsRunningAMailingTypeByTaskId() {
+    $task = $this->taskFactory->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/no runnable worker/');
+    $this->runner->run(SendingQueueWorker::TASK_TYPE, (int)$task->getId());
+  }
+
+  public function testItDrainsEveryDueTaskInTheSnapshot() {
+    // Bulk run snapshots the currently-due tasks and processes them all in one pass (no batch cap).
+    $tasks = [];
+    for ($i = 0; $i < 3; $i++) {
+      $tasks[] = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+    }
+
+    $result = $this->runner->run(UnsubscribeTokens::TASK_TYPE);
+
+    verify($result['completed'])->equals(3);
+    verify($result['limit_reached'])->false();
+    verify($result['backlog_drained'])->true();
+
+    foreach ($tasks as $task) {
+      $this->entityManager->refresh($task);
+      verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
+    }
+  }
+
+  public function testBulkRunProcessesEachTaskThroughTheCliClaim() {
+    // The bulk path must claim each row as 'cli' (not leave it at NULL/running) before processing, so
+    // a concurrent site daemon cannot pick it up. The stub records the status it sees at process time.
+    $task = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    $worker = $this->makeStatusRecordingWorker(UnsubscribeTokens::TASK_TYPE);
+    $runner = $this->makeTaskRunnerWithWorker($worker);
+
+    $result = $runner->run(UnsubscribeTokens::TASK_TYPE);
+
+    verify($result['completed'])->equals(1);
+    verify($worker->seenStatuses)->equals([ScheduledTaskEntity::STATUS_CLI]);
+
+    $this->entityManager->refresh($task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
+  }
+
+  public function testBulkRunDoesNotChaseSelfRescheduledContinuations() {
+    // KEY REGRESSION: a self-rescheduling batched worker (like subscribers_engagement_score) completes
+    // its task and schedules a new due-now continuation. The bulk run must process only the snapshotted
+    // task and leave the single continuation for the site cron, NOT loop and drain the whole dataset.
+    $original = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    $worker = $this->makeSelfReschedulingWorker(UnsubscribeTokens::TASK_TYPE);
+    $runner = $this->makeTaskRunnerWithWorker($worker);
+
+    $result = $runner->run(UnsubscribeTokens::TASK_TYPE);
+
+    // Exactly one task processed (the original), not a runaway over the continuation chain.
+    verify($result['completed'])->equals(1);
+    verify($worker->processCount)->equals(1);
+
+    $this->entityManager->refresh($original);
+    verify($original->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
+
+    // Exactly one continuation left, still scheduled (untouched), for the site cron to pick up.
+    $scheduled = $this->scheduledTasksRepository->findDueByType(UnsubscribeTokens::TASK_TYPE);
+    verify(count($scheduled))->equals(1);
+    verify($scheduled[0]->getId())->notEquals((int)$original->getId());
+    verify($scheduled[0]->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+  }
+
+  public function testBulkRunDoesNotClaimAnythingWhenRequirementsAreNotMet() {
+    // Requirements are pre-checked once before claiming, so a due task is left untouched (scheduled)
+    // when the worker's requirements are not met — nothing is claimed or removed.
+    $task = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    $worker = $this->makeRequirementsNotMetWorker(UnsubscribeTokens::TASK_TYPE);
+    $runner = $this->makeTaskRunnerWithWorker($worker);
+
+    $result = $runner->run(UnsubscribeTokens::TASK_TYPE);
+
+    verify($result['completed'])->equals(0);
+    verify($result['limit_reached'])->false();
+    // Nothing ran and the due task is left scheduled, so the backlog is not drained (command warns).
+    verify($result['backlog_drained'])->false();
+    verify($result['message'])->stringContainsString('requirements not met');
+
+    $this->entityManager->refresh($task);
+    // Still scheduled and present: nothing was claimed or removed.
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+  }
+
+  public function testItRunsOnlyTheTargetedTaskByTaskIdLeavingOtherDueRowsUntouched() {
+    // --task-id runs exactly one row via the claim path; the other due rows are left for the daemon
+    // (or a bulk `run <type>`). This is the deliberate contrast with the no-task-id backlog drain.
+    $others = [];
+    for ($i = 0; $i < 3; $i++) {
+      $others[] = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+    }
+    $targeted = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->addDays(5));
+
+    $result = $this->runner->run(UnsubscribeTokens::TASK_TYPE, (int)$targeted->getId());
+
+    verify($result['completed'])->equals(1);
+    verify($result['limit_reached'])->false();
+
+    $this->entityManager->clear();
+    $persistedTargeted = $this->scheduledTasksRepository->findOneById((int)$targeted->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $persistedTargeted);
+    verify($persistedTargeted->getStatus())->same(ScheduledTaskEntity::STATUS_COMPLETED);
+
+    foreach ($others as $other) {
+      $persistedOther = $this->scheduledTasksRepository->findOneById((int)$other->getId());
+      $this->assertInstanceOf(ScheduledTaskEntity::class, $persistedOther);
+      verify($persistedOther->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+    }
+  }
+
+  public function testItThrowsOnUnknownTypeListingValidTypes() {
+    try {
+      $this->runner->run('totally_bogus_type');
+      $this->fail('Expected an InvalidArgumentException.');
+    } catch (InvalidArgumentException $e) {
+      verify($e->getMessage())->stringContainsString("Unknown task type 'totally_bogus_type'");
+      verify($e->getMessage())->stringContainsString(UnsubscribeTokens::TASK_TYPE);
+    }
+  }
+
+  public function testItReportsLimitReachedWhenTimeoutIsHit() {
+    $task = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    // timeout=0 means any elapsed time exceeds the limit, so the runner aborts before claiming anything.
+    $result = $this->runner->run(UnsubscribeTokens::TASK_TYPE, null, 0);
+
+    verify($result['limit_reached'])->true();
+    verify($result['completed'])->equals(0);
+    verify($result['message'])->stringContainsString('Execution limit');
+
+    $this->entityManager->refresh($task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+  }
+
+  public function testBulkRunHandsBackTasksThatDoNotComplete() {
+    // A worker that completes nothing (partial work) hands every due task back to the site cron.
+    $task = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    $worker = $this->makePartialWorker(UnsubscribeTokens::TASK_TYPE);
+    $runner = $this->makeTaskRunnerWithWorker($worker);
+
+    $result = $runner->run(UnsubscribeTokens::TASK_TYPE);
+
+    verify($result['completed'])->equals(0);
+    // Handed-back tasks are not drained, so the command surfaces a warning rather than success.
+    verify($result['backlog_drained'])->false();
+    verify($result['message'])->stringContainsString('handed back');
+
+    $this->entityManager->refresh($task);
+    // Handed back to the site cron: scheduled and due now.
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+  }
+
+  public function testBulkRunReportsLimitReachedWhenAWorkerHitsTheExecutionLimit() {
+    // A worker that hits the execution limit yields rather than fails: the run stops with limit_reached
+    // and the task is handed back, not reported as an error.
+    $task = $this->taskFactory->create(UnsubscribeTokens::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+
+    $runner = $this->makeTaskRunnerWithWorker($this->makeLimitWorker(UnsubscribeTokens::TASK_TYPE));
+
+    $result = $runner->run(UnsubscribeTokens::TASK_TYPE);
+
+    verify($result['limit_reached'])->true();
+    verify($result['completed'])->equals(0);
+    verify($result['backlog_drained'])->false();
+
+    $this->entityManager->refresh($task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+  }
+
+  public function testItRunsTheMailingStatsNotificationWorker() {
+    // No scheduled stats notifications exist, so the worker simply runs and completes nothing.
+    $result = $this->runner->run(StatsNotificationsWorker::TASK_TYPE);
+
+    verify($result['limit_reached'])->false();
+    verify($result['completed'])->equals(0);
+  }
+
+  public function testItErrorsForSendingWhenMailerIsNotConfigured() {
+    // Clear the mailer config and sender that a sibling test (DaemonRunnerTest::_before) writes to
+    // the shared settings table, so the SendingQueue worker resolves an unconfigured mailer.
+    $this->settings->delete(Mailer::MAILER_CONFIG_SETTING_NAME);
+    $this->settings->delete('sender');
+    $this->settings->resetCache();
+
+    // The SendingQueue worker is a shared container service; a sibling test builds it with a configured
+    // mailer, so the cached instance never re-evaluates these settings. Drive a fresh worker through a
+    // stub factory so its constructor genuinely builds the mailer against the now-unconfigured settings.
+    $runner = $this->makeTaskRunnerWithFreshQueueWorker();
+
+    try {
+      $runner->run(SendingQueueWorker::TASK_TYPE);
+      $this->fail('Expected a RuntimeException for an unconfigured mailer.');
+    } catch (RuntimeException $e) {
+      verify($e->getMessage())->stringContainsString('Sending is not configured');
+    }
+  }
+
+  public function testItRunsSchedulerThenSendingQueueForSending() {
+    $this->configureMailer();
+
+    // A scheduled sending task whose newsletter is a draft: the Scheduler runs and pauses it
+    // (it is not active/scheduled/sending). The PAUSED status proves the Scheduler executed; the
+    // SendingQueue then runs over runner tasks without error.
+    $newsletter = (new NewsletterFactory())
+      ->withType(NewsletterEntity::TYPE_STANDARD)
+      ->withDraftStatus()
+      ->create();
+    $task = $this->taskFactory->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+    (new SendingQueueFactory())->create($task, $newsletter);
+
+    $result = $this->runner->run(SendingQueueWorker::TASK_TYPE);
+
+    verify($result['limit_reached'])->false();
+    $this->entityManager->refresh($task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_PAUSED);
+  }
+
+  private function configureMailer(): void {
+    $this->settings->set(Mailer::MAILER_CONFIG_SETTING_NAME, ['method' => Mailer::METHOD_PHPMAIL]);
+    $this->settings->set('sender', ['name' => 'Sender', 'address' => 'sender@example.com']);
+  }
+
+  /**
+   * A worker that records the task status it sees at process time, proving the bulk path claims rows
+   * as 'cli' before processing. The return type is left off so the caller can read the public
+   * recording properties on the anonymous class.
+   */
+  private function makeStatusRecordingWorker(string $type) {
+    return new class($type) implements CronWorkerInterface {
+      /** @var string */
+      private $type;
+      /** @var array<int, string|null> */
+      public $seenStatuses = [];
+
+      public function __construct(
+        string $type
+      ) {
+        $this->type = $type;
+      }
+
+      public function getTaskType() {
+        return $this->type;
+      }
+
+      public function scheduleAutomatically() {
+        return false;
+      }
+
+      public function supportsMultipleInstances() {
+        return true;
+      }
+
+      public function checkProcessingRequirements() {
+        return true;
+      }
+
+      public function init() {
+      }
+
+      public function prepareTaskStrategy(ScheduledTaskEntity $task, $timer) {
+        return true;
+      }
+
+      public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+        $this->seenStatuses[] = $task->getStatus();
+        return true;
+      }
+
+      public function getNextRunDate() {
+        return Carbon::now();
+      }
+    };
+  }
+
+  /**
+   * A self-rescheduling batched worker: completing the task schedules one new due-now continuation of
+   * the same type, mimicking SubscribersEngagementScore. Used to prove the bulk run does not chase
+   * continuations created mid-run. The return type is left off so the caller can read the public
+   * processCount on the anonymous class.
+   */
+  private function makeSelfReschedulingWorker(string $type) {
+    return new class($type, $this->scheduledTasksRepository) implements CronWorkerInterface {
+      /** @var string */
+      private $type;
+      /** @var ScheduledTasksRepository */
+      private $repository;
+      /** @var int */
+      public $processCount = 0;
+
+      public function __construct(
+        string $type,
+        ScheduledTasksRepository $repository
+      ) {
+        $this->type = $type;
+        $this->repository = $repository;
+      }
+
+      public function getTaskType() {
+        return $this->type;
+      }
+
+      public function scheduleAutomatically() {
+        return false;
+      }
+
+      public function supportsMultipleInstances() {
+        return true;
+      }
+
+      public function checkProcessingRequirements() {
+        return true;
+      }
+
+      public function init() {
+      }
+
+      public function prepareTaskStrategy(ScheduledTaskEntity $task, $timer) {
+        return true;
+      }
+
+      public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+        $this->processCount++;
+        $continuation = new ScheduledTaskEntity();
+        $continuation->setType($this->type);
+        $continuation->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+        $continuation->setScheduledAt(Carbon::now());
+        $this->repository->persist($continuation);
+        $this->repository->flush();
+        return true;
+      }
+
+      public function getNextRunDate() {
+        return Carbon::now();
+      }
+    };
+  }
+
+  /**
+   * A worker whose requirements are never met. The bulk run must not claim any task for it.
+   */
+  private function makeRequirementsNotMetWorker(string $type): CronWorkerInterface {
+    return new class($type) implements CronWorkerInterface {
+      /** @var string */
+      private $type;
+
+      public function __construct(
+        string $type
+      ) {
+        $this->type = $type;
+      }
+
+      public function getTaskType() {
+        return $this->type;
+      }
+
+      public function scheduleAutomatically() {
+        return false;
+      }
+
+      public function supportsMultipleInstances() {
+        return true;
+      }
+
+      public function checkProcessingRequirements() {
+        return false;
+      }
+
+      public function init() {
+      }
+
+      public function prepareTaskStrategy(ScheduledTaskEntity $task, $timer) {
+        return true;
+      }
+
+      public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+        return true;
+      }
+
+      public function getNextRunDate() {
+        return Carbon::now();
+      }
+    };
+  }
+
+  /**
+   * A worker that processes (requirements met, prepare true) but never completes, so every due task is
+   * handed back to the site cron.
+   */
+  private function makePartialWorker(string $type): CronWorkerInterface {
+    return new class($type) implements CronWorkerInterface {
+      /** @var string */
+      private $type;
+
+      public function __construct(
+        string $type
+      ) {
+        $this->type = $type;
+      }
+
+      public function getTaskType() {
+        return $this->type;
+      }
+
+      public function scheduleAutomatically() {
+        return false;
+      }
+
+      public function supportsMultipleInstances() {
+        return true;
+      }
+
+      public function checkProcessingRequirements() {
+        return true;
+      }
+
+      public function init() {
+      }
+
+      public function prepareTaskStrategy(ScheduledTaskEntity $task, $timer) {
+        return true;
+      }
+
+      public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+        return false;
+      }
+
+      public function getNextRunDate() {
+        return Carbon::now();
+      }
+    };
+  }
+
+  private function makeLimitWorker(string $type): CronWorkerInterface {
+    return new class($type) implements CronWorkerInterface {
+      /** @var string */
+      private $type;
+
+      public function __construct(
+        string $type
+      ) {
+        $this->type = $type;
+      }
+
+      public function getTaskType() {
+        return $this->type;
+      }
+
+      public function scheduleAutomatically() {
+        return false;
+      }
+
+      public function supportsMultipleInstances() {
+        return true;
+      }
+
+      public function checkProcessingRequirements() {
+        return true;
+      }
+
+      public function init() {
+      }
+
+      public function prepareTaskStrategy(ScheduledTaskEntity $task, $timer) {
+        return true;
+      }
+
+      public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+        throw new \Exception('execution limit reached', CronHelper::DAEMON_EXECUTION_LIMIT_REACHED);
+      }
+
+      public function getNextRunDate() {
+        return Carbon::now();
+      }
+    };
+  }
+
+  private function makeTaskRunnerWithWorker(CronWorkerInterface $worker): TaskRunner {
+    return new class(
+      $this->diContainer->get(WorkerTypesCatalog::class),
+      $this->diContainer->get(WorkersFactory::class),
+      $this->diContainer->get(ExecutionLimitOverride::class),
+      $this->diContainer->get(ScheduledTasksRepository::class),
+      $this->diContainer->get(ScheduledTaskResolver::class),
+      $this->diContainer->get(ClaimedTaskRunner::class),
+      $worker
+    ) extends TaskRunner {
+      /** @var ?CronWorkerInterface */
+      private $stubWorker;
+
+      public function __construct(
+        WorkerTypesCatalog $workerTypesCatalog,
+        WorkersFactory $workersFactory,
+        ExecutionLimitOverride $executionLimitOverride,
+        ScheduledTasksRepository $scheduledTasksRepository,
+        ScheduledTaskResolver $taskResolver,
+        ClaimedTaskRunner $claimedTaskRunner,
+        CronWorkerInterface $stubWorker
+      ) {
+        parent::__construct(
+          $workerTypesCatalog,
+          $workersFactory,
+          $executionLimitOverride,
+          $scheduledTasksRepository,
+          $taskResolver,
+          $claimedTaskRunner
+        );
+        $this->stubWorker = $stubWorker;
+      }
+
+      protected function resolveWorker(string $type): ?CronWorkerInterface {
+        return $this->stubWorker;
+      }
+    };
+  }
+
+  /**
+   * A TaskRunner whose WorkersFactory rebuilds the mailer on createQueueWorker(), bypassing the shared
+   * container singletons (SendingQueue worker + MailerTask) that a sibling test already built with a
+   * configured mailer. Building a fresh MailerTask runs the real mailer resolution against the
+   * now-unconfigured settings, so it throws InvalidStateException exactly as a first-time build would.
+   */
+  private function makeTaskRunnerWithFreshQueueWorker(): TaskRunner {
+    $freshWorkersFactory = new class($this->diContainer) extends WorkersFactory {
+      /** @var ContainerWrapper */
+      private $container;
+
+      public function __construct(
+        ContainerWrapper $container
+      ) {
+        parent::__construct($container);
+        $this->container = $container;
+      }
+
+      public function createQueueWorker() {
+        // Building MailerTask eagerly resolves the mailer and throws on an unconfigured site, which is
+        // the failure runSending() catches. MailerFactory reads settings live, so a fresh MailerTask
+        // reflects the current (unconfigured) state instead of the cached singleton.
+        new MailerTask($this->container->get(MailerFactory::class));
+        return $this->container->get(SendingQueueWorker::class);
+      }
+    };
+
+    return new TaskRunner(
+      $this->diContainer->get(WorkerTypesCatalog::class),
+      $freshWorkersFactory,
+      $this->diContainer->get(ExecutionLimitOverride::class),
+      $this->diContainer->get(ScheduledTasksRepository::class),
+      $this->diContainer->get(ScheduledTaskResolver::class),
+      $this->diContainer->get(ClaimedTaskRunner::class)
+    );
+  }
+}

--- a/mailpoet/tests/integration/Cron/CliCommands/TaskTriggerTest.php
+++ b/mailpoet/tests/integration/Cron/CliCommands/TaskTriggerTest.php
@@ -1,0 +1,155 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\CliCommands;
+
+use InvalidArgumentException;
+use MailPoet\Cron\CliCommands\TaskTrigger;
+use MailPoet\Cron\Workers\Bounce;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+class TaskTriggerTest extends \MailPoetTest {
+  /** @var TaskTrigger */
+  private $trigger;
+
+  /** @var ScheduledTaskFactory */
+  private $taskFactory;
+
+  public function _before() {
+    parent::_before();
+    $this->trigger = $this->diContainer->get(TaskTrigger::class);
+    $this->taskFactory = new ScheduledTaskFactory();
+  }
+
+  public function testItTriggersTheNextScheduledTaskByType() {
+    $task = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->addDays(5));
+
+    $result = $this->trigger->trigger(Bounce::TASK_TYPE);
+
+    verify($result['id'])->equals($task->getId());
+    verify($result['type'])->same(Bounce::TASK_TYPE);
+
+    $this->entityManager->refresh($task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->assertIsDueNow($task);
+  }
+
+  public function testItTriggersTheSoonestDueTaskWhenSeveralOfTheSameTypeAreScheduled() {
+    $soonest = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->addDays(1));
+    $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->addDays(5));
+
+    $result = $this->trigger->trigger(Bounce::TASK_TYPE);
+
+    verify($result['id'])->equals($soonest->getId());
+  }
+
+  public function testItThrowsWhenNoScheduledTaskOfTypeExists() {
+    $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED);
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/no scheduled task of type/i');
+    $this->trigger->trigger(Bounce::TASK_TYPE);
+  }
+
+  public function testItTriggersAScheduledTaskById() {
+    $task = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->addDays(5));
+
+    $result = $this->trigger->trigger(Bounce::TASK_TYPE, (int)$task->getId());
+
+    verify($result['id'])->equals($task->getId());
+    $this->entityManager->refresh($task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->assertIsDueNow($task);
+  }
+
+  public function testItTriggersAPausedTaskByIdAndReschedulesIt() {
+    $task = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_PAUSED, Carbon::now()->addDays(5));
+
+    $result = $this->trigger->trigger(Bounce::TASK_TYPE, (int)$task->getId());
+
+    verify($result['id'])->equals($task->getId());
+    $this->entityManager->refresh($task);
+    verify($task->getStatus())->same(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->assertIsDueNow($task);
+  }
+
+  public function testItThrowsWhenTaskIdTypeDoesNotMatch() {
+    $task = $this->createTask('woocommerce_sync', ScheduledTaskEntity::STATUS_SCHEDULED);
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/not \'bounce\'/');
+    $this->trigger->trigger(Bounce::TASK_TYPE, (int)$task->getId());
+  }
+
+  public function testItThrowsWhenTaskIdDoesNotExist() {
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/No task with ID/');
+    $this->trigger->trigger(Bounce::TASK_TYPE, 999999);
+  }
+
+  public function testItThrowsWhenTaskIsSoftDeleted() {
+    $task = $this->taskFactory->create(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now(), Carbon::now());
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/No task with ID/');
+    $this->trigger->trigger(Bounce::TASK_TYPE, (int)$task->getId());
+  }
+
+  public function testItThrowsWhenTriggeringACompletedTaskById() {
+    $task = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED);
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/cannot be triggered/');
+    $this->trigger->trigger(Bounce::TASK_TYPE, (int)$task->getId());
+  }
+
+  public function testItThrowsWhenTriggeringACancelledTaskById() {
+    $task = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_CANCELLED);
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/cannot be triggered/');
+    $this->trigger->trigger(Bounce::TASK_TYPE, (int)$task->getId());
+  }
+
+  public function testItThrowsWhenTriggeringARunningTaskById() {
+    $task = $this->createTask(Bounce::TASK_TYPE, null);
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessageMatches('/running.*cannot be triggered/');
+    $this->trigger->trigger(Bounce::TASK_TYPE, (int)$task->getId());
+  }
+
+  public function testItThrowsWhenTriggeringACliTaskById() {
+    $task = $this->createTask(Bounce::TASK_TYPE, ScheduledTaskEntity::STATUS_CLI);
+
+    $this->expectException(InvalidArgumentException::class);
+    // The raw 'cli' status is surfaced in the message (nameStatus only maps the NULL placeholder).
+    $this->expectExceptionMessageMatches('/\'cli\'.*cannot be triggered/');
+    $this->trigger->trigger(Bounce::TASK_TYPE, (int)$task->getId());
+  }
+
+  public function testItThrowsOnUnknownTypeListingValidTypes() {
+    try {
+      $this->trigger->trigger('totally_bogus_type');
+      $this->fail('Expected an InvalidArgumentException.');
+    } catch (InvalidArgumentException $e) {
+      verify($e->getMessage())->stringContainsString("Unknown task type 'totally_bogus_type'");
+      verify($e->getMessage())->stringContainsString('sending');
+      verify($e->getMessage())->stringContainsString(Bounce::TASK_TYPE);
+    }
+  }
+
+  private function assertIsDueNow(ScheduledTaskEntity $task): void {
+    $scheduledAt = $task->getScheduledAt();
+    if ($scheduledAt === null) {
+      $this->fail('Expected the triggered task to have a scheduled_at timestamp.');
+    }
+    $diff = abs(Carbon::now()->getTimestamp() - $scheduledAt->getTimestamp());
+    verify($diff <= 120)->true();
+  }
+
+  private function createTask(string $type, ?string $status, ?Carbon $scheduledAt = null): ScheduledTaskEntity {
+    return $this->taskFactory->create($type, $status, $scheduledAt ?? Carbon::now());
+  }
+}

--- a/mailpoet/tests/integration/Cron/CliCommands/WorkerTypesCatalogTest.php
+++ b/mailpoet/tests/integration/Cron/CliCommands/WorkerTypesCatalogTest.php
@@ -1,0 +1,186 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\CliCommands;
+
+use MailPoet\Cron\CliCommands\WorkerTypesCatalog;
+use MailPoet\Cron\CronWorkerInterface;
+use MailPoet\Cron\Workers\WorkersFactory;
+use ReflectionMethod;
+
+class WorkerTypesCatalogTest extends \MailPoetTest {
+  /** @var WorkerTypesCatalog */
+  private $catalog;
+
+  public function _before() {
+    parent::_before();
+    $this->catalog = $this->diContainer->get(WorkerTypesCatalog::class);
+  }
+
+  public function testItReturnsTheConfiguredColumns() {
+    $rows = $this->catalog->getRows();
+
+    verify($rows)->arrayHasKey(0);
+    verify(array_keys($rows[0]))->same(WorkerTypesCatalog::FIELDS);
+  }
+
+  public function testItSortsTypesAlphabetically() {
+    $rows = $this->catalog->getRows();
+
+    $types = array_column($rows, 'type');
+    $sorted = $types;
+    sort($sorted);
+    verify($types)->same($sorted);
+  }
+
+  public function testItListsTypesWithoutDuplicates() {
+    $types = array_column($this->catalog->getRows(), 'type');
+
+    verify($types)->same(array_values(array_unique($types)));
+  }
+
+  public function testSimpleWorkersAreAddableAndStandard() {
+    $woocommerceSync = $this->findRow('woocommerce_sync');
+    verify($woocommerceSync['addable'])->true();
+    verify($woocommerceSync['mailing'])->false();
+    verify($woocommerceSync['schedule_automatically'])->false();
+    verify($woocommerceSync['supports_multiple_instances'])->false();
+
+    $logCleanup = $this->findRow('log_cleanup');
+    verify($logCleanup['addable'])->true();
+    verify($logCleanup['mailing'])->false();
+    verify($logCleanup['schedule_automatically'])->true();
+    verify($logCleanup['supports_multiple_instances'])->false();
+
+    // Built by createStatsNotificationsWorkerForAutomatedEmails, whose name does not end in "Worker".
+    $automatedEmails = $this->findRow('stats_notification_automated_emails');
+    verify($automatedEmails['addable'])->true();
+    verify($automatedEmails['mailing'])->false();
+  }
+
+  public function testMailingTypesAppearOnceWithMailingFlags() {
+    $rows = $this->catalog->getRows();
+
+    foreach (['sending', 'stats_notification'] as $type) {
+      $matching = array_values(array_filter($rows, function (array $row) use ($type): bool {
+        return $row['type'] === $type;
+      }));
+      verify($matching)->arrayCount(1);
+      verify($matching[0]['mailing'])->true();
+      verify($matching[0]['addable'])->false();
+      verify($matching[0]['schedule_automatically'])->false();
+      verify($matching[0]['supports_multiple_instances'])->false();
+    }
+  }
+
+  public function testGetAddableTypesReturnsStandardTypesWithoutMailingOnes() {
+    $addable = $this->catalog->getAddableTypes();
+
+    // Sorted and unique.
+    $sorted = $addable;
+    sort($sorted);
+    verify($addable)->same($sorted);
+    verify($addable)->same(array_values(array_unique($addable)));
+
+    // Excludes the mailing types.
+    foreach (WorkerTypesCatalog::MAILING_TYPES as $mailingType) {
+      verify(in_array($mailingType, $addable, true))->false();
+    }
+
+    // Matches exactly the rows flagged addable in the catalog.
+    $expected = array_column(array_filter($this->catalog->getRows(), function (array $row): bool {
+      return $row['addable'] === true;
+    }), 'type');
+    sort($expected);
+    verify($addable)->same($expected);
+
+    // A known standard type is present.
+    verify(in_array('log_cleanup', $addable, true))->true();
+  }
+
+  public function testItListsExactlyTheKnownTaskTypes() {
+    // Hardcoded ground truth on purpose: adding or removing a worker must be a deliberate change here.
+    // Deriving the expected list from the factory (as this test used to) only mirrors the implementation,
+    // so it would pass even if the catalog and the factory drifted together.
+    $expected = [
+      'authorized_email_addresses_check',
+      'automation_abandoned_cart',
+      'backfill_engagement_data',
+      'bounce',
+      'bounce_task_subscribers_cleanup',
+      'bulk_confirmation_email_resend',
+      'export_files_cleanup',
+      'inactive_subscribers',
+      'log_cleanup',
+      'mixpanel',
+      'newsletter_templates_thumbnails',
+      'premium_key_check',
+      'schedule_re_engagement_email',
+      'sending',
+      'sending_queue_body_cleanup',
+      'sending_service_key_check',
+      'sending_task_subscribers_cleanup',
+      'statistics_export',
+      'stats_notification',
+      'stats_notification_automated_emails',
+      'subscriber_limit_notification',
+      'subscriber_link_tokens',
+      'subscribers_count_cache_recalculation',
+      'subscribers_email_count',
+      'subscribers_engagement_score',
+      'subscribers_last_engagement',
+      'subscribers_stats_report',
+      'tracks',
+      'unconfirmed_subscribers_cleanup',
+      'unsubscribe_tokens',
+      'woocommerce_past_orders',
+      'woocommerce_sync',
+    ];
+    sort($expected);
+
+    $types = array_column($this->catalog->getRows(), 'type');
+    sort($types);
+
+    verify($types)->same($expected);
+  }
+
+  public function testEveryFactoryCreateMethodResolvesToAManagedWorker() {
+    // Guards the reflection-based discovery in WorkerTypesCatalog: every argument-less create*() on the
+    // factory must either be a known mailing method or resolve to a CronWorkerInterface the catalog
+    // exposes. A worker added with a different naming or return convention fails here instead of
+    // silently disappearing from `wp mailpoet cron`.
+    $factory = $this->diContainer->get(WorkersFactory::class);
+    $exposedTypes = $this->catalog->getTypes();
+
+    foreach (get_class_methods($factory) as $method) {
+      if (strpos($method, 'create') !== 0) {
+        continue;
+      }
+      if (in_array($method, WorkerTypesCatalog::MAILING_FACTORY_METHODS, true)) {
+        continue;
+      }
+
+      // A create*() needing arguments is skipped by the catalog, hiding its worker from the CLI.
+      verify((new ReflectionMethod($factory, $method))->getNumberOfRequiredParameters())->same(0);
+
+      $worker = $factory->{$method}();
+      $this->assertInstanceOf(
+        CronWorkerInterface::class,
+        $worker,
+        sprintf("%s() must return a CronWorkerInterface or be listed in WorkerTypesCatalog::MAILING_FACTORY_METHODS.", $method)
+      );
+      verify(in_array($worker->getTaskType(), $exposedTypes, true))->true();
+    }
+  }
+
+  /**
+   * @return array{type: string, addable: bool, schedule_automatically: bool, supports_multiple_instances: bool, mailing: bool}
+   */
+  private function findRow(string $type): array {
+    foreach ($this->catalog->getRows() as $row) {
+      if ($row['type'] === $type) {
+        return $row;
+      }
+    }
+    $this->fail("No catalog row found for type '{$type}'.");
+  }
+}


### PR DESCRIPTION
## Description

Adds a `wp mailpoet cron` WP-CLI command set for inspecting and running MailPoet's background (cron) tasks from the command line. Today, debugging or operating those tasks means using the admin UI or poking the database. This is dev/support tooling now, and a step toward the 1M-subscriber scaling goal: the end state is heavy publishers disabling selected job types in the web-request runner and running them from system cron via WP-CLI.

Seven subcommands:

- `list` — list scheduled tasks (status/type filters, standard `--format`)
- `types` — catalog of worker task types and their attributes
- `trigger` — mark a task due so the site's own cron runs it
- `run` — run a worker (or one `--task-id`) to completion in the CLI process
- `run-daemon` — one full daemon pass in the CLI process
- `add` — schedule a new task, optionally running it immediately (`--run`)
- `cancel` — cancel a scheduled / paused / cli task

User-facing docs: `doc/wp-cli-cron-commands.md` (linked from `doc/Readme.md`).

<img width="1108" height="678" alt="Screenshot 2026-06-15 at 16 58 13" src="https://github.com/user-attachments/assets/2711d75d-cf22-4bc7-bf12-373adaa1f5f4" />


## Code review notes

- **Best reviewed commit-by-commit.** The 6 commits each add one coherent slice (scaffolding+list → types → trigger → run/run-daemon → add/cancel → docs); every file lands in its final form.
- **Architecture:** `CronCommand` is a thin WP-CLI wrapper; all logic lives in per-concern services under `lib/Cron/CliCommands/`. This is deliberate — WP-CLI classes aren't loadable in the integration test environment, so the services are what the tests target.


## QA notes

In `wp-env` (prefix `pnpm wp`):

```
pnpm wp mailpoet cron list
pnpm wp mailpoet cron types
pnpm wp mailpoet cron add log_cleanup --run      # claims (status cli) + runs in-process
pnpm wp mailpoet cron run log_cleanup
pnpm wp mailpoet cron run-daemon
pnpm wp mailpoet cron trigger <type>
pnpm wp mailpoet cron cancel <task-id>
```

Integration tests: `pnpm test:integration --file=tests/integration/Cron/CliCommands` 

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8159](https://linear.app/a8c/issue/STOMAIL-8159/add-wp-cli-commands-for-mailpoet-cron-jobs)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_ — CLI only.

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:cron-jobs-wp-cli)

_The latest successful build from `cron-jobs-wp-cli` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->