### PR TITLE
Double column safeguard in wp mailpoet import

### DIFF
--- a/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
@@ -325,6 +325,8 @@ class Cli {
   private function buildColumns(array $header): array {
     $columns = [];
     $unknown = [];
+    $duplicates = [];
+    $namesByField = [];
     foreach ($header as $index => $name) {
       $name = trim((string)$name);
       if ($name === '') {
@@ -335,6 +337,11 @@ class Cli {
         $unknown[] = $name;
         continue;
       }
+      if (isset($columns[$field])) {
+        $duplicates[$field] = array_merge($namesByField[$field], [$name]);
+        continue;
+      }
+      $namesByField[$field] = [$name];
       $columns[$field] = ['index' => $index];
     }
 
@@ -343,6 +350,16 @@ class Cli {
         'Unrecognized CSV column(s): %s. Use MailPoet field names (%s) or an existing custom field name.',
         implode(', ', $unknown),
         implode(', ', self::BASE_FIELDS)
+      ));
+    }
+
+    if ($duplicates) {
+      $details = array_map(function (array $names): string {
+        return implode(', ', $names);
+      }, $duplicates);
+      throw new \RuntimeException(sprintf(
+        'Duplicate CSV column(s) mapping to the same field: %s. Each field may only appear once in the header.',
+        implode('; ', $details)
       ));
     }
 

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/CliTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/CliTest.php
@@ -167,6 +167,34 @@ class CliTest extends \MailPoetTest {
     $this->cli->run($file, self::DEFAULT_OPTIONS);
   }
 
+  public function testItThrowsOnCaseInsensitiveDuplicateColumn(): void {
+    $file = $this->writeCsv([
+      ['Email', 'email'],
+      ['first@example.com', 'second@example.com'],
+    ]);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Duplicate CSV column(s) mapping to the same field: Email, email');
+    $this->cli->run($file, self::DEFAULT_OPTIONS);
+  }
+
+  public function testItThrowsOnDuplicateCustomFieldColumn(): void {
+    $customField = $this->customFieldsRepository->createOrUpdate([
+      'name' => 'Country',
+      'type' => CustomFieldEntity::TYPE_TEXT,
+    ]);
+    $this->assertInstanceOf(CustomFieldEntity::class, $customField);
+
+    $file = $this->writeCsv([
+      ['email', 'Country', 'Country'],
+      ['traveler@example.com', 'France', 'Spain'],
+    ]);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Duplicate CSV column(s) mapping to the same field');
+    $this->cli->run($file, self::DEFAULT_OPTIONS);
+  }
+
   public function testItThrowsForMissingFile(): void {
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('does not exist or is not readable');


### PR DESCRIPTION
## Description

Forgot the double columns safeguard in https://github.com/mailpoet/mailpoet/pull/6860

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/wp-cli-import-subscribers-command)

_The latest successful build from `add/wp-cli-import-subscribers-command` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issues Found: 1

**Bug (Logic Error):**
The duplicate column detection logic in `buildColumns()` has a flaw when handling 3 or more columns that map to the same field. When a duplicate is encountered, the code executes:
```php
$duplicates[$field] = array_merge($namesByField[$field], [$name]);
```
However, it never updates `$namesByField[$field]` after detecting the first duplicate. This means that for subsequent duplicates of the same field, `$namesByField[$field]` still contains only the first occurrence, so the reported error message will show incomplete duplicate information.

For example, with CSV headers `[email, Custom, Custom, Custom]`:
- 1st Custom: Added to columns
- 2nd Custom: `$duplicates` = `[Custom, Custom]`, but `$namesByField` not updated
- 3rd Custom: `$duplicates` = `[Custom, Custom]` (overwrites!), still missing the 2nd Custom

The error message would report "Custom, Custom" instead of correctly identifying all three occurrences. This undermines the purpose of the duplicate detection—alerting users to all problematic columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->