### PR TITLE
Fix Woo attribution last-click source

### DIFF
--- a/mailpoet/changelog/2026-06-15-21-41-44-fixed-woocommerce-order-attribution-now-credits-mailpoet.md
+++ b/mailpoet/changelog/2026-06-15-21-41-44-fixed-woocommerce-order-attribution-now-credits-mailpoet.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+WooCommerce order attribution now credits MailPoet when the email click is the latest source

--- a/mailpoet/lib/WooCommerce/OrderAttributionReconciler.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionReconciler.php
@@ -3,6 +3,7 @@
 namespace MailPoet\WooCommerce;
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
@@ -160,7 +161,7 @@ class OrderAttributionReconciler {
     $lastClickPurchase = $this->getLastClickPurchase($purchases);
     $lastClick = $lastClickPurchase ? $lastClickPurchase->getClick() : null;
     $legacyLastClickId = $lastClick ? (int)$lastClick->getId() : null;
-    $foreignSourcePreserved = $this->isForeignSourcePreserved($order, $wooClickId);
+    $foreignSourcePreserved = $this->isForeignSourcePreserved($order, $wooClickId, $lastClick);
 
     [$outcome, $reason, $classification] = $this->resolveOutcome(
       $legacyClickIds,
@@ -344,17 +345,29 @@ class OrderAttributionReconciler {
     return (float)$order->get_remaining_refund_amount();
   }
 
-  private function isForeignSourcePreserved(WC_Order $order, ?int $wooClickId): bool {
-    if ($wooClickId === null) {
+  private function isForeignSourcePreserved(
+    WC_Order $order,
+    ?int $wooClickId,
+    ?StatisticsClickEntity $click
+  ): bool {
+    if ($wooClickId === null || is_null($click)) {
       return false;
     }
-    $sourceType = $order->get_meta(OrderAttributionFields::getMetaKey('source_type'));
-    $utmSource = $order->get_meta(OrderAttributionFields::getMetaKey('utm_source'));
-    $sourceType = is_scalar($sourceType) ? (string)$sourceType : '';
-    $utmSource = is_scalar($utmSource) ? (string)$utmSource : '';
-    $isOverwritable = in_array($sourceType, OrderAttributionWriter::OVERWRITABLE_SOURCE_TYPES, true)
-      || $utmSource === 'mailpoet';
-    return !$isOverwritable;
+    $sourceType = $this->getMetaString($order, OrderAttributionFields::getMetaKey('source_type'));
+    $utmSource = $this->getMetaString($order, OrderAttributionFields::getMetaKey('utm_source'));
+    $sessionStartTime = $this->getMetaString($order, OrderAttributionFields::getMetaKey('session_start_time'));
+    return !OrderAttributionWriter::shouldWriteStandardSourceFields(
+      $sourceType,
+      $utmSource,
+      $sessionStartTime,
+      $click->getUpdatedAt(),
+      $this->wp->wpTimezone()
+    );
+  }
+
+  private function getMetaString(WC_Order $order, string $metaKey): string {
+    $value = $order->get_meta($metaKey);
+    return is_scalar($value) ? (string)$value : '';
   }
 
   private function isWooAttributionAvailable(): bool {

--- a/mailpoet/lib/WooCommerce/OrderAttributionWriter.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionWriter.php
@@ -235,8 +235,8 @@ class OrderAttributionWriter {
   private function writeStandardSourceFields(WC_Order $order, StatisticsClickEntity $click): void {
     $sourceType = $this->getMetaString($order, OrderAttributionFields::getMetaKey('source_type'));
     $utmSource = $this->getMetaString($order, OrderAttributionFields::getMetaKey('utm_source'));
-    $isOverwritable = in_array($sourceType, self::OVERWRITABLE_SOURCE_TYPES, true) || $utmSource === 'mailpoet';
-    if (!$isOverwritable) {
+    $sessionStartTime = $this->getMetaString($order, OrderAttributionFields::getMetaKey('session_start_time'));
+    if (!self::shouldWriteStandardSourceFields($sourceType, $utmSource, $sessionStartTime, $click->getUpdatedAt(), $this->wp->wpTimezone())) {
       return;
     }
     $values = [
@@ -253,6 +253,44 @@ class OrderAttributionWriter {
     foreach ($values as $fieldName => $value) {
       $order->update_meta_data(OrderAttributionFields::getMetaKey($fieldName), $this->wp->sanitizeTextField($value));
     }
+  }
+
+  public static function shouldWriteStandardSourceFields(
+    string $sourceType,
+    string $utmSource,
+    string $sessionStartTime,
+    \DateTimeInterface $clickUpdatedAt,
+    \DateTimeZone $wooSessionTimeZone
+  ): bool {
+    if (in_array($sourceType, self::OVERWRITABLE_SOURCE_TYPES, true) || $utmSource === 'mailpoet') {
+      return true;
+    }
+    $wooSessionStart = self::parseWooSessionStartTime($sessionStartTime, $wooSessionTimeZone);
+    return $wooSessionStart && $clickUpdatedAt->getTimestamp() >= $wooSessionStart->getTimestamp();
+  }
+
+  /**
+   * Woo stores session_start_time as sourcebuster's `current_add.fd`, a wall-clock
+   * string with no timezone. It is the visitor's browser-local time, which the server
+   * cannot recover exactly, so we interpret it in the site timezone as the best
+   * single-region approximation. Multi-region skew is accepted within the documented
+   * last-click tolerance (STOMAIL-8186).
+   */
+  private static function parseWooSessionStartTime(string $sessionStartTime, \DateTimeZone $timeZone): ?\DateTimeImmutable {
+    $sessionStartTime = trim($sessionStartTime);
+    if ($sessionStartTime === '') {
+      return null;
+    }
+    $date = \DateTimeImmutable::createFromFormat(
+      '!Y-m-d H:i:s',
+      $sessionStartTime,
+      $timeZone
+    );
+    $errors = \DateTimeImmutable::getLastErrors();
+    if (!$date || ($errors !== false && ((int)$errors['warning_count'] > 0 || (int)$errors['error_count'] > 0))) {
+      return null;
+    }
+    return $date;
   }
 
   /**

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionReconcilerTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionReconcilerTest.php
@@ -123,6 +123,54 @@ class OrderAttributionReconcilerTest extends \MailPoetTest {
     verify($record['woo_revenue'])->equals(15.0);
   }
 
+  public function testItDoesNotRecordPreservedForeignSourceWhenMailPoetClickIsNewer(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->setWooSourceMeta(
+      $order,
+      'utm',
+      'google',
+      $this->formatWooSessionStartTime($click->getUpdatedAt(), -DAY_IN_SECONDS)
+    );
+
+    $this->completeOrder($order);
+
+    $order = $this->reloadOrder($order);
+    $record = $this->getRecord($order);
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_source')))->equals('mailpoet');
+    verify($record['outcome'])->equals(OrderAttributionReconciler::OUTCOME_MATCH);
+    verify($record['reason'])->equals(OrderAttributionReconciler::REASON_MATCHED);
+    verify($record['classification'])->null();
+    verify($record['foreign_source_preserved'])->false();
+    verify($record['woo_click_id'])->equals($click->getId());
+  }
+
+  public function testItRecordsPreservedForeignSourceWhenMailPoetClickIsOlder(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->setWooSourceMeta(
+      $order,
+      'utm',
+      'google',
+      $this->formatWooSessionStartTime($click->getUpdatedAt(), DAY_IN_SECONDS)
+    );
+
+    $this->completeOrder($order);
+
+    $order = $this->reloadOrder($order);
+    $record = $this->getRecord($order);
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_source')))->equals('google');
+    verify($record['outcome'])->equals(OrderAttributionReconciler::OUTCOME_DIVERGED);
+    verify($record['reason'])->equals(OrderAttributionReconciler::REASON_FOREIGN_SOURCE_PRESERVED);
+    verify($record['classification'])->equals(OrderAttributionReconciler::CLASSIFICATION_INTENTIONAL);
+    verify($record['foreign_source_preserved'])->true();
+    verify($record['woo_click_id'])->equals($click->getId());
+  }
+
   public function testItRecordsMissingWooAttribution(): void {
     $this->createClick($this->link, $this->subscriber);
     $this->entityManager->flush();
@@ -313,6 +361,24 @@ class OrderAttributionReconcilerTest extends \MailPoetTest {
     $reloaded = wc_get_order($order->get_id());
     $this->assertInstanceOf(WC_Order::class, $reloaded);
     return $reloaded;
+  }
+
+  private function setWooSourceMeta(
+    WC_Order $order,
+    string $sourceType,
+    string $utmSource,
+    string $sessionStartTime
+  ): void {
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('source_type'), $sourceType);
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('utm_source'), $utmSource);
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('session_start_time'), $sessionStartTime);
+    $order->save_meta_data();
+  }
+
+  private function formatWooSessionStartTime(\DateTimeInterface $date, int $offsetSeconds = 0): string {
+    return (new \DateTimeImmutable('@' . ($date->getTimestamp() + $offsetSeconds)))
+      ->setTimezone(wp_timezone())
+      ->format('Y-m-d H:i:s');
   }
 
   /**

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionWriterTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionWriterTest.php
@@ -135,6 +135,102 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$click->getId());
   }
 
+  public function testItOverwritesExistingSourceWhenMailPoetClickIsNewer(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->setWooSourceMeta(
+      $order,
+      'utm',
+      'google',
+      $this->formatWooSessionStartTime($click->getUpdatedAt(), -DAY_IN_SECONDS)
+    );
+
+    $this->writer->writeForOrder($order->get_id());
+
+    $order = $this->reloadOrder($order);
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('source_type')))->equals('utm');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_source')))->equals('mailpoet');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_medium')))->equals('email');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$click->getId());
+  }
+
+  public function testItPreservesExistingSourceWhenMailPoetClickIsOlder(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->setWooSourceMeta(
+      $order,
+      'utm',
+      'google',
+      $this->formatWooSessionStartTime($click->getUpdatedAt(), DAY_IN_SECONDS)
+    );
+
+    $this->writer->writeForOrder($order->get_id());
+
+    $order = $this->reloadOrder($order);
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('source_type')))->equals('utm');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_source')))->equals('google');
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey('utm_medium')))->false();
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$click->getId());
+  }
+
+  public function testItOverwritesExistingSourceWhenMailPoetClickMatchesWooSessionTime(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->setWooSourceMeta(
+      $order,
+      'utm',
+      'google',
+      $this->formatWooSessionStartTime($click->getUpdatedAt())
+    );
+
+    $this->writer->writeForOrder($order->get_id());
+
+    $order = $this->reloadOrder($order);
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('source_type')))->equals('utm');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_source')))->equals('mailpoet');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_medium')))->equals('email');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$click->getId());
+  }
+
+  public function testItOverwritesEmptyDirectAndUnknownSourcesWithoutSessionStartTime(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+
+    foreach (OrderAttributionWriter::OVERWRITABLE_SOURCE_TYPES as $sourceType) {
+      $order = $this->createOrder($this->subscriber->getEmail());
+      $this->setWooSourceMeta($order, $sourceType, '(direct)');
+
+      $this->writer->writeForOrder($order->get_id());
+
+      $order = $this->reloadOrder($order);
+      verify($order->get_meta(OrderAttributionFields::getMetaKey('source_type')))->equals('utm');
+      verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_source')))->equals('mailpoet');
+      verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$click->getId());
+    }
+  }
+
+  public function testItPreservesExistingSourceWhenSessionStartTimeIsUnparseable(): void {
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+
+    $order = $this->createOrder($this->subscriber->getEmail());
+    $this->setWooSourceMeta($order, 'utm', 'google', 'not-a-date');
+
+    $this->writer->writeForOrder($order->get_id());
+
+    $order = $this->reloadOrder($order);
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('source_type')))->equals('utm');
+    verify($order->get_meta(OrderAttributionFields::getMetaKey('utm_source')))->equals('google');
+    verify($order->meta_exists(OrderAttributionFields::getMetaKey('utm_medium')))->false();
+    verify($order->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))->equals((string)$click->getId());
+  }
+
   public function testItIsIdempotent(): void {
     $click = $this->createClick($this->link, $this->subscriber);
     $this->entityManager->flush();
@@ -307,6 +403,26 @@ class OrderAttributionWriterTest extends \MailPoetTest {
     $reloaded = wc_get_order($order->get_id());
     $this->assertInstanceOf(WC_Order::class, $reloaded);
     return $reloaded;
+  }
+
+  private function setWooSourceMeta(
+    WC_Order $order,
+    string $sourceType,
+    string $utmSource,
+    ?string $sessionStartTime = null
+  ): void {
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('source_type'), $sourceType);
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('utm_source'), $utmSource);
+    if (!is_null($sessionStartTime)) {
+      $order->update_meta_data(OrderAttributionFields::getMetaKey('session_start_time'), $sessionStartTime);
+    }
+    $order->save_meta_data();
+  }
+
+  private function formatWooSessionStartTime(\DateTimeInterface $date, int $offsetSeconds = 0): string {
+    return (new \DateTimeImmutable('@' . ($date->getTimestamp() + $offsetSeconds)))
+      ->setTimezone(wp_timezone())
+      ->format('Y-m-d H:i:s');
   }
 
   private function createWriterForRequestContext(


### PR DESCRIPTION
## Description

Resolve a WooCommerce order's standard attribution source by last-click timestamp instead of source-emptiness.

Previously MailPoet only overwrote Woo's standard source with `mailpoet` when Woo's `source_type` was empty/`typein`/`unknown`. An earlier non-email click (e.g. Google Ads) captured before a later email click would win, systematically under-crediting email.

`writeStandardSourceFields()` now overwrites with `mailpoet` when: the source type is overwritable, OR `utm_source` is already `mailpoet`, OR the resolved MailPoet click is at least as recent as Woo's captured `session_start_time`. `OrderAttributionReconciler` mirrors the same rule via a shared static method so dual-run reconciliation reports no phantom divergence.

## Code review notes

- Woo's `session_start_time` is sourcebuster's `current_add.fd` — a wall-clock string with no timezone (visitor browser-local). The server cannot recover the exact offset, so it is interpreted in the site timezone as the best single-region approximation; multi-region skew is accepted within the documented last-click tolerance. Documented inline in `parseWooSessionStartTime()`.
- Tie (click timestamp == session start) resolves to MailPoet (`>=`).
- Missing/unparseable `session_start_time` falls back to the prior emptiness behavior — a clear non-MailPoet source is never overwritten.

## QA notes

Covered by integration tests in `OrderAttributionWriterTest` and `OrderAttributionReconcilerTest`: newer click → `mailpoet`, older click → preserved, tie → `mailpoet`, empty/typein/unknown → `mailpoet`, unparseable session time → preserved, reconciler classification matches the writer.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8186

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I added sufficient test coverage

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8186-last-click-order-source)

_The latest successful build from `fix/stomail-8186-last-click-order-source` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 1 issue found

**Category: Suggestion**

- **Code Duplication**: The `getMetaString()` method is duplicated identically in both `OrderAttributionWriter.php` and `OrderAttributionReconciler.php`. While functionally correct, this violates the DRY (Don't Repeat Yourself) principle and could be consolidated into a shared utility class or trait for better maintainability.

**Observation:** The implementation is otherwise sound. The logic correctly handles timestamp comparisons using `>=` (ties resolve in favor of MailPoet), properly parses Woo's session start time with error checking, gracefully falls back when parsing fails, and includes comprehensive test coverage for all edge cases (newer clicks, older clicks, equal timestamps, unparseable times, and overwritable source types).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->