### PR TITLE
Fix MailPoet Woo revenue source gate

### DIFF
--- a/mailpoet/changelog/2026-06-15-21-41-44-fixed-woocommerce-order-attribution-now-credits-mailpoet.md
+++ b/mailpoet/changelog/2026-06-15-21-41-44-fixed-woocommerce-order-attribution-now-credits-mailpoet.md
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-WooCommerce order attribution now credits MailPoet when the email click is the latest source

--- a/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
@@ -535,6 +535,7 @@ class OrderAttributionRevenueReader {
       OrderAttributionFields::FIELD_SUBSCRIBER_ID,
       OrderAttributionFields::FIELD_QUEUE_ID,
     ]);
+    $utmSourceMetaKey = OrderAttributionFields::getMetaKey('utm_source');
 
     $having = 'click_id IS NOT NULL AND click_id <> \'\' AND newsletter_id IS NOT NULL AND newsletter_id <> \'\'';
     $havingParams = [];
@@ -558,6 +559,9 @@ class OrderAttributionRevenueReader {
           MAX(CASE WHEN meta.meta_key = %s THEN meta.meta_value END) AS subscriber_id,
           MAX(CASE WHEN meta.meta_key = %s THEN meta.meta_value END) AS queue_id
         FROM %i woo_order
+        INNER JOIN %i source_meta ON source_meta.%i = ' . $orderIdColumn . '
+          AND source_meta.meta_key = %s
+          AND source_meta.meta_value = %s
         INNER JOIN %i meta ON meta.%i = ' . $orderIdColumn . '
           AND meta.meta_key IN (%s, %s, %s, %s)
         WHERE 1 = 1
@@ -570,6 +574,10 @@ class OrderAttributionRevenueReader {
         $metaKeys,
         [
           $orderLookup['table'],
+          $meta['table'],
+          $meta['order_id_column'],
+          $utmSourceMetaKey,
+          'mailpoet',
           $meta['table'],
           $meta['order_id_column'],
         ],
@@ -724,6 +732,9 @@ class OrderAttributionRevenueReader {
 
     $params = [];
     $exists = [];
+    // Namespace completeness is intentional here: post-boundary legacy fallback
+    // must not re-add orders where email touched the order but did not win
+    // standard-source arbitration.
     foreach ($requiredFields as $fieldName) {
       $exists[] = 'EXISTS (SELECT 1 FROM %i woo_meta WHERE woo_meta.%i = ' . $orderIdExpression . ' AND woo_meta.meta_key = %s AND woo_meta.meta_value <> \'\')';
       $params[] = $meta['table'];

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
@@ -200,6 +200,8 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
     $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID), (string)$this->newsletter->getId());
     $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_QUEUE_ID), (string)$queue->getId());
     $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID), (string)$this->subscriber->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('source_type'), 'utm');
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('utm_source'), 'mailpoet');
     $order->save_meta_data();
     return $order;
   }

--- a/mailpoet/tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php
@@ -255,6 +255,30 @@ class SubscriberStatisticsRepositoryTest extends \MailPoetTest {
     verify($result->getValue())->equals((float)$order->get_remaining_refund_amount());
   }
 
+  public function testWooBackedSubscriberRevenueSkipsOrdersWhenMailPoetDidNotWinSource(): void {
+    $this->enableWooBackedRevenueReadModel();
+    $subscriber = (new Subscriber())->create();
+    $newsletter = (new Newsletter())->withSendingQueue()->create();
+    $link = (new NewsletterLink($newsletter))->create();
+    $click = (new StatisticsClicks($link, $subscriber))->create();
+
+    $order = $this->createCompletedOrderWithAttribution($click, $subscriber, 40);
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('utm_source'), 'google');
+    $order->save_meta_data();
+
+    (new StatisticsWooCommercePurchases($click, [
+      'id' => $order->get_id(),
+      'currency' => 'USD',
+      'total' => 18.00,
+    ]))->withCreatedAt(new \DateTimeImmutable('-30 minutes'))->create();
+
+    $result = $this->repository->getWooCommerceRevenue($subscriber, Carbon::now()->subHour());
+
+    $this->assertInstanceOf(WooCommerceRevenue::class, $result);
+    verify($result->getOrdersCount())->equals(0);
+    verify($result->getValue())->equals(0.00);
+  }
+
   public function testWooBackedSubscriberRevenueFallsBackToLegacyWhenSubscriberMetaIsMissing(): void {
     $this->enableWooBackedRevenueReadModel();
     $subscriber = (new Subscriber())->create();
@@ -297,6 +321,8 @@ class SubscriberStatisticsRepositoryTest extends \MailPoetTest {
     $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID), (string)$click->getId());
     $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID), (string)$newsletter->getId());
     $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_QUEUE_ID), (string)$queue->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('source_type'), 'utm');
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('utm_source'), 'mailpoet');
     $order->save_meta_data();
 
     (new StatisticsWooCommercePurchases($click, [
@@ -339,6 +365,8 @@ class SubscriberStatisticsRepositoryTest extends \MailPoetTest {
     $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_NEWSLETTER_ID), (string)$newsletter->getId());
     $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_QUEUE_ID), (string)$queue->getId());
     $order->update_meta_data(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_SUBSCRIBER_ID), (string)$subscriber->getId());
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('source_type'), 'utm');
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('utm_source'), 'mailpoet');
     $order->save_meta_data();
     return $order;
   }

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionCompatibilityTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionCompatibilityTest.php
@@ -128,6 +128,61 @@ class OrderAttributionCompatibilityTest extends \MailPoetTest {
     ];
   }
 
+  public function testWooBackedRevenueMatchesWooMailPoetSourceForArbitratedOrders(): void {
+    $this->settings->set('tracking.level', TrackingConfig::LEVEL_FULL);
+    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
+    $this->diContainer->get(FeaturesController::class)->resetCache();
+    update_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION, '2000-01-01 00:00:00');
+
+    $click = $this->createClick($this->link, $this->subscriber);
+    $this->entityManager->flush();
+
+    $newerEmailClickOrder = $this->createOrder($this->subscriber->getEmail(), false, 30);
+    $this->completeOrderWithWooSource(
+      $newerEmailClickOrder,
+      'utm',
+      'google',
+      $this->formatWooSessionStartTime($click->getUpdatedAt(), -DAY_IN_SECONDS)
+    );
+
+    $olderEmailClickOrder = $this->createOrder($this->subscriber->getEmail(), false, 40);
+    $this->completeOrderWithWooSource(
+      $olderEmailClickOrder,
+      'utm',
+      'google',
+      $this->formatWooSessionStartTime($click->getUpdatedAt(), DAY_IN_SECONDS)
+    );
+
+    $unknownSourceOrder = $this->createOrder($this->subscriber->getEmail(), false, 20);
+    $this->completeOrderWithWooSource($unknownSourceOrder, 'unknown', '', null);
+
+    $unparseableSessionOrder = $this->createOrder($this->subscriber->getEmail(), false, 50);
+    $this->completeOrderWithWooSource($unparseableSessionOrder, 'utm', 'google', 'not-a-date');
+
+    $reader = $this->diContainer->get(OrderAttributionRevenueReader::class);
+    $revenues = $reader->getNewsletterRevenues(
+      [(int)$this->newsletter->getId()],
+      new DateTimeImmutable('@0'),
+      new DateTimeImmutable('+1 day')
+    );
+    $mailPoetRevenue = $revenues[(int)$this->newsletter->getId()] ?? ['total' => 0.0, 'count' => 0];
+    $wooMailPoetRevenue = $this->getWooMailPoetSourceRevenue([
+      $newerEmailClickOrder,
+      $olderEmailClickOrder,
+      $unknownSourceOrder,
+      $unparseableSessionOrder,
+    ]);
+
+    verify($mailPoetRevenue)->equals($wooMailPoetRevenue);
+    verify($mailPoetRevenue['total'])->equals(50.0);
+    verify($mailPoetRevenue['count'])->equals(2);
+
+    $olderEmailClickOrder = $this->reloadOrder($olderEmailClickOrder);
+    verify($olderEmailClickOrder->get_meta(OrderAttributionFields::getMetaKey(OrderAttributionFields::FIELD_CLICK_ID)))
+      ->equals((string)$click->getId());
+    verify($olderEmailClickOrder->get_meta(OrderAttributionFields::getMetaKey('utm_source')))->equals('google');
+  }
+
   private function writeThroughContext(string $context, WC_Order $order): void {
     switch ($context) {
       case self::CONTEXT_CLASSIC_BLOCK_CHECKOUT:
@@ -207,16 +262,55 @@ class OrderAttributionCompatibilityTest extends \MailPoetTest {
     return $rows ?? [];
   }
 
-  private function createOrder(string $billingEmail, bool $loggedIn): WC_Order {
+  private function createOrder(string $billingEmail, bool $loggedIn, float $total = 15.0): WC_Order {
     $order = wc_create_order();
     $this->assertInstanceOf(WC_Order::class, $order);
     $order->set_billing_email($billingEmail);
-    $order->set_total('15');
+    $order->set_total((string)$total);
     if ($loggedIn) {
       $order->set_customer_id($this->ensureWpUser($billingEmail));
     }
     $order->save();
     return $order;
+  }
+
+  private function completeOrderWithWooSource(
+    WC_Order $order,
+    string $sourceType,
+    string $utmSource,
+    ?string $sessionStartTime
+  ): void {
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('source_type'), $sourceType);
+    $order->update_meta_data(OrderAttributionFields::getMetaKey('utm_source'), $utmSource);
+    if ($sessionStartTime !== null) {
+      $order->update_meta_data(OrderAttributionFields::getMetaKey('session_start_time'), $sessionStartTime);
+    }
+    $order->save_meta_data();
+    $order->set_status('completed');
+    $order->save();
+  }
+
+  /**
+   * @param WC_Order[] $orders
+   * @return array{total: float, count: int}
+   */
+  private function getWooMailPoetSourceRevenue(array $orders): array {
+    $revenue = ['total' => 0.0, 'count' => 0];
+    foreach ($orders as $order) {
+      $order = $this->reloadOrder($order);
+      if ($order->get_meta(OrderAttributionFields::getMetaKey('utm_source')) !== 'mailpoet') {
+        continue;
+      }
+      $revenue['total'] += (float)$order->get_remaining_refund_amount();
+      $revenue['count']++;
+    }
+    return $revenue;
+  }
+
+  private function formatWooSessionStartTime(\DateTimeInterface $date, int $offsetSeconds = 0): string {
+    return (new \DateTimeImmutable('@' . ($date->getTimestamp() + $offsetSeconds)))
+      ->setTimezone(wp_timezone())
+      ->format('Y-m-d H:i:s');
   }
 
   private function ensureWpUser(string $email): int {


### PR DESCRIPTION
## Description

Make MailPoet revenue reporting count the same orders as Woo Analytics for the `mailpoet` source.

MailPoet's Woo-path reader counted any order carrying the `_wc_order_attribution_mailpoet_*` namespace meta, which is written whenever email touched the order — even when a more recent non-email click won Woo's standard source. This over-counted relative to Woo Analytics.

The Woo-path query (`getWooAttributedOrders`, shared by newsletter revenue, subscriber revenue, and order rows) now requires the standard `_wc_order_attribution_utm_source = mailpoet` in addition to namespace presence. The namespace write is unchanged, preserving full click/newsletter/subscriber detail; only the read reports the won subset. Legacy/pre-boundary reads are unchanged.

## Code review notes

- The post-boundary legacy-fallback exclusion (`getCompleteWooAttributionExclusionSql`) stays gated on namespace completeness, not `utm_source`. Gating it on `utm_source` would let the fallback re-add orders email touched but did not win. Documented inline.
- The new `utm_source` condition is a single-table column-vs-literal match — no cross-collation join.

## QA notes

Integration test `OrderAttributionCompatibilityTest::testWooBackedRevenueMatchesWooMailPoetSourceForArbitratedOrders` seeds orders across all STOMAIL-8186 timing cases and asserts the MailPoet reader total equals Woo's `source=mailpoet` total. Subscriber-path skip case covered in `SubscriberStatisticsRepositoryTest`.

## Linked PRs

Stacked on #6870 (base branch).

## Linked tickets

STOMAIL-8187

## After-merge notes

Once `FEATURE_WOO_BACKED_REVENUE_REPORTING` is enabled, reported MailPoet Woo-path revenue drops to match Woo Analytics for affected campaigns — this is the intended over-count correction, not a regression.

## Tasks

- [x] I have added a changelog entry
- [x] I added sufficient test coverage

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8187-match-woo-analytics-revenue)

_The latest successful build from `fix/stomail-8187-match-woo-analytics-revenue` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->