### PR TITLE
Use MailPoet sender details in inbox preview panel

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/inbox-preview-card.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/inbox-preview-card.tsx
@@ -1,6 +1,5 @@
 import { Card } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { MAILPOET_EMAIL_POST_TYPE } from '../constants';
 
@@ -16,20 +15,20 @@ export function InboxPreviewCard() {
     'mailpoet_data',
   );
 
-  const siteData = useSelect((select) => {
-    const site = select('core').getSite();
-    return {
-      title: (site?.title as string) || '',
-      email: (site?.email as string) || '',
-    };
-  }, []);
+  const senderName = (mailpoetEmailData?.sender_name as string) || '';
+  const senderAddress = (mailpoetEmailData?.sender_address as string) || '';
+
+  let fromAddress = __('(No sender)', 'mailpoet') as string;
+  if (senderAddress) {
+    fromAddress = senderName
+      ? `${senderName} <${senderAddress}>`
+      : senderAddress;
+  }
 
   return (
     <Card className="mailpoet-inbox-preview-panel__card">
       <div className="mailpoet-inbox-preview-panel__from-address">
-        {siteData.title && siteData.email
-          ? `${siteData.title} <${siteData.email}>`
-          : __('(No sender)', 'mailpoet')}
+        {fromAddress}
       </div>
       <div className="mailpoet-inbox-preview-panel__subject">
         {mailpoetEmailData?.subject || __('(No subject)', 'mailpoet')}

--- a/mailpoet/changelog/2026-06-16-08-00-24-changed-inbox-preview-panel-now-shows-the-mailpoet-sender-.md
+++ b/mailpoet/changelog/2026-06-16-08-00-24-changed-inbox-preview-panel-now-shows-the-mailpoet-sender-.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Inbox preview panel now shows the MailPoet sender details instead of the WordPress site title and admin email

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -14,6 +14,7 @@ use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Sharing\ShareVisibility;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\NotFoundException;
+use MailPoet\Settings\SettingsController;
 use MailPoet\UnexpectedValueException;
 use MailPoet\Validator\Builder;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -40,6 +41,9 @@ class EmailApiController {
   /** @var ShareVisibility */
   private $shareVisibility;
 
+  /** @var SettingsController */
+  private $settings;
+
   public function __construct(
     NewslettersRepository $newsletterRepository,
     NewsletterUrl $newsletterUrl,
@@ -47,7 +51,8 @@ class EmailApiController {
     NewsletterOptionsRepository $newsletterOptionsRepository,
     NewsletterSegmentRepository $newsletterSegmentRepository,
     EntityManager $entityManager,
-    ShareVisibility $shareVisibility
+    ShareVisibility $shareVisibility,
+    SettingsController $settings
   ) {
     $this->newsletterRepository = $newsletterRepository;
     $this->newsletterUrl = $newsletterUrl;
@@ -56,6 +61,7 @@ class EmailApiController {
     $this->newsletterSegmentRepository = $newsletterSegmentRepository;
     $this->entityManager = $entityManager;
     $this->shareVisibility = $shareVisibility;
+    $this->settings = $settings;
   }
 
   /**
@@ -68,10 +74,13 @@ class EmailApiController {
     $showInArchive = $newsletter
       ? $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE) !== '1'
       : true;
+    $sender = $this->resolveSender($newsletter);
     return [
       'id' => $newsletter ? $newsletter->getId() : null,
       'subject' => $newsletter ? $newsletter->getSubject() : '',
       'preheader' => $newsletter ? $newsletter->getPreheader() : '',
+      'sender_name' => $sender['name'],
+      'sender_address' => $sender['address'],
       'preview_url' => $this->newsletterUrl->getViewInBrowserUrl($newsletter),
       'deleted_at' => $newsletter && $newsletter->getDeletedAt() !== null ? $newsletter->getDeletedAt()->format('c') : null,
       'scheduled_at' => $newsletter ? $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SCHEDULED_AT) : null,
@@ -89,6 +98,27 @@ class EmailApiController {
         : $this->shareVisibility->getDefaultVisibility(),
       'can_share' => $newsletter ? $this->shareVisibility->canShare($newsletter) : false,
       'show_in_archive' => $showInArchive,
+    ];
+  }
+
+  /**
+   * Resolves the sender address and name using the same logic as the mailer.
+   * The newsletter's own sender is used only when it has an address, otherwise
+   * the whole sender falls back to the default configured in settings.
+   *
+   * @return array{name: string, address: string}
+   */
+  private function resolveSender(?NewsletterEntity $newsletter): array {
+    if ($newsletter && $newsletter->getSenderAddress()) {
+      return [
+        'name' => (string)$newsletter->getSenderName(),
+        'address' => (string)$newsletter->getSenderAddress(),
+      ];
+    }
+    $defaultSender = $this->settings->get('sender', []);
+    return [
+      'name' => (string)($defaultSender['name'] ?? ''),
+      'address' => (string)($defaultSender['address'] ?? ''),
     ];
   }
 
@@ -258,6 +288,8 @@ class EmailApiController {
       'id' => Builder::integer()->nullable(),
       'subject' => Builder::string(),
       'preheader' => Builder::string(),
+      'sender_name' => Builder::string(),
+      'sender_address' => Builder::string(),
       'preview_url' => Builder::string(),
       'deleted_at' => Builder::string()->nullable(),
       'scheduled_at' => Builder::string()->nullable(),

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailApiControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailApiControllerTest.php
@@ -9,6 +9,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sharing\ShareVisibility;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\NotFoundException;
+use MailPoet\Settings\SettingsController;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\NewsletterOption;
 use MailPoet\Test\DataFactories\NewsletterOptionField;
@@ -22,9 +23,13 @@ class EmailApiControllerTest extends \MailPoetTest {
   /** @var NewslettersRepository */
   private $newslettersRepository;
 
+  /** @var SettingsController */
+  private $settings;
+
   public function _before() {
     $this->emailApiController = $this->diContainer->get(EmailApiController::class);
     $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
+    $this->settings = $this->diContainer->get(SettingsController::class);
   }
 
   public function testItGetsEmailDataFromNewsletterEntity(): void {
@@ -39,6 +44,58 @@ class EmailApiControllerTest extends \MailPoetTest {
     verify($emailData['subject'])->equals('New subject');
     verify($emailData['preheader'])->equals('New preheader');
     verify($emailData['id'])->equals($newsletter->getId());
+  }
+
+  public function testItUsesNewsletterSenderWhenAddressIsSet(): void {
+    $wpPostId = 20;
+    (new NewsletterFactory())
+      ->withSenderName('Jane Doe')
+      ->withSenderAddress('jane@example.com')
+      ->withWpPostId($wpPostId)
+      ->create();
+
+    $this->settings->set('sender', ['name' => 'Default Name', 'address' => 'default@example.com']);
+
+    $emailData = $this->emailApiController->getEmailData(['id' => $wpPostId]);
+    verify($emailData['sender_name'])->equals('Jane Doe');
+    verify($emailData['sender_address'])->equals('jane@example.com');
+  }
+
+  public function testItFallsBackToDefaultSenderWhenNewsletterAddressIsMissing(): void {
+    $wpPostId = 21;
+    (new NewsletterFactory())
+      ->withSenderName('')
+      ->withSenderAddress('')
+      ->withWpPostId($wpPostId)
+      ->create();
+
+    $this->settings->set('sender', ['name' => 'Default Name', 'address' => 'default@example.com']);
+
+    $emailData = $this->emailApiController->getEmailData(['id' => $wpPostId]);
+    verify($emailData['sender_name'])->equals('Default Name');
+    verify($emailData['sender_address'])->equals('default@example.com');
+  }
+
+  public function testItKeepsNewsletterSenderNameEmptyWhenOnlyAddressIsSet(): void {
+    $wpPostId = 22;
+    (new NewsletterFactory())
+      ->withSenderName('')
+      ->withSenderAddress('jane@example.com')
+      ->withWpPostId($wpPostId)
+      ->create();
+
+    $this->settings->set('sender', ['name' => 'Default Name', 'address' => 'default@example.com']);
+
+    $emailData = $this->emailApiController->getEmailData(['id' => $wpPostId]);
+    verify($emailData['sender_name'])->equals('');
+    verify($emailData['sender_address'])->equals('jane@example.com');
+  }
+
+  public function testEmailDataSchemaIncludesSenderStrings(): void {
+    $schema = $this->emailApiController->getEmailDataSchema();
+
+    verify($schema['properties']['sender_name']['type'])->equals('string');
+    verify($schema['properties']['sender_address']['type'])->equals('string');
   }
 
   public function testItGetsSharingEmailData(): void {


### PR DESCRIPTION
## Description

The inbox preview panel's "from" line now shows MailPoet's sender details instead of the WordPress site title and admin email. We are using the same logic as the mailer - the newsletter's own sender is used when it has
an address, otherwise the whole sender falls back to the default configured in MailPoet settings.

The previous preview pulled the site title/admin email via `select('core').getSite()`, which is unrelated to what recipients see in their inbox. This makes the preview match the real sender.

## Code review notes

_N/A_

## QA notes

1. Open an email in the block editor with the inbox preview panel.
2. With a newsletter sender set, the "from" line shows that sender. You may need use the old Send screen (`/wp-admin/admin.php?page=mailpoet-newsletters#/send/<NEWSLETTER_ID>`) since we don't have sender controls in the editor yet.
3. With no newsletter sender, it falls back to the default sender from MailPoet settings.
4. Sender name empty but address set → renders just the address.

## Linked PRs

[STOMAIL-8160: Use MailPoet sender details in inbox preview panel](https://linear.app/a8c/issue/STOMAIL-8160/use-mailpoet-sender-details-in-inbox-preview-panel)

## Linked tickets

[STOMAIL-8160: Use MailPoet sender details in inbox preview panel](https://linear.app/a8c/issue/STOMAIL-8160/use-mailpoet-sender-details-in-inbox-preview-panel)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="2242" height="1505" alt="5ST2GNVCZuZy9idr@2x" src="https://github.com/user-attachments/assets/5133be10-61dc-41e3-976f-959f4cc3be08" /> | <img width="2242" height="1504" alt="gaffR4QQAFYtoL4O@2x" src="https://github.com/user-attachments/assets/ad924b17-45f8-498f-99c4-4205e5974d4f" /> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8160-use-mailpoet-sender-details-in-inbox-preview-panel)

_The latest successful build from `stomail-8160-use-mailpoet-sender-details-in-inbox-preview-panel` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->