### PR TITLE
Preserve test plugins during cache cleanup

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -43,13 +43,17 @@ class RoboFile extends \Robo\Tasks {
       ->run();
   }
 
-  public function cleanupCachedFiles() {
+  public function cleanupCachedFiles($opts = ['include-plugins' => false]) {
     $this->say('Cleaning up generated folder.');
     $this->_exec('rm -rf ' . __DIR__ . '/generated/*');
     $this->say('Cleaning up PHPStan cache.');
     $this->_exec('rm -rf ' . __DIR__ . '/temp/*');
-    $this->say('Cleaning up old testing plugins.');
-    $this->_exec('rm -rf ' . __DIR__ . '/tests/plugins/*');
+    if (!empty($opts['include-plugins'])) {
+      $this->say('Cleaning up old testing plugins.');
+      $this->_exec('rm -rf ' . __DIR__ . '/tests/plugins/*');
+    } else {
+      $this->say('Skipping testing plugins cleanup. Use --include-plugins to remove them.');
+    }
   }
 
   public function update() {


### PR DESCRIPTION
## Description

This changes the behavior of `./do cleanup:cached-files` command (`mailpoet/tests/plugins/*`). It still deletes the `generated` folder and the PHPStan cache as the default behavior and skips deleting the downloaded plugin. The plugin cache deletion is now explicit through `./do cleanup:cached-files --include-plugins`.

### Why?
In my experience, 99% of the time when I run `./do cleanup:cached-files` I want to keep the downloaded and extracted WooCommerce test plugins, because deleting them breaks running wp-env sites that still mount and activate those plugin directories. After we switched to WP-Env, the plugins are also used for the dev site.

## Code review notes

`cleanupCachedFiles()` is both a standalone Robo command and a callback used by commands like `install:php`. The option check uses `!empty($opts['include-plugins'])` so callback invocations without CLI options preserve plugins safely.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-missing-plugins)

_The latest successful build from `fix-missing-plugins` will be used. If none is available, the link won't work._