### PR TITLE
Show notice when editing an already-sent email

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/components/sent-email-notice.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/components/sent-email-notice.tsx
@@ -1,0 +1,88 @@
+import { useEffect } from '@wordpress/element';
+import { select, useSelect, useDispatch } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+import { store as noticesStore } from '@wordpress/notices';
+import { storeName as emailEditorStore } from '@woocommerce/email-editor';
+import { __ } from '@wordpress/i18n';
+import { MailPoet } from 'mailpoet';
+import { duplicateNewsletter } from '../../newsletters/api';
+import { MAILPOET_EMAIL_POST_TYPE } from '../constants';
+
+const NOTICE_ID = 'mailpoet-email-already-sent';
+const NOTICE_CONTEXT = 'email-editor';
+
+export function SentEmailNotice(): null {
+  const { isEmailSent, postType } = useSelect(
+    (rootSelect) => ({
+      isEmailSent: rootSelect(emailEditorStore).isEmailSent(),
+      postType: rootSelect(editorStore).getCurrentPostType(),
+    }),
+    [],
+  );
+  const { createNotice, removeNotice, createErrorNotice } =
+    useDispatch(noticesStore);
+
+  useEffect(() => {
+    // Only render the notice a MailPoet email that has already been sent — not for templates or other post types.
+    if (postType !== MAILPOET_EMAIL_POST_TYPE || !isEmailSent) {
+      return undefined;
+    }
+
+    // Duplicate the saved newsletter and open the copy.
+    const duplicateAndEdit = async (): Promise<void> => {
+      const postId = select(editorStore).getCurrentPostId();
+      const editedPost = select(coreDataStore).getEditedEntityRecord(
+        'postType',
+        MAILPOET_EMAIL_POST_TYPE,
+        postId,
+      );
+      // @ts-expect-error Property 'mailpoet_data' does not exist edited entry record type.
+      const newsletterId = editedPost?.mailpoet_data?.id as number | undefined;
+
+      if (!newsletterId) {
+        return;
+      }
+
+      try {
+        const response = await duplicateNewsletter(newsletterId);
+        window.location.href = MailPoet.getActiveEmailEditorUrl(response.data);
+      } catch (e) {
+        void createErrorNotice(
+          __(
+            'The email could not be duplicated. Please try again.',
+            'mailpoet',
+          ),
+          { type: 'snackbar' },
+        );
+      }
+    };
+
+    void createNotice(
+      'warning',
+      __(
+        'This email has already been sent. It can be edited, but not sent again. Duplicate this email if you want to send it again.',
+        'mailpoet',
+      ),
+      {
+        id: NOTICE_ID,
+        isDismissible: false,
+        context: NOTICE_CONTEXT,
+        actions: [
+          {
+            label: __('Duplicate', 'mailpoet'),
+            onClick: () => {
+              void duplicateAndEdit();
+            },
+          },
+        ],
+      },
+    );
+
+    return () => {
+      void removeNotice(NOTICE_ID, NOTICE_CONTEXT);
+    };
+  }, [isEmailSent, postType, createNotice, removeNotice, createErrorNotice]);
+
+  return null;
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -190,6 +190,7 @@ type StripPostStatusMiddlewareModule =
 type EmailSidebarExtensionModule = typeof import('./email-sidebar-extension');
 type AutomationSaveButtonModule =
   typeof import('./components/automation-save-button');
+type SentEmailNoticeModule = typeof import('./components/sent-email-notice');
 
 /* eslint-disable global-require, @typescript-eslint/no-var-requires -- These imports must run after the MailPoet coupon block extension registers its block-type filter, but must stay in this bundle instead of creating async chunks. */
 const initializeMailPoetEmailEditor = (): void => {
@@ -205,6 +206,15 @@ const initializeMailPoetEmailEditor = (): void => {
 
     registerPlugin('mailpoet-settings-sidebar', {
       render: EmailSidebarExtension,
+      scope: 'woocommerce-email-editor',
+    });
+
+    // Render a notice for email that has already been sent.
+    const { SentEmailNotice } =
+      require('./components/sent-email-notice') as SentEmailNoticeModule;
+
+    registerPlugin('mailpoet-sent-email-notice', {
+      render: SentEmailNotice,
       scope: 'woocommerce-email-editor',
     });
   }

--- a/mailpoet/changelog/2026-06-16-10-08-17-added-notice-in-the-email-editor-explaining-a-sent-email.md
+++ b/mailpoet/changelog/2026-06-16-10-08-17-added-notice-in-the-email-editor-explaining-a-sent-email.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Notice in the email editor explaining a sent email can be edited but must be duplicated to send again, with a Duplicate action


### PR DESCRIPTION
## Description

In the block email editor the "Review & send" button is disabled once an email has been sent, but nothing explained why. This adds a non-dismissible warning notice in the editor, matching the legacy editor behavior. It tells the user the email has already been sent, can still be edited, and must be duplicated to be sent again.

The notice also includes a **Duplicate** action that duplicates the saved newsletter (via the same REST endpoint the listing uses) and opens the copy in the editor.

## Code review notes

_N/A_

## QA notes

1. Send an email created in the block editor, then open it in the editor again.
2. A warning notice appears explaining the email was sent and the send button is disabled.
3. Click **Duplicate** → a copy is created and opened in the editor.
4. Confirm the notice does not appear for emails that haven't been sent, or when editing a template.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8178: Show notice when editing an already-sent email](https://linear.app/a8c/issue/STOMAIL-8178/show-notice-when-editing-an-already-sent-email)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="2242" height="1506" alt="xSOEVtpjG5uaoeBV@2x" src="https://github.com/user-attachments/assets/65742392-9e72-4fb4-a9c8-8b7a993b8dc2" /> | <img width="2242" height="1506" alt="O3Mbu40PPoHSi7ps@2x" src="https://github.com/user-attachments/assets/5170bca5-09d8-48a7-a99b-1ffd491ee7e7" /> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8178-show-notice-when-editing-an-already-sent-email)

_The latest successful build from `stomail-8178-show-notice-when-editing-an-already-sent-email` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issues Found: 2 (1 Bug, 1 Suggestion)

### Bug
**Insufficient validation of API response before navigation**: In `sent-email-notice.tsx` (line 49), the duplicated newsletter data is passed directly to `MailPoet.getActiveEmailEditorUrl(response.data)` without validation. While `getActiveEmailEditorUrl` includes a null check and returns `#` as a fallback, navigating to `#` does not provide a user-friendly experience and silently fails to open the duplicated email. The API response should be validated to ensure `response.data` contains the required `id` field before attempting navigation.

### Suggestion
**Potential race condition with async duplication**: If the component unmounts while the `duplicateAndEdit` async operation is pending, the `window.location.href` assignment could execute after unmount (though this is unlikely given the immediate navigation). Consider adding an abort signal or mounted state check to prevent state updates after unmount, following React best practices for cleanup in async operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->