### PR TITLE
Add subscription email content patterns for automations

### DIFF
--- a/mailpoet/changelog/2026-06-03-15-30-05-added-subscription-email-content-patterns-for-automation.md
+++ b/mailpoet/changelog/2026-06-03-15-30-05-added-subscription-email-content-patterns-for-automation.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Subscription email content patterns for automations

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SubscriptionAutomationEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SubscriptionAutomationEmailPattern.php
@@ -1,0 +1,163 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+use MailPoet\Util\CdnAssetUrl;
+
+/**
+ * Subscription automation email pattern.
+ */
+class SubscriptionAutomationEmailPattern extends Pattern {
+  public const VARIANT_PURCHASE = 'purchase';
+  public const VARIANT_RENEWAL = 'renewal';
+  public const VARIANT_FAILED_RENEWAL = 'failed-renewal';
+
+  protected $name = 'subscription-purchase-follow-up';
+  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $categories = ['subscriptions'];
+  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+  /** @var string */
+  private $variant;
+
+  public function __construct(
+    CdnAssetUrl $cdnAssetUrl,
+    string $variant
+  ) {
+    parent::__construct($cdnAssetUrl);
+    $this->variant = $variant;
+
+    if ($variant === self::VARIANT_RENEWAL) {
+      $this->name = 'subscription-renewal-follow-up';
+    } elseif ($variant === self::VARIANT_FAILED_RENEWAL) {
+      $this->name = 'subscription-failed-renewal-follow-up';
+    }
+  }
+
+  protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->variant === self::VARIANT_RENEWAL) {
+      return $this->buildContent(
+        __('Your subscription renewed', 'mailpoet'),
+        [
+          sprintf(
+            /* translators: %s: Subscriber first name personalization tag */
+            __('Hi %s, your subscription has renewed successfully. Thanks for staying with us.', 'mailpoet'),
+            $this->getSubscriberFirstNameTag()
+          ),
+          sprintf(
+            /* translators: %s: WooCommerce subscription title personalization tag */
+            __('Your %s subscription is active for the new billing period, so there is nothing you need to do right now.', 'mailpoet'),
+            '<!--[mailpoet/woocommerce-subscription-title]-->'
+          ),
+          __('We’ll keep working to make every renewal worth it. If you have questions, reply to this email and we’ll help.', 'mailpoet'),
+        ],
+        __('Visit our site', 'mailpoet'),
+        __('Thanks for being with us,', 'mailpoet')
+      );
+    }
+
+    if ($this->variant === self::VARIANT_FAILED_RENEWAL) {
+      return $this->buildContent(
+        __('We couldn’t renew your subscription', 'mailpoet'),
+        [
+          sprintf(
+            /* translators: %s: Subscriber first name personalization tag */
+            __('Hi %s, we tried to renew your subscription but the payment did not go through.', 'mailpoet'),
+            $this->getSubscriberFirstNameTag()
+          ),
+          sprintf(
+            /* translators: %s: WooCommerce subscription title personalization tag */
+            __('To keep %s active, please sign in to your account and update your payment details.', 'mailpoet'),
+            '<!--[mailpoet/woocommerce-subscription-title]-->'
+          ),
+          __('If you already updated your details, you can ignore this message. If you need help, reply and we’ll take a look.', 'mailpoet'),
+        ],
+        __('Visit our site', 'mailpoet'),
+        __('We’re here to help,', 'mailpoet')
+      );
+    }
+
+    return $this->buildContent(
+      __('Welcome to your subscription', 'mailpoet'),
+      [
+        sprintf(
+          /* translators: %s: Subscriber first name personalization tag */
+          __('Hi %s, thanks for subscribing. Your subscription is active, and we’re glad to have you with us.', 'mailpoet'),
+          $this->getSubscriberFirstNameTag()
+        ),
+        sprintf(
+          /* translators: %s: WooCommerce subscription title personalization tag */
+          __('You’re subscribed to %s. We’ll send you useful updates, renewal reminders, and anything you need to get the most from it.', 'mailpoet'),
+          '<!--[mailpoet/woocommerce-subscription-title]-->'
+        ),
+        __('You can review billing, renewals, and subscription details from your account on our site.', 'mailpoet'),
+      ],
+      __('Visit our site', 'mailpoet'),
+      __('Thanks for joining us,', 'mailpoet')
+    );
+  }
+
+  protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->variant === self::VARIANT_RENEWAL) {
+      return __('Subscription Renewal Follow-up', 'mailpoet');
+    }
+
+    if ($this->variant === self::VARIANT_FAILED_RENEWAL) {
+      return __('Subscription Failed Renewal Follow-up', 'mailpoet');
+    }
+
+    return __('Subscription Purchase Follow-up', 'mailpoet');
+  }
+
+  /**
+   * @param string[] $paragraphs
+   */
+  private function buildContent(string $heading, array $paragraphs, string $buttonText, string $signoff): string {
+    $paragraphBlocks = '';
+    foreach ($paragraphs as $paragraph) {
+      $paragraphBlocks .= '
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . $paragraph . '</p>
+      <!-- /wp:paragraph -->';
+    }
+
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' . $heading . '</h1>
+      <!-- /wp:heading -->
+
+      ' . $paragraphBlocks . '
+
+      <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
+      <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . $buttonText . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . $signoff . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  private function getSubscriberFirstNameTag(): string {
+    return sprintf(
+      '<!--[mailpoet/subscriber-firstname default="%s"]-->',
+      /* translators: Default placeholder used when no subscriber name is available in "Hi %s" */
+      esc_attr(_x('there', 'subscriber name placeholder', 'mailpoet'))
+    );
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+use MailPoet\Util\CdnAssetUrl;
 
 /**
  * Welcome email pattern for new subscribers.

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
@@ -4,7 +4,6 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
-use MailPoet\Util\CdnAssetUrl;
 
 /**
  * Welcome email pattern for new subscribers.

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -18,6 +18,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\PostPurchaseThan
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\ProductPurchaseFollowUpPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\ProductRestockNotificationPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\SaleAnnouncementPattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\SubscriptionAutomationEmailPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\TagPurchaseFollowUpPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\WelcomeEmailPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\WelcomeWithDiscountEmailPattern;
@@ -122,6 +123,9 @@ class PatternsController {
         new AbandonedCartReminderPattern($this->cdnAssetUrl),
         new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'positive-follow-up'),
         new AskForReviewPostPurchasePattern($this->cdnAssetUrl, 'negative-follow-up'),
+        new SubscriptionAutomationEmailPattern($this->cdnAssetUrl, SubscriptionAutomationEmailPattern::VARIANT_PURCHASE),
+        new SubscriptionAutomationEmailPattern($this->cdnAssetUrl, SubscriptionAutomationEmailPattern::VARIANT_RENEWAL),
+        new SubscriptionAutomationEmailPattern($this->cdnAssetUrl, SubscriptionAutomationEmailPattern::VARIANT_FAILED_RENEWAL),
       ]);
 
       if ($this->wooCommerceHelper->wcSupportsOrderReviewUrl()) {
@@ -288,6 +292,11 @@ class PatternsController {
         'name' => 'review',
         'label' => _x('Review', 'Block pattern category', 'mailpoet'),
         'description' => __('A collection of review follow-up email layouts.', 'mailpoet'),
+      ];
+      $categories[] = [
+        'name' => 'subscriptions',
+        'label' => _x('Subscriptions', 'Block pattern category', 'mailpoet'),
+        'description' => __('A collection of subscription email layouts.', 'mailpoet'),
       ];
     }
 

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -55,6 +55,9 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/reward-positive-reviewer', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
+    $this->assertContains('mailpoet/subscription-purchase-follow-up', $patternNames);
+    $this->assertContains('mailpoet/subscription-renewal-follow-up', $patternNames);
+    $this->assertContains('mailpoet/subscription-failed-renewal-follow-up', $patternNames);
 
     // WooCommerce 10.8.0+ patterns (uses generated coupon block)
     $this->assertContains('mailpoet/welcome-with-discount-email-content', $patternNames);
@@ -63,7 +66,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(26, $blockPatterns);
+    $this->assertCount(29, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
@@ -124,6 +127,11 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertIsArray($reviewCategory);
     $this->assertEquals('review', $reviewCategory['name']);
     $this->assertNotEmpty($reviewCategory['label']);
+
+    $subscriptionsCategory = $registry->get_registered('subscriptions');
+    $this->assertIsArray($subscriptionsCategory);
+    $this->assertEquals('subscriptions', $subscriptionsCategory['name']);
+    $this->assertNotEmpty($subscriptionsCategory['label']);
   }
 
   public function testItDoesNotRegisterCouponPatternsWhenWooCommerceVersionIsBelowMinimum(): void {
@@ -160,6 +168,9 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/negative-review-follow-up', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
+    $this->assertContains('mailpoet/subscription-purchase-follow-up', $patternNames);
+    $this->assertContains('mailpoet/subscription-renewal-follow-up', $patternNames);
+    $this->assertContains('mailpoet/subscription-failed-renewal-follow-up', $patternNames);
 
     // Should NOT include generated coupon block patterns (require WooCommerce 10.8.0+)
     $this->assertNotContains('mailpoet/welcome-with-discount-email-content', $patternNames);
@@ -169,7 +180,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/reward-positive-reviewer', $patternNames);
 
     // Verify total count (all patterns except 5 coupon patterns)
-    $this->assertCount(21, $blockPatterns);
+    $this->assertCount(24, $blockPatterns);
   }
 
   /**
@@ -405,6 +416,35 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertStringContainsString('Shop again', $content);
   }
 
+  public function testSubscriptionOnboardingPatternsContainSubscriptionCopy(): void {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
+
+    $patterns = new PatternsController(
+      $this->diContainer->get(CdnAssetUrl::class),
+      $this->diContainer->get(WPFunctions::class),
+      $wooCommerceHelper
+    );
+
+    $purchaseContent = $patterns->getPatternContent('subscription-purchase-follow-up');
+    $this->assertIsString($purchaseContent);
+    $this->assertStringContainsString('Welcome to your subscription', $purchaseContent);
+    $this->assertStringContainsString('<!--[mailpoet/subscriber-firstname default="there"]-->', $purchaseContent);
+    $this->assertStringContainsString('<!--[mailpoet/woocommerce-subscription-title]-->', $purchaseContent);
+
+    $renewalContent = $patterns->getPatternContent('subscription-renewal-follow-up');
+    $this->assertIsString($renewalContent);
+    $this->assertStringContainsString('Your subscription renewed', $renewalContent);
+    $this->assertStringContainsString('nothing you need to do right now', $renewalContent);
+
+    $failedRenewalContent = $patterns->getPatternContent('subscription-failed-renewal-follow-up');
+    $this->assertIsString($failedRenewalContent);
+    $this->assertStringContainsString('We couldn’t renew your subscription', $failedRenewalContent);
+    $this->assertStringContainsString('update your payment details', $failedRenewalContent);
+  }
+
   public function testItDoesNotRegisterAskForReviewPatternWhenOrderReviewUrlIsUnsupported(): void {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
@@ -461,6 +501,9 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/abandoned-cart-content', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-reminder-content', $patternNames);
     $this->assertNotContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
+    $this->assertNotContains('mailpoet/subscription-purchase-follow-up', $patternNames);
+    $this->assertNotContains('mailpoet/subscription-renewal-follow-up', $patternNames);
+    $this->assertNotContains('mailpoet/subscription-failed-renewal-follow-up', $patternNames);
 
     // Verify total count (only non-WooCommerce patterns)
     $this->assertCount(9, $blockPatterns);
@@ -496,6 +539,9 @@ class PatternsControllerTest extends \MailPoetTest {
 
     $reviewCategory = $registry->get_registered('review');
     $this->assertNull($reviewCategory);
+
+    $subscriptionsCategory = $registry->get_registered('subscriptions');
+    $this->assertNull($subscriptionsCategory);
   }
 
   public function testItAddsEmailContentToRestResponseForSplitPatterns(): void {


### PR DESCRIPTION
## Description

Adds block-editor email content patterns for subscription automations and registers them in the patterns controller. These patterns back the subscription onboarding/purchase automation templates.

## Code review notes

_N/A_

## QA notes

With WooCommerce Subscriptions active, open the subscription automation templates in the email editor and confirm the subscription email content renders.

## Linked PRs

Premium: mailpoet/mailpoet-premium#1100

## Linked tickets

STOMAIL-8126

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I added sufficient test coverage
