### PR TITLE
Add subscription retention email content patterns

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SubscriptionAutomationEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SubscriptionAutomationEmailPattern.php
@@ -13,6 +13,9 @@ class SubscriptionAutomationEmailPattern extends Pattern {
   public const VARIANT_PURCHASE = 'purchase';
   public const VARIANT_RENEWAL = 'renewal';
   public const VARIANT_FAILED_RENEWAL = 'failed-renewal';
+  public const VARIANT_CHURNED = 'churned';
+  public const VARIANT_TRIAL_ENDED = 'trial-ended';
+  public const VARIANT_WIN_BACK = 'win-back';
 
   protected $name = 'subscription-purchase-follow-up';
   protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
@@ -34,6 +37,12 @@ class SubscriptionAutomationEmailPattern extends Pattern {
       $this->name = 'subscription-renewal-follow-up';
     } elseif ($variant === self::VARIANT_FAILED_RENEWAL) {
       $this->name = 'subscription-failed-renewal-follow-up';
+    } elseif ($variant === self::VARIANT_CHURNED) {
+      $this->name = 'subscription-churned-follow-up';
+    } elseif ($variant === self::VARIANT_TRIAL_ENDED) {
+      $this->name = 'subscription-trial-ended-follow-up';
+    } elseif ($variant === self::VARIANT_WIN_BACK) {
+      $this->name = 'subscription-win-back';
     }
   }
 
@@ -80,6 +89,69 @@ class SubscriptionAutomationEmailPattern extends Pattern {
       );
     }
 
+    if ($this->variant === self::VARIANT_CHURNED) {
+      return $this->buildContent(
+        __('We’d value your feedback', 'mailpoet'),
+        [
+          sprintf(
+            /* translators: %s: Subscriber first name personalization tag */
+            __('Hi %s, we noticed your subscription has ended. We’re sorry to see you go.', 'mailpoet'),
+            $this->getSubscriberFirstNameTag()
+          ),
+          sprintf(
+            /* translators: %s: WooCommerce subscription title personalization tag */
+            __('If %s was not the right fit, we’d be grateful to know what would have made it better for you.', 'mailpoet'),
+            '<!--[mailpoet/woocommerce-subscription-title]-->'
+          ),
+          __('You can reply directly to this email. Every note helps us improve the experience for future subscribers.', 'mailpoet'),
+        ],
+        __('Visit our site', 'mailpoet'),
+        __('Thanks for your feedback,', 'mailpoet')
+      );
+    }
+
+    if ($this->variant === self::VARIANT_TRIAL_ENDED) {
+      return $this->buildContent(
+        __('Your trial has ended', 'mailpoet'),
+        [
+          sprintf(
+            /* translators: %s: Subscriber first name personalization tag */
+            __('Hi %s, thanks for trying us. We hope your trial gave you a useful look at what’s included.', 'mailpoet'),
+            $this->getSubscriberFirstNameTag()
+          ),
+          sprintf(
+            /* translators: %s: WooCommerce subscription title personalization tag */
+            __('If %s helped you, you can keep the benefits going from your account on our site.', 'mailpoet'),
+            '<!--[mailpoet/woocommerce-subscription-title]-->'
+          ),
+          __('Still deciding? Reply with any questions and we’ll help you choose the next step.', 'mailpoet'),
+        ],
+        __('Visit our site', 'mailpoet'),
+        __('Thanks for trying us,', 'mailpoet')
+      );
+    }
+
+    if ($this->variant === self::VARIANT_WIN_BACK) {
+      return $this->buildContent(
+        __('See what’s new', 'mailpoet'),
+        [
+          sprintf(
+            /* translators: %s: Subscriber first name personalization tag */
+            __('Hi %s, it’s been a while since your subscription ended, and we’d love to welcome you back.', 'mailpoet'),
+            $this->getSubscriberFirstNameTag()
+          ),
+          sprintf(
+            /* translators: %s: WooCommerce subscription title personalization tag */
+            __('We’ve been improving the experience around %s, with new reasons to give it another look.', 'mailpoet'),
+            '<!--[mailpoet/woocommerce-subscription-title]-->'
+          ),
+          __('When you’re ready, visit our site to see what’s changed and start again.', 'mailpoet'),
+        ],
+        __('Visit our site', 'mailpoet'),
+        __('Hope to see you again,', 'mailpoet')
+      );
+    }
+
     return $this->buildContent(
       __('Welcome to your subscription', 'mailpoet'),
       [
@@ -107,6 +179,18 @@ class SubscriptionAutomationEmailPattern extends Pattern {
 
     if ($this->variant === self::VARIANT_FAILED_RENEWAL) {
       return __('Subscription Failed Renewal Follow-up', 'mailpoet');
+    }
+
+    if ($this->variant === self::VARIANT_CHURNED) {
+      return __('Subscription Churned Follow-up', 'mailpoet');
+    }
+
+    if ($this->variant === self::VARIANT_TRIAL_ENDED) {
+      return __('Subscription Trial Ended Follow-up', 'mailpoet');
+    }
+
+    if ($this->variant === self::VARIANT_WIN_BACK) {
+      return __('Subscription Win-back', 'mailpoet');
     }
 
     return __('Subscription Purchase Follow-up', 'mailpoet');

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
@@ -4,7 +4,6 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
-use MailPoet\Util\CdnAssetUrl;
 
 /**
  * Welcome email pattern for new subscribers.
@@ -16,38 +15,12 @@ class WelcomeEmailPattern extends Pattern {
   protected $categories = ['welcome'];
   protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
-  /** @var string */
-  private $variant;
-
-  public function __construct(
-    CdnAssetUrl $cdnAssetUrl,
-    string $variant = 'welcome'
-  ) {
-    parent::__construct($cdnAssetUrl);
-    $this->variant = $variant;
-    if ($variant === 'subscription-churned') {
-      $this->name = 'subscription-churned-follow-up';
-      $this->categories = ['subscriptions'];
-    } elseif ($variant === 'subscription-trial-ending') {
-      $this->name = 'subscription-trial-ending-follow-up';
-      $this->categories = ['subscriptions'];
-    }
-  }
-
   /**
    * Get pattern content.
    *
    * @return string Pattern HTML content.
    */
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    if ($this->variant === 'subscription-churned') {
-      return $this->getSubscriptionChurnedContent();
-    }
-
-    if ($this->variant === 'subscription-trial-ending') {
-      return $this->getSubscriptionTrialEndingContent();
-    }
-
     return '
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
@@ -101,87 +74,7 @@ class WelcomeEmailPattern extends Pattern {
     ';
   }
 
-  private function getSubscriptionChurnedContent(): string {
-    return '
-    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
-      <!-- wp:heading {"level":1} -->
-      <h1 class="wp-block-heading">' . __('Can we ask why you left?', 'mailpoet') . '</h1>
-      <!-- /wp:heading -->
-
-      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
-      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('We noticed your subscription ended. If something did not work for you, we would appreciate your feedback.', 'mailpoet') . '</p>
-      <!-- /wp:paragraph -->
-
-      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
-      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('Your thoughts help us improve the experience for every subscriber.', 'mailpoet') . '</p>
-      <!-- /wp:paragraph -->
-
-      <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
-      <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">
-      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Share feedback', 'mailpoet') . '</a></div>
-      <!-- /wp:button -->
-      </div>
-      <!-- /wp:buttons -->
-
-      <!-- wp:paragraph {"fontSize":"medium"} -->
-      <p class="has-medium-font-size">' . __('Thanks for helping us improve,', 'mailpoet') . '</p>
-      <!-- /wp:paragraph -->
-
-      <!-- wp:paragraph {"fontSize":"medium"} -->
-      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
-      <!-- /wp:paragraph -->
-    </div>
-    <!-- /wp:group -->
-    ';
-  }
-
-  private function getSubscriptionTrialEndingContent(): string {
-    return '
-    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
-      <!-- wp:heading {"level":1} -->
-      <h1 class="wp-block-heading">' . __('How was your trial?', 'mailpoet') . '</h1>
-      <!-- /wp:heading -->
-
-      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
-      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('Your trial is ending soon. Keep your subscription active to continue enjoying everything included.', 'mailpoet') . '</p>
-      <!-- /wp:paragraph -->
-
-      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
-      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('If you have questions before continuing, reply to this email and we will help.', 'mailpoet') . '</p>
-      <!-- /wp:paragraph -->
-
-      <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
-      <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">
-      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Continue subscription', 'mailpoet') . '</a></div>
-      <!-- /wp:button -->
-      </div>
-      <!-- /wp:buttons -->
-
-      <!-- wp:paragraph {"fontSize":"medium"} -->
-      <p class="has-medium-font-size">' . __('We hope you stay with us,', 'mailpoet') . '</p>
-      <!-- /wp:paragraph -->
-
-      <!-- wp:paragraph {"fontSize":"medium"} -->
-      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
-      <!-- /wp:paragraph -->
-    </div>
-    <!-- /wp:group -->
-    ';
-  }
-
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    if ($this->variant === 'subscription-churned') {
-      return __('Subscription churned follow-up', 'mailpoet');
-    }
-
-    if ($this->variant === 'subscription-trial-ending') {
-      return __('Subscription trial ending follow-up', 'mailpoet');
-    }
-
     /* translators: Name of a content pattern used as starting content of an email */
     return __('Welcome Email', 'mailpoet');
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
@@ -28,6 +28,9 @@ class WelcomeEmailPattern extends Pattern {
     if ($variant === 'subscription-churned') {
       $this->name = 'subscription-churned-follow-up';
       $this->categories = ['subscriptions'];
+    } elseif ($variant === 'subscription-trial-ending') {
+      $this->name = 'subscription-trial-ending-follow-up';
+      $this->categories = ['subscriptions'];
     }
   }
 
@@ -39,6 +42,10 @@ class WelcomeEmailPattern extends Pattern {
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     if ($this->variant === 'subscription-churned') {
       return $this->getSubscriptionChurnedContent();
+    }
+
+    if ($this->variant === 'subscription-trial-ending') {
+      return $this->getSubscriptionTrialEndingContent();
     }
 
     return '
@@ -130,9 +137,49 @@ class WelcomeEmailPattern extends Pattern {
     ';
   }
 
+  private function getSubscriptionTrialEndingContent(): string {
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' . __('How was your trial?', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('Your trial is ending soon. Keep your subscription active to continue enjoying everything included.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('If you have questions before continuing, reply to this email and we will help.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
+      <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Continue subscription', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . __('We hope you stay with us,', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     if ($this->variant === 'subscription-churned') {
       return __('Subscription churned follow-up', 'mailpoet');
+    }
+
+    if ($this->variant === 'subscription-trial-ending') {
+      return __('Subscription trial ending follow-up', 'mailpoet');
     }
 
     /* translators: Name of a content pattern used as starting content of an email */

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+use MailPoet\Util\CdnAssetUrl;
 
 /**
  * Welcome email pattern for new subscribers.
@@ -15,12 +16,31 @@ class WelcomeEmailPattern extends Pattern {
   protected $categories = ['welcome'];
   protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
+  /** @var string */
+  private $variant;
+
+  public function __construct(
+    CdnAssetUrl $cdnAssetUrl,
+    string $variant = 'welcome'
+  ) {
+    parent::__construct($cdnAssetUrl);
+    $this->variant = $variant;
+    if ($variant === 'subscription-churned') {
+      $this->name = 'subscription-churned-follow-up';
+      $this->categories = ['subscriptions'];
+    }
+  }
+
   /**
    * Get pattern content.
    *
    * @return string Pattern HTML content.
    */
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->variant === 'subscription-churned') {
+      return $this->getSubscriptionChurnedContent();
+    }
+
     return '
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
@@ -74,7 +94,47 @@ class WelcomeEmailPattern extends Pattern {
     ';
   }
 
+  private function getSubscriptionChurnedContent(): string {
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' . __('Can we ask why you left?', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('We noticed your subscription ended. If something did not work for you, we would appreciate your feedback.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . __('Your thoughts help us improve the experience for every subscriber.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
+      <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Share feedback', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . __('Thanks for helping us improve,', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->variant === 'subscription-churned') {
+      return __('Subscription churned follow-up', 'mailpoet');
+    }
+
     /* translators: Name of a content pattern used as starting content of an email */
     return __('Welcome Email', 'mailpoet');
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -126,6 +126,9 @@ class PatternsController {
         new SubscriptionAutomationEmailPattern($this->cdnAssetUrl, SubscriptionAutomationEmailPattern::VARIANT_PURCHASE),
         new SubscriptionAutomationEmailPattern($this->cdnAssetUrl, SubscriptionAutomationEmailPattern::VARIANT_RENEWAL),
         new SubscriptionAutomationEmailPattern($this->cdnAssetUrl, SubscriptionAutomationEmailPattern::VARIANT_FAILED_RENEWAL),
+        new SubscriptionAutomationEmailPattern($this->cdnAssetUrl, SubscriptionAutomationEmailPattern::VARIANT_CHURNED),
+        new SubscriptionAutomationEmailPattern($this->cdnAssetUrl, SubscriptionAutomationEmailPattern::VARIANT_TRIAL_ENDED),
+        new SubscriptionAutomationEmailPattern($this->cdnAssetUrl, SubscriptionAutomationEmailPattern::VARIANT_WIN_BACK),
       ]);
 
       if ($this->wooCommerceHelper->wcSupportsOrderReviewUrl()) {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -58,6 +58,9 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/subscription-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/subscription-renewal-follow-up', $patternNames);
     $this->assertContains('mailpoet/subscription-failed-renewal-follow-up', $patternNames);
+    $this->assertContains('mailpoet/subscription-churned-follow-up', $patternNames);
+    $this->assertContains('mailpoet/subscription-trial-ended-follow-up', $patternNames);
+    $this->assertContains('mailpoet/subscription-win-back', $patternNames);
 
     // WooCommerce 10.8.0+ patterns (uses generated coupon block)
     $this->assertContains('mailpoet/welcome-with-discount-email-content', $patternNames);
@@ -66,7 +69,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(29, $blockPatterns);
+    $this->assertCount(32, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
@@ -171,6 +174,9 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/subscription-purchase-follow-up', $patternNames);
     $this->assertContains('mailpoet/subscription-renewal-follow-up', $patternNames);
     $this->assertContains('mailpoet/subscription-failed-renewal-follow-up', $patternNames);
+    $this->assertContains('mailpoet/subscription-churned-follow-up', $patternNames);
+    $this->assertContains('mailpoet/subscription-trial-ended-follow-up', $patternNames);
+    $this->assertContains('mailpoet/subscription-win-back', $patternNames);
 
     // Should NOT include generated coupon block patterns (require WooCommerce 10.8.0+)
     $this->assertNotContains('mailpoet/welcome-with-discount-email-content', $patternNames);
@@ -180,7 +186,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/reward-positive-reviewer', $patternNames);
 
     // Verify total count (all patterns except 5 coupon patterns)
-    $this->assertCount(24, $blockPatterns);
+    $this->assertCount(27, $blockPatterns);
   }
 
   /**
@@ -443,6 +449,21 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertIsString($failedRenewalContent);
     $this->assertStringContainsString('We couldn’t renew your subscription', $failedRenewalContent);
     $this->assertStringContainsString('update your payment details', $failedRenewalContent);
+
+    $churnedContent = $patterns->getPatternContent('subscription-churned-follow-up');
+    $this->assertIsString($churnedContent);
+    $this->assertStringContainsString('We’d value your feedback', $churnedContent);
+    $this->assertStringContainsString('reply directly to this email', $churnedContent);
+
+    $trialEndedContent = $patterns->getPatternContent('subscription-trial-ended-follow-up');
+    $this->assertIsString($trialEndedContent);
+    $this->assertStringContainsString('Your trial has ended', $trialEndedContent);
+    $this->assertStringContainsString('Still deciding?', $trialEndedContent);
+
+    $winBackContent = $patterns->getPatternContent('subscription-win-back');
+    $this->assertIsString($winBackContent);
+    $this->assertStringContainsString('See what’s new', $winBackContent);
+    $this->assertStringContainsString('welcome you back', $winBackContent);
   }
 
   public function testItDoesNotRegisterAskForReviewPatternWhenOrderReviewUrlIsUnsupported(): void {
@@ -504,6 +525,9 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/subscription-purchase-follow-up', $patternNames);
     $this->assertNotContains('mailpoet/subscription-renewal-follow-up', $patternNames);
     $this->assertNotContains('mailpoet/subscription-failed-renewal-follow-up', $patternNames);
+    $this->assertNotContains('mailpoet/subscription-churned-follow-up', $patternNames);
+    $this->assertNotContains('mailpoet/subscription-trial-ended-follow-up', $patternNames);
+    $this->assertNotContains('mailpoet/subscription-win-back', $patternNames);
 
     // Verify total count (only non-WooCommerce patterns)
     $this->assertCount(9, $blockPatterns);


### PR DESCRIPTION
## Description

Adds block-editor email content patterns for the subscription retention automations (churned subscription, trial ended, win-back) and registers them in the patterns controller.

## Code review notes

_N/A_

## QA notes

With WooCommerce Subscriptions active, open the subscription retention automation templates in the email editor and confirm the content renders.

## Linked PRs

Premium: mailpoet/mailpoet-premium#1101

## Linked tickets

STOMAIL-8127

## After-merge notes

No changelog on this branch by design — the subscription automation changelog from STOMAIL-8126 (already in trunk) covers this release.

## Tasks

- [x] I added sufficient test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Code Review: 1 Suggestion

**Suggestion (1):**
- **Unescaped HTML Output in buildContent Method** - The `buildContent()` method in `SubscriptionAutomationEmailPattern.php` (lines 207, 215, 223, 229) directly concatenates parameters (`$paragraph`, `$heading`, `$buttonText`, `$signoff`) into HTML output without escaping. While the current implementation is safe because these parameters are sourced from translation strings and hardcoded template placeholders, this pattern could introduce XSS vulnerabilities if the method is extended in the future to accept dynamic user input. Consider adding appropriate escaping (e.g., `esc_html()`, `wp_kses_post()`) or documenting that only static template content is intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->