### PR TITLE
Add booking confirmation email content patterns

### DIFF
--- a/mailpoet/changelog/2026-06-03-15-53-26-added-booking-email-content-patterns-for-automation-temp.md
+++ b/mailpoet/changelog/2026-06-03-15-53-26-added-booking-email-content-patterns-for-automation-temp.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Booking email content patterns for automation templates

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -90,6 +90,7 @@ class SendEmailAction implements Action {
     'woocommerce:buys-a-product',
     'woocommerce-bookings:booking-created',
     'woocommerce-bookings:booking-status-changed',
+    'woocommerce-bookings:booking-starts',
   ];
 
   private AutomationController $automationController;

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/BookingAutomationEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/BookingAutomationEmailPattern.php
@@ -1,0 +1,170 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+use MailPoet\Util\CdnAssetUrl;
+
+/**
+ * Booking automation email pattern.
+ */
+class BookingAutomationEmailPattern extends Pattern {
+  public const VARIANT_ABANDONED_SPOT = 'abandoned-spot';
+  public const VARIANT_NEW_BOOKING = 'new-booking';
+  public const VARIANT_PRE_VISIT_REMINDER = 'pre-visit-reminder';
+
+  protected $name = 'booking-abandoned-spot';
+  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $categories = ['bookings'];
+  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+  /** @var string */
+  private $variant;
+
+  public function __construct(
+    CdnAssetUrl $cdnAssetUrl,
+    string $variant
+  ) {
+    parent::__construct($cdnAssetUrl);
+    $this->variant = $variant;
+
+    if ($variant === self::VARIANT_NEW_BOOKING) {
+      $this->name = 'booking-new-booking-follow-up';
+    } elseif ($variant === self::VARIANT_PRE_VISIT_REMINDER) {
+      $this->name = 'booking-pre-visit-reminder';
+    }
+  }
+
+  protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->variant === self::VARIANT_NEW_BOOKING) {
+      return $this->buildContent(
+        __('Your booking is confirmed', 'mailpoet'),
+        [
+          sprintf(
+            /* translators: %s: Subscriber first name personalization tag */
+            __('Hi %s, your booking is confirmed. We’re looking forward to seeing you.', 'mailpoet'),
+            $this->getSubscriberFirstNameTag()
+          ),
+          sprintf(
+            /* translators: %s: WooCommerce booking product name personalization tag */
+            __('You booked %s. Keep this email handy so the details are easy to find.', 'mailpoet'),
+            '<!--[mailpoet/woocommerce-booking-product-name]-->'
+          ),
+          $this->getBookingDetailsCopy(),
+          __('If anything changes or you have questions before your visit, reply to this email and we’ll help.', 'mailpoet'),
+        ],
+        __('Visit our site', 'mailpoet'),
+        __('See you soon,', 'mailpoet')
+      );
+    }
+
+    if ($this->variant === self::VARIANT_PRE_VISIT_REMINDER) {
+      return $this->buildContent(
+        __('Your booking is coming up', 'mailpoet'),
+        [
+          sprintf(
+            /* translators: %s: Subscriber first name personalization tag */
+            __('Hi %s, this is a friendly reminder about your upcoming booking.', 'mailpoet'),
+            $this->getSubscriberFirstNameTag()
+          ),
+          $this->getBookingDetailsCopy(),
+          __('Please arrive a few minutes early so we can get everything started on time. Reply to this email if you need to make a change.', 'mailpoet'),
+        ],
+        __('Visit our site', 'mailpoet'),
+        __('We’ll see you soon,', 'mailpoet')
+      );
+    }
+
+    return $this->buildContent(
+      __('Your booking spot is waiting', 'mailpoet'),
+      [
+        sprintf(
+          /* translators: %s: Subscriber first name personalization tag */
+          __('Hi %s, it looks like you started a booking but did not finish reserving your spot.', 'mailpoet'),
+          $this->getSubscriberFirstNameTag()
+        ),
+        sprintf(
+          /* translators: %s: WooCommerce booking product name personalization tag */
+          __('If you still want to book %s, come back and complete your reservation while availability is still open.', 'mailpoet'),
+          '<!--[mailpoet/woocommerce-booking-product-name]-->'
+        ),
+        __('Booking availability can change quickly, so finishing sooner gives you the best chance of keeping the time you selected.', 'mailpoet'),
+      ],
+      __('Return to our site', 'mailpoet'),
+      __('Hope to see you soon,', 'mailpoet')
+    );
+  }
+
+  protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    if ($this->variant === self::VARIANT_NEW_BOOKING) {
+      return __('Booking Confirmation Follow-up', 'mailpoet');
+    }
+
+    if ($this->variant === self::VARIANT_PRE_VISIT_REMINDER) {
+      return __('Booking Pre-visit Reminder', 'mailpoet');
+    }
+
+    return __('Abandoned Booking Reminder', 'mailpoet');
+  }
+
+  /**
+   * @param string[] $paragraphs
+   */
+  private function buildContent(string $heading, array $paragraphs, string $buttonText, string $signoff): string {
+    $paragraphBlocks = '';
+    foreach ($paragraphs as $paragraph) {
+      $paragraphBlocks .= '
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' . $paragraph . '</p>
+      <!-- /wp:paragraph -->';
+    }
+
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' . $heading . '</h1>
+      <!-- /wp:heading -->
+
+      ' . $paragraphBlocks . '
+
+      <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
+      <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . $buttonText . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . $signoff . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  private function getBookingDetailsCopy(): string {
+    return sprintf(
+      /* translators: 1: WooCommerce booking start date tag, 2: WooCommerce booking end date tag, 3: WooCommerce booking persons count tag */
+      __('Details: starts %1$s, ends %2$s, for %3$s person(s).', 'mailpoet'),
+      '<!--[mailpoet/woocommerce-booking-start-date]-->',
+      '<!--[mailpoet/woocommerce-booking-end-date]-->',
+      '<!--[mailpoet/woocommerce-booking-persons-count]-->'
+    );
+  }
+
+  private function getSubscriberFirstNameTag(): string {
+    return sprintf(
+      '<!--[mailpoet/subscriber-firstname default="%s"]-->',
+      /* translators: Default placeholder used when no subscriber name is available in "Hi %s" */
+      esc_attr(_x('there', 'subscriber name placeholder', 'mailpoet'))
+    );
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -7,6 +7,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartRem
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartWithDiscountPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AskForReviewPostPurchasePattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\BirthdayEmailPattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\BookingAutomationEmailPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\CategoryPurchaseFollowUpPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EducationalCampaignPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EventInvitationPattern;
@@ -129,6 +130,9 @@ class PatternsController {
         new SubscriptionAutomationEmailPattern($this->cdnAssetUrl, SubscriptionAutomationEmailPattern::VARIANT_CHURNED),
         new SubscriptionAutomationEmailPattern($this->cdnAssetUrl, SubscriptionAutomationEmailPattern::VARIANT_TRIAL_ENDED),
         new SubscriptionAutomationEmailPattern($this->cdnAssetUrl, SubscriptionAutomationEmailPattern::VARIANT_WIN_BACK),
+        new BookingAutomationEmailPattern($this->cdnAssetUrl, BookingAutomationEmailPattern::VARIANT_ABANDONED_SPOT),
+        new BookingAutomationEmailPattern($this->cdnAssetUrl, BookingAutomationEmailPattern::VARIANT_NEW_BOOKING),
+        new BookingAutomationEmailPattern($this->cdnAssetUrl, BookingAutomationEmailPattern::VARIANT_PRE_VISIT_REMINDER),
       ]);
 
       if ($this->wooCommerceHelper->wcSupportsOrderReviewUrl()) {
@@ -300,6 +304,11 @@ class PatternsController {
         'name' => 'subscriptions',
         'label' => _x('Subscriptions', 'Block pattern category', 'mailpoet'),
         'description' => __('A collection of subscription email layouts.', 'mailpoet'),
+      ];
+      $categories[] = [
+        'name' => 'bookings',
+        'label' => _x('Bookings', 'Block pattern category', 'mailpoet'),
+        'description' => __('A collection of booking email layouts.', 'mailpoet'),
       ];
     }
 

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -337,6 +337,14 @@ class Functions {
     return get_post_type($post);
   }
 
+  /**
+   * @param string $status
+   * @return object|null
+   */
+  public function getPostStatusObject($status) {
+    return get_post_status_object($status);
+  }
+
   public function getPosts(?array $args = null) {
     return get_posts($args);
   }

--- a/mailpoet/lib/WooCommerce/WooCommerceBookings/Helper.php
+++ b/mailpoet/lib/WooCommerce/WooCommerceBookings/Helper.php
@@ -48,7 +48,12 @@ class Helper {
       if (!$object) {
         continue;
       }
-      $label = is_string($object->label ?? null) && $object->label !== '' ? $object->label : ucwords(str_replace('-', ' ', $cartStatus));
+      // WordPress falls back the label to the status key when a post status registers
+      // label => false (as Bookings does for was-in-cart), so humanize it in that case.
+      $label = $object->label ?? '';
+      if (!is_string($label) || $label === '' || $label === $cartStatus) {
+        $label = ucwords(str_replace('-', ' ', $cartStatus));
+      }
       $statuses[$cartStatus] = $label;
     }
 

--- a/mailpoet/lib/WooCommerce/WooCommerceBookings/Helper.php
+++ b/mailpoet/lib/WooCommerce/WooCommerceBookings/Helper.php
@@ -18,12 +18,41 @@ class Helper {
     return $this->wp->isPluginActive('woocommerce-bookings/woocommerce-bookings.php');
   }
 
+  /**
+   * Returns all booking statuses keyed by status with their labels.
+   *
+   * WooCommerce Bookings splits its statuses across several "contexts" and none of them
+   * exposes every status, so we merge them. We also add the cart statuses, which Bookings
+   * registers as post statuses but leaves out of the contexts above (in particular the
+   * internal "was-in-cart" status that the abandoned booking automation relies on).
+   *
+   * @return array<string, string>
+   */
   public function getBookingStatuses(): array {
     if (!function_exists('get_wc_booking_statuses')) {
       return [];
     }
 
-    return get_wc_booking_statuses('fully_booked', true);
+    $statuses = [];
+    foreach (['fully_booked', 'user', 'cancel', 'scheduled'] as $context) {
+      foreach (get_wc_booking_statuses($context, true) as $status => $label) {
+        $statuses[$status] = $label;
+      }
+    }
+
+    foreach (['in-cart', 'was-in-cart'] as $cartStatus) {
+      if (isset($statuses[$cartStatus])) {
+        continue;
+      }
+      $object = $this->wp->getPostStatusObject($cartStatus);
+      if (!$object) {
+        continue;
+      }
+      $label = is_string($object->label ?? null) && $object->label !== '' ? $object->label : ucwords(str_replace('-', ' ', $cartStatus));
+      $statuses[$cartStatus] = $label;
+    }
+
+    return $statuses;
   }
 
   /**

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -881,6 +881,13 @@ class SendEmailActionTest extends \MailPoetTest {
       'expected_type' => NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
     ];
 
+    $bookingStartsTrigger = new Step('trigger', Step::TYPE_TRIGGER, 'woocommerce-bookings:booking-starts', [], [new NextStep('emailstep')]);
+
+    $isTransactionalWithBookingStarts = [
+      'steps' => [$root, $bookingStartsTrigger, $emailStep],
+      'expected_type' => NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
+    ];
+
     $orderPaidTrigger = new Step('trigger', Step::TYPE_TRIGGER, 'woocommerce:order-paid', [], [new NextStep('emailstep')]);
 
     $isTransactionalWithOrderPaid = [
@@ -899,6 +906,7 @@ class SendEmailActionTest extends \MailPoetTest {
       'is_marketing_with_delay_in_branch' => $isMarketingWithDelayInBranch,
       'is_transactional_with_booking_created' => $isTransactionalWithBookingCreated,
       'is_transactional_with_booking_status_changed' => $isTransactionalWithBookingStatusChanged,
+      'is_transactional_with_booking_starts' => $isTransactionalWithBookingStarts,
       'is_transactional_with_order_paid' => $isTransactionalWithOrderPaid,
     ];
   }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -493,6 +493,27 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertStringContainsString('arrive a few minutes early', $preVisitContent);
   }
 
+  public function testBookingNewBookingFollowUpPatternContainsBookingCopy(): void {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
+
+    $patterns = new PatternsController(
+      $this->diContainer->get(CdnAssetUrl::class),
+      $this->diContainer->get(WPFunctions::class),
+      $wooCommerceHelper
+    );
+
+    $content = $patterns->getPatternContent('booking-new-booking-follow-up');
+
+    $this->assertIsString($content);
+    $this->assertStringContainsString('Your booking is confirmed', $content);
+    $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-product-name]-->', $content);
+    $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-start-date]-->', $content);
+    $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-end-date]-->', $content);
+  }
+
   public function testItDoesNotRegisterAskForReviewPatternWhenOrderReviewUrlIsUnsupported(): void {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -61,6 +61,9 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/subscription-churned-follow-up', $patternNames);
     $this->assertContains('mailpoet/subscription-trial-ended-follow-up', $patternNames);
     $this->assertContains('mailpoet/subscription-win-back', $patternNames);
+    $this->assertContains('mailpoet/booking-abandoned-spot', $patternNames);
+    $this->assertContains('mailpoet/booking-new-booking-follow-up', $patternNames);
+    $this->assertContains('mailpoet/booking-pre-visit-reminder', $patternNames);
 
     // WooCommerce 10.8.0+ patterns (uses generated coupon block)
     $this->assertContains('mailpoet/welcome-with-discount-email-content', $patternNames);
@@ -69,7 +72,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(32, $blockPatterns);
+    $this->assertCount(35, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
@@ -135,6 +138,11 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertIsArray($subscriptionsCategory);
     $this->assertEquals('subscriptions', $subscriptionsCategory['name']);
     $this->assertNotEmpty($subscriptionsCategory['label']);
+
+    $bookingsCategory = $registry->get_registered('bookings');
+    $this->assertIsArray($bookingsCategory);
+    $this->assertEquals('bookings', $bookingsCategory['name']);
+    $this->assertNotEmpty($bookingsCategory['label']);
   }
 
   public function testItDoesNotRegisterCouponPatternsWhenWooCommerceVersionIsBelowMinimum(): void {
@@ -177,6 +185,9 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/subscription-churned-follow-up', $patternNames);
     $this->assertContains('mailpoet/subscription-trial-ended-follow-up', $patternNames);
     $this->assertContains('mailpoet/subscription-win-back', $patternNames);
+    $this->assertContains('mailpoet/booking-abandoned-spot', $patternNames);
+    $this->assertContains('mailpoet/booking-new-booking-follow-up', $patternNames);
+    $this->assertContains('mailpoet/booking-pre-visit-reminder', $patternNames);
 
     // Should NOT include generated coupon block patterns (require WooCommerce 10.8.0+)
     $this->assertNotContains('mailpoet/welcome-with-discount-email-content', $patternNames);
@@ -186,7 +197,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/reward-positive-reviewer', $patternNames);
 
     // Verify total count (all patterns except 5 coupon patterns)
-    $this->assertCount(27, $blockPatterns);
+    $this->assertCount(30, $blockPatterns);
   }
 
   /**
@@ -464,6 +475,22 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertIsString($winBackContent);
     $this->assertStringContainsString('See what’s new', $winBackContent);
     $this->assertStringContainsString('welcome you back', $winBackContent);
+
+    $abandonedBookingContent = $patterns->getPatternContent('booking-abandoned-spot');
+    $this->assertIsString($abandonedBookingContent);
+    $this->assertStringContainsString('Your booking spot is waiting', $abandonedBookingContent);
+    $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-product-name]-->', $abandonedBookingContent);
+    $this->assertStringContainsString('Return to our site', $abandonedBookingContent);
+
+    $newBookingContent = $patterns->getPatternContent('booking-new-booking-follow-up');
+    $this->assertIsString($newBookingContent);
+    $this->assertStringContainsString('Your booking is confirmed', $newBookingContent);
+    $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-start-date]-->', $newBookingContent);
+
+    $preVisitContent = $patterns->getPatternContent('booking-pre-visit-reminder');
+    $this->assertIsString($preVisitContent);
+    $this->assertStringContainsString('Your booking is coming up', $preVisitContent);
+    $this->assertStringContainsString('arrive a few minutes early', $preVisitContent);
   }
 
   public function testItDoesNotRegisterAskForReviewPatternWhenOrderReviewUrlIsUnsupported(): void {
@@ -528,6 +555,9 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/subscription-churned-follow-up', $patternNames);
     $this->assertNotContains('mailpoet/subscription-trial-ended-follow-up', $patternNames);
     $this->assertNotContains('mailpoet/subscription-win-back', $patternNames);
+    $this->assertNotContains('mailpoet/booking-abandoned-spot', $patternNames);
+    $this->assertNotContains('mailpoet/booking-new-booking-follow-up', $patternNames);
+    $this->assertNotContains('mailpoet/booking-pre-visit-reminder', $patternNames);
 
     // Verify total count (only non-WooCommerce patterns)
     $this->assertCount(9, $blockPatterns);
@@ -566,6 +596,9 @@ class PatternsControllerTest extends \MailPoetTest {
 
     $subscriptionsCategory = $registry->get_registered('subscriptions');
     $this->assertNull($subscriptionsCategory);
+
+    $bookingsCategory = $registry->get_registered('bookings');
+    $this->assertNull($bookingsCategory);
   }
 
   public function testItAddsEmailContentToRestResponseForSplitPatterns(): void {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -529,7 +529,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $content = $patterns->getPatternContent('booking-pre-visit-reminder');
 
     $this->assertIsString($content);
-    $this->assertStringContainsString('A reminder about your upcoming booking', $content);
+    $this->assertStringContainsString('Your booking is coming up', $content);
     $this->assertStringContainsString('Please arrive a few minutes early', $content);
     $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-start-date]-->', $content);
     $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-end-date]-->', $content);

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -514,6 +514,27 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-end-date]-->', $content);
   }
 
+  public function testBookingPreVisitReminderPatternContainsBookingCopy(): void {
+    $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
+    $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
+    $wooCommerceHelper->method('getWooCommerceVersion')->willReturn('10.8.0');
+    $wooCommerceHelper->method('wcSupportsOrderReviewUrl')->willReturn(true);
+
+    $patterns = new PatternsController(
+      $this->diContainer->get(CdnAssetUrl::class),
+      $this->diContainer->get(WPFunctions::class),
+      $wooCommerceHelper
+    );
+
+    $content = $patterns->getPatternContent('booking-pre-visit-reminder');
+
+    $this->assertIsString($content);
+    $this->assertStringContainsString('A reminder about your upcoming booking', $content);
+    $this->assertStringContainsString('Please arrive a few minutes early', $content);
+    $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-start-date]-->', $content);
+    $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-end-date]-->', $content);
+  }
+
   public function testItDoesNotRegisterAskForReviewPatternWhenOrderReviewUrlIsUnsupported(): void {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);


### PR DESCRIPTION
## Description

Adds block-editor email content patterns for the booking confirmation automations (abandoned booking, booking confirmation, pre-visit reminder), and makes the booking status triggers list every booking status.

## Code review notes

`getBookingStatuses()` now merges all `get_wc_booking_statuses()` contexts and adds the registered cart statuses, so the status-changed trigger can target any status (including the internal `was-in-cart`, whose blank label is humanized).

## QA notes

With WooCommerce Bookings active, open the booking confirmation automation templates in the email editor and confirm the content renders. In the booking status-changed trigger, confirm the status dropdown lists all statuses with readable labels.

## Linked PRs

Premium: mailpoet/mailpoet-premium#1102

## Linked tickets

STOMAIL-8128

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I added sufficient test coverage

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8128-add-email-templates-for-booking-confirmation-automations)

_The latest successful build from `stomail-8128-add-email-templates-for-booking-confirmation-automations` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->