### PR TITLE
Fix CAPTCHA page reset on update

### DIFF
--- a/mailpoet/changelog/2026-06-16-18-53-17-fixed-custom-captcha-page-selection-after-updates.md
+++ b/mailpoet/changelog/2026-06-16-18-53-17-fixed-custom-captcha-page-selection-after-updates.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Custom CAPTCHA page selection no longer reset after plugin update

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -218,7 +218,9 @@ class Populator {
       $captchaPageId = $captchaPage->ID;
     }
 
-    $this->settings->set('subscription.pages.captcha', $captchaPageId);
+    if (empty($this->settings->get('subscription.pages.captcha'))) {
+      $this->settings->set('subscription.pages.captcha', $captchaPageId);
+    }
   }
 
   private function createDefaultSettings() {

--- a/mailpoet/tests/integration/Config/PopulatorTest.php
+++ b/mailpoet/tests/integration/Config/PopulatorTest.php
@@ -6,6 +6,8 @@ use MailPoet\Config\Populator;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterTemplateEntity;
+use MailPoet\Settings\Pages;
+use MailPoet\Settings\SettingsController;
 use MailPoetTest;
 use MailPoetVendor\Doctrine\ORM\Query;
 
@@ -122,6 +124,18 @@ class PopulatorTest extends MailPoetTest {
     $populator->up();
     $templates = $this->getAllTemplates();
     $this->assertSame(self::TEMPLATE_COUNT, count($templates));
+  }
+
+  public function testItPreservesExistingCaptchaPageSetting(): void {
+    $populator = $this->diContainer->get(Populator::class);
+    $settings = $this->diContainer->get(SettingsController::class);
+    $customCaptchaPageId = Pages::createMailPoetPage('custom-captcha-page');
+
+    $settings->set('subscription.pages.captcha', $customCaptchaPageId);
+
+    $populator->up();
+
+    $this->assertSame($customCaptchaPageId, (int)$settings->get('subscription.pages.captcha'));
   }
 
   private function getAllOptionFields(): array {


### PR DESCRIPTION
## Description

Fixes STOMAIL-8191 by preserving a custom built-in CAPTCHA page selection when MailPoet population runs during plugin updates.

## Code review notes

`Populator::createMailPoetPage()` still creates the default CAPTCHA page when missing; it now only writes `subscription.pages.captcha` when no CAPTCHA page is saved.

## QA notes

_N/A_
## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8191

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8191-custom-captcha-page-resets-after-updates)

_The latest successful build from `stomail-8191-custom-captcha-page-resets-after-updates` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issues Addressed

**1 Bug**
- Fixed an issue where custom CAPTCHA page selections were being reset during MailPoet's population process on plugin updates (STOMAIL-8191)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->