### PR TITLE
Add booking follow-up email content patterns

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/BookingAutomationEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/BookingAutomationEmailPattern.php
@@ -13,6 +13,10 @@ class BookingAutomationEmailPattern extends Pattern {
   public const VARIANT_ABANDONED_SPOT = 'abandoned-spot';
   public const VARIANT_NEW_BOOKING = 'new-booking';
   public const VARIANT_PRE_VISIT_REMINDER = 'pre-visit-reminder';
+  public const VARIANT_PRE_VISIT_WHAT_TO_EXPECT = 'pre-visit-what-to-expect';
+  public const VARIANT_PRE_VISIT_TIPS = 'pre-visit-tips';
+  public const VARIANT_POST_VISIT_REVIEW = 'post-visit-review';
+  public const VARIANT_NEXT_BOOKING_NUDGE = 'next-booking-nudge';
 
   protected $name = 'booking-abandoned-spot';
   protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
@@ -34,6 +38,14 @@ class BookingAutomationEmailPattern extends Pattern {
       $this->name = 'booking-new-booking-follow-up';
     } elseif ($variant === self::VARIANT_PRE_VISIT_REMINDER) {
       $this->name = 'booking-pre-visit-reminder';
+    } elseif ($variant === self::VARIANT_PRE_VISIT_WHAT_TO_EXPECT) {
+      $this->name = 'booking-pre-visit-what-to-expect';
+    } elseif ($variant === self::VARIANT_PRE_VISIT_TIPS) {
+      $this->name = 'booking-pre-visit-tips';
+    } elseif ($variant === self::VARIANT_POST_VISIT_REVIEW) {
+      $this->name = 'booking-post-visit-review';
+    } elseif ($variant === self::VARIANT_NEXT_BOOKING_NUDGE) {
+      $this->name = 'booking-next-booking-nudge';
     }
   }
 
@@ -77,6 +89,78 @@ class BookingAutomationEmailPattern extends Pattern {
       );
     }
 
+    if ($this->variant === self::VARIANT_PRE_VISIT_WHAT_TO_EXPECT) {
+      return $this->buildContent(
+        __('What to expect at your booking', 'mailpoet'),
+        [
+          sprintf(
+            /* translators: 1: Subscriber first name personalization tag, 2: WooCommerce booking product name personalization tag */
+            __('Hi %1$s, here are a few details for your upcoming %2$s booking.', 'mailpoet'),
+            $this->getSubscriberFirstNameTag(),
+            '<!--[mailpoet/woocommerce-booking-product-name]-->'
+          ),
+          $this->getBookingDetailsCopy(),
+          __('Please arrive a few minutes early and bring anything you need for the visit. If you have questions, reply to this email before your appointment.', 'mailpoet'),
+        ],
+        __('View our site', 'mailpoet'),
+        __('See you soon,', 'mailpoet')
+      );
+    }
+
+    if ($this->variant === self::VARIANT_PRE_VISIT_TIPS) {
+      return $this->buildContent(
+        __('Make the most of your booking', 'mailpoet'),
+        [
+          sprintf(
+            /* translators: 1: Subscriber first name personalization tag, 2: WooCommerce booking product name personalization tag */
+            __('Hi %1$s, your %2$s booking is coming up soon. A little preparation can help you get the most out of it.', 'mailpoet'),
+            $this->getSubscriberFirstNameTag(),
+            '<!--[mailpoet/woocommerce-booking-product-name]-->'
+          ),
+          $this->getBookingDetailsCopy(),
+          __('Review the details, plan enough time before and after your visit, and reply to this email if there is anything we should know ahead of time.', 'mailpoet'),
+        ],
+        __('Review details', 'mailpoet'),
+        __('We’ll see you soon,', 'mailpoet')
+      );
+    }
+
+    if ($this->variant === self::VARIANT_POST_VISIT_REVIEW) {
+      return $this->buildContent(
+        __('How was your booking?', 'mailpoet'),
+        [
+          sprintf(
+            /* translators: 1: Subscriber first name personalization tag, 2: WooCommerce booking product name personalization tag */
+            __('Hi %1$s, thanks for joining us for %2$s. We hope everything went smoothly.', 'mailpoet'),
+            $this->getSubscriberFirstNameTag(),
+            '<!--[mailpoet/woocommerce-booking-product-name]-->'
+          ),
+          $this->getBookingDetailsCopy(),
+          __('Your feedback helps us improve future bookings. Send us a quick note or visit our site to leave feedback.', 'mailpoet'),
+        ],
+        __('Leave feedback', 'mailpoet'),
+        __('Thank you,', 'mailpoet')
+      );
+    }
+
+    if ($this->variant === self::VARIANT_NEXT_BOOKING_NUDGE) {
+      return $this->buildContent(
+        __('Ready for your next booking?', 'mailpoet'),
+        [
+          sprintf(
+            /* translators: 1: Subscriber first name personalization tag, 2: WooCommerce booking product name personalization tag */
+            __('Hi %1$s, it has been a little while since your %2$s booking. We would love to see you again.', 'mailpoet'),
+            $this->getSubscriberFirstNameTag(),
+            '<!--[mailpoet/woocommerce-booking-product-name]-->'
+          ),
+          $this->getBookingDetailsCopy(),
+          __('Book your next visit whenever you are ready. If you need help choosing a time, reply to this email and we’ll point you in the right direction.', 'mailpoet'),
+        ],
+        __('Book again', 'mailpoet'),
+        __('Hope to see you soon,', 'mailpoet')
+      );
+    }
+
     return $this->buildContent(
       __('Your booking spot is waiting', 'mailpoet'),
       [
@@ -104,6 +188,22 @@ class BookingAutomationEmailPattern extends Pattern {
 
     if ($this->variant === self::VARIANT_PRE_VISIT_REMINDER) {
       return __('Booking Pre-visit Reminder', 'mailpoet');
+    }
+
+    if ($this->variant === self::VARIANT_PRE_VISIT_WHAT_TO_EXPECT) {
+      return __('Booking Preparation', 'mailpoet');
+    }
+
+    if ($this->variant === self::VARIANT_PRE_VISIT_TIPS) {
+      return __('Booking Tips', 'mailpoet');
+    }
+
+    if ($this->variant === self::VARIANT_POST_VISIT_REVIEW) {
+      return __('Booking Review Request', 'mailpoet');
+    }
+
+    if ($this->variant === self::VARIANT_NEXT_BOOKING_NUDGE) {
+      return __('Next Booking Nudge', 'mailpoet');
     }
 
     return __('Abandoned Booking Reminder', 'mailpoet');

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/BookingAutomationEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/BookingAutomationEmailPattern.php
@@ -149,12 +149,16 @@ class BookingAutomationEmailPattern extends Pattern {
         [
           sprintf(
             /* translators: 1: Subscriber first name personalization tag, 2: WooCommerce booking product name personalization tag */
-            __('Hi %1$s, it has been a little while since your %2$s booking. We would love to see you again.', 'mailpoet'),
+            __('Hi %1$s, it’s been a little while since your %2$s booking, and we’d love to welcome you back.', 'mailpoet'),
             $this->getSubscriberFirstNameTag(),
             '<!--[mailpoet/woocommerce-booking-product-name]-->'
           ),
-          $this->getBookingDetailsCopy(),
-          __('Book your next visit whenever you are ready. If you need help choosing a time, reply to this email and we’ll point you in the right direction.', 'mailpoet'),
+          sprintf(
+            /* translators: %s: WooCommerce booking start date personalization tag */
+            __('Last time, you joined us on %s. We hope it was time well spent.', 'mailpoet'),
+            '<!--[mailpoet/woocommerce-booking-start-date]-->'
+          ),
+          __('Whenever you’re ready for your next visit, we’ll be glad to have you. Just reply to this email if you’d like a hand picking a time.', 'mailpoet'),
         ],
         __('Book again', 'mailpoet'),
         __('Hope to see you soon,', 'mailpoet')

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -133,6 +133,10 @@ class PatternsController {
         new BookingAutomationEmailPattern($this->cdnAssetUrl, BookingAutomationEmailPattern::VARIANT_ABANDONED_SPOT),
         new BookingAutomationEmailPattern($this->cdnAssetUrl, BookingAutomationEmailPattern::VARIANT_NEW_BOOKING),
         new BookingAutomationEmailPattern($this->cdnAssetUrl, BookingAutomationEmailPattern::VARIANT_PRE_VISIT_REMINDER),
+        new BookingAutomationEmailPattern($this->cdnAssetUrl, BookingAutomationEmailPattern::VARIANT_PRE_VISIT_WHAT_TO_EXPECT),
+        new BookingAutomationEmailPattern($this->cdnAssetUrl, BookingAutomationEmailPattern::VARIANT_PRE_VISIT_TIPS),
+        new BookingAutomationEmailPattern($this->cdnAssetUrl, BookingAutomationEmailPattern::VARIANT_POST_VISIT_REVIEW),
+        new BookingAutomationEmailPattern($this->cdnAssetUrl, BookingAutomationEmailPattern::VARIANT_NEXT_BOOKING_NUDGE),
       ]);
 
       if ($this->wooCommerceHelper->wcSupportsOrderReviewUrl()) {

--- a/mailpoet/lib/WooCommerce/NonPersistablePreviewData.php
+++ b/mailpoet/lib/WooCommerce/NonPersistablePreviewData.php
@@ -25,9 +25,13 @@ trait NonPersistablePreviewData {
   abstract public function get_id();
 
   /**
+   * Accepts an optional argument so the signature stays compatible with
+   * WooCommerce types whose save() takes a parameter (e.g. WC_Booking::save($status_transition)).
+   *
+   * @param bool $statusTransition Ignored; nothing is written to the database.
    * @return int|string The placeholder ID; nothing is written to the database.
    */
-  public function save() {
+  public function save($statusTransition = true) {
     $this->logPreviewPersistAttempt('save');
     return $this->get_id();
   }

--- a/mailpoet/lib/WooCommerce/WooCommerceBookings/Helper.php
+++ b/mailpoet/lib/WooCommerce/WooCommerceBookings/Helper.php
@@ -71,4 +71,34 @@ class Helper {
 
     return get_wc_booking($id);
   }
+
+  /**
+   * Counts a customer's bookings created within the last $seconds, excluding one booking id
+   * (typically the booking that triggered the automation) and cancelled/in-cart bookings.
+   *
+   * Used to detect whether a customer has booked again, e.g. before sending a rebooking nudge.
+   */
+  public function countRecentCustomerBookings(int $customerId, int $seconds, int $excludeBookingId = 0): int {
+    if ($customerId <= 0 || $seconds <= 0 || !class_exists(\WC_Booking_Data_Store::class)) {
+      return 0;
+    }
+
+    $threshold = time() - $seconds;
+    $ignoredStatuses = ['cancelled', 'was-in-cart', 'in-cart'];
+    $count = 0;
+    foreach (\WC_Booking_Data_Store::get_bookings_for_user($customerId) as $booking) {
+      if (!$booking instanceof \WC_Booking || $booking->get_id() === $excludeBookingId) {
+        continue;
+      }
+      if (in_array($booking->get_status(), $ignoredStatuses, true)) {
+        continue;
+      }
+      $created = $booking->get_date_created();
+      if ($created && $created->getTimestamp() >= $threshold) {
+        $count++;
+      }
+    }
+
+    return $count;
+  }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -550,18 +550,23 @@ class PatternsControllerTest extends \MailPoetTest {
       'booking-pre-visit-what-to-expect' => [
         'heading' => 'What to expect at your booking',
         'cta' => 'View our site',
+        'hasEndDate' => true,
       ],
       'booking-pre-visit-tips' => [
         'heading' => 'Make the most of your booking',
         'cta' => 'Review details',
+        'hasEndDate' => true,
       ],
       'booking-post-visit-review' => [
         'heading' => 'How was your booking?',
         'cta' => 'Leave feedback',
+        'hasEndDate' => true,
       ],
+      // The rebooking nudge fires after the visit, so it recaps the past start date only.
       'booking-next-booking-nudge' => [
         'heading' => 'Ready for your next booking?',
         'cta' => 'Book again',
+        'hasEndDate' => false,
       ],
     ];
 
@@ -574,7 +579,11 @@ class PatternsControllerTest extends \MailPoetTest {
       $this->assertStringContainsString('<!--[mailpoet/subscriber-firstname default="there"]-->', $content);
       $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-product-name]-->', $content);
       $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-start-date]-->', $content);
-      $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-end-date]-->', $content);
+      if ($expected['hasEndDate']) {
+        $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-end-date]-->', $content);
+      } else {
+        $this->assertStringNotContainsString('<!--[mailpoet/woocommerce-booking-end-date]-->', $content);
+      }
     }
   }
 

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -64,6 +64,10 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/booking-abandoned-spot', $patternNames);
     $this->assertContains('mailpoet/booking-new-booking-follow-up', $patternNames);
     $this->assertContains('mailpoet/booking-pre-visit-reminder', $patternNames);
+    $this->assertContains('mailpoet/booking-pre-visit-what-to-expect', $patternNames);
+    $this->assertContains('mailpoet/booking-pre-visit-tips', $patternNames);
+    $this->assertContains('mailpoet/booking-post-visit-review', $patternNames);
+    $this->assertContains('mailpoet/booking-next-booking-nudge', $patternNames);
 
     // WooCommerce 10.8.0+ patterns (uses generated coupon block)
     $this->assertContains('mailpoet/welcome-with-discount-email-content', $patternNames);
@@ -72,7 +76,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/abandoned-cart-with-discount-content', $patternNames);
 
     // Verify total count
-    $this->assertCount(35, $blockPatterns);
+    $this->assertCount(39, $blockPatterns);
   }
 
   public function testItRegistersAllCategoriesWhenWooCommerceIsActive(): void {
@@ -188,6 +192,10 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertContains('mailpoet/booking-abandoned-spot', $patternNames);
     $this->assertContains('mailpoet/booking-new-booking-follow-up', $patternNames);
     $this->assertContains('mailpoet/booking-pre-visit-reminder', $patternNames);
+    $this->assertContains('mailpoet/booking-pre-visit-what-to-expect', $patternNames);
+    $this->assertContains('mailpoet/booking-pre-visit-tips', $patternNames);
+    $this->assertContains('mailpoet/booking-post-visit-review', $patternNames);
+    $this->assertContains('mailpoet/booking-next-booking-nudge', $patternNames);
 
     // Should NOT include generated coupon block patterns (require WooCommerce 10.8.0+)
     $this->assertNotContains('mailpoet/welcome-with-discount-email-content', $patternNames);
@@ -197,7 +205,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/reward-positive-reviewer', $patternNames);
 
     // Verify total count (all patterns except 5 coupon patterns)
-    $this->assertCount(30, $blockPatterns);
+    $this->assertCount(34, $blockPatterns);
   }
 
   /**
@@ -535,6 +543,41 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-end-date]-->', $content);
   }
 
+  public function testBookingFollowUpPatternsContainBookingCopy(): void {
+    $patterns = $this->createControllerWithWooCommerce();
+
+    $expectedContent = [
+      'booking-pre-visit-what-to-expect' => [
+        'heading' => 'What to expect at your booking',
+        'cta' => 'View our site',
+      ],
+      'booking-pre-visit-tips' => [
+        'heading' => 'Make the most of your booking',
+        'cta' => 'Review details',
+      ],
+      'booking-post-visit-review' => [
+        'heading' => 'How was your booking?',
+        'cta' => 'Leave feedback',
+      ],
+      'booking-next-booking-nudge' => [
+        'heading' => 'Ready for your next booking?',
+        'cta' => 'Book again',
+      ],
+    ];
+
+    foreach ($expectedContent as $patternName => $expected) {
+      $content = $patterns->getPatternContent($patternName);
+
+      $this->assertIsString($content);
+      $this->assertStringContainsString($expected['heading'], $content);
+      $this->assertStringContainsString($expected['cta'], $content);
+      $this->assertStringContainsString('<!--[mailpoet/subscriber-firstname default="there"]-->', $content);
+      $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-product-name]-->', $content);
+      $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-start-date]-->', $content);
+      $this->assertStringContainsString('<!--[mailpoet/woocommerce-booking-end-date]-->', $content);
+    }
+  }
+
   public function testItDoesNotRegisterAskForReviewPatternWhenOrderReviewUrlIsUnsupported(): void {
     $wooCommerceHelper = $this->createMock(WooCommerceHelper::class);
     $wooCommerceHelper->method('isWooCommerceActive')->willReturn(true);
@@ -600,6 +643,10 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertNotContains('mailpoet/booking-abandoned-spot', $patternNames);
     $this->assertNotContains('mailpoet/booking-new-booking-follow-up', $patternNames);
     $this->assertNotContains('mailpoet/booking-pre-visit-reminder', $patternNames);
+    $this->assertNotContains('mailpoet/booking-pre-visit-what-to-expect', $patternNames);
+    $this->assertNotContains('mailpoet/booking-pre-visit-tips', $patternNames);
+    $this->assertNotContains('mailpoet/booking-post-visit-review', $patternNames);
+    $this->assertNotContains('mailpoet/booking-next-booking-nudge', $patternNames);
 
     // Verify total count (only non-WooCommerce patterns)
     $this->assertCount(9, $blockPatterns);


### PR DESCRIPTION
## Description

Adds block-editor email content patterns for the booking follow-up automations (pre-visit preparation/tips, post-visit review, next booking nudge). The rebooking nudge uses a past-tense recap, and a helper counts a customer's recent bookings so the nudge can be skipped when they already booked again. Also makes preview-only WooCommerce data compatible with WC_Booking so booking email previews render.

## Code review notes

`NonPersistablePreviewData::save()` now accepts an optional argument so a preview subclass of `WC_Booking` (whose `save()` takes a parameter) no longer fatals; other WC types keep working since the parameter is optional.

## QA notes

With WooCommerce Bookings active, preview the booking follow-up emails and confirm they render. Confirm the next booking nudge recaps the past booking date.

## Linked PRs

Premium: mailpoet/mailpoet-premium#1103

## Linked tickets

STOMAIL-8129

## After-merge notes

No changelog on this branch by design — the booking automation changelog from STOMAIL-8128 (already in trunk) covers this release.

## Tasks

- [x] I added sufficient test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->