### PR TITLE
Prevent image optimizers from breaking public email pages

### DIFF
--- a/mailpoet/changelog/2026-06-16-19-24-37-fixed-restored-images-on-public-email-pages-when-an-imag.md
+++ b/mailpoet/changelog/2026-06-16-19-24-37-fixed-restored-images-on-public-email-pages-when-an-imag.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Load images on public email URL when image optimizer plugin is active

--- a/mailpoet/lib/Newsletter/Sharing/PublicEmailRoute.php
+++ b/mailpoet/lib/Newsletter/Sharing/PublicEmailRoute.php
@@ -4,6 +4,7 @@ namespace MailPoet\Newsletter\Sharing;
 
 use InvalidArgumentException;
 use MailPoet\Newsletter\Url as NewsletterUrl;
+use MailPoet\Util\ThirdPartyOutput;
 use MailPoet\WP\Functions as WPFunctions;
 
 class PublicEmailRoute {
@@ -121,6 +122,7 @@ class PublicEmailRoute {
   }
 
   private function display(string $html): void {
+    ThirdPartyOutput::preventHtmlRewriting();
     header('Content-Type: text/html; charset=utf-8');
     header('Cache-Control: private, no-store, max-age=0');
     header('X-Robots-Tag: noindex, nofollow');

--- a/mailpoet/lib/Router/Endpoints/ViewInBrowser.php
+++ b/mailpoet/lib/Router/Endpoints/ViewInBrowser.php
@@ -4,6 +4,7 @@ namespace MailPoet\Router\Endpoints;
 
 use MailPoet\Config\AccessControl;
 use MailPoet\Newsletter\ViewInBrowser\ViewInBrowserController;
+use MailPoet\Util\ThirdPartyOutput;
 use MailPoet\WP\Functions as WPFunctions;
 
 class ViewInBrowser {
@@ -35,6 +36,7 @@ class ViewInBrowser {
 
   private function displayNewsletter($result) {
     if ($result) {
+      ThirdPartyOutput::preventHtmlRewriting();
       header('Content-Type: text/html; charset=utf-8');
       // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
       echo $result;

--- a/mailpoet/lib/Util/ThirdPartyOutput.php
+++ b/mailpoet/lib/Util/ThirdPartyOutput.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util;
+
+class ThirdPartyOutput {
+  /**
+   * Public email pages (view-in-browser, public share) emit bare, fully-rendered
+   * email HTML and exit early. They include no wp_head()/wp_footer(), so no
+   * front-end JS ever loads. Image-optimizer / lazy-load plugins that buffer the
+   * whole page output and rewrite <img src> into JS-driven <img data-src>
+   * placeholders therefore break every image: the placeholder is never swapped
+   * back in because their loader script is absent.
+   *
+   * Signal those plugins to skip this response, and discard any output buffers
+   * they already opened so their flush callbacks never process our HTML.
+   */
+  public static function preventHtmlRewriting(): void {
+    $bypassConstants = [
+      'DONOTCACHEPAGE',
+      'DONOTMINIFY',
+      'DONOTLAZYLOAD',
+      'DONOTROCKETOPTIMIZE',
+    ];
+    foreach ($bypassConstants as $constant) {
+      if (!defined($constant)) {
+        define($constant, true);
+      }
+    }
+
+    // Discard foreign output buffers. Stop if a buffer cannot be removed (e.g.
+    // zlib.output_compression) to avoid an infinite loop.
+    while (ob_get_level() > 0) {
+      if (!ob_end_clean()) {
+        break;
+      }
+    }
+  }
+}

--- a/mailpoet/tests/unit/Util/ThirdPartyOutputTest.php
+++ b/mailpoet/tests/unit/Util/ThirdPartyOutputTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Util;
+
+use MailPoet\Util\ThirdPartyOutput;
+
+class ThirdPartyOutputTest extends \MailPoetUnitTest {
+  public function testItDiscardsOpenOutputBuffers() {
+    $baseline = ob_get_level();
+    ob_start();
+    ob_start();
+    echo 'lazy-load rewriter must never see this';
+
+    ThirdPartyOutput::preventHtmlRewriting();
+    $levelAfter = ob_get_level();
+
+    // Restore the buffer level the test framework started with so we do not
+    // disturb output capture for the rest of the suite.
+    while (ob_get_level() < $baseline) {
+      ob_start();
+    }
+
+    verify($levelAfter)->equals(0);
+  }
+
+  public function testItDefinesOptimizerBypassConstants() {
+    $baseline = ob_get_level();
+
+    ThirdPartyOutput::preventHtmlRewriting();
+
+    // Restore the framework's buffer level discarded by the call above.
+    while (ob_get_level() < $baseline) {
+      ob_start();
+    }
+
+    verify(defined('DONOTCACHEPAGE'))->true();
+    verify(defined('DONOTMINIFY'))->true();
+    verify(defined('DONOTLAZYLOAD'))->true();
+    verify(defined('DONOTROCKETOPTIMIZE'))->true();
+  }
+}


### PR DESCRIPTION
## Description

Public email pages (`view-in-browser`, public share `/mailpoet-email/...`) emit bare email HTML and `exit` — no `wp_head`/`wp_footer`, so no front-end JS loads. Image-optimizer / lazy-load plugins (e.g. Smush, ShortPixel) that buffer the page and rewrite `<img src>` → `<img data-src>` leave every image broken: their loader script is never present to swap the placeholder back.

To fix, MailPoet defines bypass constants (`DONOTCACHEPAGE`, `DONOTMINIFY`, `DONOTLAZYLOAD`, `DONOTROCKETOPTIMIZE`) and discards foreign output buffers so their flush callbacks never touch email HTML.

Reported in https://wordpress.org/support/topic/images-are-missing-6/ and https://wordpress.org/support/topic/images-not-showing-in-archived-newsletters/

## Code review notes

_N/A_

## QA notes

1. Activate Smush or ShortPixel Adaptive Images (or any `<img src>`→`<img data-src>` lazy-loader).
2. Open a newsletter's "view in browser" link and public share `/mailpoet-email/...` URL.
3. Before: images broken. After: images render.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8192

## After-merge notes

_N/A_

## Screenshots or screencast

| Before | After | 
| ---- | ---- |
| <img width="691" height="428" alt="Screenshot 2026-06-16 at 21 45 45" src="https://github.com/user-attachments/assets/5043a241-5e36-45cc-8036-ea1daf2f5350" /> | <img width="688" height="372" alt="Screenshot 2026-06-16 at 21 45 55" src="https://github.com/user-attachments/assets/2ef8ec70-6e38-4fcf-b5d7-2dc3a4c8b629" /> | 

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The implementation is sound:
- The `ThirdPartyOutput::preventHtmlRewriting()` method correctly defines widely-recognized optimizer bypass constants (`DONOTCACHEPAGE`, `DONOTMINIFY`, `DONOTLAZYLOAD`, `DONOTROCKETOPTIMIZE`) and clears all active output buffers to prevent third-party plugin modifications
- Buffer cleanup includes proper error handling that breaks on `ob_end_clean()` failure (e.g., for zlib.output_compression) to avoid infinite loops
- Both integration points (`ViewInBrowser` and `PublicEmailRoute`) call the method at the correct timing—immediately before sending headers and output, within the `template_redirect` hook
- Unit test coverage validates that buffers are properly discarded and constants are defined
- The approach of clearing buffers prevents lazy-load/optimizer plugin flush callbacks from rewriting the email HTML, directly addressing the broken images issue described in the PR objectives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->