### PR TITLE
Remove DISTINCT from static segment subscriber query

### DIFF
--- a/mailpoet/changelog/2026-06-18-09-26-23-improved-speed-up-adding-subscribers-to-sending-tasks-for-l.md
+++ b/mailpoet/changelog/2026-06-18-09-26-23-improved-speed-up-adding-subscribers-to-sending-tasks-for-l.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Speed up adding subscribers to sending tasks for large static segments by removing a redundant DISTINCT that forced a temporary table

--- a/mailpoet/lib/Migrations/Db/Migration_20260610_120000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260610_120000_Db.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20260610_120000_Db extends DbMigration {
+  public function run(): void {
+    $subscriberSegmentTable = $this->getTableName(SubscriberSegmentEntity::class);
+
+    // Index (segment_id, status, subscriber_id) to speed up the subscriber
+    // listing under a static-list filter. Those queries join the membership
+    // table by segment_id and constrain on the per-list status (ss.status),
+    // and the status tabs run one such count per status. Without this index each
+    // count scans the whole segment's memberships (tens of seconds on large
+    // lists); with it the join seeks by segment_id, filters on status, and the
+    // trailing subscriber_id covers the join so the lookup stays index-only.
+    if (!$this->indexExists($subscriberSegmentTable, 'segment_id_status')) {
+      $this->connection->executeQuery(
+        "ALTER TABLE `{$subscriberSegmentTable}`
+          ADD INDEX `segment_id_status` (`segment_id`, `status`, `subscriber_id`)"
+      );
+    }
+  }
+}

--- a/mailpoet/lib/Segments/SubscribersFinder.php
+++ b/mailpoet/lib/Segments/SubscribersFinder.php
@@ -151,7 +151,10 @@ class SubscribersFinder {
     $connection = $this->entityManager->getConnection();
     $selectQueryBuilder = $connection->createQueryBuilder();
     $selectQueryBuilder
-      ->select('DISTINCT :task_id as task_id', 'subscribers.id as subscriber_id', ':processed as processed')
+      // No DISTINCT needed: the INSERT IGNORE relies on the (task_id, subscriber_id)
+      // primary key of scheduled_task_subscribers to drop duplicates, and DISTINCT
+      // forces an expensive temporary table on large segments.
+      ->select(':task_id as task_id', 'subscribers.id as subscriber_id', ':processed as processed')
       ->from($subscriberSegmentTable, 'relation')
       ->join('relation', $subscriberTable, 'subscribers', 'subscribers.id = relation.subscriber_id')
       ->where('subscribers.deleted_at IS NULL')

--- a/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
@@ -109,6 +109,31 @@ class SubscribersFinderTest extends \MailPoetTest {
     verify($subscribersIds)->equals([$this->subscriber2->getId()]);
   }
 
+  public function testItAddsSubscriberInMultipleStaticSegmentsOnlyOnce() {
+    // Subscriber is a member of both static segments passed together. The INNER JOIN
+    // against subscriber_segment yields one row per (subscriber, segment), so this
+    // produces a duplicate subscriber_id that INSERT IGNORE must deduplicate.
+    $subscriberInBothSegments = (new SubscriberFactory())
+      ->withEmail('both@mailpoet.com')
+      ->withSegments([$this->segment1, $this->segment2])
+      ->create();
+
+    $this->subscribersFinder->addSubscribersToTaskFromSegments(
+      $this->scheduledTask,
+      [
+        (int)$this->segment1->getId(),
+        (int)$this->segment2->getId(),
+      ]
+    );
+
+    $subscribersIds = $this->getScheduledTasksSubscribers((int)$this->scheduledTask->getId());
+    // subscriber2 (segment1 only) + subscriberInBothSegments (segment1 & segment2), each once
+    verify($subscribersIds)->equalsCanonicalizing([
+      $this->subscriber2->getId(),
+      $subscriberInBothSegments->getId(),
+    ]);
+  }
+
   public function testItDoesNotAddSubscribersToTaskFromNoSegment() {
     $this->segment3->setType('Invalid type');
     $this->subscribersFinder->addSubscribersToTaskFromSegments(


### PR DESCRIPTION
## Description

`subscriber_id,segment_id` is unique on the `wp_mailpoet_scheduled_task_subscribers` table.

https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/lib/Migrations/Db/Migration_20221028_105818.php#L277

Therefore we do not need `DISTINCT` and this helps us to improve the performance of the query which inserts subscribers for the sending task significantly.

We also add an index `segment_id_status` which helps as well and is useful in other queries in the plugin too.

Before:
```
MariaDB [wp1744149]> explain INSERT IGNORE INTO wp_mailpoet_scheduled_task_subscribers (task_id, subscriber_id, processed) SELECT DISTINCT 27 as task_id, subscribers.id as subscriber_id, 0 as processed FROM wp_mailpoet_subscriber_segment relation INNER JOIN wp_mailpoet_subscribers subscribers ON subscribers.id = relation.subscriber_id WHERE (subscribers.deleted_at IS NULL) AND (subscribers.status = 'subscribed') AND (relation.status = 'subscribed') AND (relation.segment_id IN (4));
+------+-------------+-------------+--------+---------------------------------------------------+------------------------+---------+--------------------------------+---------+-------------------------------------------+
| id   | select_type | table       | type   | possible_keys                                     | key                    | key_len | ref                            | rows    | Extra                                     |
+------+-------------+-------------+--------+---------------------------------------------------+------------------------+---------+--------------------------------+---------+-------------------------------------------+
|    1 | SIMPLE      | subscribers | ref    | PRIMARY,idx_sub_cleanup_legacy,deleted_at_created | idx_sub_cleanup_legacy | 55      | const,const                    | 2406716 | Using where; Using index; Using temporary |
|    1 | SIMPLE      | relation    | eq_ref | subscriber_segment,segment_id,segment_id_status   | subscriber_segment     | 8       | wp1744149.subscribers.id,const | 1       | Using where; Distinct                     |
+------+-------------+-------------+--------+---------------------------------------------------+------------------------+---------+--------------------------------+---------+-------------------------------------------+
2 rows in set (0.068 sec)
```

After:
```
MariaDB [wp1744149]> explain INSERT IGNORE INTO wp_mailpoet_scheduled_task_subscribers (task_id, subscriber_id, processed) SELECT 27 as task_id, subscribers.id as subscriber_id, 0 as processed FROM wp_mailpoet_subscriber_segment relation INNER JOIN wp_mailpoet_subscribers subscribers ON subscribers.id = relation.subscriber_id WHERE (subscribers.deleted_at IS NULL) AND (subscribers.status = 'subscribed') AND (relation.status = 'subscribed') AND (relation.segment_id IN (4));
+------+-------------+-------------+--------+---------------------------------------------------+-------------------+---------+----------------------------------+---------+--------------------------+
| id   | select_type | table       | type   | possible_keys                                     | key               | key_len | ref                              | rows    | Extra                    |
+------+-------------+-------------+--------+---------------------------------------------------+-------------------+---------+----------------------------------+---------+--------------------------+
|    1 | SIMPLE      | relation    | ref    | subscriber_segment,segment_id,segment_id_status   | segment_id_status | 54      | const,const                      | 2484739 | Using where; Using index |
|    1 | SIMPLE      | subscribers | eq_ref | PRIMARY,idx_sub_cleanup_legacy,deleted_at_created | PRIMARY           | 4       | wp1744149.relation.subscriber_id | 1       | Using where              |
+------+-------------+-------------+--------+---------------------------------------------------+-------------------+---------+----------------------------------+---------+--------------------------+
2 rows in set (0.001 sec)
```

## Linked tickets

RSM-4426

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:rsm-4426-remove-distinct-from-segment-subscriber-query)

_The latest successful build from `rsm-4426-remove-distinct-from-segment-subscriber-query` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->