### PR TITLE
Fix disabled Apply button in subscriber bulk action modals

### DIFF
--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -37,11 +37,11 @@ import { MssAccessNotices } from 'notices/mss-access-notices';
 import { GlobalContext, type GlobalContextValue } from 'context';
 import { SubscribersHeading } from './heading';
 import { getSubscriberFields } from './fields';
+import { getInitialPickerValue, type PickerConfig } from './picker-value';
 import {
   bulkAction,
   getSubscribers,
   sendConfirmationEmail,
-  type Segment,
   type Subscriber,
   type SubscriberApiError,
   type SubscriberBulkAction,
@@ -232,15 +232,6 @@ function isItemDeletable(subscriber: Subscriber): boolean {
 function formatCount(count: number): string {
   return count.toLocaleString();
 }
-
-type PickerKind = 'segment' | 'tag';
-
-type PickerConfig = {
-  kind: PickerKind;
-  fieldId: string;
-  endpoint: 'segments' | 'tags';
-  filter?: (segment: Segment) => boolean;
-};
 
 const PICKERS: Record<
   Exclude<PendingModalAction, 'unsubscribe' | 'resendConfirmationEmails'>,
@@ -537,7 +528,9 @@ function PickerModal({
   // The legacy `Selection` form widget wraps Select2 + jQuery. We treat it as
   // a controlled component by reading values out of its `onValueChange` callback
   // — no jQuery DOM lookups leak into this file.
-  const [value, setValue] = useState<number>(0);
+  const [value, setValue] = useState<number>(() =>
+    getInitialPickerValue(config),
+  );
   const fieldConfig = useMemo(
     () => ({
       id: config.fieldId,

--- a/mailpoet/assets/js/src/subscribers/picker-value.ts
+++ b/mailpoet/assets/js/src/subscribers/picker-value.ts
@@ -1,0 +1,26 @@
+import type { Segment } from './api';
+
+export type PickerKind = 'segment' | 'tag';
+
+export type PickerConfig = {
+  kind: PickerKind;
+  fieldId: string;
+  endpoint: 'segments' | 'tags';
+  filter?: (segment: Segment) => boolean;
+};
+
+// Select2 shows its first option as soon as it renders, but notifies a
+// controlled consumer only through its change event, which never fires on
+// mount. Returning that first option lets a consumer seed its state to match
+// what is already on screen.
+export function getInitialPickerValue(config: PickerConfig): number {
+  if (config.endpoint === 'segments') {
+    const segments = window.mailpoet_segments ?? [];
+    const selectable = config.filter
+      ? segments.filter(config.filter)
+      : segments;
+    return selectable.length ? Number(selectable[0].id) : 0;
+  }
+  const tags = window.mailpoet_tags ?? [];
+  return tags.length ? Number(tags[0].id) : 0;
+}

--- a/mailpoet/changelog/2026-06-18-09-16-17-fixed-apply-button-in-the-subscribers-bulk-action-modals.md
+++ b/mailpoet/changelog/2026-06-18-09-16-17-fixed-apply-button-in-the-subscribers-bulk-action-modals.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Apply button in the subscribers bulk action modals being disabled until the pre-selected list was changed

--- a/mailpoet/tests/javascript/subscribers/picker-value.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/picker-value.spec.ts
@@ -1,0 +1,110 @@
+import { type Segment } from '../../../assets/js/src/subscribers/api';
+import {
+  getInitialPickerValue,
+  type PickerConfig,
+} from '../../../assets/js/src/subscribers/picker-value';
+
+const addToList: PickerConfig = {
+  kind: 'segment',
+  fieldId: 'add_to_segment',
+  endpoint: 'segments',
+  filter: (segment) => !!(!segment.deleted_at && segment.type === 'default'),
+};
+
+const removeFromList: PickerConfig = {
+  kind: 'segment',
+  fieldId: 'remove_from_segment',
+  endpoint: 'segments',
+  filter: (segment) => segment.type === 'default',
+};
+
+const addTag: PickerConfig = {
+  kind: 'tag',
+  fieldId: 'add_tag',
+  endpoint: 'tags',
+};
+
+type WindowGlobals = typeof globalThis & {
+  window?: Partial<Window> & typeof globalThis;
+};
+
+function setWindow(data: {
+  segments?: Segment[];
+  tags?: { id: number; name: string }[];
+}): void {
+  const globals = global as WindowGlobals;
+  globals.window = {
+    mailpoet_segments: data.segments,
+    mailpoet_tags: data.tags,
+  } as unknown as Window & typeof globalThis;
+}
+
+describe('getInitialPickerValue', () => {
+  afterEach(() => {
+    delete (global as WindowGlobals).window;
+  });
+
+  it('seeds the first selectable list so Apply is enabled on open', () => {
+    setWindow({
+      segments: [
+        { id: '7', name: 'Newsletter', subscribers: '3', type: 'default' },
+        { id: '8', name: 'Updates', subscribers: '1', type: 'default' },
+      ],
+    });
+    expect(getInitialPickerValue(addToList)).to.equal(7);
+  });
+
+  it('skips lists removed by the filter when picking the first value', () => {
+    setWindow({
+      segments: [
+        {
+          id: '2',
+          name: 'Deleted',
+          subscribers: '0',
+          type: 'default',
+          deleted_at: '2026-01-01 00:00:00',
+        },
+        { id: '5', name: 'Newsletter', subscribers: '3', type: 'default' },
+      ],
+    });
+    expect(getInitialPickerValue(addToList)).to.equal(5);
+  });
+
+  it('applies each picker filter, so remove-from-list keeps deleted lists that add-to-list skips', () => {
+    setWindow({
+      segments: [
+        {
+          id: '2',
+          name: 'Deleted',
+          subscribers: '0',
+          type: 'default',
+          deleted_at: '2026-01-01 00:00:00',
+        },
+        { id: '5', name: 'Newsletter', subscribers: '3', type: 'default' },
+      ],
+    });
+    // removeFromList filters on type only (no deleted_at check), so the deleted
+    // list stays selectable and remains the first option.
+    expect(getInitialPickerValue(removeFromList)).to.equal(2);
+  });
+
+  it('returns 0 when no list is selectable', () => {
+    setWindow({ segments: [] });
+    expect(getInitialPickerValue(addToList)).to.equal(0);
+  });
+
+  it('seeds the first tag for tag pickers', () => {
+    setWindow({
+      tags: [
+        { id: 3, name: 'VIP' },
+        { id: 4, name: 'Lead' },
+      ],
+    });
+    expect(getInitialPickerValue(addTag)).to.equal(3);
+  });
+
+  it('returns 0 when no tags exist', () => {
+    setWindow({});
+    expect(getInitialPickerValue(addTag)).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Description

After the subscribers listing was migrated to `@wordpress/dataviews`, the bulk action modals (Add to list, Move to list, Remove from list, Add tag, Remove tag) open with the first option already shown in the Select2 dropdown, but the **Apply** button is greyed out and cannot be clicked. The button only becomes enabled after the user opens the dropdown and selects a different option. When only a single list exists (for example the default "Newsletter mailing list"), Apply can never be enabled.

Root cause: `PickerModal`'s controlled `value` state starts at `0`, while Select2 visually shows the first option as soon as the modal mounts. The state only updates from the dropdown's `change` event, which never fires on mount, so the value stays `0` and Apply stays disabled until a *different* option fires a change.

The fix seeds the initial `value` with the same first selectable option the dropdown already shows, so the Apply button is active on open and matches what the user sees.

## Code review notes

_N/A_

## QA notes

To reproduce the original bug on `trunk`:

1. Check out `trunk` and run `pnpm compile:js`.
2. Go to *MailPoet > Subscribers*.
3. Select one or more subscribers with the checkboxes.
4. Choose the **Add to list** bulk action.
5. Observe that the modal opens with a list shown in the dropdown, but **Apply** is greyed out.

To verify the fix on this branch:

1. Check out this branch and run `pnpm compile:js`, then hard-refresh the browser.
2. Repeat steps 2 to 4 above.
3. Confirm **Apply** is enabled immediately on open and applies to the pre-selected list.
4. Repeat for **Move to list**, **Remove from list**, **Add tag**, and **Remove tag**.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8181

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

### 📹 Before

https://github.com/user-attachments/assets/c51909c9-f4a3-4d75-821d-7e83fda9848b

### 📹 After

https://github.com/user-attachments/assets/2cecd7b2-f08e-4a39-a4c4-a5c043623179

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8181-subscribers-add-to-list-apply-button-disabled)

_The latest successful build from `fix/stomail-8181-subscribers-add-to-list-apply-button-disabled` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The PR implements a well-designed fix for the disabled Apply button bug in subscriber bulk action modals. The implementation correctly:

- Initializes the controlled `value` state with the first selectable item returned by `getInitialPickerValue()`, matching what Select2 displays visually
- Handles type conversions properly by converting string segment IDs to numbers
- Applies picker-specific filters correctly before selecting the first item
- Returns a safe default of `0` when no items are selectable, which appropriately disables the Apply button
- Includes comprehensive test coverage for all critical scenarios (filter application, empty lists, different picker types)
- Maintains TypeScript type safety with proper type exports (`PickerKind` and `PickerConfig`)

The solution follows the existing architectural patterns in the codebase where the legacy `Selection` component wraps Select2, and properly integrates with the controlled component pattern used in `PickerModal`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->