### PR TITLE
Add Gutenberg latest nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,12 +351,15 @@ jobs:
           path: test-results/mocha
           destination: mocha
   acceptance_tests:
-    parallelism: 20
+    parallelism: << parameters.parallelism >>
     working_directory: /home/circleci/mailpoet/mailpoet
     machine:
       image: default
       docker_layer_caching: false
     parameters:
+      parallelism:
+        type: integer
+        default: 20
       multisite:
         type: integer
         default: 0
@@ -405,12 +408,16 @@ jobs:
       wordpress_version:
         type: string
         default: ''
+      gutenberg_version:
+        type: string
+        default: ''
     environment:
       MYSQL_COMMAND: << parameters.mysql_command >>
       MYSQL_IMAGE: << parameters.mysql_image >>
       CODECEPTION_IMAGE_VERSION: << parameters.codeception_image_version >>
       WORDPRESS_IMAGE_VERSION: << parameters.wordpress_image_version >>
       WORDPRESS_VERSION: << parameters.wordpress_version >>
+      GUTENBERG_VERSION: << parameters.gutenberg_version >>
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -536,6 +543,7 @@ jobs:
             -e ENABLE_HPOS_SYNC=<< parameters.enable_hpos_sync >> \
             -e DISABLE_HPOS=<< parameters.disable_hpos >> \
             -e WORDPRESS_VERSION=${WORDPRESS_VERSION} \
+            -e GUTENBERG_VERSION=${GUTENBERG_VERSION} \
             codeception_acceptance "${args[@]}"
       - run:
           name: Check exceptions
@@ -1186,6 +1194,16 @@ workflows:
           name: acceptance_latest_blockbased_theme
           group: frontend
           blockbased_theme: 1
+          mysql_image: mysql:8.3
+          mysql_command: --default-authentication-plugin=mysql_native_password
+          requires:
+            - build
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_gutenberg_latest
+          group: gutenberg-latest
+          gutenberg_version: latest
+          parallelism: 5
           mysql_image: mysql:8.3
           mysql_command: --default-authentication-plugin=mysql_native_password
           requires:

--- a/mailpoet/lib/Util/ConflictResolver.php
+++ b/mailpoet/lib/Util/ConflictResolver.php
@@ -47,6 +47,12 @@ class ConflictResolver {
     ],
   ];
 
+  /** @var string[] */
+  public $permittedScriptHandles = [
+    'wp-commands',
+    'wp-core-commands',
+  ];
+
   public function init() {
     WPFunctions::get()->addAction(
       'mailpoet_conflict_resolver_router_url_query_parameters',
@@ -142,6 +148,9 @@ class ConflictResolver {
     $dequeueScripts = function() use($_this) {
       global $wp_scripts; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       foreach ($wp_scripts->queue as $wpScript) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        if (in_array($wpScript, $_this->permittedScriptHandles, true)) {
+          continue;
+        }
         if (empty($wp_scripts->registered[$wpScript])) continue; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
         $registeredScript = $wp_scripts->registered[$wpScript]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
         if (!is_string($registeredScript->src)) {

--- a/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
@@ -4,6 +4,9 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group gutenberg-latest
+ */
 class CreateAutomationEmailWithBlockEditorCest {
   public function _before(\AcceptanceTester $i) {
     $settings = new Settings();

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -4,6 +4,9 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group gutenberg-latest
+ */
 class CreateAndSendEmailUsingGutenbergCest {
   public function createAndSendStandardNewsletter(\AcceptanceTester $i, $scenario) {
     if (!$i->checkEmailEditorRequiredWordpressVersion()) {

--- a/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
@@ -2,6 +2,9 @@
 
 namespace MailPoet\Test\Acceptance;
 
+/**
+ * @group gutenberg-latest
+ */
 class EmailTemplatesCest {
   public function selectEditSwapAndResetEmailTemplate(\AcceptanceTester $i, $scenario) {
     if (!$i->checkEmailEditorRequiredWordpressVersion()) {

--- a/mailpoet/tests/acceptance/Forms/EditorCreateBlankFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorCreateBlankFormCest.php
@@ -4,6 +4,9 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Segment;
 
+/**
+ * @group gutenberg-latest
+ */
 class EditorCreateBlankFormCest {
   public function createBlankForm(\AcceptanceTester $i) {
     $i->wantTo('Create a blank form');

--- a/mailpoet/tests/acceptance/Forms/FormsListingCest.php
+++ b/mailpoet/tests/acceptance/Forms/FormsListingCest.php
@@ -4,6 +4,9 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Form;
 
+/**
+ * @group gutenberg-latest
+ */
 class FormsListingCest {
   public function formsListing(\AcceptanceTester $i) {
     $i->wantTo('Open forms listings page');

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -9,6 +9,7 @@ use MailPoet\Test\DataFactories\Settings;
 
 /**
  * @group frontend
+ * @group gutenberg-latest
  */
 class GutenbergFormBlockCest {
 

--- a/mailpoet/tests/integration/Util/ConflictResolverTest.php
+++ b/mailpoet/tests/integration/Util/ConflictResolverTest.php
@@ -102,6 +102,23 @@ class ConflictResolverTest extends \MailPoetTest {
     verify(in_array('permitted_script_2', $wp_scripts->queue))->true(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
+  public function testItKeepsWordPressCommandScriptsServedByGutenberg() {
+    wp_deregister_script('wp-commands');
+    wp_deregister_script('wp-core-commands');
+    wp_enqueue_script('wp-commands', '/wp-content/plugins/gutenberg/build/scripts/commands/index.js');
+    wp_enqueue_script('wp-core-commands', '/wp-content/plugins/gutenberg/build/scripts/core-commands/index.js');
+    wp_enqueue_script('gutenberg_plugin_script', '/wp-content/plugins/gutenberg/build/scripts/plugin/index.js');
+
+    $this->conflictResolver->resolveScriptsConflict();
+    do_action('wp_print_scripts');
+    do_action('admin_print_footer_scripts');
+
+    global $wp_scripts; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify(in_array('wp-commands', $wp_scripts->queue))->true(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify(in_array('wp-core-commands', $wp_scripts->queue))->true(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify(in_array('gutenberg_plugin_script', $wp_scripts->queue))->false(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  }
+
   public function testItWhitelistsScripts() {
     wp_enqueue_script('select2', '/wp-content/some/offending/plugin/select2.js');
     $wp = new WPFunctions;

--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -59,6 +59,16 @@ wp core version
 echo "TEST RUNNER PHP VERSION:"
 php --version
 
+if [[ -n "$GUTENBERG_VERSION" ]]; then
+  echo "Installing Gutenberg plugin version: $GUTENBERG_VERSION"
+  if [[ "$GUTENBERG_VERSION" == "latest" ]]; then
+    wp plugin install gutenberg --activate --force
+  else
+    wp plugin install gutenberg --version="$GUTENBERG_VERSION" --activate --force
+  fi
+  wp plugin get gutenberg --fields=name,status,version
+fi
+
 # Force Action Scheduler to use the DB store. Tests deactivate WC often, which
 # wipes the migration_status option and reverts AS to the HybridStore — whose
 # claim path races on the legacy wpPostStore when async queue-runner requests


### PR DESCRIPTION
## Description

Adds a nightly-only `acceptance_gutenberg_latest` CircleCI job for WOOPRD-1787. The job installs and activates the latest standalone Gutenberg plugin before MailPoet activation, then runs the existing acceptance tests tagged with `@group gutenberg-latest`.

This is meant to catch Gutenberg plugin-only regressions in the existing Automation, EmailEditor, and Forms tests.

The branch also includes the conflict-resolver fix found while validating with the latest Gutenberg: MailPoet now preserves the WordPress command palette handles that Gutenberg latest needs on wp-admin pages and was causing errors on MailPoet's admin pages [[failed build](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/23905/workflows/f916976f-7883-4726-b0dd-12d8d4cb81a2/jobs/420456/parallel-runs/4?filterBy=FAILED)]

## Code review notes

I pushed a testing branch to get a testing build with the current Gutenberg version: https://app.circleci.com/pipelines/github/mailpoet/mailpoet/23915/workflows/a004215a-c8e0-4c76-896a-b675995c5a77/jobs/420635

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

WOOPRD-1787

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issues Found

**1 issue identified:**

### Bug
In `mailpoet/tests/integration/Util/ConflictResolverTest.php`, the `testItWhitelistsScripts()` method (line 132) calls `$this->conflictResolver->resolveStylesConflict()` when it should call `$this->conflictResolver->resolveScriptsConflict()`. The test is checking script whitelisting behavior but invokes the wrong conflict resolver method, which will cause the test to pass without actually testing the intended functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->