### PR TITLE
Improve large-send performance by splitting scheduled_task_subscribers into a queue + log

### DIFF
--- a/mailpoet/assets/js/src/help/data-inconsistencies.tsx
+++ b/mailpoet/assets/js/src/help/data-inconsistencies.tsx
@@ -37,6 +37,10 @@ export function DataInconsistencies() {
         'Orphaned Sending Task Subscribers',
         'mailpoet',
       ),
+      orphaned_sending_task_queued_subscribers: __(
+        'Orphaned Sending Task Queued Subscribers',
+        'mailpoet',
+      ),
       sending_queue_without_newsletter: __(
         'Sending Queues without Newsletter',
         'mailpoet',

--- a/mailpoet/assets/js/src/newsletters/sending-status/sending-status.tsx
+++ b/mailpoet/assets/js/src/newsletters/sending-status/sending-status.tsx
@@ -34,9 +34,19 @@ import {
 
 const listingPerPage = Number(window.mailpoet_listing_per_page);
 
-const SUPPORTED_GROUPS = ['all', 'sent', 'failed', 'unprocessed'] as const;
+// One chip per single-table query: Unprocessed reads the queue, Sent/Failed
+// read the processed log. There is no combined "All" tab (it would need a
+// cross-table union, which the queue/log split exists to avoid).
+const SUPPORTED_GROUPS = ['unprocessed', 'sent', 'failed'] as const;
 
-const DEFAULT_SORT = { field: 'failed', direction: 'desc' as const };
+const DEFAULT_GROUP = 'sent';
+
+const DEFAULT_SORT = { field: 'subscriberId', direction: 'asc' as const };
+
+// The queue table is lean (subscriber identity only), so the Unprocessed tab
+// drops the status / failure-reason columns the log-backed tabs show.
+const PROCESSED_FIELDS = ['failed', 'error'];
+const UNPROCESSED_FIELDS: string[] = [];
 
 type Newsletter = {
   id: string;
@@ -153,8 +163,18 @@ export function SendingStatus() {
     () => parseHash(window.location.hash, baseUrl, [...SUPPORTED_GROUPS]),
     [baseUrl],
   );
-  const [group, setGroup] = useState<string>(hashState.group ?? 'all');
+  const [group, setGroup] = useState<string>(hashState.group ?? DEFAULT_GROUP);
   const fields = useMemo(() => buildFields(), []);
+  const isUnprocessed = group === 'unprocessed';
+  // The queue tab has no status/error columns to render or to toggle in the
+  // view config, so hide those field definitions entirely on that tab.
+  const visibleFields = useMemo(
+    () =>
+      isUnprocessed
+        ? fields.filter((field) => field.id === 'subscriberId')
+        : fields,
+    [fields, isUnprocessed],
+  );
 
   const getPreferredView = useCallback(
     () =>
@@ -165,7 +185,7 @@ export function SendingStatus() {
           perPage: listingPerPage,
           page: 1,
           sort: DEFAULT_SORT,
-          fields: ['failed', 'error'],
+          fields: PROCESSED_FIELDS,
           titleField: 'subscriberId',
           showTitle: true,
         },
@@ -258,7 +278,7 @@ export function SendingStatus() {
       const next = parseHash(window.location.hash, baseUrl, [
         ...SUPPORTED_GROUPS,
       ]);
-      setGroup(next.group ?? 'all');
+      setGroup(next.group ?? DEFAULT_GROUP);
       clearError();
       // Fill hash segments the URL omits from the preference-merged defaults
       // (not the in-memory view) so back/forward resolves a URL exactly like
@@ -282,6 +302,19 @@ export function SendingStatus() {
     window.addEventListener('hashchange', applyHash);
     return () => window.removeEventListener('hashchange', applyHash);
   }, [baseUrl, clearError, getPreferredView, setView]);
+
+  // Keep the visible columns in sync with the active tab: the queue tab shows
+  // only the subscriber, the log tabs add status + failure reason.
+  useEffect(() => {
+    const nextFields = isUnprocessed ? UNPROCESSED_FIELDS : PROCESSED_FIELDS;
+    setView((currentView) => {
+      const currentFields = currentView.fields ?? [];
+      const unchanged =
+        currentFields.length === nextFields.length &&
+        currentFields.every((field, index) => field === nextFields[index]);
+      return unchanged ? currentView : { ...currentView, fields: nextFields };
+    });
+  }, [isUnprocessed, setView]);
 
   // Auto-refresh on the WP heartbeat tick.
   useEffect(() => {
@@ -350,13 +383,14 @@ export function SendingStatus() {
     [meta],
   );
 
-  // The legacy page showed this notice once the per-subscriber records had
-  // been cleaned up: the email is sent, yet the unfiltered listing is empty.
+  // Show this notice once the per-subscriber log records have been cleaned up
+  // by retention: the email is sent, yet the Sent tab is empty. (Failed/
+  // Unprocessed being empty is normal, so the notice keys off Sent only.)
   const showRetentionNotice =
     newsletter.sent &&
     !isLoading &&
     !loadError &&
-    group === 'all' &&
+    group === 'sent' &&
     !view.search &&
     meta.count === 0;
 
@@ -432,7 +466,7 @@ export function SendingStatus() {
       >
         <DataViews<SendingStatusItem>
           data={items}
-          fields={fields}
+          fields={visibleFields}
           view={view}
           onChangeView={persistedViewChange}
           actions={actions}
@@ -440,7 +474,13 @@ export function SendingStatus() {
           defaultLayouts={{ table: {} }}
           getItemId={(item) => `${item.taskId}-${item.subscriberId}`}
           isLoading={isLoading}
-          empty={<p>{__('No sending task found.', 'mailpoet')}</p>}
+          empty={
+            <p>
+              {isUnprocessed
+                ? __('No recipients are waiting to be sent.', 'mailpoet')
+                : __('No sending task found.', 'mailpoet')}
+            </p>
+          }
         >
           <div className="mailpoet-dataviews__toolbar">
             <DataViews.Search label={__('Search', 'mailpoet')} />

--- a/mailpoet/changelog/2026-06-18-09-03-17-improved-sending-performance-for-large-subscriber-lists.md
+++ b/mailpoet/changelog/2026-06-18-09-03-17-improved-sending-performance-for-large-subscriber-lists.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Sending performance for large subscriber lists

--- a/mailpoet/lib/API/JSON/ResponseBuilders/ScheduledTaskSubscriberResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/ScheduledTaskSubscriberResponseBuilder.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\API\JSON\ResponseBuilders;
 
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 
 class ScheduledTaskSubscriberResponseBuilder {
@@ -24,6 +25,35 @@ class ScheduledTaskSubscriberResponseBuilder {
     $data = [];
     foreach ($scheduledSubscribers as $scheduledSubscriber) {
       $data[] = $this->build($scheduledSubscriber);
+    }
+    return $data;
+  }
+
+  /**
+   * The queue table is lean (no processed/failed/error columns) — every row in
+   * it is, by definition, a pending recipient. Project those columns as a
+   * synthetic "unprocessed" status so the Unprocessed tab shares the item shape
+   * the React listing expects.
+   */
+  public function buildQueued(ScheduledTaskQueuedSubscriberEntity $queuedSubscriber) {
+    $subscriber = $queuedSubscriber->getSubscriber();
+    $task = $queuedSubscriber->getTask();
+    return [
+      'processed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
+      'failed' => ScheduledTaskSubscriberEntity::FAIL_STATUS_OK,
+      'error' => null,
+      'taskId' => $task ? $task->getId() : null,
+      'email' => $subscriber ? $subscriber->getEmail() : null,
+      'subscriberId' => $subscriber ? $subscriber->getId() : null,
+      'firstName' => $subscriber ? $subscriber->getFirstName() : null,
+      'lastName' => $subscriber ? $subscriber->getLastName() : null,
+    ];
+  }
+
+  public function buildForQueuedListing(array $queuedSubscribers) {
+    $data = [];
+    foreach ($queuedSubscribers as $queuedSubscriber) {
+      $data[] = $this->buildQueued($queuedSubscriber);
     }
     return $data;
   }

--- a/mailpoet/lib/API/JSON/v1/SendingQueue.php
+++ b/mailpoet/lib/API/JSON/v1/SendingQueue.php
@@ -192,7 +192,7 @@ class SendingQueue extends APIEndpoint {
 
         $this->scheduledTasksRepository->refresh($scheduledTask);
         $this->subscribersFinder->addSubscribersToTaskFromSegments($scheduledTask, $segments, $newsletter->getFilterSegmentId());
-        $subscribersCount = $scheduledTask->getSubscribers()->count();
+        $subscribersCount = $scheduledTask->getQueuedCount();
 
         if (!$subscribersCount) {
           return $this->errorResponse([

--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -8,6 +8,7 @@ use MailPoet\Cron\ActionScheduler\Actions\DaemonTrigger;
 use MailPoet\Cron\CronHelper;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
@@ -131,11 +132,8 @@ class Help {
     if ($task->getType() === SendingQueue::TASK_TYPE) {
       $queue = $this->sendingQueuesRepository->findOneBy(['task' => $task]);
       $newsletter = $queue ? $queue->getNewsletter() : null;
-      $subscribers = $task->getSubscribers();
-      // We only show subscriber's email for 1:1 emails (e.g. automations) and not bulk campaigns
-      if ($subscribers->count() === 1) {
-        $subscriber = $subscribers->first() ? $subscribers->first()->getSubscriber() : null;
-      }
+      // We only show subscriber's email for 1:1 emails (e.g. automations) and not bulk campaigns.
+      $subscriber = $this->getSingleTaskSubscriber($task);
     }
 
     return [
@@ -164,5 +162,21 @@ class Help {
       ],
       'subscriberEmail' => $subscriber ? $subscriber->getEmail() : null,
     ];
+  }
+
+  private function getSingleTaskSubscriber(ScheduledTaskEntity $task): ?SubscriberEntity {
+    // 1:1 emails (e.g. automations) target exactly one recipient total, whether it is
+    // still pending in the queue or already moved to the log once sent.
+    if ($task->getTotalSubscribersCount() !== 1) {
+      return null;
+    }
+
+    $queued = $task->getFirstQueuedSubscriber();
+    if ($queued) {
+      return $queued;
+    }
+
+    $logged = $task->getSubscribers()->first();
+    return $logged ? $logged->getSubscriber() : null;
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -24,7 +24,6 @@ use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUr
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Newsletter\NewsletterSaveController;
@@ -419,14 +418,14 @@ class SendEmailAction implements Action {
     }
 
     // email sending failed
-    if ($scheduledTaskSubscriber->getFailed() === ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED) {
+    if ($scheduledTaskSubscriber->hasFailed()) {
       throw InvalidStateException::create()->withMessage(
         // translators: %s is the error message.
         sprintf(__('Email failed to send. Error: %s', 'mailpoet'), $scheduledTaskSubscriber->getError() ?: 'Unknown error')
       );
     }
 
-    $wasSent = $scheduledTaskSubscriber->getProcessed() === ScheduledTaskSubscriberEntity::STATUS_PROCESSED;
+    $wasSent = $scheduledTaskSubscriber->wasProcessed();
     $isLastRun = $args->getRunNumber() >= 1 + count(self::POLL_INTERVALS);
 
     // email was never sent

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendLatestNewsletterAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendLatestNewsletterAction.php
@@ -14,7 +14,6 @@ use MailPoet\Automation\Integrations\MailPoet\Payloads\SubscriberPayload;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SegmentSubject;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Newsletter\NewslettersRepository;
@@ -199,12 +198,12 @@ class SendLatestNewsletterAction implements Action {
       return true;
     }
 
-    $newsletter = $this->latestNewsletterScheduler->getScheduledTaskSubscriber(
+    $taskSubscriber = $this->latestNewsletterScheduler->getScheduledTaskSubscriber(
       $this->getNewsletter($newsletterId),
       $subscriber,
       $args->getAutomationRun()
     );
-    if (!$newsletter) {
+    if (!$taskSubscriber) {
       if ($this->isSubscriberIneligible($subscriber, $segmentId)) {
         $this->saveOutcome($controller, self::OUTCOME_SKIPPED_INELIGIBLE_SUBSCRIBER, $newsletterId);
         return true;
@@ -212,22 +211,21 @@ class SendLatestNewsletterAction implements Action {
       throw InvalidStateException::create()->withMessage(__('Email failed to schedule.', 'mailpoet'));
     }
 
-    if ($newsletter->getFailed() === ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED) {
+    if ($taskSubscriber->hasFailed()) {
       throw InvalidStateException::create()->withMessage(
         // translators: %s is the error message.
-        sprintf(__('Email failed to send. Error: %s', 'mailpoet'), $newsletter->getError() ?: 'Unknown error')
+        sprintf(__('Email failed to send. Error: %s', 'mailpoet'), $taskSubscriber->getError() ?: 'Unknown error')
       );
     }
 
-    $wasSent = $newsletter->getProcessed() === ScheduledTaskSubscriberEntity::STATUS_PROCESSED;
-    if ($wasSent) {
+    if ($taskSubscriber->wasProcessed()) {
       $this->saveOutcome($controller, self::OUTCOME_SENT, $newsletterId);
       return true;
     }
 
     if ($this->isSubscriberIneligible($subscriber, $segmentId)) {
       $this->latestNewsletterScheduler->saveErrorAndPause(
-        $newsletter,
+        $taskSubscriber,
         __('Subscriber is no longer eligible for this email.', 'mailpoet')
       );
       $this->saveOutcome($controller, self::OUTCOME_SKIPPED_INELIGIBLE_SUBSCRIBER, $newsletterId);
@@ -243,7 +241,7 @@ class SendLatestNewsletterAction implements Action {
     }
 
     $error = __('Email sending process timed out.', 'mailpoet');
-    $this->latestNewsletterScheduler->saveErrorAndPause($newsletter, $error);
+    $this->latestNewsletterScheduler->saveErrorAndPause($taskSubscriber, $error);
     throw InvalidStateException::create()->withMessage($error);
   }
 

--- a/mailpoet/lib/Cron/Workers/BulkConfirmationEmailResend.php
+++ b/mailpoet/lib/Cron/Workers/BulkConfirmationEmailResend.php
@@ -7,7 +7,7 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Logging\LogRepository;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriberMover;
 use MailPoet\Subscribers\BulkConfirmationEmailResender;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -29,8 +29,8 @@ class BulkConfirmationEmailResend extends SimpleWorker {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
-  /** @var ScheduledTaskSubscribersRepository */
-  private $scheduledTaskSubscribersRepository;
+  /** @var ScheduledTaskSubscriberMover */
+  private $scheduledTaskSubscriberMover;
 
   /** @var LogRepository */
   private $logRepository;
@@ -38,12 +38,12 @@ class BulkConfirmationEmailResend extends SimpleWorker {
   public function __construct(
     ConfirmationEmailMailer $confirmationEmailMailer,
     SubscribersRepository $subscribersRepository,
-    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    ScheduledTaskSubscriberMover $scheduledTaskSubscriberMover,
     LogRepository $logRepository
   ) {
     $this->confirmationEmailMailer = $confirmationEmailMailer;
     $this->subscribersRepository = $subscribersRepository;
-    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->scheduledTaskSubscriberMover = $scheduledTaskSubscriberMover;
     $this->logRepository = $logRepository;
     parent::__construct();
   }
@@ -69,7 +69,7 @@ class BulkConfirmationEmailResend extends SimpleWorker {
         try {
           $result = $this->confirmationEmailMailer->sendAdminConfirmationEmail($subscriber, $oldestLifecycleDate);
         } catch (\Throwable $throwable) {
-          $this->scheduledTaskSubscribersRepository->saveError($task, (int)$subscriberId, 'send_failed:mailer_error');
+          $this->scheduledTaskSubscriberMover->moveFailedToLog($task, (int)$subscriberId, 'send_failed:mailer_error');
           $failedCount++;
           continue;
         }
@@ -81,12 +81,14 @@ class BulkConfirmationEmailResend extends SimpleWorker {
           $this->saveSkipped($task, (int)$subscriberId, $result['reason'] ?? 'not_found', $skippedByReason);
           $failedCount++;
         } else {
-          $this->scheduledTaskSubscribersRepository->saveError($task, (int)$subscriberId, 'send_failed:' . ($result['reason'] ?? 'sending_method'));
+          $this->scheduledTaskSubscriberMover->moveFailedToLog($task, (int)$subscriberId, 'send_failed:' . ($result['reason'] ?? 'sending_method'));
           $failedCount++;
         }
       }
 
-      $this->scheduledTaskSubscribersRepository->updateProcessedSubscribers($task, $sentIds);
+      if ($sentIds) {
+        $this->scheduledTaskSubscriberMover->moveProcessedToLog($task, $sentIds);
+      }
     }
 
     $meta = $task->getMeta() ?? [];
@@ -105,7 +107,7 @@ class BulkConfirmationEmailResend extends SimpleWorker {
    */
   private function saveSkipped(ScheduledTaskEntity $task, int $subscriberId, string $reason, array &$skippedByReason): void {
     $skippedByReason[$reason] = ($skippedByReason[$reason] ?? 0) + 1;
-    $this->scheduledTaskSubscribersRepository->saveError($task, $subscriberId, 'skipped:' . $reason);
+    $this->scheduledTaskSubscriberMover->moveFailedToLog($task, $subscriberId, 'skipped:' . $reason);
   }
 
   /**

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -7,7 +7,6 @@ use MailPoet\Cron\CronWorkerScheduler;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
@@ -120,6 +119,7 @@ class Scheduler {
     $scheduledTasks = $this->getScheduledSendingTasks();
     $this->updateTasks($scheduledTasks);
     foreach ($scheduledTasks as $task) {
+      $this->scheduledTasksRepository->refresh($task);
       $queue = $task->getSendingQueue();
       if (!$queue) {
         $this->deleteByTask($task);
@@ -169,12 +169,12 @@ class Scheduler {
   }
 
   public function processWelcomeNewsletter(NewsletterEntity $newsletter, ScheduledTaskEntity $task) {
-    $subscribers = $task->getSubscribers();
-    if (empty($subscribers[0])) {
+    $subscriber = $task->getFirstQueuedSubscriber();
+    $subscriberId = $subscriber ? $subscriber->getId() : null;
+    if (!$subscriberId) {
       $this->deleteByTask($task);
       return false;
     }
-    $subscriberId = (int)$subscribers[0]->getSubscriberId();
     if ($newsletter->getOptionValue('event') === 'segment') {
       if ($this->verifyMailpoetSubscriber($subscriberId, $newsletter, $task) === false) {
         return false;
@@ -210,7 +210,7 @@ class Scheduler {
 
     // ensure that subscribers are in segments
     $this->subscribersFinder->addSubscribersToTaskFromSegments($task, $segments, $newsletter->getFilterSegmentId());
-    $subscribersCount = $task->getSubscribers()->count();
+    $subscribersCount = $task->getQueuedCount();
     if (empty($subscribersCount)) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_POST_NOTIFICATIONS)->info(
         'post notification no subscribers',
@@ -257,14 +257,13 @@ class Scheduler {
       $segment = $this->segmentsRepository->findOneById($newsletter->getOptionValue('segment'));
       if ($segment instanceof SegmentEntity) {
         $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [(int)$segment->getId()]);
-        if (!$task->getSubscribers()->count()) {
+        if (!$task->getQueuedCount()) {
           $this->deleteByTask($task);
           return false;
         }
       }
     } else {
-      $subscribers = $task->getSubscribers();
-      $subscriber = isset($subscribers[0]) ? $subscribers[0]->getSubscriber() : null;
+      $subscriber = $task->getFirstQueuedSubscriber();
       if (!$subscriber) {
         $this->deleteByTask($task);
         return false;
@@ -280,8 +279,7 @@ class Scheduler {
   }
 
   public function processScheduledAutomationEmail(ScheduledTaskEntity $task): bool {
-    $subscribers = $task->getSubscribers();
-    $subscriber = isset($subscribers[0]) ? $subscribers[0]->getSubscriber() : null;
+    $subscriber = $task->getFirstQueuedSubscriber();
     if (!$subscriber) {
       $this->deleteByTask($task);
       return false;
@@ -296,8 +294,7 @@ class Scheduler {
   }
 
   public function processScheduledTransactionalEmail(ScheduledTaskEntity $task): bool {
-    $subscribers = $task->getSubscribers();
-    $subscriber = isset($subscribers[0]) ? $subscribers[0]->getSubscriber() : null;
+    $subscriber = $task->getFirstQueuedSubscriber();
     if (!$subscriber) {
       $this->deleteByTask($task);
       return false;
@@ -335,21 +332,22 @@ class Scheduler {
   }
 
   private function processLatestNewsletterReplay(ScheduledTaskEntity $task): bool {
-    $subscribers = $task->getSubscribers();
-    if ($subscribers->isEmpty()) {
+    $subscribersCount = $task->getQueuedCount();
+    if ($subscribersCount === 0) {
       $this->deleteByTask($task);
       return false;
     }
 
     $queue = $task->getSendingQueue();
     $meta = $queue ? $queue->getMeta() : [];
-    $taskSubscriber = $subscribers->first();
+    $firstQueuedSubscriber = $task->getFirstQueuedSubscriber();
+    $subscriberId = $firstQueuedSubscriber ? $firstQueuedSubscriber->getId() : null;
     $expectedSubscriberId = $meta[NewsletterReplayMetadata::REPLAY_SUBSCRIBER_ID] ?? null;
     if (
-      $subscribers->count() !== 1
-      || !$taskSubscriber instanceof ScheduledTaskSubscriberEntity
+      $subscribersCount !== 1
+      || $subscriberId === null
       || !is_numeric($expectedSubscriberId)
-      || (int)$taskSubscriber->getSubscriberId() !== (int)$expectedSubscriberId
+      || $subscriberId !== (int)$expectedSubscriberId
     ) {
       $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
       $this->scheduledTasksRepository->flush();

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingErrorHandler.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingErrorHandler.php
@@ -7,12 +7,16 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriberMover;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 
 class SendingErrorHandler {
-  /** @var ScheduledTaskSubscribersRepository */
-  private $scheduledTaskSubscribersRepository;
+  /** @var ScheduledTaskSubscriberMover */
+  private $scheduledTaskSubscriberMover;
+
+  /** @var ScheduledTaskQueuedSubscriberRepository */
+  private $scheduledTaskQueuedSubscriberRepository;
 
   /** @var SendingThrottlingHandler */
   private $throttlingHandler;
@@ -24,12 +28,14 @@ class SendingErrorHandler {
   private $loggerFactory;
 
   public function __construct(
-    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    ScheduledTaskSubscriberMover $scheduledTaskSubscriberMover,
+    ScheduledTaskQueuedSubscriberRepository $scheduledTaskQueuedSubscriberRepository,
     SendingThrottlingHandler $throttlingHandler,
     SendingQueuesRepository $sendingQueuesRepository,
     LoggerFactory $loggerFactory
   ) {
-    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->scheduledTaskSubscriberMover = $scheduledTaskSubscriberMover;
+    $this->scheduledTaskQueuedSubscriberRepository = $scheduledTaskQueuedSubscriberRepository;
     $this->throttlingHandler = $throttlingHandler;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->loggerFactory = $loggerFactory;
@@ -63,8 +69,9 @@ class SendingErrorHandler {
     foreach ($error->getSubscriberErrors() as $subscriberError) {
       $subscriberIdIndex = array_search($subscriberError->getEmail(), $preparedSubscribers);
       $message = $subscriberError->getMessage() ?: $error->getMessage();
-      $this->scheduledTaskSubscribersRepository->saveError($task, $preparedSubscribersIds[$subscriberIdIndex], $message ?? '');
+      $this->scheduledTaskSubscriberMover->moveFailedToLog($task, $preparedSubscribersIds[$subscriberIdIndex], $message ?? '');
     }
+    $this->scheduledTaskQueuedSubscriberRepository->checkCompleted($task);
 
     $queue = $task->getSendingQueue();
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -16,7 +16,9 @@ use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\MetaInfo;
 use MailPoet\Newsletter\Sending\NewsletterReplayMetadata;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriberMover;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
@@ -79,6 +81,12 @@ class SendingQueue {
   /** @var ScheduledTaskSubscribersRepository */
   private $scheduledTaskSubscribersRepository;
 
+  /** @var ScheduledTaskQueuedSubscriberRepository */
+  private $scheduledTaskQueuedSubscriberRepository;
+
+  /** @var ScheduledTaskSubscriberMover */
+  private $scheduledTaskSubscriberMover;
+
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
@@ -109,6 +117,8 @@ class SendingQueue {
     Links $links,
     ScheduledTasksRepository $scheduledTasksRepository,
     ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    ScheduledTaskQueuedSubscriberRepository $scheduledTaskQueuedSubscriberRepository,
+    ScheduledTaskSubscriberMover $scheduledTaskSubscriberMover,
     MailerTask $mailerTask,
     SubscribersRepository $subscribersRepository,
     SendingQueuesRepository $sendingQueuesRepository,
@@ -132,6 +142,8 @@ class SendingQueue {
     $this->links = $links;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->scheduledTaskQueuedSubscriberRepository = $scheduledTaskQueuedSubscriberRepository;
+    $this->scheduledTaskSubscriberMover = $scheduledTaskSubscriberMover;
     $this->subscribersRepository = $subscribersRepository;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->entityManager = $entityManager;
@@ -144,6 +156,7 @@ class SendingQueue {
     $timer = $timer ?: microtime(true);
     $this->enforceSendingAndExecutionLimits($timer);
     foreach ($this->scheduledTasksRepository->findRunningSendingTasks(self::TASK_BATCH_SIZE) as $task) {
+      $this->scheduledTasksRepository->refresh($task);
       $queue = $task->getSendingQueue();
       if (!$queue) {
         continue;
@@ -308,7 +321,10 @@ class SendingQueue {
           $foundSubscribersIds
         );
 
-        $this->scheduledTaskSubscribersRepository->deleteByScheduledTaskAndSubscriberIds($task, $subscribersToRemove);
+        $this->scheduledTaskQueuedSubscriberRepository->deleteByScheduledTaskAndSubscriberIds($task, $subscribersToRemove);
+        // Removing the last pending recipients (all deleted/unsubscribed) can empty
+        // the queue without any send happening, so re-check completion here too.
+        $this->scheduledTaskQueuedSubscriberRepository->checkCompleted($task);
         $this->sendingQueuesRepository->updateCounts($queue);
 
         // if there aren't any subscribers to process in the batch (e.g. all unsubscribed or were deleted), continue with the next batch
@@ -545,7 +561,9 @@ class SendingQueue {
         return;
       }
       try {
-        $this->scheduledTaskSubscribersRepository->updateProcessedSubscribers($task, $preparedSubscribersIds);
+        $this->scheduledTaskSubscriberMover->moveProcessedToLog($task, $preparedSubscribersIds);
+        // The mover does not mark the task complete, so the completion check is explicit.
+        $this->scheduledTaskQueuedSubscriberRepository->checkCompleted($task);
         $this->sendingQueuesRepository->updateCounts($queue);
       } catch (Throwable $e) {
         MailerLog::processError(
@@ -678,7 +696,7 @@ class SendingQueue {
     // This may happen when we send to all but the execution is interrupted (e.g. by PHP time limit) and we don't update the task status
     // or if we trigger sending to a newsletter without any subscriber (e.g. scheduled for long time but all were deleted)
     // Lets set status to completed and update the queue counts
-    if ($task->getStatus() === null && $this->scheduledTaskSubscribersRepository->countUnprocessed($task) === 0) {
+    if ($task->getStatus() === null && $this->scheduledTaskQueuedSubscriberRepository->countForTask($task) === 0) {
       $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
       $queue = $task->getSendingQueue();
       if ($queue) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -345,8 +345,9 @@ class Newsletter {
 
   private function getTaskSubscriberCount(SendingQueueEntity $queue): int {
     $task = $queue->getTask();
-    $subscribers = $task ? $task->getSubscribers() : null;
-    return $subscribers ? count($subscribers) : 0;
+    // Coupon preflight runs before any recipient is sent, so the still-pending
+    // recipients live in the queue. For a single-recipient automation this is 1.
+    return $task ? $task->getQueuedCount() : 0;
   }
 
   /**

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -675,6 +675,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\ScheduledTaskSubscriberMover::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\ScheduledTaskSubscribersListingRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscribersListingRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\SendingQueuesRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sharing\PublicEmailController::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -498,6 +498,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       ->setArgument('$container', new Reference(ContainerWrapper::class));
     // Mailer
     $container->autowire(\MailPoet\Mailer\MailerFactory::class)->setPublic(true);
+    $container->autowire(\MailPoet\Mailer\MigrationSendingPauser::class)->setPublic(true);
     $container->autowire(\MailPoet\Mailer\WordPress\WordpressMailerReplacer::class);
     $container->autowire(\MailPoet\Mailer\Methods\Common\BlacklistCheck::class);
     $container->autowire(\MailPoet\Mailer\MetaInfo::class);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -671,6 +671,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\Scheduler\ReEngagementScheduler::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\ScheduledTasksRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Sending\ScheduledTaskSubscriberMover::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\ScheduledTaskSubscribersListingRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\SendingQueuesRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Coupons/EmailContextBuilder.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Coupons/EmailContextBuilder.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet\Coupons;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\AutomationEmailContextProvider;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -49,8 +50,8 @@ class EmailContextBuilder {
     }
 
     $task = $sendingQueue->getTask();
-    $subscribers = $task ? $task->getSubscribers() : null;
-    $subscriberCount = $subscribers ? count($subscribers) : 0;
+    // A 1:1 automation send targets exactly one recipient total (queue + log).
+    $subscriberCount = $task ? $task->getTotalSubscribersCount() : 0;
     $context['subscriber_count'] = $subscriberCount;
 
     if ($subscriberCount !== 1) {
@@ -65,9 +66,7 @@ class EmailContextBuilder {
     // Only one-recipient automation sends can safely expose a unique recipient
     // email to WooCommerce. Bulk renders must not use the first subscriber as a
     // stand-in for everyone who will receive the email.
-    $firstSubscriber = $subscribers ? $subscribers->first() : null;
-    $subscriber = $firstSubscriber ? $firstSubscriber->getSubscriber() : null;
-    $recipientEmail = $subscriber ? $subscriber->getEmail() : null;
+    $recipientEmail = $task ? $this->getFirstQueuedRecipientEmail($task) : null;
     if (is_string($recipientEmail) && $this->wp->isEmail($recipientEmail)) {
       $context['recipient_email'] = $recipientEmail;
     }
@@ -77,8 +76,12 @@ class EmailContextBuilder {
 
   private function getQueueSubscriberCount(SendingQueueEntity $sendingQueue): int {
     $task = $sendingQueue->getTask();
-    $subscribers = $task ? $task->getSubscribers() : null;
-    return $subscribers ? count($subscribers) : 0;
+    return $task ? $task->getQueuedCount() : 0;
+  }
+
+  private function getFirstQueuedRecipientEmail(ScheduledTaskEntity $task): ?string {
+    $subscriber = $task->getFirstQueuedSubscriber();
+    return $subscriber ? $subscriber->getEmail() : null;
   }
 
   private function isAutomationType(NewsletterEntity $newsletter): bool {

--- a/mailpoet/lib/Entities/ScheduledTaskEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskEntity.php
@@ -98,6 +98,12 @@ class ScheduledTaskEntity {
   private $subscribers;
 
   /**
+   * @ORM\OneToMany(targetEntity="MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity", mappedBy="task", fetch="EXTRA_LAZY")
+   * @var Collection<int, ScheduledTaskQueuedSubscriberEntity>
+   */
+  private $queuedSubscribers;
+
+  /**
    * @ORM\OneToOne(targetEntity="MailPoet\Entities\SendingQueueEntity", mappedBy="task", fetch="EAGER")
    * @var SendingQueueEntity|null
    */
@@ -105,6 +111,7 @@ class ScheduledTaskEntity {
 
   public function __construct() {
     $this->subscribers = new ArrayCollection();
+    $this->queuedSubscribers = new ArrayCollection();
   }
 
   /**
@@ -235,6 +242,46 @@ class ScheduledTaskEntity {
    */
   public function getSubscribers(): Collection {
     return $this->subscribers;
+  }
+
+  /**
+   * Pending recipients of an in-flight task that uses subscriber queue/log storage.
+   *
+   * @return Collection<int, ScheduledTaskQueuedSubscriberEntity>
+   */
+  public function getQueuedSubscribers(): Collection {
+    return $this->queuedSubscribers;
+  }
+
+  /**
+   * Total recipients across the queue (pending) and the log (processed).
+   * Both collections are EXTRA_LAZY, so this is two COUNT queries, no hydration.
+   */
+  public function getTotalSubscribersCount(): int {
+    return $this->subscribers->count() + $this->queuedSubscribers->count();
+  }
+
+  /**
+   * Number of pending recipients in the queue. The collection is EXTRA_LAZY, so
+   * this is a single COUNT query and never hydrates the (possibly huge) set.
+   * Only accurate for a managed (DB-loaded) task.
+   */
+  public function getQueuedCount(): int {
+    return $this->queuedSubscribers->count();
+  }
+
+  /**
+   * First pending recipient (lowest subscriber id), or null if the queue is empty.
+   * Criteria matching on the EXTRA_LAZY collection runs a single
+   * `ORDER BY subscriber_id LIMIT 1` query instead of hydrating the queue.
+   * Only accurate for a managed (DB-loaded) task.
+   */
+  public function getFirstQueuedSubscriber(): ?SubscriberEntity {
+    $criteria = Criteria::create()
+      ->orderBy(['subscriber' => 'ASC'])
+      ->setMaxResults(1);
+    $first = $this->queuedSubscribers->matching($criteria)->first();
+    return ($first instanceof ScheduledTaskQueuedSubscriberEntity) ? $first->getSubscriber() : null;
   }
 
   /**

--- a/mailpoet/lib/Entities/ScheduledTaskQueuedSubscriberEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskQueuedSubscriberEntity.php
@@ -1,0 +1,75 @@
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+
+namespace MailPoet\Entities;
+
+use MailPoet\Doctrine\EntityTraits\CreatedAtTrait;
+use MailPoet\Doctrine\EntityTraits\SafeToOneAssociationLoadTrait;
+use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="scheduled_task_queued_subscribers")
+ */
+class ScheduledTaskQueuedSubscriberEntity {
+  use CreatedAtTrait;
+  use SafeToOneAssociationLoadTrait;
+
+  /**
+   * @ORM\Id @ORM\ManyToOne(targetEntity="MailPoet\Entities\ScheduledTaskEntity", inversedBy="queuedSubscribers")
+   * @var ScheduledTaskEntity|null
+   */
+  private $task;
+
+  /**
+   * @ORM\Id @ORM\ManyToOne(targetEntity="MailPoet\Entities\SubscriberEntity")
+   * @var SubscriberEntity|null
+   */
+  private $subscriber;
+
+  public function __construct(
+    ScheduledTaskEntity $task,
+    SubscriberEntity $subscriber
+  ) {
+    $this->task = $task;
+    $this->subscriber = $subscriber;
+  }
+
+  /**
+   * @return ScheduledTaskEntity|null
+   */
+  public function getTask() {
+    $this->safelyLoadToOneAssociation('task');
+    return $this->task;
+  }
+
+  public function setTask(ScheduledTaskEntity $task) {
+    $this->task = $task;
+  }
+
+  /**
+   * @return SubscriberEntity|null
+   */
+  public function getSubscriber() {
+    $this->safelyLoadToOneAssociation('subscriber');
+    return $this->subscriber;
+  }
+
+  /**
+   * Get the ID of the subscriber without querying wp_mailpoet_subscribers.
+   * $this->getSubscriber->getId() queries wp_mailpoet_subscribers because of
+   * the way the SafeToOneAssociationLoadTrait works.
+   *
+   * @return int|null
+   */
+  public function getSubscriberId() {
+    if ($this->subscriber instanceof SubscriberEntity) {
+      return $this->subscriber->getId();
+    }
+
+    return null;
+  }
+
+  public function setSubscriber(SubscriberEntity $subscriber) {
+    $this->subscriber = $subscriber;
+  }
+}

--- a/mailpoet/lib/Mailer/MigrationSendingPauser.php
+++ b/mailpoet/lib/Mailer/MigrationSendingPauser.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Mailer;
+
+use MailPoet\Settings\SettingsController;
+
+/**
+ * @phpstan-import-type MailerLogData from MailerLog
+ */
+class MigrationSendingPauser {
+  const BACKUP_SETTING_NAME = 'mta_log_migration_sending_pause_backup';
+
+  /** @var SettingsController */
+  private $settings;
+
+  public function __construct(
+    SettingsController $settings
+  ) {
+    $this->settings = $settings;
+  }
+
+  public function pause(): void {
+    $mailerLog = MailerLog::getMailerLog();
+    if (MailerLog::isSendingPaused($mailerLog)) {
+      return;
+    }
+
+    if (!$this->settings->hasSavedValue(self::BACKUP_SETTING_NAME)) {
+      $this->settings->set(self::BACKUP_SETTING_NAME, $mailerLog);
+    }
+
+    MailerLog::pauseSending($mailerLog);
+  }
+
+  public function resume(): void {
+    if (!$this->settings->hasSavedValue(self::BACKUP_SETTING_NAME)) {
+      return;
+    }
+
+    /** @var MailerLogData $mailerLog */
+    $mailerLog = $this->settings->get(self::BACKUP_SETTING_NAME);
+    MailerLog::updateMailerLog($mailerLog);
+    $this->settings->delete(self::BACKUP_SETTING_NAME);
+  }
+}

--- a/mailpoet/lib/Migrations/App/Migration_20260617_130000_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20260617_130000_App.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Cron\Workers\BulkConfirmationEmailResend;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Mailer\MigrationSendingPauser;
+use MailPoet\Migrator\AppMigration;
+use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
+use MailPoetVendor\Doctrine\DBAL\ParameterType;
+
+/**
+ * Backfills the new queue table for in-flight sending and confirmation-resend tasks.
+ *
+ * Sending and bulk confirmation resend now read pending recipients from
+ * `scheduled_task_queued_subscribers` instead of `scheduled_task_subscribers`.
+ * Existing not-yet-completed tasks of those types still have their pending
+ * (`processed = 0`) rows in the old table, so we copy those into the queue and
+ * delete them from the log (copy-then-delete keeps a uniform model: pending only
+ * in the queue, processed only in the log).
+ *
+ * Scoped to not-completed tasks of those types (found via the smaller, better
+ * indexed scheduled_tasks table) so the copy is a PK-range per task, never a full
+ * scan of the log.
+ *
+ * Sending is paused for the duration via MigrationSendingPauser. resume() is
+ * only reached on success: if this migration is interrupted it leaves sending
+ * paused (with the user notice) and is retried on the next run — both the
+ * INSERT IGNORE and the processed=0 DELETE are idempotent.
+ */
+class Migration_20260617_130000_App extends AppMigration {
+  public function run(): void {
+    $connection = $this->entityManager->getConnection();
+    $logTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    $queueTable = $this->entityManager->getClassMetadata(ScheduledTaskQueuedSubscriberEntity::class)->getTableName();
+    $tasksTable = $this->entityManager->getClassMetadata(ScheduledTaskEntity::class)->getTableName();
+
+    $taskIds = $connection->executeQuery(
+      "SELECT `id` FROM {$tasksTable}
+       WHERE `type` IN (:types)
+         AND (`status` IS NULL OR `status` != :completed)
+         AND `deleted_at` IS NULL",
+      [
+        'types' => [SendingQueueWorker::TASK_TYPE, BulkConfirmationEmailResend::TASK_TYPE],
+        'completed' => ScheduledTaskEntity::STATUS_COMPLETED,
+      ],
+      [
+        'types' => ArrayParameterType::STRING,
+        'completed' => ParameterType::STRING,
+      ]
+    )->fetchFirstColumn();
+
+    /** @var MigrationSendingPauser $pauser */
+    $pauser = $this->container->get(MigrationSendingPauser::class);
+    if (!$taskIds) {
+      $pauser->resume();
+      return;
+    }
+
+    /** @var int[] $taskIds */
+    $taskIdsList = implode(',', array_map('intval', $taskIds));
+
+    $pauser->pause();
+
+    $connection->executeStatement(
+      "INSERT IGNORE INTO {$queueTable} (task_id, subscriber_id, created_at)
+       SELECT sts.`task_id`, sts.`subscriber_id`, sts.`created_at`
+       FROM {$logTable} sts
+       WHERE sts.`task_id` IN ({$taskIdsList})
+         AND sts.`processed` = :unprocessed",
+      ['unprocessed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED],
+      ['unprocessed' => ParameterType::INTEGER]
+    );
+
+    $connection->executeStatement(
+      "DELETE FROM {$logTable}
+       WHERE `task_id` IN ({$taskIdsList})
+         AND `processed` = :unprocessed",
+      ['unprocessed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED],
+      ['unprocessed' => ParameterType::INTEGER]
+    );
+
+    $pauser->resume();
+  }
+}

--- a/mailpoet/lib/Migrations/Db/Migration_20260617_120000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260617_120000_Db.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20260617_120000_Db extends DbMigration {
+  public function run(): void {
+    global $wpdb;
+
+    $table = $this->getTableName(ScheduledTaskQueuedSubscriberEntity::class);
+    if ($this->tableExists($table)) {
+      return;
+    }
+
+    $charsetCollate = $wpdb->get_charset_collate();
+    $this->connection->executeStatement("
+      CREATE TABLE `{$table}` (
+        `task_id` int(11) unsigned NOT NULL,
+        `subscriber_id` int(11) unsigned NOT NULL,
+        `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (`task_id`, `subscriber_id`)
+      ) {$charsetCollate}
+    ");
+  }
+}

--- a/mailpoet/lib/Newsletter/AutomaticEmailsRepository.php
+++ b/mailpoet/lib/Newsletter/AutomaticEmailsRepository.php
@@ -4,6 +4,8 @@ namespace MailPoet\Newsletter;
 
 use MailPoet\Doctrine\Repository;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
@@ -26,11 +28,15 @@ class AutomaticEmailsRepository extends Repository {
   }
 
   private function getAllQueuesForSubscscriberQuery(QueryBuilder $query, int $newsletterId, int $subscriberId): QueryBuilder {
+    // A recipient lives in the queue while the task is pending and moves to the
+    // processed log once it is sent, so the subscriber may be in either table.
     return $query
       ->join('q.task', 't')
-      ->join('t.subscribers', 's')
       ->andWhere('q.newsletter = :newsletterId')
-      ->andWhere('s.subscriber = :subscriberId')
+      ->andWhere(
+        'EXISTS (SELECT 1 FROM ' . ScheduledTaskSubscriberEntity::class . ' sts WHERE sts.task = t AND sts.subscriber = :subscriberId)'
+        . ' OR EXISTS (SELECT 1 FROM ' . ScheduledTaskQueuedSubscriberEntity::class . ' stsq WHERE stsq.task = t AND stsq.subscriber = :subscriberId)'
+      )
       ->setParameter('newsletterId', $newsletterId)
       ->setParameter('subscriberId', $subscriberId);
   }

--- a/mailpoet/lib/Newsletter/NewsletterResendController.php
+++ b/mailpoet/lib/Newsletter/NewsletterResendController.php
@@ -7,7 +7,7 @@ use MailPoet\Cron\CronTrigger;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
@@ -280,27 +280,25 @@ class NewsletterResendController {
 
   /** @param int[] $subscriberIds */
   private function addSubscribersToTask(ScheduledTaskEntity $task, array $subscriberIds): int {
-    $scheduledTaskSubscriberTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    $scheduledTaskQueuedSubscriberTable = $this->entityManager->getClassMetadata(ScheduledTaskQueuedSubscriberEntity::class)->getTableName();
     $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
 
     $connection = $this->entityManager->getConnection();
 
     $result = $connection->executeQuery(
-      "INSERT IGNORE INTO $scheduledTaskSubscriberTable
-       (task_id, subscriber_id, processed)
-       SELECT DISTINCT ? as task_id, subscribers.`id` as subscriber_id, ? as processed
+      "INSERT IGNORE INTO $scheduledTaskQueuedSubscriberTable
+       (task_id, subscriber_id)
+       SELECT DISTINCT ? as task_id, subscribers.`id` as subscriber_id
        FROM $subscriberTable subscribers
        WHERE subscribers.`deleted_at` IS NULL
        AND subscribers.`status` = ?
        AND subscribers.`id` IN (?)",
       [
         $task->getId(),
-        ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
         SubscriberEntity::STATUS_SUBSCRIBED,
         $subscriberIds,
       ],
       [
-        ParameterType::INTEGER,
         ParameterType::INTEGER,
         ParameterType::STRING,
         ArrayParameterType::INTEGER,

--- a/mailpoet/lib/Newsletter/RestApi/Endpoints/SendingStatusListingEndpoint.php
+++ b/mailpoet/lib/Newsletter/RestApi/Endpoints/SendingStatusListingEndpoint.php
@@ -11,6 +11,7 @@ use MailPoet\Cron\CronHelper;
 use MailPoet\Listing\Handler as ListingHandler;
 use MailPoet\Listing\ListingDefinition;
 use MailPoet\Listing\ListingRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscribersListingRepository;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersListingRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Settings\SettingsController;
@@ -20,15 +21,27 @@ use MailPoet\WP\Functions as WPFunctions;
 /**
  * `GET /mailpoet/v1/newsletters/{id}/sending-status`
  *
- * Per-subscriber send status (Sent / Failed / Unprocessed) for a single
- * newsletter. Replaces the legacy `sending_task_subscribers` JSON listing.
- * The response shape stays 1:1 with the other DataViews-backed listings
- * (`items`, `meta`, `filters`, `groups`) and additionally carries the
- * mailer / cron envelope the page uses to surface sending notices.
+ * Per-subscriber send status for a single newsletter, surfaced as three tabs:
+ * **Unprocessed** (pending recipients, read from the lean queue table) and
+ * **Sent** / **Failed** (read from the processed log). The `group` request
+ * param selects the tab and routes to the matching single-table repository —
+ * there is no cross-table query. The response shape stays 1:1 with the other
+ * DataViews-backed listings (`items`, `meta`, `filters`, `groups`) and
+ * additionally carries the mailer / cron envelope the page uses to surface
+ * sending notices.
  */
 class SendingStatusListingEndpoint extends AbstractListingEndpoint {
+  private const GROUP_UNPROCESSED = 'unprocessed';
+  private const DEFAULT_GROUP = 'sent';
+
+  /** @var ListingHandler */
+  private $listingHandler;
+
   /** @var ScheduledTaskSubscribersListingRepository */
   private $taskSubscribersListingRepository;
+
+  /** @var ScheduledTaskQueuedSubscribersListingRepository */
+  private $queuedSubscribersListingRepository;
 
   /** @var ScheduledTaskSubscriberResponseBuilder */
   private $responseBuilder;
@@ -45,9 +58,23 @@ class SendingStatusListingEndpoint extends AbstractListingEndpoint {
   /** @var WPFunctions */
   private $wp;
 
+  /**
+   * The tab the current request targets, resolved at the top of `handle()` and
+   * consumed synchronously within the same call by `getListingRepository()` —
+   * the one extension point the base class calls without the request or the
+   * listing definition. Everywhere else (e.g. `buildItems()`) reads the group
+   * off the `ListingDefinition`. A WordPress REST request is handled in a
+   * single-threaded PHP process, so this per-request value is never shared
+   * across requests.
+   *
+   * @var string
+   */
+  private $activeGroup = self::DEFAULT_GROUP;
+
   public function __construct(
     ListingHandler $listingHandler,
     ScheduledTaskSubscribersListingRepository $taskSubscribersListingRepository,
+    ScheduledTaskQueuedSubscribersListingRepository $queuedSubscribersListingRepository,
     ScheduledTaskSubscriberResponseBuilder $responseBuilder,
     SendingQueuesRepository $sendingQueuesRepository,
     SettingsController $settings,
@@ -55,7 +82,9 @@ class SendingStatusListingEndpoint extends AbstractListingEndpoint {
     WPFunctions $wp
   ) {
     parent::__construct($listingHandler);
+    $this->listingHandler = $listingHandler;
     $this->taskSubscribersListingRepository = $taskSubscribersListingRepository;
+    $this->queuedSubscribersListingRepository = $queuedSubscribersListingRepository;
     $this->responseBuilder = $responseBuilder;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->settings = $settings;
@@ -68,10 +97,15 @@ class SendingStatusListingEndpoint extends AbstractListingEndpoint {
   }
 
   public function handle(Request $request): Response {
+    $this->activeGroup = $this->resolveGroup($request);
+
     /** @var Response $response */
     $response = parent::handle($request);
     $payload = $response->get_data();
     if (is_array($payload) && isset($payload['data']) && is_array($payload['data'])) {
+      // Every tab shows the full chip set with counts, regardless of which tab
+      // is active. Each count is its own cheap single-table query.
+      $payload['data']['groups'] = $this->buildGroups($this->getTaskIds($request));
       $payload['data']['mta_log'] = $this->settings->get('mta_log');
       $payload['data']['mta_method'] = $this->settings->get('mta.method');
       $payload['data']['cron_accessible'] = $this->cronHelper->isDaemonAccessible();
@@ -88,35 +122,63 @@ class SendingStatusListingEndpoint extends AbstractListingEndpoint {
   }
 
   protected function getListingRepository(): ListingRepository {
-    return $this->taskSubscribersListingRepository;
+    return $this->activeGroup === self::GROUP_UNPROCESSED
+      ? $this->queuedSubscribersListingRepository
+      : $this->taskSubscribersListingRepository;
   }
 
   protected function buildItems(array $rows, ListingDefinition $definition): array {
-    return $this->responseBuilder->buildForListing($rows);
+    return $definition->getGroup() === self::GROUP_UNPROCESSED
+      ? $this->responseBuilder->buildForQueuedListing($rows)
+      : $this->responseBuilder->buildForListing($rows);
   }
 
   protected function getDefaultSortBy(): string {
-    return 'failed';
+    return 'subscriberId';
   }
 
   protected function getDefaultSortOrder(): string {
-    return 'desc';
+    return 'asc';
   }
 
   protected function getDefaultGroup(): ?string {
-    return 'all';
+    return self::DEFAULT_GROUP;
   }
 
   protected function getRequestParameters(Request $request): array {
+    return ['task_ids' => $this->getTaskIds($request)];
+  }
+
+  private function resolveGroup(Request $request): string {
+    $groupParam = $request->getParam('group');
+    return is_string($groupParam) && $groupParam !== '' ? $groupParam : self::DEFAULT_GROUP;
+  }
+
+  /**
+   * @return int[]
+   */
+  private function getTaskIds(Request $request): array {
     $idParam = $request->getParam('id');
     $newsletterId = is_numeric($idParam) ? (int)$idParam : 0;
     $taskIds = $newsletterId > 0
       ? $this->sendingQueuesRepository->getTaskIdsByNewsletterId($newsletterId)
       : [];
-    // The repository filters task subscribers by `task IN (:taskIds)`. When the
-    // newsletter has no sending tasks (never sent, or the per-subscriber
-    // records were cleaned up) fall back to a sentinel that matches no rows so
-    // the listing returns empty instead of every subscriber across all emails.
-    return ['task_ids' => $taskIds ?: [0]];
+    // The repositories filter by `task IN (:taskIds)`. When the newsletter has
+    // no sending tasks (never sent, or the per-subscriber records were cleaned
+    // up) fall back to a sentinel that matches no rows so the listing returns
+    // empty instead of every subscriber across all emails.
+    return $taskIds ?: [0];
+  }
+
+  /**
+   * @param int[] $taskIds
+   * @return array<int, array{name: string, label: string, count: int}>
+   */
+  private function buildGroups(array $taskIds): array {
+    $definition = $this->listingHandler->getListingDefinition(['params' => ['task_ids' => $taskIds]]);
+    return array_merge(
+      $this->queuedSubscribersListingRepository->getGroups($definition),
+      $this->taskSubscribersListingRepository->getGroups($definition)
+    );
   }
 }

--- a/mailpoet/lib/Newsletter/RestApi/Endpoints/SendingStatusResendEndpoint.php
+++ b/mailpoet/lib/Newsletter/RestApi/Endpoints/SendingStatusResendEndpoint.php
@@ -8,6 +8,8 @@ use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Config\AccessControl;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriberMover;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Validator\Builder;
@@ -24,6 +26,9 @@ class SendingStatusResendEndpoint extends Endpoint {
   /** @var ScheduledTaskSubscribersRepository */
   private $scheduledTaskSubscribersRepository;
 
+  /** @var ScheduledTaskSubscriberMover */
+  private $scheduledTaskSubscriberMover;
+
   /** @var SendingQueuesRepository */
   private $sendingQueuesRepository;
 
@@ -32,10 +37,12 @@ class SendingStatusResendEndpoint extends Endpoint {
 
   public function __construct(
     ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    ScheduledTaskSubscriberMover $scheduledTaskSubscriberMover,
     SendingQueuesRepository $sendingQueuesRepository,
     WPFunctions $wp
   ) {
     $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->scheduledTaskSubscriberMover = $scheduledTaskSubscriberMover;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->wp = $wp;
   }
@@ -101,8 +108,17 @@ class SendingStatusResendEndpoint extends Endpoint {
       );
     }
 
-    $taskSubscriber->resetToUnprocessed();
-    $taskSubscriber->getTask()->setStatus(null);
+    $task = $taskSubscriber->getTask();
+    if (!$task instanceof ScheduledTaskEntity) {
+      throw new ApiException(
+        __('Failed sending task not found!', 'mailpoet'),
+        404,
+        'mailpoet_sending_status_task_not_found'
+      );
+    }
+    // Move the failed recipient from the log back into the queue so the next cron run resends it.
+    $this->scheduledTaskSubscriberMover->moveBackToQueue($task, (int)$taskSubscriber->getSubscriberId());
+    $task->setStatus(null);
     if (!$newsletter->canBeSetActive()) {
       $newsletter->setStatus(NewsletterEntity::STATUS_SENDING);
     }

--- a/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomaticEmailScheduler.php
@@ -6,9 +6,10 @@ use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
@@ -27,15 +28,20 @@ class AutomaticEmailScheduler {
   /** @var ScheduledTaskSubscribersRepository */
   private $scheduledTaskSubscribersRepository;
 
+  /** @var ScheduledTaskQueuedSubscriberRepository */
+  private $scheduledTaskQueuedSubscriberRepository;
+
   public function __construct(
     Scheduler $scheduler,
     ScheduledTasksRepository $scheduledTasksRepository,
     ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    ScheduledTaskQueuedSubscriberRepository $scheduledTaskQueuedSubscriberRepository,
     SendingQueuesRepository $sendingQueuesRepository
   ) {
     $this->scheduler = $scheduler;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->scheduledTaskQueuedSubscriberRepository = $scheduledTaskQueuedSubscriberRepository;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
   }
 
@@ -127,6 +133,9 @@ class AutomaticEmailScheduler {
           $this->sendingQueuesRepository->remove($queue);
         }
         $this->scheduledTaskSubscribersRepository->deleteByScheduledTask($task);
+        // The recipient of a still-scheduled task lives in the queue, so clear
+        // it too — otherwise removing the task orphans the queue row.
+        $this->scheduledTaskQueuedSubscriberRepository->deleteByScheduledTask($task);
         $this->scheduledTasksRepository->remove($task);
         $this->scheduledTasksRepository->flush();
       }
@@ -163,10 +172,9 @@ class AutomaticEmailScheduler {
     $this->sendingQueuesRepository->flush();
 
     if ($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SEND_TO) === 'user' && $subscriber) {
-      $scheduledTaskSubscriber = new ScheduledTaskSubscriberEntity($scheduledTask, $subscriber);
-      $this->scheduledTaskSubscribersRepository->persist($scheduledTaskSubscriber);
-      $this->scheduledTaskSubscribersRepository->flush();
-      $scheduledTask->getSubscribers()->add($scheduledTaskSubscriber);
+      $scheduledTaskSubscriber = new ScheduledTaskQueuedSubscriberEntity($scheduledTask, $subscriber);
+      $this->scheduledTaskQueuedSubscriberRepository->persist($scheduledTaskSubscriber);
+      $this->scheduledTaskQueuedSubscriberRepository->flush();
     }
 
     return $scheduledTask;

--- a/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
@@ -6,10 +6,13 @@ use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\InvalidStateException;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriber;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriberMover;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -20,12 +23,16 @@ class AutomationEmailScheduler {
 
   private ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository;
 
+  private ScheduledTaskSubscriberMover $scheduledTaskSubscriberMover;
+
   public function __construct(
     EntityManager $entityManager,
-    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository
+    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    ScheduledTaskSubscriberMover $scheduledTaskSubscriberMover
   ) {
     $this->entityManager = $entityManager;
     $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->scheduledTaskSubscriberMover = $scheduledTaskSubscriberMover;
   }
 
   public function createSendingTask(NewsletterEntity $email, SubscriberEntity $subscriber, array $meta): ScheduledTaskEntity {
@@ -44,7 +51,7 @@ class AutomationEmailScheduler {
     $task->setMeta($meta);
     $this->entityManager->persist($task);
 
-    $taskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
+    $taskSubscriber = new ScheduledTaskQueuedSubscriberEntity($task, $subscriber);
     $this->entityManager->persist($taskSubscriber);
 
     $queue = new SendingQueueEntity();
@@ -59,41 +66,70 @@ class AutomationEmailScheduler {
     return $task;
   }
 
-  public function getScheduledTaskSubscriber(NewsletterEntity $email, SubscriberEntity $subscriber, AutomationRun $run): ?ScheduledTaskSubscriberEntity {
+  public function getScheduledTaskSubscriber(NewsletterEntity $email, SubscriberEntity $subscriber, AutomationRun $run): ?ScheduledTaskSubscriber {
+    // a finished send (sent or failed) was moved to the log
+    $processed = $this->findRunTaskSubscriber(ScheduledTaskSubscriberEntity::class, 'sts', $email, $subscriber, $run);
+    if ($processed instanceof ScheduledTaskSubscriberEntity) {
+      return ScheduledTaskSubscriber::fromProcessed($processed);
+    }
+
+    // a still-pending send sits in the queue
+    $queued = $this->findRunTaskSubscriber(ScheduledTaskQueuedSubscriberEntity::class, 'stsq', $email, $subscriber, $run);
+    if ($queued instanceof ScheduledTaskQueuedSubscriberEntity) {
+      return ScheduledTaskSubscriber::fromQueued($queued);
+    }
+
+    return null;
+  }
+
+  public function saveError(ScheduledTaskSubscriber $scheduledTaskSubscriber, string $error): void {
+    $task = $scheduledTaskSubscriber->getTask();
+    $subscriberId = $scheduledTaskSubscriber->getSubscriberId();
+    if (!$task || !$subscriberId) {
+      return;
+    }
+    if ($scheduledTaskSubscriber->isPending()) {
+      $this->scheduledTaskSubscriberMover->moveFailedToLog($task, $subscriberId, $error);
+    } else {
+      $this->scheduledTaskSubscribersRepository->saveError($task, $subscriberId, $error);
+    }
+  }
+
+  /**
+   * @param class-string $entityClass
+   * @return ScheduledTaskSubscriberEntity|ScheduledTaskQueuedSubscriberEntity|null
+   */
+  private function findRunTaskSubscriber(string $entityClass, string $alias, NewsletterEntity $email, SubscriberEntity $subscriber, AutomationRun $run) {
     $results = $this->entityManager->createQueryBuilder()
-      ->select('sts')
-      ->from(ScheduledTaskSubscriberEntity::class, 'sts')
-      ->join('sts.task', 'st')
+      ->select($alias)
+      ->from($entityClass, $alias)
+      ->join("$alias.task", 'st')
       ->join('st.sendingQueue', 'sq')
       ->where('sq.newsletter = :newsletter')
-      ->andWhere('sts.subscriber = :subscriber')
+      ->andWhere("$alias.subscriber = :subscriber")
       ->andWhere('st.createdAt >= :runCreatedAt')
       ->setParameter('newsletter', $email)
       ->setParameter('subscriber', $subscriber)
       ->setParameter('runCreatedAt', $run->getCreatedAt())
       ->getQuery()
       ->getResult();
-    $result = null;
-    foreach ($results as $scheduledTaskSubscriber) {
-      $task = $scheduledTaskSubscriber->getTask();
+
+    foreach ($results as $taskSubscriber) {
+      if (
+        !$taskSubscriber instanceof ScheduledTaskSubscriberEntity
+        && !$taskSubscriber instanceof ScheduledTaskQueuedSubscriberEntity
+      ) {
+        continue;
+      }
+      $task = $taskSubscriber->getTask();
       if (!$task instanceof ScheduledTaskEntity) {
         continue;
       }
       $meta = $task->getMeta();
       if (($meta['automation']['run_id'] ?? null) === $run->getId()) {
-        $result = $scheduledTaskSubscriber;
-        break;
+        return $taskSubscriber;
       }
     }
-    return $result instanceof ScheduledTaskSubscriberEntity ? $result : null;
-  }
-
-  public function saveError(ScheduledTaskSubscriberEntity $scheduledTaskSubscriber, string $error): void {
-    $task = $scheduledTaskSubscriber->getTask();
-    $subscriber = $scheduledTaskSubscriber->getSubscriber();
-    if (!$task || !$subscriber || !$subscriber->getId()) {
-      return;
-    }
-    $this->scheduledTaskSubscribersRepository->saveError($task, $subscriber->getId(), $error);
+    return null;
   }
 }

--- a/mailpoet/lib/Newsletter/Scheduler/LatestNewsletterScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/LatestNewsletterScheduler.php
@@ -6,6 +6,7 @@ use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
@@ -13,6 +14,8 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\NewsletterReplayMetadata;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriber;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriberMover;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -29,19 +32,23 @@ class LatestNewsletterScheduler {
 
   private ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository;
 
+  private ScheduledTaskSubscriberMover $scheduledTaskSubscriberMover;
+
   public function __construct(
     EntityManager $entityManager,
     NewslettersRepository $newslettersRepository,
-    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository
+    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    ScheduledTaskSubscriberMover $scheduledTaskSubscriberMover
   ) {
     $this->entityManager = $entityManager;
     $this->newslettersRepository = $newslettersRepository;
     $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->scheduledTaskSubscriberMover = $scheduledTaskSubscriberMover;
   }
 
   /**
    * @param array{id:mixed,run_id:mixed,step_id:mixed,run_number:mixed} $automationMeta
-   * @return array{outcome: string, newsletter: NewsletterEntity|null, task_subscriber: ScheduledTaskSubscriberEntity|null}
+   * @return array{outcome: string, newsletter: NewsletterEntity|null, task_subscriber: ScheduledTaskSubscriber|null}
    */
   public function schedule(SubscriberEntity $subscriber, int $segmentId, array $automationMeta): array {
     $source = $this->newslettersRepository->findLatestSentStandardForSegment($segmentId);
@@ -84,7 +91,7 @@ class LatestNewsletterScheduler {
         }
 
         $existingReplay = $this->findExistingReplayTaskSubscriber($newsletter, $subscriber);
-        if ($existingReplay instanceof ScheduledTaskSubscriberEntity) {
+        if ($existingReplay !== null) {
           $task = $existingReplay->getTask();
           $meta = $task ? $task->getMeta() : [];
           $isSameRun = ($meta[NewsletterReplayMetadata::AUTOMATION]['run_id'] ?? null) === ($automationMeta['run_id'] ?? null);
@@ -107,14 +114,49 @@ class LatestNewsletterScheduler {
     }
   }
 
-  public function getScheduledTaskSubscriber(NewsletterEntity $newsletter, SubscriberEntity $subscriber, AutomationRun $run): ?ScheduledTaskSubscriberEntity {
+  public function getScheduledTaskSubscriber(NewsletterEntity $newsletter, SubscriberEntity $subscriber, AutomationRun $run): ?ScheduledTaskSubscriber {
+    // a finished send (sent or failed) was moved to the log
+    $processed = $this->findRunReplayTaskSubscriber(ScheduledTaskSubscriberEntity::class, 'sts', $newsletter, $subscriber, $run);
+    if ($processed instanceof ScheduledTaskSubscriberEntity) {
+      return ScheduledTaskSubscriber::fromProcessed($processed);
+    }
+
+    // a still-pending send sits in the queue
+    $queued = $this->findRunReplayTaskSubscriber(ScheduledTaskQueuedSubscriberEntity::class, 'stsq', $newsletter, $subscriber, $run);
+    if ($queued instanceof ScheduledTaskQueuedSubscriberEntity) {
+      return ScheduledTaskSubscriber::fromQueued($queued);
+    }
+
+    return null;
+  }
+
+  public function saveErrorAndPause(ScheduledTaskSubscriber $scheduledTaskSubscriber, string $error): void {
+    $task = $scheduledTaskSubscriber->getTask();
+    $subscriberId = $scheduledTaskSubscriber->getSubscriberId();
+    if (!$task || !$subscriberId) {
+      return;
+    }
+    if ($scheduledTaskSubscriber->isPending()) {
+      $this->scheduledTaskSubscriberMover->moveFailedToLog($task, $subscriberId, $error);
+    } else {
+      $this->scheduledTaskSubscribersRepository->saveError($task, $subscriberId, $error);
+    }
+    $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
+    $this->entityManager->flush();
+  }
+
+  /**
+   * @param class-string $entityClass
+   * @return ScheduledTaskSubscriberEntity|ScheduledTaskQueuedSubscriberEntity|null
+   */
+  private function findRunReplayTaskSubscriber(string $entityClass, string $alias, NewsletterEntity $newsletter, SubscriberEntity $subscriber, AutomationRun $run) {
     $results = $this->entityManager->createQueryBuilder()
-      ->select('sts')
-      ->from(ScheduledTaskSubscriberEntity::class, 'sts')
-      ->join('sts.task', 'st')
+      ->select($alias)
+      ->from($entityClass, $alias)
+      ->join("$alias.task", 'st')
       ->join('st.sendingQueue', 'sq')
       ->where('sq.newsletter = :newsletter')
-      ->andWhere('sts.subscriber = :subscriber')
+      ->andWhere("$alias.subscriber = :subscriber")
       ->andWhere('st.createdAt >= :runCreatedAt')
       ->setParameter('newsletter', $newsletter)
       ->setParameter('subscriber', $subscriber)
@@ -122,31 +164,23 @@ class LatestNewsletterScheduler {
       ->getQuery()
       ->getResult();
 
-    foreach ($results as $scheduledTaskSubscriber) {
-      if (!$scheduledTaskSubscriber instanceof ScheduledTaskSubscriberEntity) {
+    foreach ($results as $taskSubscriber) {
+      if (
+        !$taskSubscriber instanceof ScheduledTaskSubscriberEntity
+        && !$taskSubscriber instanceof ScheduledTaskQueuedSubscriberEntity
+      ) {
         continue;
       }
-      $task = $scheduledTaskSubscriber->getTask();
+      $task = $taskSubscriber->getTask();
       if (!$task instanceof ScheduledTaskEntity || !NewsletterReplayMetadata::isLatestNewsletterReplayMeta($task->getMeta())) {
         continue;
       }
       $meta = $task->getMeta();
       if (($meta[NewsletterReplayMetadata::AUTOMATION]['run_id'] ?? null) === $run->getId()) {
-        return $scheduledTaskSubscriber;
+        return $taskSubscriber;
       }
     }
     return null;
-  }
-
-  public function saveErrorAndPause(ScheduledTaskSubscriberEntity $scheduledTaskSubscriber, string $error): void {
-    $task = $scheduledTaskSubscriber->getTask();
-    $subscriber = $scheduledTaskSubscriber->getSubscriber();
-    if (!$task || !$subscriber || !$subscriber->getId()) {
-      return;
-    }
-    $this->scheduledTaskSubscribersRepository->saveError($task, $subscriber->getId(), $error);
-    $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
-    $this->entityManager->flush();
   }
 
   private function hasSuccessfulProcessedSend(NewsletterEntity $newsletter, SubscriberEntity $subscriber): bool {
@@ -174,18 +208,16 @@ class LatestNewsletterScheduler {
   private function hasPendingNonReplayTaskSubscriber(NewsletterEntity $newsletter, SubscriberEntity $subscriber): bool {
     $result = $this->entityManager->createQueryBuilder()
       ->select('COUNT(st)')
-      ->from(ScheduledTaskSubscriberEntity::class, 'sts')
-      ->join('sts.task', 'st')
+      ->from(ScheduledTaskQueuedSubscriberEntity::class, 'stsq')
+      ->join('stsq.task', 'st')
       ->join(SendingQueueEntity::class, 'sq', Join::WITH, 'sq.task = st')
       ->where('sq.newsletter = :newsletter')
-      ->andWhere('sts.subscriber = :subscriber')
-      ->andWhere('sts.failed = :notFailed')
+      ->andWhere('stsq.subscriber = :subscriber')
       ->andWhere('(st.status = :scheduled OR st.status IS NULL)')
       ->andWhere('st.meta IS NULL OR st.meta NOT LIKE :latestNewsletterReplayMeta')
       ->andWhere('sq.meta IS NULL OR sq.meta NOT LIKE :latestNewsletterReplayMeta')
       ->setParameter('newsletter', $newsletter)
       ->setParameter('subscriber', $subscriber)
-      ->setParameter('notFailed', ScheduledTaskSubscriberEntity::FAIL_STATUS_OK)
       ->setParameter('scheduled', ScheduledTaskEntity::STATUS_SCHEDULED)
       ->setParameter('latestNewsletterReplayMeta', NewsletterReplayMetadata::getMetaLikePattern())
       ->getQuery()
@@ -208,8 +240,35 @@ class LatestNewsletterScheduler {
     return (int)$result > 0;
   }
 
-  private function findExistingReplayTaskSubscriber(NewsletterEntity $newsletter, SubscriberEntity $subscriber): ?ScheduledTaskSubscriberEntity {
-    $results = $this->entityManager->createQueryBuilder()
+  private function findExistingReplayTaskSubscriber(NewsletterEntity $newsletter, SubscriberEntity $subscriber): ?ScheduledTaskSubscriber {
+    // a pending replay still sits in the queue
+    $queuedResults = $this->entityManager->createQueryBuilder()
+      ->select('stsq')
+      ->from(ScheduledTaskQueuedSubscriberEntity::class, 'stsq')
+      ->join('stsq.task', 'st')
+      ->join(SendingQueueEntity::class, 'sq', Join::WITH, 'sq.task = st')
+      ->where('sq.newsletter = :newsletter')
+      ->andWhere('stsq.subscriber = :subscriber')
+      ->setParameter('newsletter', $newsletter)
+      ->setParameter('subscriber', $subscriber)
+      ->getQuery()
+      ->getResult();
+
+    foreach ($queuedResults as $queued) {
+      if (!$queued instanceof ScheduledTaskQueuedSubscriberEntity) {
+        continue;
+      }
+      $task = $queued->getTask();
+      if (!$task instanceof ScheduledTaskEntity || !NewsletterReplayMetadata::isLatestNewsletterReplayMeta($task->getMeta())) {
+        continue;
+      }
+      if (in_array($task->getStatus(), [ScheduledTaskEntity::STATUS_SCHEDULED, null], true)) {
+        return ScheduledTaskSubscriber::fromQueued($queued);
+      }
+    }
+
+    // a completed replay was moved to the log
+    $processedResults = $this->entityManager->createQueryBuilder()
       ->select('sts')
       ->from(ScheduledTaskSubscriberEntity::class, 'sts')
       ->join('sts.task', 'st')
@@ -223,32 +282,29 @@ class LatestNewsletterScheduler {
       ->getQuery()
       ->getResult();
 
-    foreach ($results as $scheduledTaskSubscriber) {
-      if (!$scheduledTaskSubscriber instanceof ScheduledTaskSubscriberEntity) {
+    foreach ($processedResults as $processed) {
+      if (!$processed instanceof ScheduledTaskSubscriberEntity) {
         continue;
       }
-      $task = $scheduledTaskSubscriber->getTask();
+      $task = $processed->getTask();
       if (!$task instanceof ScheduledTaskEntity || !NewsletterReplayMetadata::isLatestNewsletterReplayMeta($task->getMeta())) {
         continue;
       }
-      $status = $task->getStatus();
-      if (in_array($status, [ScheduledTaskEntity::STATUS_SCHEDULED, null], true)) {
-        return $scheduledTaskSubscriber;
-      }
       if (
-        $status === ScheduledTaskEntity::STATUS_COMPLETED
-        && $scheduledTaskSubscriber->getProcessed() === ScheduledTaskSubscriberEntity::STATUS_PROCESSED
+        $task->getStatus() === ScheduledTaskEntity::STATUS_COMPLETED
+        && $processed->getProcessed() === ScheduledTaskSubscriberEntity::STATUS_PROCESSED
       ) {
-        return $scheduledTaskSubscriber;
+        return ScheduledTaskSubscriber::fromProcessed($processed);
       }
     }
+
     return null;
   }
 
   /**
    * @param array{newsletter: NewsletterEntity, queue: SendingQueueEntity, task: ScheduledTaskEntity} $source
    */
-  private function createReplaySendingTask(array $source, SubscriberEntity $subscriber, array $automationMeta): ScheduledTaskSubscriberEntity {
+  private function createReplaySendingTask(array $source, SubscriberEntity $subscriber, array $automationMeta): ScheduledTaskSubscriber {
     $sourceTask = $source['task'];
     $sourceQueue = $source['queue'];
     $newsletter = $source['newsletter'];
@@ -270,9 +326,8 @@ class LatestNewsletterScheduler {
     $task->setMeta($meta);
     $this->entityManager->persist($task);
 
-    $taskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
+    $taskSubscriber = new ScheduledTaskQueuedSubscriberEntity($task, $subscriber);
     $this->entityManager->persist($taskSubscriber);
-    $task->getSubscribers()->add($taskSubscriber);
 
     $queue = new SendingQueueEntity();
     $queue->setTask($task);
@@ -283,7 +338,7 @@ class LatestNewsletterScheduler {
     $queue->setCountTotal(1);
     $this->entityManager->persist($queue);
 
-    return $taskSubscriber;
+    return ScheduledTaskSubscriber::fromQueued($taskSubscriber);
   }
 
   private function acquireLock(string $lockName): void {

--- a/mailpoet/lib/Newsletter/Scheduler/ReEngagementScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/ReEngagementScheduler.php
@@ -6,7 +6,7 @@ use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -130,14 +130,14 @@ class ReEngagementScheduler {
     $taskId = $scheduledTask->getId();
     $subscribedStatus = SubscriberEntity::STATUS_SUBSCRIBED;
     $newsletterStatsTable = $this->entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName();
-    $scheduledTaskSubscribersTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    $scheduledTaskQueuedSubscribersTable = $this->entityManager->getClassMetadata(ScheduledTaskQueuedSubscriberEntity::class)->getTableName();
     $subscriberSegmentTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $nowSql = Carbon::now()->millisecond(0)->toDateTimeString();
 
-    $query = "INSERT IGNORE INTO $scheduledTaskSubscribersTable
-      (subscriber_id, task_id,  processed, created_at)
-      SELECT DISTINCT ns.subscriber_id as subscriber_id, :taskId as task_id, 0 as processed, :now as created_at
+    $query = "INSERT IGNORE INTO $scheduledTaskQueuedSubscribersTable
+      (subscriber_id, task_id, created_at)
+      SELECT DISTINCT ns.subscriber_id as subscriber_id, :taskId as task_id, :now as created_at
       FROM $newsletterStatsTable as ns
       JOIN $subscribersTable s ON
         ns.subscriber_id = s.id

--- a/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/WelcomeScheduler.php
@@ -6,7 +6,7 @@ use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -143,8 +143,7 @@ class WelcomeScheduler {
     $this->entityManager->persist($queue);
 
     // task subscriber
-    $taskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
-    $task->getSubscribers()->add($taskSubscriber);
+    $taskSubscriber = new ScheduledTaskQueuedSubscriberEntity($task, $subscriber);
     $this->entityManager->persist($taskSubscriber);
 
     $this->entityManager->flush();

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskQueuedSubscriberRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskQueuedSubscriberRepository.php
@@ -1,0 +1,159 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Sending;
+
+use MailPoet\Doctrine\Repository;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
+use MailPoetVendor\Doctrine\DBAL\ParameterType;
+use MailPoetVendor\Doctrine\ORM\QueryBuilder;
+
+/**
+ * @extends Repository<ScheduledTaskQueuedSubscriberEntity>
+ */
+class ScheduledTaskQueuedSubscriberRepository extends Repository {
+  protected function getEntityClassName() {
+    return ScheduledTaskQueuedSubscriberEntity::class;
+  }
+
+  /** @param int[] $subscriberIds */
+  public function addSubscribersByIds(ScheduledTaskEntity $task, array $subscriberIds): int {
+    $subscriberIds = array_values(array_unique(array_filter(array_map('intval', $subscriberIds))));
+    if ($subscriberIds === []) {
+      return 0;
+    }
+
+    $scheduledTaskQueuedSubscribersTable = $this->entityManager->getClassMetadata(ScheduledTaskQueuedSubscriberEntity::class)->getTableName();
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+
+    $result = $this->entityManager->getConnection()->executeQuery(
+      "INSERT IGNORE INTO $scheduledTaskQueuedSubscribersTable
+       (task_id, subscriber_id)
+       SELECT ? as task_id, subscribers.`id` as subscriber_id
+       FROM $subscribersTable subscribers
+       WHERE subscribers.`deleted_at` IS NULL
+       AND subscribers.`status` = ?
+       AND subscribers.`id` IN (?)",
+      [
+        $task->getId(),
+        SubscriberEntity::STATUS_SUBSCRIBED,
+        $subscriberIds,
+      ],
+      [
+        ParameterType::INTEGER,
+        ParameterType::STRING,
+        ArrayParameterType::INTEGER,
+      ]
+    );
+
+    return (int)$result->rowCount();
+  }
+
+  public function getSubscriberIdsBatchForTask(int $taskId, int $lastProcessedSubscriberId, int $limit): array {
+    $queryBuilder = $this->getBaseSubscribersIdsBatchForTaskQuery($taskId, $lastProcessedSubscriberId);
+    /** @var string[] $subscribersIds */
+    $subscribersIds = $queryBuilder
+      ->select('IDENTITY(stsq.subscriber) AS subscriber_id')
+      ->orderBy('stsq.subscriber', 'asc')
+      ->setMaxResults($limit)
+      ->getQuery()
+      ->getSingleColumnResult();
+
+    return array_map('intval', $subscribersIds);
+  }
+
+  public function countForTask(ScheduledTaskEntity $task): int {
+    return $this->countBy(['task' => $task]);
+  }
+
+  public function countSubscriberIdsBatchForTask(int $taskId, int $lastProcessedSubscriberId): int {
+    $queryBuilder = $this->getBaseSubscribersIdsBatchForTaskQuery($taskId, $lastProcessedSubscriberId);
+    $count = $queryBuilder
+      ->select('count(stsq.subscriber)')
+      ->getQuery()
+      ->getSingleScalarResult();
+
+    return (int)$count;
+  }
+
+  public function checkCompleted(ScheduledTaskEntity $task): void {
+    if ($this->hasUnprocessed($task)) {
+      return;
+    }
+    $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+    $task->setProcessedAt(Carbon::now()->millisecond(0));
+    $this->entityManager->flush();
+  }
+
+  public function hasUnprocessed(ScheduledTaskEntity $task): bool {
+    $scheduledTaskQueuedSubscribersTable = $this->entityManager->getClassMetadata(ScheduledTaskQueuedSubscriberEntity::class)->getTableName();
+    $result = $this->entityManager->getConnection()->executeQuery(
+      "SELECT 1 FROM $scheduledTaskQueuedSubscribersTable
+       WHERE `task_id` = ?
+       LIMIT 1",
+      [$task->getId()],
+      [ParameterType::INTEGER]
+    )->fetchOne();
+
+    return $result !== false;
+  }
+
+  public function deleteByScheduledTask(ScheduledTaskEntity $scheduledTask): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(ScheduledTaskQueuedSubscriberEntity::class, 'stsq')
+      ->where('stsq.task = :task')
+      ->setParameter('task', $scheduledTask)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (ScheduledTaskQueuedSubscriberEntity $entity) use ($scheduledTask) {
+      return $entity->getTask() === $scheduledTask;
+    });
+  }
+
+  public function deleteByScheduledTaskAndSubscriberIds(ScheduledTaskEntity $scheduledTask, array $subscriberIds): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(ScheduledTaskQueuedSubscriberEntity::class, 'stsq')
+      ->where('stsq.task = :task')
+      ->andWhere('stsq.subscriber IN (:subscriberIds)')
+      ->setParameter('task', $scheduledTask)
+      ->setParameter('subscriberIds', $subscriberIds, ArrayParameterType::INTEGER)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (ScheduledTaskQueuedSubscriberEntity $entity) use ($scheduledTask, $subscriberIds) {
+      return $entity->getTask() === $scheduledTask && in_array($entity->getSubscriberId(), $subscriberIds, true);
+    });
+  }
+
+  /** @param int[] $taskIds */
+  public function deleteByTaskIds(array $taskIds): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(ScheduledTaskQueuedSubscriberEntity::class, 'stsq')
+      ->where('stsq.task IN (:taskIds)')
+      ->setParameter('taskIds', $taskIds)
+      ->getQuery()
+      ->execute();
+
+    // delete was done via DQL, make sure the entities are also detached from the entity manager
+    $this->detachAll(function (ScheduledTaskQueuedSubscriberEntity $entity) use ($taskIds) {
+      $task = $entity->getTask();
+      return $task && in_array($task->getId(), $taskIds, true);
+    });
+  }
+
+  private function getBaseSubscribersIdsBatchForTaskQuery(int $taskId, int $lastProcessedSubscriberId): QueryBuilder {
+    return $this->entityManager
+      ->createQueryBuilder()
+      ->from(ScheduledTaskQueuedSubscriberEntity::class, 'stsq')
+      ->andWhere('stsq.task = :taskId')
+      ->andWhere('stsq.subscriber > :lastProcessedSubscriberId')
+      ->setParameter('taskId', $taskId)
+      ->setParameter('lastProcessedSubscriberId', $lastProcessedSubscriberId);
+  }
+}

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskQueuedSubscribersListingRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskQueuedSubscribersListingRepository.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Sending;
+
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
+use MailPoet\Listing\ListingDefinition;
+use MailPoet\Listing\ListingRepository;
+use MailPoet\Util\Helpers;
+use MailPoetVendor\Doctrine\ORM\QueryBuilder;
+
+/**
+ * Powers the "Unprocessed" tab of the Sending Status screen. Reads the lean
+ * queue table (`scheduled_task_queued_subscribers`), which holds only the
+ * pending recipients of in-flight sending tasks. There is no processed/failed/
+ * error column here — those live in the log and are surfaced by
+ * {@see ScheduledTaskSubscribersListingRepository}.
+ */
+class ScheduledTaskQueuedSubscribersListingRepository extends ListingRepository {
+  public function getGroups(ListingDefinition $definition): array {
+    $queryBuilder = clone $this->queryBuilder;
+    $this->applyFromClause($queryBuilder);
+    $this->applyParameters($queryBuilder, $definition->getParameters());
+    $queryBuilder->select('COUNT(stsq.subscriber) AS subscriberCount');
+    $count = (int)$queryBuilder->getQuery()->getSingleScalarResult();
+
+    return [
+      [
+        'name' => 'unprocessed',
+        'label' => __('Unprocessed', 'mailpoet'),
+        'count' => $count,
+      ],
+    ];
+  }
+
+  protected function applySelectClause(QueryBuilder $queryBuilder) {
+    $queryBuilder->select('PARTIAL stsq.{task,subscriber}, PARTIAL s.{id, email, firstName, lastName}');
+  }
+
+  protected function applyFromClause(QueryBuilder $queryBuilder) {
+    $queryBuilder->from(ScheduledTaskQueuedSubscriberEntity::class, 'stsq')
+      ->leftJoin('stsq.subscriber', 's');
+  }
+
+  protected function applyGroup(QueryBuilder $queryBuilder, string $group) {
+    // The queue table is, by definition, the unprocessed set — there is no
+    // sub-group to filter on.
+  }
+
+  protected function applySorting(QueryBuilder $queryBuilder, string $sortBy, string $sortOrder) {
+    // Ordering by subscriberId is mapped to email for consistency with the
+    // Subscriber listing; the queue exposes no other sortable column.
+    $sortBy = $sortBy === 'subscriberId' ? 's.email' : 'stsq.subscriber';
+    $queryBuilder->addOrderBy($sortBy, $sortOrder);
+  }
+
+  protected function applySearch(QueryBuilder $queryBuilder, string $search, array $parameters = []) {
+    $search = Helpers::escapeSearch($search);
+    $queryBuilder
+      ->andWhere('s.email LIKE :search or s.firstName LIKE :search or s.lastName LIKE :search')
+      ->setParameter('search', "%$search%");
+  }
+
+  protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
+    // the parent class requires this method, but the queue listing doesn't currently support filters.
+  }
+
+  protected function applyParameters(QueryBuilder $queryBuilder, array $parameters) {
+    if (isset($parameters['task_ids']) && !empty($parameters['task_ids'])) {
+      $queryBuilder->andWhere('stsq.task IN (:taskIds)')
+        ->setParameter('taskIds', $parameters['task_ids']);
+    }
+  }
+
+  public function getCount(ListingDefinition $definition): int {
+    $queryBuilder = clone $this->queryBuilder;
+    $this->applyFromClause($queryBuilder);
+    $this->applyConstraints($queryBuilder, $definition);
+    $queryBuilder->select('COUNT(DISTINCT stsq.subscriber)');
+    return intval($queryBuilder->getQuery()->getSingleScalarResult());
+  }
+}

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscriber.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscriber.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Sending;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+
+/**
+ * A single sending-task recipient lives in one of two tables depending on its
+ * state: pending recipients sit in the queue (`scheduled_task_queued_subscribers`),
+ * processed ones are moved to the log (`scheduled_task_subscribers`). This wraps
+ * whichever entity represents the recipient and exposes a state-oriented API so
+ * callers polling for completion don't have to know which table it came from.
+ */
+class ScheduledTaskSubscriber {
+  private ?ScheduledTaskSubscriberEntity $processed;
+
+  private ?ScheduledTaskQueuedSubscriberEntity $queued;
+
+  private function __construct(
+    ?ScheduledTaskSubscriberEntity $processed,
+    ?ScheduledTaskQueuedSubscriberEntity $queued
+  ) {
+    $this->processed = $processed;
+    $this->queued = $queued;
+  }
+
+  public static function fromProcessed(ScheduledTaskSubscriberEntity $entity): self {
+    return new self($entity, null);
+  }
+
+  public static function fromQueued(ScheduledTaskQueuedSubscriberEntity $entity): self {
+    return new self(null, $entity);
+  }
+
+  public function isPending(): bool {
+    return $this->queued !== null;
+  }
+
+  public function wasProcessed(): bool {
+    return $this->processed !== null
+      && $this->processed->getProcessed() === ScheduledTaskSubscriberEntity::STATUS_PROCESSED;
+  }
+
+  public function hasFailed(): bool {
+    return $this->processed !== null
+      && $this->processed->getFailed() === ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED;
+  }
+
+  public function getError(): ?string {
+    return $this->processed !== null ? $this->processed->getError() : null;
+  }
+
+  public function getTask(): ?ScheduledTaskEntity {
+    if ($this->processed !== null) {
+      return $this->processed->getTask();
+    }
+    if ($this->queued !== null) {
+      return $this->queued->getTask();
+    }
+    return null;
+  }
+
+  public function getSubscriberId(): ?int {
+    if ($this->processed !== null) {
+      return $this->processed->getSubscriberId();
+    }
+    if ($this->queued !== null) {
+      return $this->queued->getSubscriberId();
+    }
+    return null;
+  }
+}

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscriberMover.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscriberMover.php
@@ -1,0 +1,214 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Sending;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
+use MailPoetVendor\Doctrine\DBAL\Connection;
+use MailPoetVendor\Doctrine\DBAL\ParameterType;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class ScheduledTaskSubscriberMover {
+  private EntityManager $entityManager;
+  private ScheduledTaskQueuedSubscriberRepository $scheduledTaskQueuedSubscriberRepository;
+  private ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository;
+
+  public function __construct(
+    EntityManager $entityManager,
+    ScheduledTaskQueuedSubscriberRepository $scheduledTaskQueuedSubscriberRepository,
+    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository
+  ) {
+    $this->entityManager = $entityManager;
+    $this->scheduledTaskQueuedSubscriberRepository = $scheduledTaskQueuedSubscriberRepository;
+    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+  }
+
+  /**
+   * @param int[] $subscriberIds
+   */
+  public function moveProcessedToLog(ScheduledTaskEntity $task, array $subscriberIds): void {
+    $subscriberIds = $this->normalizeSubscriberIds($subscriberIds);
+    if ($subscriberIds === []) {
+      return;
+    }
+
+    $this->entityManager->getConnection()->transactional(function (Connection $connection) use ($task, $subscriberIds): void {
+      $this->insertProcessedToLog($connection, $task, $subscriberIds);
+      $this->deleteFromQueue($connection, $task, $subscriberIds);
+    });
+    $this->detachQueuedFromIdentityMap($task, $subscriberIds);
+  }
+
+  public function moveFailedToLog(ScheduledTaskEntity $task, int $subscriberId, string $error): void {
+    $this->entityManager->getConnection()->transactional(function (Connection $connection) use ($task, $subscriberId, $error): void {
+      $this->insertFailedToLog($connection, $task, $subscriberId, $error);
+      $this->deleteFromQueue($connection, $task, [$subscriberId]);
+    });
+    $this->detachQueuedFromIdentityMap($task, [$subscriberId]);
+  }
+
+  public function moveBackToQueue(ScheduledTaskEntity $task, int $subscriberId): void {
+    $this->entityManager->getConnection()->transactional(function (Connection $connection) use ($task, $subscriberId): void {
+      $deleted = $this->deleteFromLog($connection, $task, $subscriberId);
+      if ($deleted === 0) {
+        return;
+      }
+
+      $this->insertToQueue($connection, $task, $subscriberId);
+    });
+    $this->detachLogFromIdentityMap($task, $subscriberId);
+  }
+
+  /**
+   * Moves are executed with raw SQL, so Doctrine's identity map still holds the
+   * rows we just relocated. Detach them so a later lookup re-reads from the
+   * database instead of returning a stale, already-moved entity. Callers should
+   * re-query the repositories rather than trust $task's in-memory subscriber
+   * collections after a move.
+   *
+   * @param int[] $subscriberIds
+   */
+  private function detachQueuedFromIdentityMap(ScheduledTaskEntity $task, array $subscriberIds): void {
+    $this->scheduledTaskQueuedSubscriberRepository->detachAll(function (ScheduledTaskQueuedSubscriberEntity $entity) use ($task, $subscriberIds) {
+      return $entity->getTask() === $task && in_array($entity->getSubscriberId(), $subscriberIds, true);
+    });
+  }
+
+  private function detachLogFromIdentityMap(ScheduledTaskEntity $task, int $subscriberId): void {
+    $this->scheduledTaskSubscribersRepository->detachAll(function (ScheduledTaskSubscriberEntity $entity) use ($task, $subscriberId) {
+      return $entity->getTask() === $task && $entity->getSubscriberId() === $subscriberId;
+    });
+  }
+
+  /**
+   * @param int[] $subscriberIds
+   * @return int[]
+   */
+  private function normalizeSubscriberIds(array $subscriberIds): array {
+    return array_values(array_unique(array_filter(array_map('intval', $subscriberIds))));
+  }
+
+  /**
+   * @param int[] $subscriberIds
+   */
+  private function insertProcessedToLog(Connection $connection, ScheduledTaskEntity $task, array $subscriberIds): void {
+    $scheduledTaskSubscribersTable = $this->getLogTableName();
+    $scheduledTaskQueuedSubscribersTable = $this->getQueueTableName();
+
+    $connection->executeStatement(
+      "INSERT INTO $scheduledTaskSubscribersTable
+       (`task_id`, `subscriber_id`, `processed`, `failed`, `error`, `created_at`, `updated_at`)
+       SELECT stsq.`task_id`, stsq.`subscriber_id`, :processed, :failed, NULL, stsq.`created_at`, NOW()
+       FROM $scheduledTaskQueuedSubscribersTable stsq
+       WHERE stsq.`task_id` = :taskId
+       AND stsq.`subscriber_id` IN (:subscriberIds)",
+      [
+        'processed' => ScheduledTaskSubscriberEntity::STATUS_PROCESSED,
+        'failed' => ScheduledTaskSubscriberEntity::FAIL_STATUS_OK,
+        'taskId' => $task->getId(),
+        'subscriberIds' => $subscriberIds,
+      ],
+      [
+        'processed' => ParameterType::INTEGER,
+        'failed' => ParameterType::INTEGER,
+        'taskId' => ParameterType::INTEGER,
+        'subscriberIds' => ArrayParameterType::INTEGER,
+      ]
+    );
+  }
+
+  private function insertFailedToLog(Connection $connection, ScheduledTaskEntity $task, int $subscriberId, string $error): void {
+    $scheduledTaskSubscribersTable = $this->getLogTableName();
+    $scheduledTaskQueuedSubscribersTable = $this->getQueueTableName();
+
+    $connection->executeStatement(
+      "INSERT INTO $scheduledTaskSubscribersTable
+       (`task_id`, `subscriber_id`, `processed`, `failed`, `error`, `created_at`, `updated_at`)
+       SELECT stsq.`task_id`, stsq.`subscriber_id`, :processed, :failed, :error, stsq.`created_at`, NOW()
+       FROM $scheduledTaskQueuedSubscribersTable stsq
+       WHERE stsq.`task_id` = :taskId
+       AND stsq.`subscriber_id` = :subscriberId",
+      [
+        'processed' => ScheduledTaskSubscriberEntity::STATUS_PROCESSED,
+        'failed' => ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED,
+        'error' => $error,
+        'taskId' => $task->getId(),
+        'subscriberId' => $subscriberId,
+      ],
+      [
+        'processed' => ParameterType::INTEGER,
+        'failed' => ParameterType::INTEGER,
+        'error' => ParameterType::STRING,
+        'taskId' => ParameterType::INTEGER,
+        'subscriberId' => ParameterType::INTEGER,
+      ]
+    );
+  }
+
+  /**
+   * @param int[] $subscriberIds
+   */
+  private function deleteFromQueue(Connection $connection, ScheduledTaskEntity $task, array $subscriberIds): void {
+    $scheduledTaskQueuedSubscribersTable = $this->getQueueTableName();
+
+    $connection->executeStatement(
+      "DELETE FROM $scheduledTaskQueuedSubscribersTable
+       WHERE `task_id` = :taskId
+       AND `subscriber_id` IN (:subscriberIds)",
+      [
+        'taskId' => $task->getId(),
+        'subscriberIds' => $subscriberIds,
+      ],
+      [
+        'taskId' => ParameterType::INTEGER,
+        'subscriberIds' => ArrayParameterType::INTEGER,
+      ]
+    );
+  }
+
+  private function deleteFromLog(Connection $connection, ScheduledTaskEntity $task, int $subscriberId): int {
+    $scheduledTaskSubscribersTable = $this->getLogTableName();
+
+    return (int)$connection->executeStatement(
+      "DELETE FROM $scheduledTaskSubscribersTable
+       WHERE `task_id` = :taskId
+       AND `subscriber_id` = :subscriberId",
+      [
+        'taskId' => $task->getId(),
+        'subscriberId' => $subscriberId,
+      ],
+      [
+        'taskId' => ParameterType::INTEGER,
+        'subscriberId' => ParameterType::INTEGER,
+      ]
+    );
+  }
+
+  private function insertToQueue(Connection $connection, ScheduledTaskEntity $task, int $subscriberId): void {
+    $scheduledTaskQueuedSubscribersTable = $this->getQueueTableName();
+
+    $connection->executeStatement(
+      "INSERT INTO $scheduledTaskQueuedSubscribersTable
+       (`task_id`, `subscriber_id`, `created_at`)
+       VALUES (:taskId, :subscriberId, NOW())",
+      [
+        'taskId' => $task->getId(),
+        'subscriberId' => $subscriberId,
+      ],
+      [
+        'taskId' => ParameterType::INTEGER,
+        'subscriberId' => ParameterType::INTEGER,
+      ]
+    );
+  }
+
+  private function getQueueTableName(): string {
+    return $this->entityManager->getClassMetadata(ScheduledTaskQueuedSubscriberEntity::class)->getTableName();
+  }
+
+  private function getLogTableName(): string {
+    return $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+  }
+}

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersListingRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersListingRepository.php
@@ -14,11 +14,6 @@ class ScheduledTaskSubscribersListingRepository extends ListingRepository {
     $this->applyFromClause($queryBuilder);
     $this->applyParameters($queryBuilder, $definition->getParameters());
 
-    // total count
-    $countQueryBuilder = clone $queryBuilder;
-    $countQueryBuilder->select('COUNT(sts.subscriber) AS subscriberCount');
-    $totalCount = intval($countQueryBuilder->getQuery()->getSingleScalarResult());
-
     // Sent count
     $sentCountQuery = clone $queryBuilder;
     $sentCountQuery->select('COUNT(sts.subscriber) AS subscriberCount');
@@ -35,19 +30,7 @@ class ScheduledTaskSubscribersListingRepository extends ListingRepository {
     $failedCountQuery->setParameter('failedStatus', ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED);
     $failedCount = intval($failedCountQuery->getQuery()->getSingleScalarResult());
 
-    // Unprocessed count
-    $unprocessedCountQuery = clone $queryBuilder;
-    $unprocessedCountQuery->select('COUNT(sts.subscriber) AS subscriberCount');
-    $unprocessedCountQuery->andWhere('sts.processed = :processedStatus');
-    $unprocessedCountQuery->setParameter('processedStatus', ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED);
-    $unprocessedCount = intval($unprocessedCountQuery->getQuery()->getSingleScalarResult());
-
     return [
-      [
-        'name' => 'all',
-        'label' => __('All', 'mailpoet'),
-        'count' => $totalCount,
-      ],
       [
         'name' => ScheduledTaskSubscriberEntity::SENDING_STATUS_SENT,
         'label' => __('Sent', 'mailpoet'),
@@ -57,11 +40,6 @@ class ScheduledTaskSubscribersListingRepository extends ListingRepository {
         'name' => ScheduledTaskSubscriberEntity::SENDING_STATUS_FAILED,
         'label' => __('Failed', 'mailpoet'),
         'count' => $failedCount,
-      ],
-      [
-        'name' => ScheduledTaskSubscriberEntity::SENDING_STATUS_UNPROCESSED,
-        'label' => __('Unprocessed', 'mailpoet'),
-        'count' => $unprocessedCount,
       ],
     ];
   }
@@ -84,9 +62,6 @@ class ScheduledTaskSubscribersListingRepository extends ListingRepository {
     } elseif ($group === ScheduledTaskSubscriberEntity::SENDING_STATUS_FAILED) {
       $queryBuilder->andWhere('sts.failed = :failedStatus');
       $queryBuilder->setParameter('failedStatus', ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED);
-    } elseif ($group === ScheduledTaskSubscriberEntity::SENDING_STATUS_UNPROCESSED) {
-      $queryBuilder->andWhere('sts.processed = :processedStatus');
-      $queryBuilder->setParameter('processedStatus', ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED);
     }
   }
 

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
@@ -6,16 +6,25 @@ use MailPoet\Doctrine\Repository;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\InvalidStateException;
 use MailPoetVendor\Carbon\Carbon;
-use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\DBAL\ParameterType;
-use MailPoetVendor\Doctrine\ORM\QueryBuilder;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 /**
  * @extends Repository<ScheduledTaskSubscriberEntity>
  */
 class ScheduledTaskSubscribersRepository extends Repository {
+  /** @var ScheduledTaskQueuedSubscriberRepository */
+  private $scheduledTaskQueuedSubscriberRepository;
+
+  public function __construct(
+    EntityManager $entityManager,
+    ScheduledTaskQueuedSubscriberRepository $scheduledTaskQueuedSubscriberRepository
+  ) {
+    parent::__construct($entityManager);
+    $this->scheduledTaskQueuedSubscriberRepository = $scheduledTaskQueuedSubscriberRepository;
+  }
+
   protected function getEntityClassName() {
     return ScheduledTaskSubscriberEntity::class;
   }
@@ -34,111 +43,6 @@ class ScheduledTaskSubscribersRepository extends Repository {
     return !empty($scheduledTaskSubscriber);
   }
 
-  public function createOrUpdate(array $data): ?ScheduledTaskSubscriberEntity {
-    if (!isset($data['task_id'], $data['subscriber_id'])) {
-      return null;
-    }
-
-    $taskSubscriber = $this->findOneBy(['task' => $data['task_id'], 'subscriber' => $data['subscriber_id']]);
-    if (!$taskSubscriber) {
-      $task = $this->entityManager->getReference(ScheduledTaskEntity::class, (int)$data['task_id']);
-      $subscriber = $this->entityManager->getReference(SubscriberEntity::class, (int)$data['subscriber_id']);
-      if (!$task || !$subscriber) throw new InvalidStateException('Task or subscriber not found');
-
-      $taskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
-      $this->persist($taskSubscriber);
-    }
-
-    $processed = $data['processed'] ?? ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED;
-    $failed = $data['failed'] ?? ScheduledTaskSubscriberEntity::FAIL_STATUS_OK;
-
-    $taskSubscriber->setProcessed($processed);
-    $taskSubscriber->setFailed($failed);
-    $this->flush();
-    return $taskSubscriber;
-  }
-
-  public function countSubscriberIdsBatchForTask(int $taskId, int $lastProcessedSubscriberId): int {
-    $queryBuilder = $this->getBaseSubscribersIdsBatchForTaskQuery($taskId, $lastProcessedSubscriberId);
-    $countSubscribers = $queryBuilder
-      ->select('count(sts.subscriber)')
-      ->getQuery()
-      ->getSingleScalarResult();
-
-    return intval($countSubscribers);
-  }
-
-  public function getSubscriberIdsBatchForTask(int $taskId, int $lastProcessedSubscriberId, int $limit): array {
-    $queryBuilder = $this->getBaseSubscribersIdsBatchForTaskQuery($taskId, $lastProcessedSubscriberId);
-    $subscribersIds = $queryBuilder
-      ->select('IDENTITY(sts.subscriber) AS subscriber_id')
-      ->orderBy('sts.subscriber', 'asc')
-      ->setMaxResults($limit)
-      ->getQuery()
-      ->getSingleColumnResult();
-
-    return $subscribersIds;
-  }
-
-  /**
-   * @param int[] $subscriberIds
-   */
-  public function updateProcessedSubscribers(ScheduledTaskEntity $task, array $subscriberIds): void {
-    if ($subscriberIds) {
-      $this->entityManager->createQueryBuilder()
-        ->update(ScheduledTaskSubscriberEntity::class, 'sts')
-        ->set('sts.processed', ScheduledTaskSubscriberEntity::STATUS_PROCESSED)
-        ->where('sts.subscriber IN (:subscriberIds)')
-        ->andWhere('sts.task = :task')
-        ->setParameter('subscriberIds', $subscriberIds, ArrayParameterType::INTEGER)
-        ->setParameter('task', $task)
-        ->getQuery()
-        ->execute();
-
-      // update was done via DQL, make sure the entities are also refreshed in the entity manager
-      $this->refreshAll(function (ScheduledTaskSubscriberEntity $entity) use ($task, $subscriberIds) {
-        return $entity->getTask() === $task && in_array($entity->getSubscriberId(), $subscriberIds, true);
-      });
-    }
-
-    $this->checkCompleted($task);
-  }
-
-  /** @param int[] $subscriberIds */
-  public function addSubscribersByIds(ScheduledTaskEntity $task, array $subscriberIds): int {
-    $subscriberIds = array_values(array_unique(array_filter(array_map('intval', $subscriberIds))));
-    if ($subscriberIds === []) {
-      return 0;
-    }
-
-    $scheduledTaskSubscribersTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-
-    $result = $this->entityManager->getConnection()->executeQuery(
-      "INSERT IGNORE INTO $scheduledTaskSubscribersTable
-       (task_id, subscriber_id, processed)
-       SELECT DISTINCT ? as task_id, subscribers.`id` as subscriber_id, ? as processed
-       FROM $subscribersTable subscribers
-       WHERE subscribers.`deleted_at` IS NULL
-       AND subscribers.`status` = ?
-       AND subscribers.`id` IN (?)",
-      [
-        $task->getId(),
-        ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
-        SubscriberEntity::STATUS_SUBSCRIBED,
-        $subscriberIds,
-      ],
-      [
-        ParameterType::INTEGER,
-        ParameterType::INTEGER,
-        ParameterType::STRING,
-        ArrayParameterType::INTEGER,
-      ]
-    );
-
-    return (int)$result->rowCount();
-  }
-
   /** @param int[] $ids */
   public function deleteByTaskIds(array $ids): void {
     $this->entityManager->createQueryBuilder()
@@ -153,6 +57,9 @@ class ScheduledTaskSubscribersRepository extends Repository {
       $task = $entity->getTask();
       return $task && in_array($task->getId(), $ids, true);
     });
+
+    // also clear any pending (queued) rows for these sending tasks; no-op for non-sending tasks
+    $this->scheduledTaskQueuedSubscriberRepository->deleteByTaskIds($ids);
   }
 
   public function deleteByScheduledTask(ScheduledTaskEntity $scheduledTask): void {
@@ -167,35 +74,9 @@ class ScheduledTaskSubscribersRepository extends Repository {
     $this->detachAll(function (ScheduledTaskSubscriberEntity $entity) use ($scheduledTask) {
       return $entity->getTask() === $scheduledTask;
     });
-  }
 
-  public function deleteByScheduledTaskAndSubscriberIds(ScheduledTaskEntity $scheduledTask, array $subscriberIds): void {
-    $this->entityManager->createQueryBuilder()
-      ->delete(ScheduledTaskSubscriberEntity::class, 'sts')
-      ->where('sts.task = :task')
-      ->andWhere('sts.subscriber IN (:subscriberIds)')
-      ->setParameter('task', $scheduledTask)
-      ->setParameter('subscriberIds', $subscriberIds, ArrayParameterType::INTEGER)
-      ->getQuery()
-      ->execute();
-
-    // delete was done via DQL, make sure the entities are also detached from the entity manager
-    $this->detachAll(function (ScheduledTaskSubscriberEntity $entity) use ($scheduledTask, $subscriberIds) {
-      return $entity->getTask() === $scheduledTask && in_array($entity->getSubscriberId(), $subscriberIds, true);
-    });
-
-    $this->checkCompleted($scheduledTask);
-  }
-
-  public function setSubscribers(ScheduledTaskEntity $task, array $subscriberIds): void {
-    $this->deleteByScheduledTask($task);
-
-    foreach ($subscriberIds as $subscriberId) {
-      $this->createOrUpdate([
-        'task_id' => $task->getId(),
-        'subscriber_id' => $subscriberId,
-      ]);
-    }
+    // also clear any pending (queued) rows for this sending task; no-op for non-sending tasks
+    $this->scheduledTaskQueuedSubscriberRepository->deleteByScheduledTask($scheduledTask);
   }
 
   public function saveError(ScheduledTaskEntity $scheduledTask, int $subscriberId, string $errorMessage): void {
@@ -216,7 +97,7 @@ class ScheduledTaskSubscribersRepository extends Repository {
     return $this->countBy(['task' => $scheduledTaskEntity, 'processed' => ScheduledTaskSubscriberEntity::STATUS_PROCESSED]);
   }
 
-  public function countUnprocessed(ScheduledTaskEntity $scheduledTaskEntity): int {
+  private function countUnprocessed(ScheduledTaskEntity $scheduledTaskEntity): int {
     return $this->countBy(['task' => $scheduledTaskEntity, 'processed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED]);
   }
 
@@ -323,17 +204,5 @@ class ScheduledTaskSubscribersRepository extends Repository {
       $task->setProcessedAt(Carbon::now()->millisecond(0));
       $this->entityManager->flush();
     }
-  }
-
-  private function getBaseSubscribersIdsBatchForTaskQuery(int $taskId, int $lastProcessedSubscriberId): QueryBuilder {
-    return $this->entityManager
-      ->createQueryBuilder()
-      ->from(ScheduledTaskSubscriberEntity::class, 'sts')
-      ->andWhere('sts.task = :taskId')
-      ->andWhere('sts.subscriber > :lastProcessedSubscriberId')
-      ->andWhere('sts.processed = :status')
-      ->setParameter('taskId', $taskId)
-      ->setParameter('lastProcessedSubscriberId', $lastProcessedSubscriberId)
-      ->setParameter('status', ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED);
   }
 }

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTasksRepository.php
@@ -6,6 +6,7 @@ use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Doctrine\Repository;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -100,25 +101,40 @@ class ScheduledTasksRepository extends Repository {
    * @return ScheduledTaskEntity[]
    */
   public function findByNewsletterAndSubscriberId(NewsletterEntity $newsletter, int $subscriberId): array {
-    return $this->doctrineRepository->createQueryBuilder('st')
-      ->select('st')
-      ->join(SendingQueueEntity::class, 'sq', Join::WITH, 'st = sq.task')
-      ->join(ScheduledTaskSubscriberEntity::class, 'sts', Join::WITH, 'st = sts.task')
-      ->andWhere('sq.newsletter = :newsletter')
-      ->andWhere('sts.subscriber = :subscriber')
-      ->setParameter('newsletter', $newsletter)
-      ->setParameter('subscriber', $subscriberId)
-      ->getQuery()
-      ->getResult();
+    // A recipient that is still pending lives in the queue; once sent it is moved to the log.
+    // Check both so the welcome dedup keeps matching scheduled and already-sent tasks.
+    $tasks = [];
+    foreach ([ScheduledTaskQueuedSubscriberEntity::class, ScheduledTaskSubscriberEntity::class] as $subscriberEntityClass) {
+      $results = $this->doctrineRepository->createQueryBuilder('st')
+        ->select('st')
+        ->join(SendingQueueEntity::class, 'sq', Join::WITH, 'st = sq.task')
+        ->join($subscriberEntityClass, 'sts', Join::WITH, 'st = sts.task')
+        ->andWhere('sq.newsletter = :newsletter')
+        ->andWhere('sts.subscriber = :subscriber')
+        ->setParameter('newsletter', $newsletter)
+        ->setParameter('subscriber', $subscriberId)
+        ->getQuery()
+        ->getResult();
+      foreach ($results as $task) {
+        if ($task instanceof ScheduledTaskEntity && $task->getId()) {
+          $tasks[$task->getId()] = $task;
+        }
+      }
+    }
+    return array_values($tasks);
   }
 
   public function findOneScheduledByNewsletterAndSubscriber(NewsletterEntity $newsletter, SubscriberEntity $subscriber): ?ScheduledTaskEntity {
+    // Scoped to status = scheduled: the worker has not started yet (it flips the
+    // status away from "scheduled" before moving any recipient to the log), so
+    // every recipient is still pending in the queue. Checking the queue alone is
+    // therefore correct here, even for a multi-recipient task.
     $scheduledTask = $this->doctrineRepository->createQueryBuilder('st')
       ->join(SendingQueueEntity::class, 'sq', Join::WITH, 'st = sq.task')
-      ->join(ScheduledTaskSubscriberEntity::class, 'sts', Join::WITH, 'st = sts.task')
+      ->join(ScheduledTaskQueuedSubscriberEntity::class, 'stsq', Join::WITH, 'st = stsq.task')
       ->andWhere('st.status = :status')
       ->andWhere('sq.newsletter = :newsletter')
-      ->andWhere('sts.subscriber = :subscriber')
+      ->andWhere('stsq.subscriber = :subscriber')
       ->setMaxResults(1)
       ->setParameter('status', ScheduledTaskEntity::STATUS_SCHEDULED)
       ->setParameter('newsletter', $newsletter)

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -23,6 +23,9 @@ class SendingQueuesRepository extends Repository {
   /** @var ScheduledTaskSubscribersRepository */
   private $scheduledTaskSubscribersRepository;
 
+  /** @var ScheduledTaskQueuedSubscriberRepository */
+  private $scheduledTaskQueuedSubscriberRepository;
+
   /** @var FilterFactory */
   private $filterFactory;
 
@@ -32,11 +35,13 @@ class SendingQueuesRepository extends Repository {
   public function __construct(
     EntityManager $entityManager,
     ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    ScheduledTaskQueuedSubscriberRepository $scheduledTaskQueuedSubscriberRepository,
     FilterFactory $filterFactory,
     LoggerFactory $loggerFactory
   ) {
     parent::__construct($entityManager);
     $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->scheduledTaskQueuedSubscriberRepository = $scheduledTaskQueuedSubscriberRepository;
     $this->filterFactory = $filterFactory;
     $this->loggerFactory = $loggerFactory;
   }
@@ -288,7 +293,7 @@ class SendingQueuesRepository extends Repository {
       // query DB to update counts, slower but more accurate, to be used if count isn't known
       $task = $queue->getTask();
       $processed = $task ? $this->scheduledTaskSubscribersRepository->countProcessed($task) : 0;
-      $unprocessed = $task ? $this->scheduledTaskSubscribersRepository->countUnprocessed($task) : 0;
+      $unprocessed = $task ? $this->scheduledTaskQueuedSubscriberRepository->countForTask($task) : 0;
       $queue->setCountProcessed($processed);
       $queue->setCountToProcess($unprocessed);
       $queue->setCountTotal($processed + $unprocessed);

--- a/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
+++ b/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
@@ -38,6 +38,7 @@ class TimeZoneCampaignScheduler {
   private FeaturesController $featuresController;
   private ScheduledTasksRepository $scheduledTasksRepository;
   private ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository;
+  private ScheduledTaskQueuedSubscriberRepository $scheduledTaskQueuedSubscriberRepository;
   private SendingQueuesRepository $sendingQueuesRepository;
   private SubscribersFinder $subscribersFinder;
   private SubscribersRepository $subscribersRepository;
@@ -49,6 +50,7 @@ class TimeZoneCampaignScheduler {
     FeaturesController $featuresController,
     ScheduledTasksRepository $scheduledTasksRepository,
     ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    ScheduledTaskQueuedSubscriberRepository $scheduledTaskQueuedSubscriberRepository,
     SendingQueuesRepository $sendingQueuesRepository,
     SubscribersFinder $subscribersFinder,
     SubscribersRepository $subscribersRepository,
@@ -59,6 +61,7 @@ class TimeZoneCampaignScheduler {
     $this->featuresController = $featuresController;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->scheduledTaskQueuedSubscriberRepository = $scheduledTaskQueuedSubscriberRepository;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->subscribersFinder = $subscribersFinder;
     $this->subscribersRepository = $subscribersRepository;
@@ -143,7 +146,7 @@ class TimeZoneCampaignScheduler {
         $this->sendingQueuesRepository->persist($queue);
         $this->entityManager->flush();
 
-        $this->scheduledTaskSubscribersRepository->addSubscribersByIds($task, $group['subscriberIds']);
+        $this->scheduledTaskQueuedSubscriberRepository->addSubscribersByIds($task, $group['subscriberIds']);
         $this->sendingQueuesRepository->updateCounts($queue);
         $createdQueues[] = $queue;
       }

--- a/mailpoet/lib/Segments/SubscribersFinder.php
+++ b/mailpoet/lib/Segments/SubscribersFinder.php
@@ -3,12 +3,12 @@
 namespace MailPoet\Segments;
 
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\InvalidStateException;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\DBAL\ParameterType;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -24,19 +24,19 @@ class SubscribersFinder {
   /** @var EntityManager */
   private $entityManager;
 
-  /** @var ScheduledTaskSubscribersRepository */
-  private $scheduledTaskSubscribersRepository;
+  /** @var ScheduledTaskQueuedSubscriberRepository */
+  private $scheduledTaskQueuedSubscriberRepository;
 
   public function __construct(
     SegmentSubscribersRepository $segmentSubscriberRepository,
     SegmentsRepository $segmentsRepository,
     EntityManager $entityManager,
-    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository
+    ScheduledTaskQueuedSubscriberRepository $scheduledTaskQueuedSubscriberRepository
   ) {
     $this->segmentSubscriberRepository = $segmentSubscriberRepository;
     $this->segmentsRepository = $segmentsRepository;
     $this->entityManager = $entityManager;
-    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->scheduledTaskQueuedSubscriberRepository = $scheduledTaskQueuedSubscriberRepository;
   }
 
   /**
@@ -144,7 +144,7 @@ class SubscribersFinder {
    * @return int
    */
   private function addSubscribersToTaskFromStaticSegments(ScheduledTaskEntity $task, array $segmentIds, ?int $filterSegmentId = null) {
-    $scheduledTaskSubscriberTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    $scheduledTaskQueuedSubscriberTable = $this->entityManager->getClassMetadata(ScheduledTaskQueuedSubscriberEntity::class)->getTableName();
     $subscriberSegmentTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
     $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
 
@@ -152,9 +152,9 @@ class SubscribersFinder {
     $selectQueryBuilder = $connection->createQueryBuilder();
     $selectQueryBuilder
       // No DISTINCT needed: the INSERT IGNORE relies on the (task_id, subscriber_id)
-      // primary key of scheduled_task_subscribers to drop duplicates, and DISTINCT
+      // primary key of scheduled_task_queued_subscribers to drop duplicates, and DISTINCT
       // forces an expensive temporary table on large segments.
-      ->select(':task_id as task_id', 'subscribers.id as subscriber_id', ':processed as processed')
+      ->select(':task_id as task_id', 'subscribers.id as subscriber_id')
       ->from($subscriberSegmentTable, 'relation')
       ->join('relation', $subscriberTable, 'subscribers', 'subscribers.id = relation.subscriber_id')
       ->where('subscribers.deleted_at IS NULL')
@@ -162,7 +162,6 @@ class SubscribersFinder {
       ->andWhere('relation.status = :relation_status')
       ->andWhere($selectQueryBuilder->expr()->in('relation.segment_id', ':segment_ids'))
       ->setParameter('task_id', $task->getId(), ParameterType::INTEGER)
-      ->setParameter('processed', ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED, ParameterType::INTEGER)
       ->setParameter('subscribers_status', SubscriberEntity::STATUS_SUBSCRIBED, ParameterType::STRING)
       ->setParameter('relation_status', SubscriberEntity::STATUS_SUBSCRIBED, ParameterType::STRING)
       ->setParameter('segment_ids', $segmentIds, ArrayParameterType::INTEGER);
@@ -175,7 +174,7 @@ class SubscribersFinder {
     }
 
     // queryBuilder doesn't support INSERT IGNORE directly
-    $sql = "INSERT IGNORE INTO $scheduledTaskSubscriberTable (task_id, subscriber_id, processed) " . $selectQueryBuilder->getSQL();
+    $sql = "INSERT IGNORE INTO $scheduledTaskQueuedSubscriberTable (task_id, subscriber_id) " . $selectQueryBuilder->getSQL();
     $result = $connection->executeQuery($sql, $selectQueryBuilder->getParameters(), $selectQueryBuilder->getParameterTypes());
 
     return (int)$result->rowCount();
@@ -205,7 +204,7 @@ class SubscribersFinder {
     }
 
     if ($subscriberIds) {
-      $count += $this->scheduledTaskSubscribersRepository->addSubscribersByIds($task, $subscriberIds);
+      $count += $this->scheduledTaskQueuedSubscriberRepository->addSubscribersByIds($task, $subscriberIds);
     }
     return $count;
   }

--- a/mailpoet/lib/Subscribers/BulkConfirmationEmailResender.php
+++ b/mailpoet/lib/Subscribers/BulkConfirmationEmailResender.php
@@ -5,7 +5,7 @@ namespace MailPoet\Subscribers;
 use MailPoet\Cron\Workers\BulkConfirmationEmailResend;
 use MailPoet\Entities\LogEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Listing\ListingDefinition;
 use MailPoet\Logging\LoggerFactory;
@@ -132,7 +132,7 @@ class BulkConfirmationEmailResender {
       foreach ($queuedIds as $subscriberId) {
         /** @var SubscriberEntity $subscriberReference */
         $subscriberReference = $entityManager->getReference(SubscriberEntity::class, $subscriberId);
-        $entityManager->persist(new ScheduledTaskSubscriberEntity(
+        $entityManager->persist(new ScheduledTaskQueuedSubscriberEntity(
           $task,
           $subscriberReference
         ));

--- a/mailpoet/lib/Tasks/Subscribers/BatchIterator.php
+++ b/mailpoet/lib/Tasks/Subscribers/BatchIterator.php
@@ -3,9 +3,13 @@
 namespace MailPoet\Tasks\Subscribers;
 
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 
 /**
+ * Iterates the pending recipients of a task in id-ordered batches. Pending
+ * recipients always live in the queue table (`scheduled_task_queued_subscribers`);
+ * once processed they are moved to the log, so the iterator never reads the log.
+ *
  * @implements \Iterator<null, array>
  */
 class BatchIterator implements \Iterator, \Countable {
@@ -14,8 +18,8 @@ class BatchIterator implements \Iterator, \Countable {
   private $lastProcessedId = 0;
   private $batchLastId;
 
-  /** @var ScheduledTaskSubscribersRepository */
-  private $scheduledTaskSubscribersRepository;
+  /** @var ScheduledTaskQueuedSubscriberRepository */
+  private $scheduledTaskQueuedSubscriberRepository;
 
   public function __construct(
     $taskId,
@@ -28,7 +32,7 @@ class BatchIterator implements \Iterator, \Countable {
     }
     $this->taskId = (int)$taskId;
     $this->batchSize = (int)$batchSize;
-    $this->scheduledTaskSubscribersRepository = ContainerWrapper::getInstance()->get(ScheduledTaskSubscribersRepository::class);
+    $this->scheduledTaskQueuedSubscriberRepository = ContainerWrapper::getInstance()->get(ScheduledTaskQueuedSubscriberRepository::class);
   }
 
   public function rewind(): void {
@@ -40,7 +44,7 @@ class BatchIterator implements \Iterator, \Countable {
    */
   #[\ReturnTypeWillChange]
   public function current() {
-    $subscribers = $this->scheduledTaskSubscribersRepository->getSubscriberIdsBatchForTask($this->taskId, $this->lastProcessedId, $this->batchSize);
+    $subscribers = $this->scheduledTaskQueuedSubscriberRepository->getSubscriberIdsBatchForTask($this->taskId, $this->lastProcessedId, $this->batchSize);
     $this->batchLastId = end($subscribers);
     return $subscribers;
   }
@@ -62,6 +66,7 @@ class BatchIterator implements \Iterator, \Countable {
   }
 
   public function count(): int {
-    return max(0, $this->scheduledTaskSubscribersRepository->countSubscriberIdsBatchForTask($this->taskId, $this->lastProcessedId));
+    $count = $this->scheduledTaskQueuedSubscriberRepository->countSubscriberIdsBatchForTask($this->taskId, $this->lastProcessedId);
+    return max(0, $count);
   }
 }

--- a/mailpoet/lib/Util/DataInconsistency/DataInconsistencyController.php
+++ b/mailpoet/lib/Util/DataInconsistency/DataInconsistencyController.php
@@ -7,6 +7,7 @@ use MailPoet\UnexpectedValueException;
 class DataInconsistencyController {
   const ORPHANED_SENDING_TASKS = 'orphaned_sending_tasks';
   const ORPHANED_SENDING_TASK_SUBSCRIBERS = 'orphaned_sending_task_subscribers';
+  const ORPHANED_SENDING_TASK_QUEUED_SUBSCRIBERS = 'orphaned_sending_task_queued_subscribers';
   const SENDING_QUEUE_WITHOUT_NEWSLETTER = 'sending_queue_without_newsletter';
   const ORPHANED_SUBSCRIPTIONS = 'orphaned_subscriptions';
   const ORPHANED_LINKS = 'orphaned_links';
@@ -15,6 +16,7 @@ class DataInconsistencyController {
   const SUPPORTED_INCONSISTENCY_CHECKS = [
     self::ORPHANED_SENDING_TASKS,
     self::ORPHANED_SENDING_TASK_SUBSCRIBERS,
+    self::ORPHANED_SENDING_TASK_QUEUED_SUBSCRIBERS,
     self::SENDING_QUEUE_WITHOUT_NEWSLETTER,
     self::ORPHANED_SUBSCRIPTIONS,
     self::ORPHANED_LINKS,
@@ -33,6 +35,7 @@ class DataInconsistencyController {
     $result = [
       self::ORPHANED_SENDING_TASKS => $this->repository->getOrphanedSendingTasksCount(),
       self::ORPHANED_SENDING_TASK_SUBSCRIBERS => $this->repository->getOrphanedScheduledTasksSubscribersCount(),
+      self::ORPHANED_SENDING_TASK_QUEUED_SUBSCRIBERS => $this->repository->getOrphanedScheduledTaskQueuedSubscribersCount(),
       self::SENDING_QUEUE_WITHOUT_NEWSLETTER => $this->repository->getSendingQueuesWithoutNewsletterCount(),
       self::ORPHANED_SUBSCRIPTIONS => $this->repository->getOrphanedSubscriptionsCount(),
       self::ORPHANED_LINKS => $this->repository->getOrphanedNewsletterLinksCount(),
@@ -50,6 +53,8 @@ class DataInconsistencyController {
       $this->repository->cleanupOrphanedSendingTasks();
     } elseif ($inconsistency === self::ORPHANED_SENDING_TASK_SUBSCRIBERS) {
       $this->repository->cleanupOrphanedScheduledTaskSubscribers();
+    } elseif ($inconsistency === self::ORPHANED_SENDING_TASK_QUEUED_SUBSCRIBERS) {
+      $this->repository->cleanupOrphanedScheduledTaskQueuedSubscribers();
     } elseif ($inconsistency === self::SENDING_QUEUE_WITHOUT_NEWSLETTER) {
       $this->repository->cleanupSendingQueuesWithoutNewsletter();
     } elseif ($inconsistency === self::ORPHANED_SUBSCRIPTIONS) {

--- a/mailpoet/lib/Util/DataInconsistency/DataInconsistencyRepository.php
+++ b/mailpoet/lib/Util/DataInconsistency/DataInconsistencyRepository.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\NewsletterPostEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
@@ -49,6 +50,14 @@ class DataInconsistencyRepository {
     $count = $connection->executeQuery("
       SELECT COUNT(*) FROM $stsTable sts WHERE sts.task_id IN (SELECT task_id FROM orphaned_task_ids)
     ")->fetchOne();
+    return intval($count);
+  }
+
+  public function getOrphanedScheduledTaskQueuedSubscribersCount(): int {
+    /** @var string $count */
+    $count = $this->entityManager->getConnection()->executeQuery(
+      $this->buildOrphanedQueuedSubscribersSql('SELECT COUNT(*)')
+    )->fetchOne();
     return intval($count);
   }
 
@@ -171,6 +180,12 @@ class DataInconsistencyRepository {
     return $deletedCount;
   }
 
+  public function cleanupOrphanedScheduledTaskQueuedSubscribers(): int {
+    return (int)$this->entityManager->getConnection()->executeStatement(
+      $this->buildOrphanedQueuedSubscribersSql('DELETE stqs')
+    );
+  }
+
   public function cleanupSendingQueuesWithoutNewsletter(): int {
     $sqTable = $this->entityManager->getClassMetadata(SendingQueueEntity::class)->getTableName();
     $newsletterTable = $this->entityManager->getClassMetadata(NewsletterEntity::class)->getTableName();
@@ -226,6 +241,28 @@ class DataInconsistencyRepository {
       ->andWhere('st.type = :type')
       ->setParameter('type', SendingQueue::TASK_TYPE)
       ->getQuery();
+  }
+
+  /**
+   * Builds the shared FROM/JOIN/WHERE for orphaned queue rows (task or
+   * subscriber no longer exists) behind a caller-supplied `SELECT …` / `DELETE
+   * stqs` prefix, so the count and the cleanup always target the exact same
+   * rows. The queue is working-set sized (it empties when a send completes), so
+   * a plain join is enough — no temporary tables or batched deletes like the
+   * large log table needs.
+   *
+   * $select is a fixed string from our own code, never user input.
+   */
+  private function buildOrphanedQueuedSubscribersSql(string $select): string {
+    $queueTable = $this->entityManager->getClassMetadata(ScheduledTaskQueuedSubscriberEntity::class)->getTableName();
+    $stTable = $this->entityManager->getClassMetadata(ScheduledTaskEntity::class)->getTableName();
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    return "
+      $select FROM $queueTable stqs
+      LEFT JOIN $stTable st ON st.`id` = stqs.`task_id`
+      LEFT JOIN $subscriberTable sub ON sub.`id` = stqs.`subscriber_id`
+      WHERE st.`id` IS NULL OR sub.`id` IS NULL
+    ";
   }
 
   private function createOrphanedScheduledTaskSubscribersTemporaryTables(): void {

--- a/mailpoet/lib/WooCommerce/CouponPreProcessor.php
+++ b/mailpoet/lib/WooCommerce/CouponPreProcessor.php
@@ -3,10 +3,13 @@
 namespace MailPoet\WooCommerce;
 
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\Coupon;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoet\NewsletterProcessingException;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\WP\DateTime;
 
 class CouponPreProcessor {
@@ -22,14 +25,24 @@ class CouponPreProcessor {
 
   private RandomCouponCodeGenerator $randomCouponCodeGenerator;
 
+  /** @var ScheduledTaskQueuedSubscriberRepository */
+  private $scheduledTaskQueuedSubscriberRepository;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
   public function __construct(
     Helper $wcHelper,
     NewslettersRepository $newslettersRepository,
-    RandomCouponCodeGenerator $randomCouponCodeGenerator
+    RandomCouponCodeGenerator $randomCouponCodeGenerator,
+    ScheduledTaskQueuedSubscriberRepository $scheduledTaskQueuedSubscriberRepository,
+    SubscribersRepository $subscribersRepository
   ) {
     $this->wcHelper = $wcHelper;
     $this->newslettersRepository = $newslettersRepository;
     $this->randomCouponCodeGenerator = $randomCouponCodeGenerator;
+    $this->scheduledTaskQueuedSubscriberRepository = $scheduledTaskQueuedSubscriberRepository;
+    $this->subscribersRepository = $subscribersRepository;
   }
 
   /**
@@ -138,14 +151,14 @@ class CouponPreProcessor {
       $emailRestrictions = explode(',', $couponBlock['emailRestrictions']);
     }
 
-    if (!empty($couponBlock['restrictToSubscriber']) && $sendingQueue && $sendingQueue->getTask()) {
-      $subscribers = $sendingQueue->getTask()->getSubscribers();
-      if (is_iterable($subscribers) && count($subscribers) === 1) { // Only apply to single-subscriber sending queues
-        foreach ($subscribers as $taskSubscriber) {
-          $subscriber = $taskSubscriber->getSubscriber();
-          if ($subscriber && $subscriber->getEmail()) {
-            $emailRestrictions[] = $subscriber->getEmail();
-          }
+    $task = $sendingQueue ? $sendingQueue->getTask() : null;
+    if (!empty($couponBlock['restrictToSubscriber']) && $task) {
+      // Only apply to single-recipient sends (queue + log == 1). The recipient is still
+      // pending in the queue at coupon-generation time, so we read it from there.
+      if ($task->getTotalSubscribersCount() === 1) {
+        $recipientEmail = $this->getFirstQueuedRecipientEmail($task);
+        if ($recipientEmail) {
+          $emailRestrictions[] = $recipientEmail;
         }
       }
     }
@@ -166,6 +179,19 @@ class CouponPreProcessor {
     return array_map(function ($item) {
       return $item['id'];
     }, $items);
+  }
+
+  private function getFirstQueuedRecipientEmail(ScheduledTaskEntity $task): ?string {
+    $taskId = $task->getId();
+    if (!$taskId) {
+      return null;
+    }
+    $subscriberIds = $this->scheduledTaskQueuedSubscriberRepository->getSubscriberIdsBatchForTask($taskId, 0, 1);
+    if (!$subscriberIds) {
+      return null;
+    }
+    $subscriber = $this->subscribersRepository->findOneById($subscriberIds[0]);
+    return $subscriber ? $subscriber->getEmail() : null;
   }
 
   private function shouldGenerateCoupon(array $block): bool {

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -54,6 +54,10 @@ parameters:
       message: '#Property MailPoet\\Entities\\[a-zA-Z]+::\$[a-z]+ type mapping mismatch: property can contain MailPoet\\Entities\\[a-zA-Z]+\|null but database expects MailPoet\\Entities\\[a-zA-Z]+.#'
       path: ../../lib/Entities/ScheduledTaskSubscriberEntity.php
       count: 2
+    - # Same as above for the queued subscriber entity (composite FK primary key)
+      message: '#Property MailPoet\\Entities\\[a-zA-Z]+::\$[a-z]+ type mapping mismatch: property can contain MailPoet\\Entities\\[a-zA-Z]+\|null but database expects MailPoet\\Entities\\[a-zA-Z]+.#'
+      path: ../../lib/Entities/ScheduledTaskQueuedSubscriberEntity.php
+      count: 2
     - '/Parameter #1 \$cssOrXPath of method AcceptanceTester::moveMouseOver\(\) expects string\|null, array<string, string> given./'
     - '/Call to method getName\(\) on an unknown class _generated\\([a-zA-Z])*Cookie/' # codeception generate incorrect return type in ../../tests/_support/_generated
     -

--- a/mailpoet/tests/DataFactories/ScheduledTaskQueuedSubscriber.php
+++ b/mailpoet/tests/DataFactories/ScheduledTaskQueuedSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\DataFactories;
+
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class ScheduledTaskQueuedSubscriber {
+  /** @var EntityManager */
+  private $entityManager;
+
+  public function __construct() {
+    $diContainer = ContainerWrapper::getInstance();
+    $this->entityManager = $diContainer->get(EntityManager::class);
+  }
+
+  public function create(ScheduledTaskEntity $task, SubscriberEntity $subscriber): ScheduledTaskQueuedSubscriberEntity {
+    $queuedSubscriber = new ScheduledTaskQueuedSubscriberEntity($task, $subscriber);
+    $this->entityManager->persist($queuedSubscriber);
+    $this->entityManager->flush();
+    return $queuedSubscriber;
+  }
+}

--- a/mailpoet/tests/acceptance/Newsletters/SendingStatusCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendingStatusCest.php
@@ -7,8 +7,8 @@ use MailPoet\Test\DataFactories\Subscriber;
 
 class SendingStatusCest {
   public function newsletterSendingStatus(\AcceptanceTester $i) {
-    $i->wantTo('Check the sending status page for a standard newsletter');
-    // Having a standard newsletter sent to 2 subscribers
+    $i->wantTo('Switch between the sending status tabs for a standard newsletter');
+    // Having a standard newsletter sent to 2 subscribers (one sent, one failed)
     $luckySubscriber = (new Subscriber)
       ->withFirstName('Lucky')
       ->withLastName('Luke')
@@ -37,10 +37,20 @@ class SendingStatusCest {
     // I click on the "Sent to 2 of 2" link
     $i->click('[data-automation-id="sending_status_' . $newsletter->getId() . '"]');
     $i->waitForText('Sending status');
-    // I see the subscribers with related statuses
     $taskId = $newsletter->getLatestQueue()->getTask()->getId();
+
+    // The Sent tab (default) lists only the successfully sent recipient
     $this->checkSubscriber($i, $taskId, $luckySubscriber, 'Sent');
+    $i->dontSee($unluckySubscriber->getEmail());
+
+    // The Failed tab lists only the failed recipient with its error
+    $i->click('[data-automation-id="filters_failed"]');
     $this->checkSubscriber($i, $taskId, $unluckySubscriber, 'Failed', 'Oh no!');
+    $i->dontSee($luckySubscriber->getEmail());
+
+    // The Unprocessed tab is empty for a completed send
+    $i->click('[data-automation-id="filters_unprocessed"]');
+    $i->waitForText('No recipients are waiting to be sent.');
   }
 
   private function checkSubscriber(\AcceptanceTester $i, $taskId, $subscriber, $status, $error = false) {

--- a/mailpoet/tests/integration/API/JSON/v1/HelpTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/HelpTest.php
@@ -8,6 +8,8 @@ use MailPoet\API\JSON\v1\Help;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskQueuedSubscriber as ScheduledTaskQueuedSubscriberFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\Util\DataInconsistency\DataInconsistencyController;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -140,7 +142,24 @@ class HelpTest extends \MailPoetTest {
     verify($response->data[DataInconsistencyController::ORPHANED_NEWSLETTER_POSTS] ?? null)->equals(0);
     verify($response->data[DataInconsistencyController::ORPHANED_SUBSCRIPTIONS] ?? null)->equals(0);
     verify($response->data[DataInconsistencyController::ORPHANED_SENDING_TASK_SUBSCRIBERS] ?? null)->equals(0);
+    verify($response->data[DataInconsistencyController::ORPHANED_SENDING_TASK_QUEUED_SUBSCRIBERS] ?? null)->equals(0);
     verify($response->data[DataInconsistencyController::SENDING_QUEUE_WITHOUT_NEWSLETTER] ?? null)->equals(0);
     verify($response->data[DataInconsistencyController::ORPHANED_LINKS] ?? null)->equals(0);
+  }
+
+  public function testItFixesOrphanedScheduledTaskQueuedSubscribers(): void {
+    $task = (new ScheduledTaskFactory())->create('sending', ScheduledTaskEntity::STATUS_SCHEDULED);
+    $subscriber = (new SubscriberFactory())->create();
+    (new ScheduledTaskQueuedSubscriberFactory())->create($task, $subscriber);
+
+    // Orphan the queued row by hard-deleting its task.
+    $this->entityManager->remove($task);
+    $this->entityManager->flush();
+
+    $status = $this->endpoint->getInconsistentDataStatus();
+    verify($status->data[DataInconsistencyController::ORPHANED_SENDING_TASK_QUEUED_SUBSCRIBERS] ?? null)->equals(1);
+
+    $response = $this->endpoint->fixInconsistentData(['inconsistency' => DataInconsistencyController::ORPHANED_SENDING_TASK_QUEUED_SUBSCRIBERS]);
+    verify($response->data[DataInconsistencyController::ORPHANED_SENDING_TASK_QUEUED_SUBSCRIBERS] ?? null)->equals(0);
   }
 }

--- a/mailpoet/tests/integration/AdminPages/HelpTest.php
+++ b/mailpoet/tests/integration/AdminPages/HelpTest.php
@@ -16,6 +16,9 @@ use MailPoet\Services\Bridge;
 use MailPoet\SystemReport\SystemReportCollector;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskQueuedSubscriber as ScheduledTaskQueuedSubscriberFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as ScheduledTaskSubscriberFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoetVendor\Carbon\Carbon;
 
 class HelpTest extends \MailPoetTest {
@@ -75,6 +78,57 @@ class HelpTest extends \MailPoetTest {
     verify($data['newsletter']['queueId'])->equals(null);
     verify($data['newsletter']['subject'])->equals(null);
     verify($data['newsletter']['previewUrl'])->equals(null);
+  }
+
+  public function testItExposesRecipientEmailForSingleQueuedRecipient() {
+    $task = $this->createSendingTask();
+    $subscriber = (new SubscriberFactory())->withEmail('queued@example.com')->create();
+    (new ScheduledTaskQueuedSubscriberFactory())->create($task, $subscriber);
+
+    $data = $this->helpPage->buildTaskData($this->reload($task));
+    verify($data['subscriberEmail'])->equals('queued@example.com');
+  }
+
+  public function testItExposesRecipientEmailForSingleLoggedRecipient() {
+    $task = $this->createSendingTask();
+    $subscriber = (new SubscriberFactory())->withEmail('logged@example.com')->create();
+    (new ScheduledTaskSubscriberFactory())->createProcessed($task, $subscriber);
+
+    $data = $this->helpPage->buildTaskData($this->reload($task));
+    verify($data['subscriberEmail'])->equals('logged@example.com');
+  }
+
+  public function testItDoesNotExposeRecipientEmailWhenQueueAndLogEachHoldOne() {
+    // One recipient already sent (log) and one still pending (queue) => 2 recipients total,
+    // so this is not a 1:1 email and no single subscriber email should be exposed.
+    $task = $this->createSendingTask();
+    $queued = (new SubscriberFactory())->withEmail('pending@example.com')->create();
+    $logged = (new SubscriberFactory())->withEmail('sent@example.com')->create();
+    (new ScheduledTaskQueuedSubscriberFactory())->create($task, $queued);
+    (new ScheduledTaskSubscriberFactory())->createProcessed($task, $logged);
+
+    $data = $this->helpPage->buildTaskData($this->reload($task));
+    verify($data['subscriberEmail'])->equals(null);
+  }
+
+  private function createSendingTask(): ScheduledTaskEntity {
+    // An in-flight sending task has a null status.
+    return $this->scheduledTaskFactory->create(
+      SendingQueue::TASK_TYPE,
+      null,
+      Carbon::now()
+    );
+  }
+
+  // Reload the task as the Help page does (fresh from the DB) so its lazy
+  // subscriber collections hydrate from the seeded rows instead of the
+  // empty in-memory collections of the just-created entity.
+  private function reload(ScheduledTaskEntity $task): ScheduledTaskEntity {
+    $id = (int)$task->getId();
+    $this->entityManager->clear();
+    $reloaded = $this->diContainer->get(ScheduledTasksRepository::class)->findOneById($id);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $reloaded);
+    return $reloaded;
   }
 
   private function createNewSendingQueue(?ScheduledTaskEntity $task, ?NewsletterEntity $newsletter, $renderedSubject = null): SendingQueueEntity {

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -6,10 +6,12 @@ use MailPoet\AutomaticEmails\WooCommerce\WooCommerce as WooCommerceEmail;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Scheduler\AutomaticEmailScheduler;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
@@ -63,6 +65,9 @@ class AbandonedCartTest extends \MailPoetTest {
   /** @var ScheduledTaskSubscribersRepository */
   private $scheduledTaskSubscribersRepository;
 
+  /** @var ScheduledTaskQueuedSubscriberRepository */
+  private $scheduledTaskQueuedSubscriberRepository;
+
   /** @var AutomaticEmailScheduler */
   private $automaticEmailScheduler;
 
@@ -76,6 +81,7 @@ class AbandonedCartTest extends \MailPoetTest {
     $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
     $this->sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
     $this->scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
+    $this->scheduledTaskQueuedSubscriberRepository = $this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class);
 
     $this->currentTime = Carbon::now()->millisecond(0);
     Carbon::setTestNow($this->currentTime);
@@ -258,6 +264,7 @@ class AbandonedCartTest extends \MailPoetTest {
 
     $this->assertCount(0, $this->scheduledTasksRepository->findAll());
     $this->assertCount(0, $this->scheduledTaskSubscribersRepository->findAll());
+    $this->assertCount(0, $this->scheduledTaskQueuedSubscriberRepository->findAll());
     $this->assertCount(0, $this->sendingQueuesRepository->findAll());
   }
 
@@ -376,13 +383,17 @@ class AbandonedCartTest extends \MailPoetTest {
     $this->entityManager->persist($sendingQueue);
     $this->entityManager->flush();
 
-    $sendingQueueSubscriber = new ScheduledTaskSubscriberEntity($scheduledTask, $subscriber, ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
-    $this->entityManager->persist($sendingQueueSubscriber);
-    $this->entityManager->flush();
-
     $scheduledTask->setScheduledAt($scheduleAt);
     $scheduledTask->setSendingQueue($sendingQueue);
     $scheduledTask->setStatus(($this->currentTime < $scheduleAt) ? ScheduledTaskEntity::STATUS_SCHEDULED : ScheduledTaskEntity::STATUS_COMPLETED);
+
+    // A pending (scheduled) task keeps its recipient in the queue; a completed
+    // one has already moved it into the processed log.
+    if ($scheduledTask->getStatus() === ScheduledTaskEntity::STATUS_SCHEDULED) {
+      $this->entityManager->persist(new ScheduledTaskQueuedSubscriberEntity($scheduledTask, $subscriber));
+    } else {
+      $this->entityManager->persist(new ScheduledTaskSubscriberEntity($scheduledTask, $subscriber, ScheduledTaskSubscriberEntity::STATUS_PROCESSED));
+    }
     $this->entityManager->flush();
 
     return $scheduledTask;

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -36,7 +36,9 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Exception;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\DynamicProductsBlock;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriberMover;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -296,14 +298,15 @@ class SendEmailActionTest extends \MailPoetTest {
       'automation' => ['id' => 1, 'run_id' => 1, 'step_id' => 'step-id', 'run_number' => 1],
     ], $scheduled[0]->getMeta());
 
-    // scheduled task subscriber
+    // the recipient is queued for sending
     $this->scheduledTasksRepository->refresh($scheduled[0]);
-    $scheduledTaskSubscribers = $scheduled[0]->getSubscribers();
-    $this->assertCount(1, $scheduledTaskSubscribers);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $scheduledTaskSubscribers[0]);
+    $queuedIds = $this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class)
+      ->getSubscriberIdsBatchForTask((int)$scheduled[0]->getId(), 0, 100);
+    $this->assertSame([(int)$subscriber->getId()], $queuedIds);
 
-    // mark email as sent
-    $scheduledTaskSubscribers[0]->setProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
+    // mark email as sent (simulate the sending worker moving the recipient to the log)
+    $this->diContainer->get(ScheduledTaskSubscriberMover::class)
+      ->moveProcessedToLog($scheduled[0], [(int)$subscriber->getId()]);
 
     // progress — won't throw an exception when the email was sent (= step will be completed)
     $args = new StepRunArgs($automation, $run, $step, $this->getSubjectEntries($subjects), 2);

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendLatestNewsletterActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendLatestNewsletterActionTest.php
@@ -25,6 +25,8 @@ use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Scheduler\LatestNewsletterScheduler;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriber;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Subscriber;
@@ -42,6 +44,8 @@ class SendLatestNewsletterActionTest extends \MailPoetTest {
 
   private SubscriberSubject $subscriberSubject;
 
+  private ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository;
+
   public function _before() {
     parent::_before();
     $this->action = $this->diContainer->get(SendLatestNewsletterAction::class);
@@ -49,6 +53,7 @@ class SendLatestNewsletterActionTest extends \MailPoetTest {
     $this->latestNewsletterScheduler = $this->diContainer->get(LatestNewsletterScheduler::class);
     $this->segmentSubject = $this->diContainer->get(SegmentSubject::class);
     $this->subscriberSubject = $this->diContainer->get(SubscriberSubject::class);
+    $this->scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
   }
 
   public function testItReturnsRequiredSubjects(): void {
@@ -105,7 +110,8 @@ class SendLatestNewsletterActionTest extends \MailPoetTest {
     $this->action->run($args, $controller);
 
     $taskSubscriber = $this->latestNewsletterScheduler->getScheduledTaskSubscriber($sourceNewsletter, $subscriber, $run);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $taskSubscriber);
+    $this->assertInstanceOf(ScheduledTaskSubscriber::class, $taskSubscriber);
+    $this->assertTrue($taskSubscriber->isPending());
     $task = $taskSubscriber->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
     $this->assertSame(ScheduledTaskEntity::STATUS_SCHEDULED, $task->getStatus());
@@ -122,7 +128,7 @@ class SendLatestNewsletterActionTest extends \MailPoetTest {
     $this->action->run($args, $controller);
 
     $taskSubscriber = $this->latestNewsletterScheduler->getScheduledTaskSubscriber($sourceNewsletter, $subscriber, $run);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $taskSubscriber);
+    $this->assertInstanceOf(ScheduledTaskSubscriber::class, $taskSubscriber);
     $task = $taskSubscriber->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
     [$timeoutArgs, $timeoutController] = $this->createStepRun($automation, $run, $step, $subjects, 8);
@@ -134,12 +140,14 @@ class SendLatestNewsletterActionTest extends \MailPoetTest {
       }
     );
     $this->entityManager->refresh($task);
-    $this->entityManager->refresh($taskSubscriber);
 
     $this->assertSame(ScheduledTaskEntity::STATUS_PAUSED, $task->getStatus());
-    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, $taskSubscriber->getProcessed());
-    $this->assertSame(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED, $taskSubscriber->getFailed());
-    $this->assertSame('Email sending process timed out.', $taskSubscriber->getError());
+    // the recipient was moved to the log as failed
+    $logSubscriber = $this->scheduledTaskSubscribersRepository->findOneBy(['task' => $task]);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $logSubscriber);
+    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, $logSubscriber->getProcessed());
+    $this->assertSame(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED, $logSubscriber->getFailed());
+    $this->assertSame('Email sending process timed out.', $logSubscriber->getError());
   }
 
   public function testItPausesReplayTaskWhenSubscriberBecomesIneligible(): void {
@@ -149,7 +157,7 @@ class SendLatestNewsletterActionTest extends \MailPoetTest {
     $this->action->run($args, $controller);
 
     $taskSubscriber = $this->latestNewsletterScheduler->getScheduledTaskSubscriber($sourceNewsletter, $subscriber, $run);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $taskSubscriber);
+    $this->assertInstanceOf(ScheduledTaskSubscriber::class, $taskSubscriber);
     $task = $taskSubscriber->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
 
@@ -159,12 +167,14 @@ class SendLatestNewsletterActionTest extends \MailPoetTest {
     [$pollArgs, $pollController] = $this->createStepRun($automation, $run, $step, $subjects, 2);
     $this->action->run($pollArgs, $pollController);
     $this->entityManager->refresh($task);
-    $this->entityManager->refresh($taskSubscriber);
 
     $this->assertSame(ScheduledTaskEntity::STATUS_PAUSED, $task->getStatus());
-    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, $taskSubscriber->getProcessed());
-    $this->assertSame(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED, $taskSubscriber->getFailed());
-    $this->assertSame('Subscriber is no longer eligible for this email.', $taskSubscriber->getError());
+    // the recipient was moved to the log as failed
+    $logSubscriber = $this->scheduledTaskSubscribersRepository->findOneBy(['task' => $task]);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $logSubscriber);
+    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, $logSubscriber->getProcessed());
+    $this->assertSame(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED, $logSubscriber->getFailed());
+    $this->assertSame('Subscriber is no longer eligible for this email.', $logSubscriber->getError());
     $this->assertSame('skipped-ineligible-subscriber', $pollController->getRunLog()->getLog()->getData()['outcome']);
   }
 
@@ -182,7 +192,7 @@ class SendLatestNewsletterActionTest extends \MailPoetTest {
     $this->action->run($confirmedRunArgs, $confirmedRunController);
 
     $taskSubscriber = $this->latestNewsletterScheduler->getScheduledTaskSubscriber($sourceNewsletter, $subscriber, $run);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $taskSubscriber);
+    $this->assertInstanceOf(ScheduledTaskSubscriber::class, $taskSubscriber);
     $scheduledActions = array_values(array_filter($this->getScheduledAutomationActions(), function(ActionScheduler_Action $action) use ($run, $step): bool {
       $args = $action->get_args();
       return ($args[0]['automation_run_id'] ?? null) === $run->getId()

--- a/mailpoet/tests/integration/Cron/Workers/BulkConfirmationEmailResendTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/BulkConfirmationEmailResendTest.php
@@ -5,11 +5,13 @@ namespace MailPoet\Cron\Workers;
 use Codeception\Stub;
 use MailPoet\Entities\LogEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Logging\LogRepository;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriberMover;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
@@ -23,24 +25,16 @@ class BulkConfirmationEmailResendTest extends \MailPoetTest {
       ->withCountConfirmations(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS)
       ->create();
 
-    $task = new ScheduledTaskEntity();
-    $task->setType(BulkConfirmationEmailResend::TASK_TYPE);
-    $task->setStatus(ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING);
-    $task->setScheduledAt(Carbon::now());
-    $this->entityManager->persist($task);
-    $this->entityManager->flush();
-
-    $taskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
-    $this->entityManager->persist($taskSubscriber);
-    $this->entityManager->flush();
+    $task = $this->createTaskWithSubscribers([$subscriber]);
 
     $worker = $this->diContainer->get(BulkConfirmationEmailResend::class);
     verify($worker->supportsMultipleInstances())->false();
     verify($worker->scheduleAutomatically())->false();
     verify($worker->processTaskStrategy($task, microtime(true)))->true();
 
-    $this->entityManager->refresh($taskSubscriber);
     $this->entityManager->refresh($task);
+    // The skipped recipient is moved from the queue to the log with a failure + error.
+    $taskSubscriber = $this->getTaskSubscriber($task, $subscriber);
     verify($taskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
     verify($taskSubscriber->getFailed())->equals(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED);
     verify($taskSubscriber->getError())->equals('skipped:max_confirmations_reached');
@@ -48,7 +42,9 @@ class BulkConfirmationEmailResendTest extends \MailPoetTest {
     $this->assertIsArray($taskMeta);
     verify($taskMeta['failed_count'])->equals(1);
     verify($taskMeta['skipped_by_reason']['max_confirmations_reached'])->equals(1);
-    verify($this->diContainer->get(ScheduledTaskSubscribersRepository::class)->countUnprocessed($task))->equals(0);
+    // The queue is drained and the log only holds the processed row.
+    verify($this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class)->countForTask($task))->equals(0);
+    verify($this->countPendingLogSubscribers($task))->equals(0);
   }
 
   public function testItRecordsSentFailedSkippedCountsAndIgnoresUnrelatedTasks(): void {
@@ -71,11 +67,6 @@ class BulkConfirmationEmailResendTest extends \MailPoetTest {
 
     $task = $this->createTaskWithSubscribers([$sent, $sendFailed, $skipped]);
     $unrelatedTask = $this->createTaskWithSubscribers([$unrelated]);
-    $unrelatedTaskSubscriber = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->findOneBy([
-      'task' => $unrelatedTask,
-      'subscriber' => $unrelated,
-    ]);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $unrelatedTaskSubscriber);
 
     $mailer = Stub::makeEmpty(ConfirmationEmailMailer::class, [
       'sendAdminConfirmationEmail' => function(SubscriberEntity $subscriber): array {
@@ -91,14 +82,13 @@ class BulkConfirmationEmailResendTest extends \MailPoetTest {
     $worker = new BulkConfirmationEmailResend(
       $mailer,
       $this->diContainer->get(SubscribersRepository::class),
-      $this->diContainer->get(ScheduledTaskSubscribersRepository::class),
+      $this->diContainer->get(ScheduledTaskSubscriberMover::class),
       $this->diContainer->get(LogRepository::class)
     );
 
     verify($worker->processTaskStrategy($task, microtime(true)))->true();
 
     $this->entityManager->refresh($task);
-    $this->entityManager->refresh($unrelatedTaskSubscriber);
     $sentTaskSubscriber = $this->getTaskSubscriber($task, $sent);
     $sendFailedTaskSubscriber = $this->getTaskSubscriber($task, $sendFailed);
     $skippedTaskSubscriber = $this->getTaskSubscriber($task, $skipped);
@@ -111,7 +101,14 @@ class BulkConfirmationEmailResendTest extends \MailPoetTest {
     verify($skippedTaskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
     verify($skippedTaskSubscriber->getFailed())->equals(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED);
     verify($skippedTaskSubscriber->getError())->equals('skipped:recently_sent');
-    verify($unrelatedTaskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED);
+
+    // The unrelated task was not processed, so its recipient is still pending in the queue and not in the log.
+    verify($this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class)->countForTask($unrelatedTask))->equals(1);
+    $unrelatedLogRow = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->findOneBy([
+      'task' => $unrelatedTask,
+      'subscriber' => $unrelated,
+    ]);
+    $this->assertNull($unrelatedLogRow);
 
     $taskMeta = $task->getMeta();
     $this->assertIsArray($taskMeta);
@@ -143,7 +140,7 @@ class BulkConfirmationEmailResendTest extends \MailPoetTest {
     $this->entityManager->flush();
 
     foreach ($subscribers as $subscriber) {
-      $this->entityManager->persist(new ScheduledTaskSubscriberEntity($task, $subscriber));
+      $this->entityManager->persist(new ScheduledTaskQueuedSubscriberEntity($task, $subscriber));
     }
     $this->entityManager->flush();
 
@@ -157,5 +154,12 @@ class BulkConfirmationEmailResendTest extends \MailPoetTest {
     ]);
     $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $taskSubscriber);
     return $taskSubscriber;
+  }
+
+  private function countPendingLogSubscribers(ScheduledTaskEntity $task): int {
+    return $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->count([
+      'task' => $task,
+      'processed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
+    ]);
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -11,7 +11,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -21,6 +21,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Sending\NewsletterReplayMetadata;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SubscribersFinder;
@@ -261,6 +262,7 @@ class SchedulerTest extends \MailPoetTest {
     $this->newsletterOptionFactory->create($newsletter, 'event', 'user');
     $task = $this->createTaskWithQueue($newsletter);
     $this->createTaskSubscriber($task, $subscriber);
+    [$task, $newsletter] = $this->reloadTaskAndNewsletter($task, $newsletter);
 
     // return false when WP user cannot be verified
     $scheduler = Stub::make(Scheduler::class, [
@@ -277,6 +279,7 @@ class SchedulerTest extends \MailPoetTest {
     $this->newsletterOptionFactory->create($newsletter, 'event', 'segment');
     $task = $this->createTaskWithQueue($newsletter);
     $this->createTaskSubscriber($task, $subscriber);
+    [$task, $newsletter] = $this->reloadTaskAndNewsletter($task, $newsletter);
 
     // return false when subscriber cannot be verified
     $scheduler = Stub::make(Scheduler::class, [
@@ -295,6 +298,7 @@ class SchedulerTest extends \MailPoetTest {
     // return true when subscriber is verified and update the task status to null
     $task = $this->createTaskWithQueue($newsletter);
     $this->createTaskSubscriber($task, $subscriber);
+    [$task, $newsletter] = $this->reloadTaskAndNewsletter($task, $newsletter);
     $scheduler = Stub::make(Scheduler::class, [
       'verifyMailpoetSubscriber' => Expected::exactly(1, true),
       'scheduledTasksRepository' => $this->diContainer->get(ScheduledTasksRepository::class),
@@ -316,6 +320,7 @@ class SchedulerTest extends \MailPoetTest {
     // return true when WP user is verified
     $task = $this->createTaskWithQueue($newsletter);
     $this->createTaskSubscriber($task, $subscriber);
+    [$task, $newsletter] = $this->reloadTaskAndNewsletter($task, $newsletter);
     $scheduler = Stub::make(Scheduler::class, [
       'verifyWPSubscriber' => Expected::exactly(1, true),
       'scheduledTasksRepository' => $this->diContainer->get(ScheduledTasksRepository::class),
@@ -446,11 +451,8 @@ class SchedulerTest extends \MailPoetTest {
     // return true
     verify($scheduler->processScheduledStandardNewsletter($newsletter, $task))->true();
     // update queue's list of subscribers to process
-    $updatedSubscribers = $task->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED);
-    $updatedSubscribersIds = array_map(function(SubscriberEntity $subscriber): int {
-      return (int)$subscriber->getId();
-    }, $updatedSubscribers);
-    verify($updatedSubscribersIds)->equals([$subscriber->getId()]);
+    $updatedSubscribersIds = $this->getQueuedSubscriberIds($task);
+    verify($updatedSubscribersIds)->equals([(int)$subscriber->getId()]);
     // set queue's status to null
     verify($task->getStatus())->null();
     // set newsletter's status to sending
@@ -508,11 +510,8 @@ class SchedulerTest extends \MailPoetTest {
     // to that of the notification history
     $sendingQueue = $task->getSendingQueue();
     $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
-    $updatedSubscribers = $task->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED);
-    $updatedSubscribersIds = array_map(function(SubscriberEntity $subscriber): int {
-      return (int)$subscriber->getId();
-    }, $updatedSubscribers);
-    verify($updatedSubscribersIds)->equals([$subscriber->getId()]);
+    $updatedSubscribersIds = $this->getQueuedSubscriberIds($task);
+    verify($updatedSubscribersIds)->equals([(int)$subscriber->getId()]);
     $scheduledNewsletter = $sendingQueue->getNewsletter();
     $this->assertInstanceOf(NewsletterEntity::class, $scheduledNewsletter);
     verify($scheduledNewsletter->getId())->equals($notificationHistory->getId());
@@ -537,10 +536,12 @@ class SchedulerTest extends \MailPoetTest {
     $this->entityManager->refresh($newsletter);
 
     // Prefill scheduled task subscriber
-    $scheduledTaskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
+    $scheduledTaskSubscriber = new ScheduledTaskQueuedSubscriberEntity($task, $subscriber);
     $this->entityManager->persist($scheduledTaskSubscriber);
-    $task->getSubscribers()->add($scheduledTaskSubscriber);
     $this->entityManager->flush();
+    // reload so the task's EXTRA_LAZY queue collection reads from the DB, as in
+    // production where the scheduler processes tasks loaded from the database
+    [$task, $newsletter] = $this->reloadTaskAndNewsletter($task, $newsletter);
 
     // return true
     verify($scheduler->processPostNotificationNewsletter($newsletter, $task))->true();
@@ -682,9 +683,7 @@ class SchedulerTest extends \MailPoetTest {
     verify($refetchedTask->getStatus())->null();
     verify($refetchedNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
 
-    $scheduledSubscriberIds = array_map(function (ScheduledTaskSubscriberEntity $taskSubscriber): int {
-      return (int)$taskSubscriber->getSubscriberId();
-    }, $refetchedTask->getSubscribers()->toArray());
+    $scheduledSubscriberIds = $this->getQueuedSubscriberIds($refetchedTask);
 
     verify($scheduledSubscriberIds)->equals([(int)$replaySubscriber->getId()]);
 
@@ -840,10 +839,7 @@ class SchedulerTest extends \MailPoetTest {
     $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
     verify($task->getStatus())->null();
     // task should have 1 subscriber added from segment
-    $subscribers = $task->getSubscribers();
-    $this->assertCount(1, $subscribers);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $subscribers[0]);
-    $this->assertSame($subscriber, $subscribers[0]->getSubscriber());
+    $this->assertSame([(int)$subscriber->getId()], $this->getQueuedSubscriberIds($task));
   }
 
   public function testItProcessesScheduledAutomaticEmailWhenSendingToSegmentAndSubscriberIsPrefilled() {
@@ -861,9 +857,8 @@ class SchedulerTest extends \MailPoetTest {
 
     $task = $this->createTaskWithQueue($newsletter);
     // Prefill scheduled task subscriber
-    $scheduledTaskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
+    $scheduledTaskSubscriber = new ScheduledTaskQueuedSubscriberEntity($task, $subscriber);
     $this->entityManager->persist($scheduledTaskSubscriber);
-    $task->getSubscribers()->add($scheduledTaskSubscriber);
     $this->entityManager->flush();
 
     // task should have its status set to null (i.e., sending)
@@ -874,10 +869,7 @@ class SchedulerTest extends \MailPoetTest {
     $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
     verify($task->getStatus())->null();
     // task should have 1 subscriber added from segment
-    $subscribers = $task->getSubscribers();
-    $this->assertCount(1, $subscribers);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $subscribers[0]);
-    $this->assertSame($subscriber, $subscribers[0]->getSubscriber());
+    $this->assertSame([(int)$subscriber->getId()], $this->getQueuedSubscriberIds($task));
   }
 
   public function testItProcessesScheduledAutomationEmail() {
@@ -1022,12 +1014,38 @@ class SchedulerTest extends \MailPoetTest {
     return $task;
   }
 
-  private function createTaskSubscriber(ScheduledTaskEntity $task, SubscriberEntity $subscriber): ScheduledTaskSubscriberEntity {
-    $scheduledTaskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
+  private function createTaskSubscriber(ScheduledTaskEntity $task, SubscriberEntity $subscriber): ScheduledTaskQueuedSubscriberEntity {
+    $scheduledTaskSubscriber = new ScheduledTaskQueuedSubscriberEntity($task, $subscriber);
     $this->entityManager->persist($scheduledTaskSubscriber);
-    $task->getSubscribers()->add($scheduledTaskSubscriber);
     $this->entityManager->flush();
     return $scheduledTaskSubscriber;
+  }
+
+  /**
+   * Reloads test setup entities so queue reads use DB-backed EXTRA_LAZY state
+   * after queued subscribers were inserted outside the task collection.
+   *
+   * @return array{0: ScheduledTaskEntity, 1: NewsletterEntity}
+   */
+  private function reloadTaskAndNewsletter(ScheduledTaskEntity $task, NewsletterEntity $newsletter): array {
+    $taskId = (int)$task->getId();
+    $newsletterId = (int)$newsletter->getId();
+    $this->entityManager->clear();
+    $reloadedTask = $this->scheduledTasksRepository->findOneById($taskId);
+    $reloadedNewsletter = $this->newslettersRepository->findOneById($newsletterId);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $reloadedTask);
+    $this->assertInstanceOf(NewsletterEntity::class, $reloadedNewsletter);
+    return [$reloadedTask, $reloadedNewsletter];
+  }
+
+  /** @return int[] */
+  private function getQueuedSubscriberIds(ScheduledTaskEntity $task): array {
+    $taskId = $task->getId();
+    if (!$taskId) {
+      return [];
+    }
+    return $this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class)
+      ->getSubscriberIdsBatchForTask($taskId, 0, 100);
   }
 
   private function getSchedulerMock(array $mocks): Scheduler {

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingErrorHandlerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingErrorHandlerTest.php
@@ -10,7 +10,7 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\SubscriberError;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriberMover;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoetVendor\Monolog\Logger;
 
@@ -33,10 +33,10 @@ class SendingErrorHandlerTest extends \MailPoetTest {
       $subscriberErrors
     );
 
-    $scheduledTaskSubscribersRepository = Stub::make(
-      ScheduledTaskSubscribersRepository::class,
+    $scheduledTaskSubscriberMover = Stub::make(
+      ScheduledTaskSubscriberMover::class,
       [
-        'saveError' => Expected::exactly(
+        'moveFailedToLog' => Expected::exactly(
           2,
           function ($task, $id, $message) {
             if ($id === 2) {
@@ -53,7 +53,7 @@ class SendingErrorHandlerTest extends \MailPoetTest {
     $errorHandler = $this->getServiceWithOverrides(
       SendingErrorHandler::class,
       [
-        'scheduledTaskSubscribersRepository' => $scheduledTaskSubscribersRepository,
+        'scheduledTaskSubscriberMover' => $scheduledTaskSubscriberMover,
       ]
     );
     $errorHandler->processError($error, new ScheduledTaskEntity(), $subscriberIds, $subscribers);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -21,6 +21,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
@@ -33,7 +34,9 @@ use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\SubscriberError;
 use MailPoet\Newsletter\Links\Links;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriberMover;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Router\Endpoints\Track;
@@ -105,6 +108,12 @@ class SendingQueueTest extends \MailPoetTest {
   /** @var ScheduledTaskSubscribersRepository */
   private $scheduledTaskSubscribersRepository;
 
+  /** @var ScheduledTaskQueuedSubscriberRepository */
+  private $scheduledTaskQueuedSubscriberRepository;
+
+  /** @var ScheduledTaskSubscriberMover */
+  private $scheduledTaskSubscriberMover;
+
   /** @var ScheduledTaskEntity */
   private $scheduledTask;
 
@@ -124,6 +133,8 @@ class SendingQueueTest extends \MailPoetTest {
     $this->wp = $this->diContainer->get(WPFunctions::class);
     $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
     $this->scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
+    $this->scheduledTaskQueuedSubscriberRepository = $this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class);
+    $this->scheduledTaskSubscriberMover = $this->diContainer->get(ScheduledTaskSubscriberMover::class);
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->segment = (new SegmentFactory())->withName('segment')->create();
     $this->subscriber = $this->createSubscriber('john@doe.com', 'John', 'Doe', [$this->segment]);
@@ -140,7 +151,7 @@ class SendingQueueTest extends \MailPoetTest {
     $scheduledTask = $this->sendingQueue->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
     $this->scheduledTask = $scheduledTask;
-    $this->scheduledTaskSubscribersRepository->setSubscribers($this->scheduledTask, [$this->subscriber->getId()]);
+    $this->seedQueuedSubscribers($this->scheduledTask, [$this->subscriber->getId()]);
 
     $queue = $this->newsletter->getLatestQueue();
     $this->assertInstanceOf(SendingQueueEntity::class, $queue);
@@ -220,6 +231,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->tasksLinks,
       $this->scheduledTasksRepository,
       $this->scheduledTaskSubscribersRepository,
+      $this->scheduledTaskQueuedSubscriberRepository,
+      $this->scheduledTaskSubscriberMover,
       $this->diContainer->get(MailerTask::class),
       $this->subscribersRepository,
       $this->sendingQueuesRepository,
@@ -254,6 +267,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->tasksLinks,
       $this->scheduledTasksRepository,
       $this->scheduledTaskSubscribersRepository,
+      $this->scheduledTaskQueuedSubscriberRepository,
+      $this->scheduledTaskSubscriberMover,
       $this->make(
         new MailerTask($this->diContainer->get(MailerFactory::class)),
         [
@@ -305,6 +320,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->tasksLinks,
       $this->scheduledTasksRepository,
       $this->scheduledTaskSubscribersRepository,
+      $this->scheduledTaskQueuedSubscriberRepository,
+      $this->scheduledTaskSubscriberMover,
       $this->make(
         new MailerTask($this->diContainer->get(MailerFactory::class)),
         [
@@ -354,6 +371,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->tasksLinks,
       $this->scheduledTasksRepository,
       $this->scheduledTaskSubscribersRepository,
+      $this->scheduledTaskQueuedSubscriberRepository,
+      $this->scheduledTaskSubscriberMover,
       $this->diContainer->get(MailerTask::class),
       $this->subscribersRepository,
       $this->sendingQueuesRepository,
@@ -448,7 +467,7 @@ class SendingQueueTest extends \MailPoetTest {
     verify($scheduledTask->getStatus())->equals(SendingQueueEntity::STATUS_COMPLETED);
 
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
+    verify($this->getQueuedSubscribers($scheduledTask))
       ->arrayCount(0);
     $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
     verify($processedSubscribers)->equals([$this->subscriber]);
@@ -486,7 +505,7 @@ class SendingQueueTest extends \MailPoetTest {
     $sendingQueue->setNewsletterRenderedSubject('News for [subscriber:email]');
     $scheduledTask = $sendingQueue->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
-    $this->scheduledTaskSubscribersRepository->setSubscribers($scheduledTask, [$subscriber1->getId(), $subscriber2->getId()]);
+    $this->seedQueuedSubscribers($scheduledTask, [$subscriber1->getId(), $subscriber2->getId()]);
 
     $this->settings->set('tracking.level', TrackingConfig::LEVEL_BASIC);
 
@@ -559,7 +578,7 @@ class SendingQueueTest extends \MailPoetTest {
     verify($scheduledTask->getStatus())->equals(SendingQueueEntity::STATUS_COMPLETED);
 
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
+    verify($this->getQueuedSubscribers($scheduledTask))
       ->arrayCount(0);
     $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
     verify($processedSubscribers)->equals([$this->subscriber]);
@@ -609,7 +628,7 @@ class SendingQueueTest extends \MailPoetTest {
     verify($updatedNewsletter->getSentAt())->equalsWithDelta($scheduledTask->getProcessedAt(), 1);
 
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
+    verify($this->getQueuedSubscribers($scheduledTask))
       ->arrayCount(0);
     $processedSubscribers = $scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
     verify($processedSubscribers)->equals([$this->subscriber]);
@@ -632,7 +651,7 @@ class SendingQueueTest extends \MailPoetTest {
     $sendingQueue = $this->createQueueWithTask($this->newsletter);
     $scheduledTask = $sendingQueue->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
-    $this->scheduledTaskSubscribersRepository->setSubscribers($scheduledTask, [$this->subscriber->getId(), $wrongSubscriber->getId()]);
+    $this->seedQueuedSubscribers($scheduledTask, [$this->subscriber->getId(), $wrongSubscriber->getId()]);
 
     // Error that simulates sending error from the bridge
     $mailerError = new MailerError(
@@ -657,6 +676,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->tasksLinks,
       $this->scheduledTasksRepository,
       $this->scheduledTaskSubscribersRepository,
+      $this->scheduledTaskQueuedSubscriberRepository,
+      $this->scheduledTaskSubscriberMover,
       $this->make(
         new MailerTask($this->diContainer->get(MailerFactory::class)),
         [
@@ -682,7 +703,7 @@ class SendingQueueTest extends \MailPoetTest {
     // compare data after first sending
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))->equals([$this->subscriber]);
+    verify($this->getQueuedSubscribers($scheduledTask))->equals([$this->subscriber]);
     verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))->equals([$wrongSubscriber]);
     verify($sendingQueue->getCountTotal())->equals(2);
     verify($sendingQueue->getCountProcessed())->equals(1);
@@ -700,7 +721,7 @@ class SendingQueueTest extends \MailPoetTest {
     // load queue and compare data after second sending
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))->equals([]);
+    verify($this->getQueuedSubscribers($scheduledTask))->equals([]);
     verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))->equals([$this->subscriber, $wrongSubscriber]);
     verify($sendingQueue->getCountTotal())->equals(2);
     verify($sendingQueue->getCountProcessed())->equals(2);
@@ -752,7 +773,7 @@ class SendingQueueTest extends \MailPoetTest {
     verify($this->scheduledTask->getStatus())->equals(SendingQueueEntity::STATUS_COMPLETED);
 
     // queue subscriber processed/to process count is updated
-    verify($this->scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
+    verify($this->getQueuedSubscribers($this->scheduledTask))
       ->equals([]);
     verify($this->scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([$this->subscriber]);
@@ -807,7 +828,7 @@ class SendingQueueTest extends \MailPoetTest {
       ->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)
       ->create();
 
-    $this->scheduledTaskSubscribersRepository->setSubscribers(
+    $this->seedQueuedSubscribers(
       $this->scheduledTask,
       [$this->subscriber->getId(), $unsubscribedSubscriber->getId()]
     );
@@ -876,7 +897,7 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function testItCompletesEverythingProperlyWhenThereIsNoOneToSendTo() {
     // No subscribers in queue
-    $this->scheduledTaskSubscribersRepository->setSubscribers(
+    $this->seedQueuedSubscribers(
       $this->scheduledTask,
       []
     );
@@ -912,7 +933,7 @@ class SendingQueueTest extends \MailPoetTest {
   public function testItRemovesSubscribersFromProcessingListWhenNewsletterHasSegmentAndSubscriberIsNotPartOfIt() {
     $subscriberNotPartOfNewsletterSegment = $this->createSubscriber('subscriber1@mailpoet.com', 'Subscriber', 'One');
 
-    $this->scheduledTaskSubscribersRepository->setSubscribers(
+    $this->seedQueuedSubscribers(
       $this->scheduledTask,
       [$this->subscriber->getId(), $subscriberNotPartOfNewsletterSegment->getId()]
     );
@@ -930,7 +951,7 @@ class SendingQueueTest extends \MailPoetTest {
     $sendingQueueWorker->process();
 
     // queue subscriber processed/to process count is updated
-    verify($this->scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
+    verify($this->getQueuedSubscribers($this->scheduledTask))
       ->equals([]);
     verify($this->scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([$this->subscriber]);
@@ -947,7 +968,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->newsletter->getNewsletterSegments()->clear();
     $invalidSubscriberId = 99999;
 
-    $this->scheduledTaskSubscribersRepository->setSubscribers(
+    $this->seedQueuedSubscribers(
       $this->scheduledTask,
       [$this->subscriber->getId(), $invalidSubscriberId]
     );
@@ -969,7 +990,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->sendingQueuesRepository->refresh($this->sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
+    verify($this->getQueuedSubscribers($scheduledTask))
       ->equals([]);
     verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([$this->subscriber]);
@@ -989,7 +1010,7 @@ class SendingQueueTest extends \MailPoetTest {
     }
     $subscribers[] = $this->subscriber->getId();
 
-    $this->scheduledTaskSubscribersRepository->setSubscribers($this->scheduledTask, $subscribers);
+    $this->seedQueuedSubscribers($this->scheduledTask, $subscribers);
     $this->sendingQueue->setCountTotal(count($subscribers));
     $this->entityManager->persist($this->sendingQueue);
     $this->entityManager->flush();
@@ -1013,7 +1034,7 @@ class SendingQueueTest extends \MailPoetTest {
     $this->sendingQueuesRepository->refresh($sendingQueue);
     $this->scheduledTasksRepository->refresh($scheduledTask);
     // queue subscriber processed/to process count is updated
-    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
+    verify($this->getQueuedSubscribers($scheduledTask))
       ->equals([]);
     verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([$this->subscriber]);
@@ -1024,7 +1045,7 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItUpdatesQueueSubscriberCountWhenNoneOfSubscribersExist() {
-    $this->scheduledTaskSubscribersRepository->setSubscribers($this->scheduledTask, [123, 456,]);
+    $this->seedQueuedSubscribers($this->scheduledTask, [123, 456,]);
     $this->sendingQueue->setCountTotal(2);
     $this->entityManager->persist($this->sendingQueue);
     $this->entityManager->flush();
@@ -1038,7 +1059,7 @@ class SendingQueueTest extends \MailPoetTest {
     $sendingQueueWorker->process();
 
     // queue subscriber processed/to process count is updated
-    verify($this->scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
+    verify($this->getQueuedSubscribers($this->scheduledTask))
       ->equals([]);
     verify($this->scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
       ->equals([]);
@@ -1184,9 +1205,9 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItPausesSendingWhenProcessedSubscriberListCannotBeUpdated() {
-    $scheduledTaskSubscribersRepository = $this->createMock(ScheduledTaskSubscribersRepository::class);
-    $scheduledTaskSubscribersRepository
-      ->method('updateProcessedSubscribers')
+    $scheduledTaskSubscriberMover = $this->createMock(ScheduledTaskSubscriberMover::class);
+    $scheduledTaskSubscriberMover
+      ->method('moveProcessedToLog')
       ->willThrowException(new \Exception());
     $sendingQueueWorker = $this->make(
       $this->getSendingQueueWorker()
@@ -1202,7 +1223,9 @@ class SendingQueueTest extends \MailPoetTest {
       $this->wp,
       $this->tasksLinks,
       $this->scheduledTasksRepository,
-      $scheduledTaskSubscribersRepository,
+      $this->scheduledTaskSubscribersRepository,
+      $this->scheduledTaskQueuedSubscriberRepository,
+      $scheduledTaskSubscriberMover,
       $this->construct(
         MailerTask::class,
         [$this->diContainer->get(MailerFactory::class)],
@@ -1412,7 +1435,7 @@ class SendingQueueTest extends \MailPoetTest {
   public function testCampaignIdsAreTheSameForDifferentSubscribers() {
     $mailerTaskCampaignIds = [];
     $secondSubscriber = $this->createSubscriber('sub2@example.com', 'Subscriber', 'Two', [$this->segment]);
-    $this->scheduledTaskSubscribersRepository->setSubscribers(
+    $this->seedQueuedSubscribers(
       $this->scheduledTask,
       [$this->subscriber->getId(), $secondSubscriber->getId()]
     );
@@ -1462,7 +1485,7 @@ class SendingQueueTest extends \MailPoetTest {
 
   public function testItLogsWhenSendingReachesEndAndTaskHasAnUnexpectedState() {
     // No subscribers in queue to skip batch processing
-    $this->scheduledTaskSubscribersRepository->setSubscribers(
+    $this->seedQueuedSubscribers(
       $this->scheduledTask,
       []
     );
@@ -1613,6 +1636,39 @@ class SendingQueueTest extends \MailPoetTest {
     return $queue;
   }
 
+  /**
+   * Seeds the QUEUE table (sending tasks now read pending recipients from there).
+   *
+   * @param array<int|null> $subscriberIds
+   */
+  private function seedQueuedSubscribers(ScheduledTaskEntity $task, array $subscriberIds): void {
+    $this->scheduledTaskQueuedSubscriberRepository->deleteByScheduledTask($task);
+    foreach ($subscriberIds as $subscriberId) {
+      /** @var SubscriberEntity $subscriber */
+      $subscriber = $this->entityManager->getReference(SubscriberEntity::class, (int)$subscriberId);
+      $this->entityManager->persist(new ScheduledTaskQueuedSubscriberEntity($task, $subscriber));
+    }
+    $this->entityManager->flush();
+  }
+
+  /**
+   * Returns the still-pending recipients of a sending task from the QUEUE.
+   * Replaces $task->getSubscribersByProcessed(STATUS_UNPROCESSED), which read the log relation.
+   *
+   * @return SubscriberEntity[]
+   */
+  private function getQueuedSubscribers(ScheduledTaskEntity $task): array {
+    $ids = $this->scheduledTaskQueuedSubscriberRepository->getSubscriberIdsBatchForTask((int)$task->getId(), 0, 1000);
+    $subscribers = [];
+    foreach ($ids as $id) {
+      $subscriber = $this->subscribersRepository->findOneById($id);
+      if ($subscriber instanceof SubscriberEntity) {
+        $subscribers[] = $subscriber;
+      }
+    }
+    return $subscribers;
+  }
+
   private function getSendingQueueWorker($mailerMock = null, $authorizedEmailControllerMock = null): SendingQueueWorker {
     return new SendingQueueWorker(
       $this->sendingErrorHandler,
@@ -1626,6 +1682,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->tasksLinks,
       $this->scheduledTasksRepository,
       $this->scheduledTaskSubscribersRepository,
+      $this->scheduledTaskQueuedSubscriberRepository,
+      $this->scheduledTaskSubscriberMover,
       $mailerMock ?? $this->diContainer->get(MailerTask::class),
       $this->subscribersRepository,
       $this->sendingQueuesRepository,

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Coupons/CouponBlockGenerationTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Coupons/CouponBlockGenerationTest.php
@@ -8,6 +8,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockGenerationFail
 use MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockGenerator;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
@@ -251,8 +252,9 @@ class CouponBlockGenerationTest extends \MailPoetTest {
       ->withWpPostId($postId)
       ->withScheduledQueue(['count_processed' => 0, 'count_total' => $subscriberCount]);
 
+    $subscribers = [];
     for ($i = 0; $i < $subscriberCount; $i++) {
-      $factory->withSubscriber((new SubscriberFactory())->withEmail("subscriber-{$i}@example.com")->create());
+      $subscribers[] = (new SubscriberFactory())->withEmail("subscriber-{$i}@example.com")->create();
     }
 
     $newsletter = $factory->create();
@@ -261,6 +263,11 @@ class CouponBlockGenerationTest extends \MailPoetTest {
     if ($queue && $task) {
       $this->entityManager->refresh($task);
       $task->setSendingQueue($queue);
+      // The recipients are still pending, so they live in the queue (not the log).
+      foreach ($subscribers as $subscriber) {
+        $this->entityManager->persist(new ScheduledTaskQueuedSubscriberEntity($task, $subscriber));
+      }
+      $this->entityManager->flush();
     }
     return $newsletter;
   }

--- a/mailpoet/tests/integration/Entities/ScheduledTaskEntityTest.php
+++ b/mailpoet/tests/integration/Entities/ScheduledTaskEntityTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Entities;
+
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskQueuedSubscriber as ScheduledTaskQueuedSubscriberFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+class ScheduledTaskEntityTest extends \MailPoetTest {
+  public function testItCountsQueuedSubscribers(): void {
+    $task = $this->createTask();
+    verify($task->getQueuedCount())->equals(0);
+
+    $this->queueSubscriber($task);
+    $this->queueSubscriber($task);
+
+    // reload so the EXTRA_LAZY collection counts via the database, not in-memory state
+    $task = $this->reloadTask($task);
+    verify($task->getQueuedCount())->equals(2);
+  }
+
+  public function testItReturnsNullFirstQueuedSubscriberWhenQueueEmpty(): void {
+    $task = $this->createTask();
+    $this->assertNull($task->getFirstQueuedSubscriber());
+  }
+
+  public function testItReturnsTheLowestIdFirstQueuedSubscriber(): void {
+    $task = $this->createTask();
+    $first = $this->queueSubscriber($task);
+    $second = $this->queueSubscriber($task);
+
+    $task = $this->reloadTask($task);
+
+    $firstQueued = $task->getFirstQueuedSubscriber();
+    $this->assertInstanceOf(SubscriberEntity::class, $firstQueued);
+    $lowestId = min((int)$first->getId(), (int)$second->getId());
+    verify((int)$firstQueued->getId())->equals($lowestId);
+  }
+
+  private function createTask(): ScheduledTaskEntity {
+    return (new ScheduledTaskFactory())->create('sending', ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now());
+  }
+
+  private function queueSubscriber(ScheduledTaskEntity $task): SubscriberEntity {
+    $subscriber = (new SubscriberFactory())->create();
+    (new ScheduledTaskQueuedSubscriberFactory())->create($task, $subscriber);
+    return $subscriber;
+  }
+
+  private function reloadTask(ScheduledTaskEntity $task): ScheduledTaskEntity {
+    $this->entityManager->clear();
+    $reloaded = $this->entityManager->find(ScheduledTaskEntity::class, (int)$task->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $reloaded);
+    return $reloaded;
+  }
+}

--- a/mailpoet/tests/integration/Mailer/MigrationSendingPauserTest.php
+++ b/mailpoet/tests/integration/Mailer/MigrationSendingPauserTest.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Mailer;
+
+use MailPoet\Mailer\MailerLog;
+use MailPoet\Mailer\MigrationSendingPauser;
+use MailPoet\Settings\SettingsController;
+
+/**
+ * @phpstan-import-type MailerLogData from MailerLog
+ */
+class MigrationSendingPauserTest extends \MailPoetTest {
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var MigrationSendingPauser */
+  private $pauser;
+
+  public function _before() {
+    parent::_before();
+    $this->settings = $this->diContainer->get(SettingsController::class);
+    $this->pauser = $this->diContainer->get(MigrationSendingPauser::class);
+    $this->settings->delete(MigrationSendingPauser::BACKUP_SETTING_NAME);
+    MailerLog::createMailerLog();
+  }
+
+  public function testItBlocksSendingWhilePaused(): void {
+    $this->pauser->pause();
+
+    verify(MailerLog::isSendingPaused())->true();
+
+    try {
+      MailerLog::enforceExecutionRequirements();
+      self::fail('Paused sending exception was not thrown.');
+    } catch (\Exception $e) {
+      verify($e->getMessage())->equals('Sending has been paused.');
+    }
+  }
+
+  public function testItResumesActiveSendingWithMailerLogIntact(): void {
+    $mailerLog = $this->createMailerLog([
+      'sent' => [date('Y-m-d H:i:s', time() - 60) => 7],
+      'retry_attempt' => 2,
+      'retry_at' => time() + 120,
+      'error' => [
+        'operation' => 'send',
+        'error_code' => 'smtp_temporary_failure',
+        'error_message' => 'Temporary SMTP failure',
+      ],
+      'transactional_email_last_error_at' => time() - 30,
+      'transactional_email_error_count' => 1,
+    ]);
+    MailerLog::updateMailerLog($mailerLog);
+
+    $this->pauser->pause();
+    verify(MailerLog::isSendingPaused())->true();
+
+    $this->pauser->resume();
+
+    verify(MailerLog::isSendingPaused())->false();
+    verify(MailerLog::getMailerLog())->equals($mailerLog);
+    verify($this->settings->hasSavedValue(MigrationSendingPauser::BACKUP_SETTING_NAME))->false();
+  }
+
+  public function testItLeavesAlreadyPausedSendingUntouched(): void {
+    $mailerLog = $this->createMailerLog([
+      'status' => MailerLog::STATUS_PAUSED,
+      'sent' => [date('Y-m-d H:i:s', time() - 60) => 3],
+      'retry_attempt' => 2,
+      'retry_at' => time() + 120,
+      'error' => [
+        'operation' => 'send',
+        'error_message' => 'User-paused sender error',
+      ],
+    ]);
+    MailerLog::updateMailerLog($mailerLog);
+
+    $this->pauser->pause();
+    verify($this->settings->hasSavedValue(MigrationSendingPauser::BACKUP_SETTING_NAME))->false();
+
+    $this->pauser->resume();
+
+    verify(MailerLog::isSendingPaused())->true();
+    verify(MailerLog::getMailerLog())->equals($mailerLog);
+  }
+
+  public function testItDoesNotClobberBackupOnRerun(): void {
+    $mailerLog = $this->createMailerLog([
+      'sent' => [date('Y-m-d H:i:s', time() - 60) => 11],
+      'retry_attempt' => 1,
+      'retry_at' => time() + 120,
+      'error' => [
+        'operation' => 'send',
+        'error_message' => 'Original retry state',
+      ],
+    ]);
+    MailerLog::updateMailerLog($mailerLog);
+
+    $this->pauser->pause();
+    $changedPausedLog = MailerLog::getMailerLog();
+    $changedPausedLog['sent'] = [date('Y-m-d H:i:s', time() - 30) => 99];
+    $changedPausedLog['status'] = null;
+    MailerLog::updateMailerLog($changedPausedLog);
+
+    $this->pauser->pause();
+    verify(MailerLog::isSendingPaused())->true();
+    $this->pauser->resume();
+
+    verify(MailerLog::isSendingPaused())->false();
+    verify(MailerLog::getMailerLog())->equals($mailerLog);
+    verify($this->settings->hasSavedValue(MigrationSendingPauser::BACKUP_SETTING_NAME))->false();
+  }
+
+  /**
+   * @param array<string, mixed> $overrides
+   * @return MailerLogData
+   */
+  private function createMailerLog(array $overrides = []): array {
+    /** @var MailerLogData $mailerLog */
+    $mailerLog = array_replace(MailerLog::getMailerLog(), $overrides, [
+      'started' => time() - 600,
+    ]);
+    return $mailerLog;
+  }
+}

--- a/mailpoet/tests/integration/Migrations/App/Migration_20260617_130000_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20260617_130000_App_Test.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Cron\Workers\BulkConfirmationEmailResend;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Mailer\MailerLog;
+use MailPoet\Mailer\MigrationSendingPauser;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as ScheduledTaskSubscriberFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+// phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class Migration_20260617_130000_App_Test extends \MailPoetTest {
+  /** @var Migration_20260617_130000_App */
+  private $migration;
+
+  /** @var ScheduledTaskQueuedSubscriberRepository */
+  private $queueRepository;
+
+  public function _before() {
+    parent::_before();
+    $this->migration = new Migration_20260617_130000_App($this->diContainer);
+    $this->queueRepository = $this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class);
+    MailerLog::resumeSending(); // start from a clean, active mailer log
+  }
+
+  public function testItMovesPendingRowsOfInFlightSendingTasksToTheQueue(): void {
+    $subscriber1 = $this->createSubscriber();
+    $subscriber2 = $this->createSubscriber();
+    $task = $this->createTask(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    // simulate pre-migration state: pending rows still in the log table
+    $this->createPendingLogSubscriber($task, $subscriber1);
+    $this->createPendingLogSubscriber($task, $subscriber2);
+
+    $this->migration->run();
+
+    // pending rows moved into the queue and removed from the log
+    verify($this->queueRepository->countForTask($task))->equals(2);
+    verify($this->countPendingLogSubscribers($task))->equals(0);
+    verify($this->queueRepository->getSubscriberIdsBatchForTask((int)$task->getId(), 0, 10))
+      ->equals([(int)$subscriber1->getId(), (int)$subscriber2->getId()]);
+  }
+
+  public function testItMovesPendingRowsOfInFlightConfirmationTasksToTheQueue(): void {
+    $subscriber = $this->createSubscriber();
+    $task = $this->createTask(BulkConfirmationEmailResend::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    // simulate pre-migration state: pending rows still in the log table
+    $this->createPendingLogSubscriber($task, $subscriber);
+
+    $this->migration->run();
+
+    verify($this->queueRepository->countForTask($task))->equals(1);
+    verify($this->countPendingLogSubscribers($task))->equals(0);
+  }
+
+  public function testItLeavesCompletedSendingTasksUntouched(): void {
+    $subscriber = $this->createSubscriber();
+    $task = $this->createTask(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->createPendingLogSubscriber($task, $subscriber);
+
+    $this->migration->run();
+
+    verify($this->queueRepository->countForTask($task))->equals(0);
+    verify($this->countPendingLogSubscribers($task))->equals(1);
+  }
+
+  public function testItLeavesNonSendingTasksUntouched(): void {
+    $subscriber = $this->createSubscriber();
+    $task = $this->createTask('bounce', null);
+    $this->createPendingLogSubscriber($task, $subscriber);
+
+    $this->migration->run();
+
+    verify($this->queueRepository->countForTask($task))->equals(0);
+    verify($this->countPendingLogSubscribers($task))->equals(1);
+  }
+
+  public function testItIsIdempotent(): void {
+    $subscriber = $this->createSubscriber();
+    $task = $this->createTask(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->createPendingLogSubscriber($task, $subscriber);
+
+    $this->migration->run();
+    $this->migration->run();
+
+    verify($this->queueRepository->countForTask($task))->equals(1);
+    verify($this->countPendingLogSubscribers($task))->equals(0);
+  }
+
+  public function testItRestoresActiveSendingAfterRunning(): void {
+    $subscriber = $this->createSubscriber();
+    $task = $this->createTask(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->createPendingLogSubscriber($task, $subscriber);
+
+    $this->migration->run();
+
+    verify(MailerLog::isSendingPaused())->false();
+  }
+
+  public function testItRestoresMigrationPausedSendingWhenNoTasksNeedBackfill(): void {
+    $this->diContainer->get(MigrationSendingPauser::class)->pause();
+
+    $this->migration->run();
+
+    verify(MailerLog::isSendingPaused())->false();
+  }
+
+  private function createTask(string $type, ?string $status): ScheduledTaskEntity {
+    return (new ScheduledTaskFactory())->create($type, $status, Carbon::now()->subDay());
+  }
+
+  private function createSubscriber(): SubscriberEntity {
+    return (new SubscriberFactory())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
+  }
+
+  private function createPendingLogSubscriber(ScheduledTaskEntity $task, SubscriberEntity $subscriber): void {
+    (new ScheduledTaskSubscriberFactory())->createUnprocessed($task, $subscriber);
+  }
+
+  private function countPendingLogSubscribers(ScheduledTaskEntity $task): int {
+    return $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->count([
+      'task' => $task,
+      'processed' => ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
+    ]);
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/NewsletterResendControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterResendControllerTest.php
@@ -4,7 +4,7 @@ namespace MailPoet\Newsletter;
 
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Settings\SettingsController;
@@ -314,7 +314,7 @@ class NewsletterResendControllerTest extends \MailPoetTest {
 
   private function getTaskSubscriberCount(int $taskId): int {
     $connection = $this->entityManager->getConnection();
-    $table = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    $table = $this->entityManager->getClassMetadata(ScheduledTaskQueuedSubscriberEntity::class)->getTableName();
     $result = $connection->executeQuery(
       "SELECT COUNT(*) FROM $table WHERE task_id = ?",
       [$taskId]

--- a/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/AutomaticEmailTest.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
@@ -68,10 +69,8 @@ class AutomaticEmailTest extends \MailPoetTest {
     verify($queue->getCountTotal())->equals(1);
     verify($queue->getCountToProcess())->equals(1);
     verify($queue->getCountProcessed())->equals(0);
-    // task should have 1 associated user
-    $subscribers = $task->getSubscribers()->toArray();
-    verify($subscribers)->arrayCount(1);
-    verify($subscribers[0]->getSubscriber())->equals($subscriber);
+    // task should have 1 associated user queued for sending
+    verify($this->getQueuedSubscriberIds($task))->equals([(int)$subscriber->getId()]);
   }
 
   public function testItAddsMetaToSendingQueueWhenCreatingAutomaticEmailSendingTask() {
@@ -100,9 +99,8 @@ class AutomaticEmailTest extends \MailPoetTest {
     verify($task->getPriority())->equals(SendingQueueEntity::PRIORITY_MEDIUM);
     verify($task->getStatus())->equals(SendingQueueEntity::STATUS_SCHEDULED);
     $this->tester->assertEqualDateTimes($expectedTime, $task->getScheduledAt(), 1);
-    // task should not have any subscribers
-    $subscribers = $task->getSubscribers();
-    verify($subscribers)->arrayCount(0);
+    // task should not have any subscribers queued for sending
+    verify($this->getQueuedSubscriberIds($task))->arrayCount(0);
   }
 
   public function testItDoesNotScheduleAutomaticEmailWhenGroupDoesNotMatch() {
@@ -212,5 +210,15 @@ class AutomaticEmailTest extends \MailPoetTest {
       ]
     );
     return $newsletter;
+  }
+
+  /** @return int[] */
+  private function getQueuedSubscriberIds(ScheduledTaskEntity $task): array {
+    $taskId = $task->getId();
+    if (!$taskId) {
+      return [];
+    }
+    return $this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class)
+      ->getSubscriberIdsBatchForTask($taskId, 0, 100);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/AutomationEmailSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/AutomationEmailSchedulerTest.php
@@ -4,8 +4,8 @@ namespace MailPoet\Newsletter\Scheduler;
 
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriber;
 use MailPoet\Test\DataFactories\AutomationRun;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Subscriber;
@@ -53,7 +53,8 @@ class AutomationEmailSchedulerTest extends \MailPoetTest {
     verify($scheduledTaskSubscriber)->null();
 
     $scheduledTaskSubscriber = $this->automationEmailScheduler->getScheduledTaskSubscriber($this->newsletter, $this->subscriber, $run2);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $scheduledTaskSubscriber);
+    $this->assertInstanceOf(ScheduledTaskSubscriber::class, $scheduledTaskSubscriber);
+    verify($scheduledTaskSubscriber->isPending())->true();
   }
 
   public function testGetScheduledTaskSubscriberReturnsProperEntityForRun() {
@@ -64,7 +65,7 @@ class AutomationEmailSchedulerTest extends \MailPoetTest {
     $this->automationEmailScheduler->createSendingTask($this->newsletter, $this->subscriber, $this->getMeta($run->getId() + 2));
 
     $scheduledTaskSubscriber = $this->automationEmailScheduler->getScheduledTaskSubscriber($this->newsletter, $this->subscriber, $run);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $scheduledTaskSubscriber);
+    $this->assertInstanceOf(ScheduledTaskSubscriber::class, $scheduledTaskSubscriber);
     $task = $scheduledTaskSubscriber->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
     $meta = $task->getMeta();

--- a/mailpoet/tests/integration/Newsletter/Scheduler/LatestNewsletterSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/LatestNewsletterSchedulerTest.php
@@ -5,10 +5,14 @@ namespace MailPoet\Newsletter\Scheduler;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\NewsletterReplayMetadata;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscriber;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Statistics\StatisticsNewslettersRepository;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Segment;
@@ -20,10 +24,16 @@ class LatestNewsletterSchedulerTest extends \MailPoetTest {
 
   private NewslettersRepository $newslettersRepository;
 
+  private ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository;
+
+  private ScheduledTaskQueuedSubscriberRepository $scheduledTaskQueuedSubscriberRepository;
+
   public function _before() {
     parent::_before();
     $this->scheduler = $this->diContainer->get(LatestNewsletterScheduler::class);
     $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
+    $this->scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
+    $this->scheduledTaskQueuedSubscriberRepository = $this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class);
   }
 
   public function testItFindsLatestCompletedNonReplayStandardNewsletterForSegment(): void {
@@ -96,11 +106,13 @@ class LatestNewsletterSchedulerTest extends \MailPoetTest {
     $this->assertSame(LatestNewsletterScheduler::OUTCOME_SCHEDULED, $result['outcome']);
     $this->assertInstanceOf(NewsletterEntity::class, $result['newsletter']);
     $this->assertSame($sourceNewsletter->getId(), $result['newsletter']->getId());
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $result['task_subscriber']);
+    $this->assertInstanceOf(ScheduledTaskSubscriber::class, $result['task_subscriber']);
+    $this->assertTrue($result['task_subscriber']->isPending());
     $task = $result['task_subscriber']->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
-    $this->assertCount(1, $task->getSubscribers());
-    $this->assertSame($result['task_subscriber'], $task->getSubscribers()->first());
+    // the recipient is queued for sending, not in the log
+    $this->assertSame([(int)$subscriber->getId()], $this->getQueuedSubscriberIds($task));
+    $this->assertCount(0, $task->getSubscribers());
     $queue = $task->getSendingQueue();
     $this->assertInstanceOf(SendingQueueEntity::class, $queue);
 
@@ -181,9 +193,8 @@ class LatestNewsletterSchedulerTest extends \MailPoetTest {
     $queue->setNewsletter($sourceNewsletter);
     $this->entityManager->persist($queue);
 
-    $taskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
+    $taskSubscriber = new ScheduledTaskQueuedSubscriberEntity($task, $subscriber);
     $this->entityManager->persist($taskSubscriber);
-    $task->getSubscribers()->add($taskSubscriber);
     $this->entityManager->flush();
 
     $result = $this->scheduler->schedule($subscriber, (int)$segment->getId(), $this->automationMeta());
@@ -218,7 +229,7 @@ class LatestNewsletterSchedulerTest extends \MailPoetTest {
     $result = $this->scheduler->schedule($subscriber, (int)$segment->getId(), $this->automationMeta());
 
     $this->assertSame(LatestNewsletterScheduler::OUTCOME_SCHEDULED, $result['outcome']);
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $result['task_subscriber']);
+    $this->assertInstanceOf(ScheduledTaskSubscriber::class, $result['task_subscriber']);
     $task = $result['task_subscriber']->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
     $this->assertNotSame($staleReplayTask->getId(), $task->getId());
@@ -257,18 +268,31 @@ class LatestNewsletterSchedulerTest extends \MailPoetTest {
 
     $result = $this->scheduler->schedule($subscriber, (int)$segment->getId(), $this->automationMeta());
     $taskSubscriber = $result['task_subscriber'];
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $taskSubscriber);
+    $this->assertInstanceOf(ScheduledTaskSubscriber::class, $taskSubscriber);
     $task = $taskSubscriber->getTask();
     $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
 
     $this->scheduler->saveErrorAndPause($taskSubscriber, 'Replay timed out');
     $this->entityManager->refresh($task);
-    $this->entityManager->refresh($taskSubscriber);
 
     $this->assertSame(ScheduledTaskEntity::STATUS_PAUSED, $task->getStatus());
-    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, $taskSubscriber->getProcessed());
-    $this->assertSame(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED, $taskSubscriber->getFailed());
-    $this->assertSame('Replay timed out', $taskSubscriber->getError());
+
+    // the recipient was moved from the queue to the log as failed
+    $this->assertSame(0, $this->scheduledTaskQueuedSubscriberRepository->countForTask($task));
+    $logSubscriber = $this->scheduledTaskSubscribersRepository->findOneBy(['task' => $task]);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $logSubscriber);
+    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, $logSubscriber->getProcessed());
+    $this->assertSame(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED, $logSubscriber->getFailed());
+    $this->assertSame('Replay timed out', $logSubscriber->getError());
+  }
+
+  /** @return int[] */
+  private function getQueuedSubscriberIds(ScheduledTaskEntity $task): array {
+    $taskId = $task->getId();
+    if (!$taskId) {
+      return [];
+    }
+    return $this->scheduledTaskQueuedSubscriberRepository->getSubscriberIdsBatchForTask($taskId, 0, 100);
   }
 
   private function createReplayQueue(NewsletterEntity $newsletter, Carbon $processedAt, array $meta): ScheduledTaskEntity {

--- a/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
@@ -13,6 +13,7 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterOptionField;
 use MailPoet\Test\DataFactories\Segment;
@@ -124,7 +125,7 @@ class ReEngagementSchedulerTest extends \MailPoetTest {
     $scheduledAt = $task->getScheduledAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $scheduledAt);
     verify($scheduledAt->getTimestamp())->equalsWithDelta(Carbon::now()->getTimestamp(), 1);
-    verify($task->getSubscribers()->count())->equals(2);
+    verify(count($this->getQueuedSubscriberIds($task)))->equals(2);
 
     $sendingQueue = $this->entityManager->getRepository(SendingQueueEntity::class)->findOneBy(['task' => $task]);
     $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
@@ -154,7 +155,7 @@ class ReEngagementSchedulerTest extends \MailPoetTest {
     $task = $this->scheduler->scheduleAll()[0];
     $this->entityManager->refresh($task);
     $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
-    verify($task->getSubscribers()->count())->equals(1);
+    verify(count($this->getQueuedSubscriberIds($task)))->equals(1);
 
     $sendingQueue = $this->entityManager->getRepository(SendingQueueEntity::class)->findOneBy(['task' => $task]);
     $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
@@ -207,5 +208,15 @@ class ReEngagementSchedulerTest extends \MailPoetTest {
     $subscriber->setLastSubscribedAt($lastEngagement);
     $this->entityManager->flush();
     return $subscriber;
+  }
+
+  /** @return int[] */
+  private function getQueuedSubscriberIds(ScheduledTaskEntity $task): array {
+    $taskId = $task->getId();
+    if (!$taskId) {
+      return [];
+    }
+    return $this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class)
+      ->getSubscriberIdsBatchForTask($taskId, 0, 100);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/WelcomeTest.php
@@ -10,12 +10,12 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\NewsletterOption;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as ScheduledTaskSubscriberFactory;
 use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -44,9 +44,6 @@ class WelcomeTest extends \MailPoetTest {
   /** @var NewsletterEntity */
   private $newsletter;
 
-  /** @var ScheduledTaskSubscribersRepository */
-  private $scheduledTaskSubscribersRepository;
-
   public function _before() {
     parent::_before();
     $this->segmentRepository = $this->diContainer->get(SegmentsRepository::class);
@@ -58,7 +55,6 @@ class WelcomeTest extends \MailPoetTest {
     $this->wpSegment->setType(SegmentEntity::TYPE_WP_USERS);
     $this->segmentRepository->flush();
     $this->newsletter = $this->createWelcomeNewsletter();
-    $this->scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
   }
 
   public function testItDoesNotCreateDuplicateWelcomeNotificationSendingTasks() {
@@ -73,7 +69,7 @@ class WelcomeTest extends \MailPoetTest {
 
     $scheduledTask = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, null);
     (new SendingQueueFactory())->create($scheduledTask, $newsletter);
-    $this->scheduledTaskSubscribersRepository->setSubscribers($scheduledTask, [$existingSubscriber]);
+    (new ScheduledTaskSubscriberFactory())->createProcessed($scheduledTask, $this->subscriber);
 
     // queue is not scheduled
     $this->welcomeScheduler->createWelcomeNotificationSendingTask($newsletter, $existingSubscriber);

--- a/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskQueuedSubscriberRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskQueuedSubscriberRepositoryTest.php
@@ -1,0 +1,179 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Sending;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+class ScheduledTaskQueuedSubscriberRepositoryTest extends \MailPoetTest {
+  private ScheduledTaskQueuedSubscriberRepository $repository;
+
+  private ScheduledTaskFactory $scheduledTaskFactory;
+
+  public function _before() {
+    parent::_before();
+    $this->repository = $this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class);
+    $this->scheduledTaskFactory = new ScheduledTaskFactory();
+  }
+
+  public function testItEnqueuesSubscribedNonDeletedSubscribersAndDeduplicates(): void {
+    $task = $this->createTask();
+    $eligibleSubscriber1 = $this->createSubscriber();
+    $eligibleSubscriber2 = $this->createSubscriber();
+    $unsubscribedSubscriber = $this->createSubscriber(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $deletedSubscriber = $this->createSubscriber(SubscriberEntity::STATUS_SUBSCRIBED, true);
+
+    $inserted = $this->repository->addSubscribersByIds($task, [
+      (int)$eligibleSubscriber2->getId(),
+      (int)$unsubscribedSubscriber->getId(),
+      (int)$deletedSubscriber->getId(),
+      (int)$eligibleSubscriber1->getId(),
+      (int)$eligibleSubscriber2->getId(),
+    ]);
+
+    $this->assertSame(2, $inserted);
+    $this->assertSame(0, $this->repository->addSubscribersByIds($task, [
+      (int)$eligibleSubscriber1->getId(),
+      (int)$eligibleSubscriber2->getId(),
+    ]));
+    $this->assertSame([
+      (int)$eligibleSubscriber1->getId(),
+      (int)$eligibleSubscriber2->getId(),
+    ], $this->repository->getSubscriberIdsBatchForTask((int)$task->getId(), 0, 10));
+
+    $queuedSubscribers = $this->repository->findBy(['task' => $task]);
+    $this->assertCount(2, $queuedSubscribers);
+    $this->assertNotNull($queuedSubscribers[0]->getCreatedAt());
+  }
+
+  public function testItReturnsSubscriberIdsBatchInAscendingOrderAfterCursor(): void {
+    $task = $this->createTask();
+    $subscriber1 = $this->createSubscriber();
+    $subscriber2 = $this->createSubscriber();
+    $subscriber3 = $this->createSubscriber();
+    $subscriber4 = $this->createSubscriber();
+
+    $subscriberIds = [
+      (int)$subscriber1->getId(),
+      (int)$subscriber2->getId(),
+      (int)$subscriber3->getId(),
+      (int)$subscriber4->getId(),
+    ];
+    $this->repository->addSubscribersByIds($task, [
+      $subscriberIds[2],
+      $subscriberIds[0],
+      $subscriberIds[3],
+      $subscriberIds[1],
+    ]);
+
+    $this->assertSame(
+      [$subscriberIds[0], $subscriberIds[1]],
+      $this->repository->getSubscriberIdsBatchForTask((int)$task->getId(), 0, 2)
+    );
+    $this->assertSame(
+      [$subscriberIds[2], $subscriberIds[3]],
+      $this->repository->getSubscriberIdsBatchForTask((int)$task->getId(), $subscriberIds[1], 10)
+    );
+    $this->assertSame(
+      [$subscriberIds[3]],
+      $this->repository->getSubscriberIdsBatchForTask((int)$task->getId(), $subscriberIds[2], 1)
+    );
+  }
+
+  public function testItChecksWhetherTaskHasUnprocessedSubscribers(): void {
+    $task = $this->createTask();
+
+    $this->assertFalse($this->repository->hasUnprocessed($task));
+
+    $queuedSubscriber = $this->createQueuedSubscriber($task);
+    $this->assertTrue($this->repository->hasUnprocessed($task));
+
+    $this->repository->deleteByScheduledTaskAndSubscriberIds($task, [(int)$queuedSubscriber->getSubscriberId()]);
+    $this->assertFalse($this->repository->hasUnprocessed($task));
+  }
+
+  public function testItCountsSubscribersForTask(): void {
+    $task1 = $this->createTask();
+    $task2 = $this->createTask();
+
+    $this->createQueuedSubscriber($task1);
+    $this->createQueuedSubscriber($task1);
+    $this->createQueuedSubscriber($task2);
+
+    $this->assertSame(2, $this->repository->countForTask($task1));
+    $this->assertSame(1, $this->repository->countForTask($task2));
+  }
+
+  public function testItDeletesSubscribersByScheduledTask(): void {
+    $task1 = $this->createTask();
+    $task2 = $this->createTask();
+    $task1Subscriber1 = $this->createQueuedSubscriber($task1);
+    $task1Subscriber2 = $this->createQueuedSubscriber($task1);
+    $task2Subscriber = $this->createQueuedSubscriber($task2);
+
+    $this->repository->deleteByScheduledTask($task1);
+
+    $this->assertSame(0, $this->repository->countForTask($task1));
+    $this->assertSame(1, $this->repository->countForTask($task2));
+    $this->assertFalse($this->entityManager->contains($task1Subscriber1));
+    $this->assertFalse($this->entityManager->contains($task1Subscriber2));
+    $this->assertTrue($this->entityManager->contains($task2Subscriber));
+  }
+
+  public function testItDeletesSubscribersByScheduledTaskAndSubscriberIds(): void {
+    $task1 = $this->createTask();
+    $task2 = $this->createTask();
+    $task1Subscriber1 = $this->createQueuedSubscriber($task1);
+    $task1Subscriber2 = $this->createQueuedSubscriber($task1);
+    $task2Subscriber = $this->createQueuedSubscriber($task2);
+
+    $this->repository->deleteByScheduledTaskAndSubscriberIds($task1, [(int)$task1Subscriber1->getSubscriberId()]);
+
+    $this->assertSame(1, $this->repository->countForTask($task1));
+    $this->assertSame(1, $this->repository->countForTask($task2));
+    $this->assertFalse($this->entityManager->contains($task1Subscriber1));
+    $this->assertTrue($this->entityManager->contains($task1Subscriber2));
+    $this->assertTrue($this->entityManager->contains($task2Subscriber));
+  }
+
+  public function testItDeletesSubscribersByTaskIds(): void {
+    $task1 = $this->createTask();
+    $task2 = $this->createTask();
+    $task3 = $this->createTask();
+    $task1Subscriber = $this->createQueuedSubscriber($task1);
+    $task2Subscriber = $this->createQueuedSubscriber($task2);
+    $task3Subscriber = $this->createQueuedSubscriber($task3);
+
+    $this->repository->deleteByTaskIds([(int)$task1->getId(), (int)$task2->getId()]);
+
+    $this->assertSame(0, $this->repository->countForTask($task1));
+    $this->assertSame(0, $this->repository->countForTask($task2));
+    $this->assertSame(1, $this->repository->countForTask($task3));
+    $this->assertFalse($this->entityManager->contains($task1Subscriber));
+    $this->assertFalse($this->entityManager->contains($task2Subscriber));
+    $this->assertTrue($this->entityManager->contains($task3Subscriber));
+  }
+
+  private function createTask(): ScheduledTaskEntity {
+    return $this->scheduledTaskFactory->create('sending', ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->subDay());
+  }
+
+  private function createSubscriber(string $status = SubscriberEntity::STATUS_SUBSCRIBED, bool $deleted = false): SubscriberEntity {
+    $subscriberFactory = (new SubscriberFactory())->withStatus($status);
+    if ($deleted) {
+      $subscriberFactory->withDeletedAt(Carbon::now());
+    }
+    return $subscriberFactory->create();
+  }
+
+  private function createQueuedSubscriber(ScheduledTaskEntity $task): ScheduledTaskQueuedSubscriberEntity {
+    $taskSubscriber = new ScheduledTaskQueuedSubscriberEntity($task, $this->createSubscriber());
+    $this->entityManager->persist($taskSubscriber);
+    $this->entityManager->flush();
+    return $taskSubscriber;
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskQueuedSubscribersListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskQueuedSubscribersListingRepositoryTest.php
@@ -1,0 +1,144 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Sending;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Listing\Handler;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskQueuedSubscriber as QueuedSubscriberFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+
+class ScheduledTaskQueuedSubscribersListingRepositoryTest extends \MailPoetTest {
+  /** @var Handler */
+  private $listingHandler;
+
+  /** @var ScheduledTaskQueuedSubscribersListingRepository */
+  private $repository;
+
+  /** @var ScheduledTaskFactory */
+  private $scheduledTaskFactory;
+
+  /** @var SubscriberFactory */
+  private $subscriberFactory;
+
+  /** @var QueuedSubscriberFactory */
+  private $queuedSubscriberFactory;
+
+  /** @var ScheduledTaskEntity */
+  private $scheduledTask;
+
+  public function _before() {
+    parent::_before();
+    $this->listingHandler = $this->diContainer->get(Handler::class);
+    $this->repository = $this->diContainer->get(ScheduledTaskQueuedSubscribersListingRepository::class);
+    $this->scheduledTaskFactory = new ScheduledTaskFactory();
+    $this->subscriberFactory = new SubscriberFactory();
+    $this->queuedSubscriberFactory = new QueuedSubscriberFactory();
+
+    $this->scheduledTask = $this->scheduledTaskFactory->create('sending', ScheduledTaskEntity::STATUS_SCHEDULED);
+
+    // Three pending recipients queued for this task, plus one queued for a
+    // different task and one not queued at all (must be excluded).
+    $this->queuedSubscriberFactory->create($this->scheduledTask, $this->subscriberFactory->withEmail('charlie@queue.com')->withFirstName('Charlie')->create());
+    $this->queuedSubscriberFactory->create($this->scheduledTask, $this->subscriberFactory->withEmail('alice@queue.com')->withFirstName('Alice')->create());
+    $this->queuedSubscriberFactory->create($this->scheduledTask, $this->subscriberFactory->withEmail('bob@queue.com')->withFirstName('Bob')->create());
+
+    $otherTask = $this->scheduledTaskFactory->create('sending', ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->queuedSubscriberFactory->create($otherTask, $this->subscriberFactory->withEmail('other@queue.com')->create());
+
+    $this->subscriberFactory->withEmail('notqueued@queue.com')->create();
+  }
+
+  public function testItReturnsQueuedSubscribersScopedToTheTask() {
+    $definition = $this->listingHandler->getListingDefinition([
+      'params' => ['task_ids' => [$this->scheduledTask->getId()]],
+    ]);
+    $queuedSubscribers = $this->repository->getData($definition);
+    $count = $this->repository->getCount($definition);
+
+    verify($queuedSubscribers)->arrayCount(3);
+    verify($count)->equals(3);
+    foreach ($queuedSubscribers as $queuedSubscriber) {
+      $this->assertInstanceOf(ScheduledTaskQueuedSubscriberEntity::class, $queuedSubscriber);
+      $this->assertInstanceOf(SubscriberEntity::class, $queuedSubscriber->getSubscriber());
+    }
+    $emails = array_map(function (ScheduledTaskQueuedSubscriberEntity $queuedSubscriber): ?string {
+      $subscriber = $queuedSubscriber->getSubscriber();
+      return $subscriber ? $subscriber->getEmail() : null;
+    }, $queuedSubscribers);
+    verify($emails)->arrayContains('alice@queue.com');
+    verify($emails)->arrayContains('bob@queue.com');
+    verify($emails)->arrayContains('charlie@queue.com');
+    verify($emails)->arrayNotContains('other@queue.com');
+    verify($emails)->arrayNotContains('notqueued@queue.com');
+  }
+
+  public function testItReturnsUnprocessedGroupCount() {
+    $definition = $this->listingHandler->getListingDefinition([
+      'params' => ['task_ids' => [$this->scheduledTask->getId()]],
+    ]);
+    $groups = $this->repository->getGroups($definition);
+    verify($groups)->arrayCount(1);
+    verify($groups[0]['name'])->equals('unprocessed');
+    verify($groups[0]['label'])->equals('Unprocessed');
+    verify($groups[0]['count'])->equals(3);
+  }
+
+  public function testItCanSearchByEmail() {
+    $definition = $this->listingHandler->getListingDefinition([
+      'params' => ['task_ids' => [$this->scheduledTask->getId()]],
+      'search' => 'alice@',
+    ]);
+    $queuedSubscribers = $this->repository->getData($definition);
+    $count = $this->repository->getCount($definition);
+
+    verify($queuedSubscribers)->arrayCount(1);
+    verify($count)->equals(1);
+    $subscriber = $queuedSubscribers[0]->getSubscriber();
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    verify($subscriber->getEmail())->equals('alice@queue.com');
+  }
+
+  public function testItSortsBySubscriberEmail() {
+    $definition = $this->listingHandler->getListingDefinition([
+      'params' => ['task_ids' => [$this->scheduledTask->getId()]],
+      'sort_by' => 'subscriberId',
+      'sort_order' => 'asc',
+    ]);
+    $queuedSubscribers = $this->repository->getData($definition);
+    $emails = array_map(function (ScheduledTaskQueuedSubscriberEntity $queuedSubscriber): ?string {
+      $subscriber = $queuedSubscriber->getSubscriber();
+      return $subscriber ? $subscriber->getEmail() : null;
+    }, $queuedSubscribers);
+    verify($emails)->equals(['alice@queue.com', 'bob@queue.com', 'charlie@queue.com']);
+  }
+
+  public function testItPaginatesQueuedSubscribers() {
+    $pageParams = [
+      'params' => ['task_ids' => [$this->scheduledTask->getId()]],
+      'sort_by' => 'subscriberId',
+      'sort_order' => 'asc',
+      'limit' => 2,
+    ];
+    $firstPage = $this->repository->getData($this->listingHandler->getListingDefinition($pageParams + ['offset' => 0]));
+    $secondPage = $this->repository->getData($this->listingHandler->getListingDefinition($pageParams + ['offset' => 2]));
+
+    verify($firstPage)->arrayCount(2);
+    verify($secondPage)->arrayCount(1);
+    // The total count is independent of the page window.
+    verify($this->repository->getCount($this->listingHandler->getListingDefinition($pageParams + ['offset' => 0])))->equals(3);
+  }
+
+  public function testItIsEmptyForACompletedSend() {
+    $completedTask = $this->scheduledTaskFactory->create('sending', ScheduledTaskEntity::STATUS_COMPLETED);
+    $definition = $this->listingHandler->getListingDefinition([
+      'params' => ['task_ids' => [$completedTask->getId()]],
+    ]);
+    verify($this->repository->getData($definition))->arrayCount(0);
+    verify($this->repository->getCount($definition))->equals(0);
+    $groups = $this->repository->getGroups($definition);
+    verify($groups[0]['count'])->equals(0);
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskSubscriberMoverTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskSubscriberMoverTest.php
@@ -1,0 +1,241 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Sending;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\ParameterType;
+use Throwable;
+
+class ScheduledTaskSubscriberMoverTest extends \MailPoetTest {
+  private ScheduledTaskSubscriberMover $mover;
+
+  private ScheduledTaskFactory $scheduledTaskFactory;
+
+  private string $queueTable;
+
+  private string $logTable;
+
+  public function _before() {
+    parent::_before();
+    $this->mover = $this->diContainer->get(ScheduledTaskSubscriberMover::class);
+    $this->scheduledTaskFactory = new ScheduledTaskFactory();
+    $this->queueTable = $this->entityManager->getClassMetadata(ScheduledTaskQueuedSubscriberEntity::class)->getTableName();
+    $this->logTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+  }
+
+  public function testItMovesProcessedQueueRowsToLog(): void {
+    $task = $this->createTask();
+    $subscriber1 = $this->createSubscriber();
+    $subscriber2 = $this->createSubscriber();
+    $createdAt1 = '2024-01-02 03:04:05';
+    $createdAt2 = '2024-01-02 03:05:06';
+
+    $this->createQueuedSubscriber($task, $subscriber1, $createdAt1);
+    $this->createQueuedSubscriber($task, $subscriber2, $createdAt2);
+
+    $this->mover->moveProcessedToLog($task, [
+      (int)$subscriber2->getId(),
+      (int)$subscriber1->getId(),
+    ]);
+
+    $logRow1 = $this->getLogRow($task, $subscriber1);
+    $logRow2 = $this->getLogRow($task, $subscriber2);
+    $this->assertNotNull($logRow1);
+    $this->assertNotNull($logRow2);
+    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, (int)$logRow1['processed']);
+    $this->assertSame(ScheduledTaskSubscriberEntity::FAIL_STATUS_OK, (int)$logRow1['failed']);
+    $this->assertNull($logRow1['error']);
+    $this->assertSame($createdAt1, $logRow1['created_at']);
+    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, (int)$logRow2['processed']);
+    $this->assertSame(ScheduledTaskSubscriberEntity::FAIL_STATUS_OK, (int)$logRow2['failed']);
+    $this->assertNull($logRow2['error']);
+    $this->assertSame($createdAt2, $logRow2['created_at']);
+    $this->assertNull($this->getQueueRow($task, $subscriber1));
+    $this->assertNull($this->getQueueRow($task, $subscriber2));
+  }
+
+  public function testItMovesFailedQueueRowToLog(): void {
+    $task = $this->createTask();
+    $subscriber = $this->createSubscriber();
+    $createdAt = '2024-02-03 04:05:06';
+    $error = 'SMTP rejected recipient';
+
+    $this->createQueuedSubscriber($task, $subscriber, $createdAt);
+
+    $this->mover->moveFailedToLog($task, (int)$subscriber->getId(), $error);
+
+    $logRow = $this->getLogRow($task, $subscriber);
+    $this->assertNotNull($logRow);
+    $this->assertSame(ScheduledTaskSubscriberEntity::STATUS_PROCESSED, (int)$logRow['processed']);
+    $this->assertSame(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED, (int)$logRow['failed']);
+    $this->assertSame($error, $logRow['error']);
+    $this->assertSame($createdAt, $logRow['created_at']);
+    $this->assertNull($this->getQueueRow($task, $subscriber));
+  }
+
+  public function testItKeepsQueueRowsWhenLogInsertFails(): void {
+    $task = $this->createTask();
+    $conflictingSubscriber = $this->createSubscriber();
+    $subscriber = $this->createSubscriber();
+    $createdAt = '2024-03-04 05:06:07';
+
+    $this->createQueuedSubscriber($task, $conflictingSubscriber, $createdAt);
+    $this->createQueuedSubscriber($task, $subscriber, $createdAt);
+    $this->createLogSubscriber($task, $conflictingSubscriber, $createdAt);
+
+    $moveFailed = false;
+    try {
+      $this->mover->moveProcessedToLog($task, [
+        (int)$conflictingSubscriber->getId(),
+        (int)$subscriber->getId(),
+      ]);
+    } catch (Throwable $e) {
+      $moveFailed = true;
+    }
+
+    $this->assertTrue($moveFailed, 'Expected the duplicate log row to fail the move.');
+    $this->assertNotNull($this->getQueueRow($task, $conflictingSubscriber));
+    $this->assertNotNull($this->getQueueRow($task, $subscriber));
+    $this->assertNotNull($this->getLogRow($task, $conflictingSubscriber));
+    $this->assertNull($this->getLogRow($task, $subscriber));
+  }
+
+  public function testItDoesNotCreateLogRowsForSubscribersMissingFromTheQueue(): void {
+    $task = $this->createTask();
+    $subscriber = $this->createSubscriber();
+
+    $this->mover->moveProcessedToLog($task, [(int)$subscriber->getId()]);
+
+    $this->assertNull($this->getLogRow($task, $subscriber));
+    $this->assertNull($this->getQueueRow($task, $subscriber));
+  }
+
+  public function testItMovesLogRowBackToQueue(): void {
+    $task = $this->createTask();
+    $subscriber = $this->createSubscriber();
+
+    $this->createLogSubscriber(
+      $task,
+      $subscriber,
+      '2024-04-05 06:07:08',
+      ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED,
+      'Temporary failure'
+    );
+
+    $this->mover->moveBackToQueue($task, (int)$subscriber->getId());
+
+    $queueRow = $this->getQueueRow($task, $subscriber);
+    $this->assertNotNull($queueRow);
+    $this->assertNotNull($queueRow['created_at']);
+    $this->assertNull($this->getLogRow($task, $subscriber));
+  }
+
+  private function createTask(): ScheduledTaskEntity {
+    return $this->scheduledTaskFactory->create('sending', ScheduledTaskEntity::STATUS_SCHEDULED, Carbon::now()->subDay());
+  }
+
+  private function createSubscriber(): SubscriberEntity {
+    return (new SubscriberFactory())->create();
+  }
+
+  private function createQueuedSubscriber(ScheduledTaskEntity $task, SubscriberEntity $subscriber, string $createdAt): void {
+    $this->connection->executeStatement(
+      "INSERT INTO $this->queueTable
+       (`task_id`, `subscriber_id`, `created_at`)
+       VALUES (:taskId, :subscriberId, :createdAt)",
+      [
+        'taskId' => $task->getId(),
+        'subscriberId' => $subscriber->getId(),
+        'createdAt' => $createdAt,
+      ],
+      [
+        'taskId' => ParameterType::INTEGER,
+        'subscriberId' => ParameterType::INTEGER,
+        'createdAt' => ParameterType::STRING,
+      ]
+    );
+  }
+
+  private function createLogSubscriber(
+    ScheduledTaskEntity $task,
+    SubscriberEntity $subscriber,
+    string $createdAt,
+    int $failed = ScheduledTaskSubscriberEntity::FAIL_STATUS_OK,
+    ?string $error = null
+  ): void {
+    $this->connection->executeStatement(
+      "INSERT INTO $this->logTable
+       (`task_id`, `subscriber_id`, `processed`, `failed`, `error`, `created_at`, `updated_at`)
+       VALUES (:taskId, :subscriberId, :processed, :failed, :error, :createdAt, :updatedAt)",
+      [
+        'taskId' => $task->getId(),
+        'subscriberId' => $subscriber->getId(),
+        'processed' => ScheduledTaskSubscriberEntity::STATUS_PROCESSED,
+        'failed' => $failed,
+        'error' => $error,
+        'createdAt' => $createdAt,
+        'updatedAt' => $createdAt,
+      ],
+      [
+        'taskId' => ParameterType::INTEGER,
+        'subscriberId' => ParameterType::INTEGER,
+        'processed' => ParameterType::INTEGER,
+        'failed' => ParameterType::INTEGER,
+        'error' => ParameterType::STRING,
+        'createdAt' => ParameterType::STRING,
+        'updatedAt' => ParameterType::STRING,
+      ]
+    );
+  }
+
+  /** @return array<string, mixed>|null */
+  private function getQueueRow(ScheduledTaskEntity $task, SubscriberEntity $subscriber): ?array {
+    $row = $this->connection->executeQuery(
+      "SELECT *
+       FROM $this->queueTable
+       WHERE `task_id` = :taskId
+       AND `subscriber_id` = :subscriberId",
+      [
+        'taskId' => $task->getId(),
+        'subscriberId' => $subscriber->getId(),
+      ],
+      [
+        'taskId' => ParameterType::INTEGER,
+        'subscriberId' => ParameterType::INTEGER,
+      ]
+    )->fetchAssociative();
+
+    return $row ?: null;
+  }
+
+  /**
+   * @return array<string, string|null>|null
+   */
+  private function getLogRow(ScheduledTaskEntity $task, SubscriberEntity $subscriber): ?array {
+    $row = $this->connection->executeQuery(
+      "SELECT *
+       FROM $this->logTable
+       WHERE `task_id` = :taskId
+       AND `subscriber_id` = :subscriberId",
+      [
+        'taskId' => $task->getId(),
+        'subscriberId' => $subscriber->getId(),
+      ],
+      [
+        'taskId' => ParameterType::INTEGER,
+        'subscriberId' => ParameterType::INTEGER,
+      ]
+    )->fetchAssociative();
+    if (!$row) {
+      return null;
+    }
+    /** @var array<string, string|null> $row */
+    return $row;
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskSubscribersListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskSubscribersListingRepositoryTest.php
@@ -38,8 +38,8 @@ class ScheduledTaskSubscribersListingRepositoryTest extends \MailPoetTest {
     $this->subscriberFactory = new SubscriberFactory();
     $this->taskSubscriberFactory = new TaskSubscriberFactory();
 
-    // Subscribers
-    $subscriberUnprocessed = $this->subscriberFactory->withEmail('subscriberUprocessed@email.com')->create();
+    // Subscribers — the log only holds processed recipients now; pending ones
+    // live in the queue (see ScheduledTaskQueuedSubscribersListingRepository).
     $subscriberProcessed = $this->subscriberFactory->withEmail('subscriberProcessed@email.com')->create();
     $subscriberFailed = $this->subscriberFactory->withEmail('subscriberFailed@email.com')->create();
     $this->subscriberFactory->withEmail('subscriberNotIncluded@email.com')->create();
@@ -47,21 +47,18 @@ class ScheduledTaskSubscribersListingRepositoryTest extends \MailPoetTest {
     // Scheduled Task
     $this->scheduledTask = $this->scheduledTaskFactory->create('sending', ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->subDay());
 
-    // Task Subscribers
-    $this->taskSubscriberFactory->createUnprocessed($this->scheduledTask, $subscriberUnprocessed);
+    // Task Subscribers (log)
     $this->taskSubscriberFactory->createProcessed($this->scheduledTask, $subscriberProcessed);
     $this->taskSubscriberFactory->createFailed($this->scheduledTask, $subscriberFailed, 'Error Message');
   }
 
-  public function testItGenerateCorrectGroups() {
+  public function testItGeneratesSentAndFailedGroups() {
     $listingData = [
-      'group' => 'all',
-      'params' => [ 'task_ids' => [$this->scheduledTask->getId()]],
+      'params' => ['task_ids' => [$this->scheduledTask->getId()]],
     ];
-    [$all, $sent, $failed, $unprocessed] = $this->repository->getGroups($this->listingHandler->getListingDefinition($listingData));
-    verify($all['name'])->equals('all');
-    verify($all['label'])->equals('All');
-    verify($all['count'])->equals(3);
+    $groups = $this->repository->getGroups($this->listingHandler->getListingDefinition($listingData));
+    verify($groups)->arrayCount(2);
+    [$sent, $failed] = $groups;
 
     verify($sent['name'])->equals('sent');
     verify($sent['label'])->equals('Sent');
@@ -70,39 +67,27 @@ class ScheduledTaskSubscribersListingRepositoryTest extends \MailPoetTest {
     verify($failed['name'])->equals('failed');
     verify($failed['label'])->equals('Failed');
     verify($failed['count'])->equals(1);
-
-    verify($unprocessed['name'])->equals('unprocessed');
-    verify($unprocessed['label'])->equals('Unprocessed');
-    verify($unprocessed['count'])->equals(1);
   }
 
-  public function testItReturnCorrectDataAndCountForGroupAll() {
+  public function testItReturnsSentSubscribers() {
     $listingData = [
-      'group' => 'all',
-      'params' => [ 'task_ids' => [$this->scheduledTask->getId()]],
+      'group' => 'sent',
+      'params' => ['task_ids' => [$this->scheduledTask->getId()]],
     ];
     $tasksSubscribers = $this->repository->getData($this->listingHandler->getListingDefinition($listingData));
     $count = $this->repository->getCount($this->listingHandler->getListingDefinition($listingData));
-    verify($tasksSubscribers)->arrayCount(3);
-    verify($count)->equals(3);
+    verify($tasksSubscribers)->arrayCount(1);
+    verify($count)->equals(1);
 
     $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $tasksSubscribers[0]);
     $this->assertInstanceOf(SubscriberEntity::class, $tasksSubscribers[0]->getSubscriber());
-    verify($tasksSubscribers[0]->getSubscriber()->getEmail())->equals('subscriberUprocessed@email.com');
-
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $tasksSubscribers[1]);
-    $this->assertInstanceOf(SubscriberEntity::class, $tasksSubscribers[1]->getSubscriber());
-    verify($tasksSubscribers[1]->getSubscriber()->getEmail())->equals('subscriberProcessed@email.com');
-
-    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $tasksSubscribers[2]);
-    $this->assertInstanceOf(SubscriberEntity::class, $tasksSubscribers[2]->getSubscriber());
-    verify($tasksSubscribers[2]->getSubscriber()->getEmail())->equals('subscriberFailed@email.com');
+    verify($tasksSubscribers[0]->getSubscriber()->getEmail())->equals('subscriberProcessed@email.com');
   }
 
   public function testItCanFilterByGroup() {
     $listingData = [
       'group' => 'failed',
-      'params' => [ 'task_ids' => [$this->scheduledTask->getId()]],
+      'params' => ['task_ids' => [$this->scheduledTask->getId()]],
     ];
     $tasksSubscribers = $this->repository->getData($this->listingHandler->getListingDefinition($listingData));
     $count = $this->repository->getCount($this->listingHandler->getListingDefinition($listingData));
@@ -116,8 +101,8 @@ class ScheduledTaskSubscribersListingRepositoryTest extends \MailPoetTest {
 
   public function testItCanSearchByEmail() {
     $listingData = [
-      'group' => 'all',
-      'params' => [ 'task_ids' => [$this->scheduledTask->getId()]],
+      'group' => 'sent',
+      'params' => ['task_ids' => [$this->scheduledTask->getId()]],
       'search' => 'subscriberProcessed@',
     ];
     $tasksSubscribers = $this->repository->getData($this->listingHandler->getListingDefinition($listingData));

--- a/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskSubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/ScheduledTaskSubscribersRepositoryTest.php
@@ -3,8 +3,6 @@
 namespace integration\Newsletter\Sending;
 
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as TaskSubscriberFactory;
@@ -15,105 +13,34 @@ class ScheduledTaskSubscribersRepositoryTest extends \MailPoetTest {
   /** @var ScheduledTaskSubscribersRepository */
   private $repository;
 
-  /** @var SubscriberFactory */
-  private $subscriberFactory;
-
   /** @var ScheduledTaskEntity */
   private $scheduledTask1;
 
   /** @var ScheduledTaskEntity */
   private $scheduledTask2;
 
-  /** @var SubscriberEntity */
-  private $subscriberUnprocessed;
-
-  /** @var SubscriberEntity */
-  private $subscriberProcessed;
-
-  /** @var ScheduledTaskSubscriberEntity */
-  private $taskSubscriber1;
-
-  /** @var ScheduledTaskSubscriberEntity */
-  private $taskSubscriber2;
-
-  /** @var ScheduledTaskSubscriberEntity */
-  private $taskSubscriber3;
-
-  /** @var ScheduledTaskSubscriberEntity */
-  private $taskSubscriber4;
-
-  /** @var ScheduledTaskSubscriberEntity */
-  private $taskSubscriber5;
-
   public function _before() {
     parent::_before();
     $this->repository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
     $scheduledTaskFactory = new ScheduledTaskFactory();
-    $this->subscriberFactory = new SubscriberFactory();
+    $subscriberFactory = new SubscriberFactory();
     $taskSubscriberFactory = new TaskSubscriberFactory();
 
-    $this->subscriberUnprocessed = $this->subscriberFactory->withEmail('subscriberUnprocessed@email.com')->create();
-    $this->subscriberProcessed = $this->subscriberFactory->withEmail('subscriberProcessed@email.com')->create();
-    $subscriberFailed = $this->subscriberFactory->withEmail('subscriberFailed@email.com')->create();
-    $this->subscriberFactory->withEmail('subscriberNotIncluded@email.com')->create();
+    $subscriberUnprocessed = $subscriberFactory->withEmail('subscriberUnprocessed@email.com')->create();
+    $subscriberProcessed = $subscriberFactory->withEmail('subscriberProcessed@email.com')->create();
+    $subscriberFailed = $subscriberFactory->withEmail('subscriberFailed@email.com')->create();
 
     $this->scheduledTask1 = $scheduledTaskFactory->create('sending', ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->subDay());
     $this->scheduledTask2 = $scheduledTaskFactory->create('sending', ScheduledTaskEntity::STATUS_COMPLETED, Carbon::now()->subDay());
 
-    $this->taskSubscriber1 = $taskSubscriberFactory->createUnprocessed($this->scheduledTask1, $this->subscriberUnprocessed);
-    $this->taskSubscriber2 = $taskSubscriberFactory->createProcessed($this->scheduledTask1, $this->subscriberProcessed);
-    $this->taskSubscriber3 = $taskSubscriberFactory->createFailed($this->scheduledTask1, $subscriberFailed, 'Error Message');
-
-    $this->taskSubscriber4 = $taskSubscriberFactory->createUnprocessed($this->scheduledTask2, $this->subscriberUnprocessed);
-    $this->taskSubscriber5 = $taskSubscriberFactory->createProcessed($this->scheduledTask2, $this->subscriberProcessed);
-  }
-
-  public function testItSetsSubscribers() {
-    $subscriber = $this->subscriberFactory->withEmail('newsubscriber@email.com')->create();
-
-    $this->assertCount(3, $this->repository->findBy(['task' => $this->scheduledTask1]));
-    $this->repository->setSubscribers($this->scheduledTask1, [$subscriber->getId()]);
-    $task1Subscribers = $this->repository->findBy(['task' => $this->scheduledTask1]);
-    $this->assertCount(1, $task1Subscribers);
-    $this->assertInstanceOf(SubscriberEntity::class, $task1Subscribers[0]->getSubscriber());
-    $this->assertEquals($subscriber->getId(), $task1Subscribers[0]->getSubscriber()->getId());
-
-    // check that setSubscribers() does not delete subscribers from other tasks
-    $task2Subscribers = $this->repository->findBy(['task' => $this->scheduledTask2]);
-    $this->assertCount(2, $task2Subscribers);
-    $this->assertInstanceOf(SubscriberEntity::class, $task2Subscribers[0]->getSubscriber());
-    $this->assertInstanceOf(SubscriberEntity::class, $task2Subscribers[1]->getSubscriber());
-    $this->assertEquals($this->subscriberUnprocessed->getId(), $task2Subscribers[0]->getSubscriber()->getId());
-    $this->assertEquals($this->subscriberProcessed->getId(), $task2Subscribers[1]->getSubscriber()->getId());
-  }
-
-  public function testItDeleteByScheduledTaskAndSubscriberIds() {
-    $this->repository->deleteByScheduledTaskAndSubscriberIds($this->scheduledTask1, [$this->taskSubscriber1->getSubscriberId()]);
-    $this->assertSame([$this->taskSubscriber2, $this->taskSubscriber3], $this->repository->findBy(['task' => $this->scheduledTask1]));
-    $this->assertSame([$this->taskSubscriber4, $this->taskSubscriber5], $this->repository->findBy(['task' => $this->scheduledTask2]));
-
-    $this->repository->deleteByScheduledTaskAndSubscriberIds($this->scheduledTask2, [$this->taskSubscriber4->getSubscriberId(), $this->taskSubscriber5->getSubscriberId()]);
-    $this->assertSame([$this->taskSubscriber2, $this->taskSubscriber3], $this->repository->findBy(['task' => $this->scheduledTask1]));
-    $this->assertSame([], $this->repository->findBy(['task' => $this->scheduledTask2]));
+    $taskSubscriberFactory->createUnprocessed($this->scheduledTask1, $subscriberUnprocessed);
+    $taskSubscriberFactory->createProcessed($this->scheduledTask1, $subscriberProcessed);
+    $taskSubscriberFactory->createFailed($this->scheduledTask1, $subscriberFailed, 'Error Message');
+    $taskSubscriberFactory->createProcessed($this->scheduledTask2, $subscriberProcessed);
   }
 
   public function testCountProcessed() {
     $this->assertSame(2, $this->repository->countProcessed($this->scheduledTask1));
     $this->assertSame(1, $this->repository->countProcessed($this->scheduledTask2));
-
-    $subscriberId = $this->subscriberUnprocessed->getId();
-    $this->assertIsInt($subscriberId);
-    $this->repository->updateProcessedSubscribers($this->scheduledTask2, [$subscriberId]);
-    $this->assertSame(2, $this->repository->countProcessed($this->scheduledTask2));
-  }
-
-  public function testCountUnprocessed() {
-    $this->assertSame(1, $this->repository->countUnprocessed($this->scheduledTask1));
-    $this->assertSame(1, $this->repository->countUnprocessed($this->scheduledTask2));
-
-    $subscriberId = $this->subscriberUnprocessed->getId();
-    $this->assertIsInt($subscriberId);
-    $this->repository->updateProcessedSubscribers($this->scheduledTask2, [$subscriberId]);
-    $this->assertSame(0, $this->repository->countUnprocessed($this->scheduledTask2));
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
@@ -11,8 +11,8 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\NewsletterDeleteController;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
@@ -462,7 +462,7 @@ class TimeZoneCampaignSchedulerTest extends \MailPoetTest {
 
     $sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
     $scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
-    $scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
+    $scheduledTaskQueuedSubscriberRepository = $this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class);
     $newsletterId = (int)$newsletter->getId();
 
     $queueIds = array_map(fn(SendingQueueEntity $queue): int => (int)$queue->getId(), $sendingQueuesRepository->findBy(['newsletter' => $newsletter]));
@@ -477,7 +477,7 @@ class TimeZoneCampaignSchedulerTest extends \MailPoetTest {
 
     $totalTaskSubscribers = 0;
     foreach ($taskIds as $taskId) {
-      $totalTaskSubscribers += count($scheduledTaskSubscribersRepository->findBy(['task' => $taskId]));
+      $totalTaskSubscribers += count($scheduledTaskQueuedSubscriberRepository->findBy(['task' => $taskId]));
     }
     verify($totalTaskSubscribers)->greaterThanOrEqual(2);
 
@@ -486,7 +486,7 @@ class TimeZoneCampaignSchedulerTest extends \MailPoetTest {
     verify($sendingQueuesRepository->findBy(['newsletter' => $newsletterId]))->equals([]);
     foreach ($taskIds as $taskId) {
       verify($scheduledTasksRepository->findOneById($taskId))->null();
-      verify($scheduledTaskSubscribersRepository->findBy(['task' => $taskId]))->equals([]);
+      verify($scheduledTaskQueuedSubscriberRepository->findBy(['task' => $taskId]))->equals([]);
     }
   }
 

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -21,6 +21,7 @@ use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterOption;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as ScheduledTaskSubscriberFactory;
 use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
 use MailPoet\Util\Security;
 
@@ -84,8 +85,7 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
 
     $this->scheduledTask = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, null);
     $this->sendingQueue = (new SendingQueueFactory())->create($this->scheduledTask, $newsletter);
-    $this->scheduledTaskSubscribersRepository->setSubscribers($this->scheduledTask, [$subscriber->getId()]);
-    $this->scheduledTaskSubscribersRepository->updateProcessedSubscribers($this->scheduledTask, [(int)$subscriber->getId()]);
+    (new ScheduledTaskSubscriberFactory())->createProcessed($this->scheduledTask, $subscriber);
 
     // build browser preview data
     $this->browserPreviewData = [
@@ -134,8 +134,7 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
 
   public function testItThrowsWhenSubscriberIsNotOnProcessedList() {
     $data = $this->browserPreviewData;
-    $this->scheduledTaskSubscribersRepository->setSubscribers($this->scheduledTask, []);
-    $this->scheduledTaskSubscribersRepository->updateProcessedSubscribers($this->scheduledTask, []);
+    $this->scheduledTaskSubscribersRepository->deleteByScheduledTask($this->scheduledTask);
     $this->expectViewThrowsExceptionWithMessage($this->viewInBrowserController, $data, 'Subscriber did not receive the newsletter yet');
   }
 

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
@@ -11,7 +11,6 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Links\Links;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Renderer;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Shortcodes\Shortcodes;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Router\Router;
@@ -21,6 +20,7 @@ use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterLink;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as ScheduledTaskSubscriberFactory;
 use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
 use MailPoet\WP\Emoji;
 
@@ -58,7 +58,6 @@ class ViewInBrowserRendererTest extends \MailPoetTest {
   public function _before() {
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->newsletterRepository = $this->diContainer->get(NewslettersRepository::class);
-    $scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
     $newsletterBody =
       json_decode(
         '{
@@ -130,7 +129,7 @@ class ViewInBrowserRendererTest extends \MailPoetTest {
     $this->scheduledTask = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, null);
     $this->sendingQueue = (new SendingQueueFactory())->create($this->scheduledTask, $newsletter);
     $this->sendingQueue->setNewsletterRenderedBody($this->queueRenderedNewsletterWithoutTracking);
-    $scheduledTaskSubscribersRepository->setSubscribers($this->scheduledTask, [$subscriber->getId()]);
+    (new ScheduledTaskSubscriberFactory())->createProcessed($this->scheduledTask, $subscriber);
     $this->newsletterRepository->refresh($newsletter);
     $this->newsletter = $newsletter;
 

--- a/mailpoet/tests/integration/REST/Newsletters/SendingStatusEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Newsletters/SendingStatusEndpointsTest.php
@@ -4,9 +4,11 @@ namespace MailPoet\Test\REST\Newsletters;
 
 use Codeception\Util\Fixtures;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\REST\Test;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskQueuedSubscriber as QueuedSubscriberFactory;
 use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as TaskSubscriberFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 
@@ -14,9 +16,9 @@ require_once __DIR__ . '/../Test.php';
 
 /**
  * Covers the contract surface of the sending-status REST endpoints
- * (`GET /newsletters/{id}/sending-status` and its `resend` action). Asserts
- * the HTTP layer wires the shared listing repository and the resend logic and
- * returns the expected envelope shape.
+ * (`GET /newsletters/{id}/sending-status` and its `resend` action). The listing
+ * is split across three tabs: Unprocessed (queue) + Sent / Failed (log), each
+ * a single-table query selected by the `group` param.
  */
 class SendingStatusEndpointsTest extends Test {
   private function listingPath(int $newsletterId): string {
@@ -39,6 +41,16 @@ class SendingStatusEndpointsTest extends Test {
     return $payload;
   }
 
+  /**
+   * @param array<mixed, mixed> $payload
+   * @return array<mixed, mixed>
+   */
+  private function meta(array $payload): array {
+    $meta = $payload['meta'];
+    $this->assertIsArray($meta);
+    return $meta;
+  }
+
   public function _before() {
     parent::_before();
     wp_set_current_user(1);
@@ -49,7 +61,7 @@ class SendingStatusEndpointsTest extends Test {
     wp_set_current_user(0);
   }
 
-  public function testListingReturnsTaskSubscribersForTheNewsletter(): void {
+  public function testListingReturnsSentSubscribersFromTheLog(): void {
     $newsletter = (new NewsletterFactory())
       ->withSubject('SendingStatus_' . uniqid())
       ->withBody(Fixtures::get('newsletter_body_template'))
@@ -64,17 +76,71 @@ class SendingStatusEndpointsTest extends Test {
     $taskSubscriberFactory->createProcessed($task, $sentSubscriber);
     $taskSubscriberFactory->createFailed($task, $failedSubscriber, 'Something went wrong!');
 
+    // Default tab is Sent.
     $payload = $this->payload($this->get($this->listingPath((int)$newsletter->getId()), ['query' => [
       'per_page' => 100,
     ]]));
     $items = $payload['items'];
     $this->assertIsArray($items);
-    $meta = $payload['meta'];
-    $this->assertIsArray($meta);
     $emails = array_column($items, 'email');
     $this->assertContains($sentSubscriber->getEmail(), $emails);
-    $this->assertContains($failedSubscriber->getEmail(), $emails);
-    $this->assertSame(2, $meta['count']);
+    $this->assertNotContains($failedSubscriber->getEmail(), $emails);
+    $this->assertSame(1, $this->meta($payload)['count']);
+  }
+
+  public function testListingReturnsFailedSubscribersFromTheLog(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Failed_' . uniqid())
+      ->withBody(Fixtures::get('newsletter_body_template'))
+      ->withSendingQueue()
+      ->create();
+    $task = $newsletter->getLatestQueue()->getTask();
+
+    $subscriberFactory = new SubscriberFactory();
+    $taskSubscriberFactory = new TaskSubscriberFactory();
+    $taskSubscriberFactory->createProcessed($task, $subscriberFactory->withEmail('sent_' . uniqid() . '@example.com')->create());
+    $failedSubscriber = $subscriberFactory->withEmail('failed_' . uniqid() . '@example.com')->create();
+    $taskSubscriberFactory->createFailed($task, $failedSubscriber, 'Boom');
+
+    $payload = $this->payload($this->get($this->listingPath((int)$newsletter->getId()), ['query' => [
+      'per_page' => 100,
+      'group' => 'failed',
+    ]]));
+    $items = $payload['items'];
+    $this->assertIsArray($items);
+    $this->assertCount(1, $items);
+    $this->assertIsArray($items[0]);
+    $this->assertSame($failedSubscriber->getEmail(), $items[0]['email']);
+    $this->assertSame('Boom', $items[0]['error']);
+    $this->assertSame(1, $items[0]['failed']);
+  }
+
+  public function testListingReturnsUnprocessedSubscribersFromTheQueue(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Unprocessed_' . uniqid())
+      ->withBody(Fixtures::get('newsletter_body_template'))
+      ->withSendingQueue()
+      ->create();
+    $task = $newsletter->getLatestQueue()->getTask();
+
+    $subscriberFactory = new SubscriberFactory();
+    $queuedSubscriber = $subscriberFactory->withEmail('pending_' . uniqid() . '@example.com')->create();
+    (new QueuedSubscriberFactory())->create($task, $queuedSubscriber);
+
+    $payload = $this->payload($this->get($this->listingPath((int)$newsletter->getId()), ['query' => [
+      'per_page' => 100,
+      'group' => 'unprocessed',
+    ]]));
+    $items = $payload['items'];
+    $this->assertIsArray($items);
+    $this->assertCount(1, $items);
+    $this->assertIsArray($items[0]);
+    $this->assertSame($queuedSubscriber->getEmail(), $items[0]['email']);
+    // The queue is lean — the item is projected as a synthetic unprocessed row.
+    $this->assertSame(0, $items[0]['processed']);
+    $this->assertSame(0, $items[0]['failed']);
+    $this->assertNull($items[0]['error']);
+    $this->assertSame(1, $this->meta($payload)['count']);
   }
 
   public function testListingScopesItemsToTheRequestedNewsletter(): void {
@@ -111,10 +177,8 @@ class SendingStatusEndpointsTest extends Test {
       ->create();
 
     $payload = $this->payload($this->get($this->listingPath((int)$newsletter->getId()), ['query' => ['per_page' => 100]]));
-    $meta = $payload['meta'];
-    $this->assertIsArray($meta);
     $this->assertSame([], $payload['items']);
-    $this->assertSame(0, $meta['count']);
+    $this->assertSame(0, $this->meta($payload)['count']);
   }
 
   public function testListingCarriesMailerEnvelopeFields(): void {
@@ -143,66 +207,47 @@ class SendingStatusEndpointsTest extends Test {
     $taskSubscriberFactory = new TaskSubscriberFactory();
     $taskSubscriberFactory->createProcessed($task, $subscriberFactory->withEmail('s_' . uniqid() . '@example.com')->create());
     $taskSubscriberFactory->createFailed($task, $subscriberFactory->withEmail('f_' . uniqid() . '@example.com')->create(), 'Boom');
-    $taskSubscriberFactory->createUnprocessed($task, $subscriberFactory->withEmail('u_' . uniqid() . '@example.com')->create());
+    (new QueuedSubscriberFactory())->create($task, $subscriberFactory->withEmail('u_' . uniqid() . '@example.com')->create());
 
     $payload = $this->payload($this->get($this->listingPath((int)$newsletter->getId()), ['query' => ['per_page' => 10]]));
     $groupsList = $payload['groups'];
     $this->assertIsArray($groupsList);
     $groups = array_column($groupsList, 'count', 'name');
-    $this->assertSame(3, $groups['all']);
-    $this->assertSame(1, $groups[ScheduledTaskSubscriberEntity::SENDING_STATUS_SENT]);
-    $this->assertSame(1, $groups[ScheduledTaskSubscriberEntity::SENDING_STATUS_FAILED]);
-    $this->assertSame(1, $groups[ScheduledTaskSubscriberEntity::SENDING_STATUS_UNPROCESSED]);
+    // No combined "all" group — that would need a cross-table union.
+    $this->assertArrayNotHasKey('all', $groups);
+    $this->assertSame(1, $groups['unprocessed']);
+    $this->assertSame(1, $groups['sent']);
+    $this->assertSame(1, $groups['failed']);
   }
 
-  public function testListingFiltersByGroup(): void {
-    $newsletter = (new NewsletterFactory())
-      ->withSubject('Filter_' . uniqid())
-      ->withBody(Fixtures::get('newsletter_body_template'))
-      ->withSendingQueue()
-      ->create();
-    $task = $newsletter->getLatestQueue()->getTask();
-
-    $subscriberFactory = new SubscriberFactory();
-    $taskSubscriberFactory = new TaskSubscriberFactory();
-    $taskSubscriberFactory->createProcessed($task, $subscriberFactory->withEmail('s_' . uniqid() . '@example.com')->create());
-    $failedSubscriber = $subscriberFactory->withEmail('f_' . uniqid() . '@example.com')->create();
-    $taskSubscriberFactory->createFailed($task, $failedSubscriber, 'Boom');
-
-    $payload = $this->payload($this->get($this->listingPath((int)$newsletter->getId()), ['query' => [
-      'per_page' => 10,
-      'group' => ScheduledTaskSubscriberEntity::SENDING_STATUS_FAILED,
-    ]]));
-    $items = $payload['items'];
-    $this->assertIsArray($items);
-    $this->assertCount(1, $items);
-    $this->assertIsArray($items[0]);
-    $this->assertSame($failedSubscriber->getEmail(), $items[0]['email']);
-  }
-
-  public function testResendResetsAFailedTaskSubscriber(): void {
+  public function testResendMovesAFailedLogRowBackToTheQueue(): void {
     $newsletter = (new NewsletterFactory())
       ->withSubject('Resend_' . uniqid())
       ->withBody(Fixtures::get('newsletter_body_template'))
       ->withSendingQueue()
       ->create();
     $task = $newsletter->getLatestQueue()->getTask();
+    $taskId = (int)$task->getId();
 
     $subscriberFactory = new SubscriberFactory();
     $failedSubscriber = $subscriberFactory->withEmail('resend_' . uniqid() . '@example.com')->create();
-    $failedTaskSubscriber = (new TaskSubscriberFactory())->createFailed($task, $failedSubscriber, 'Boom');
+    $subscriberId = (int)$failedSubscriber->getId();
+    (new TaskSubscriberFactory())->createFailed($task, $failedSubscriber, 'Boom');
 
     $response = $this->post($this->resendPath((int)$newsletter->getId()), ['json' => [
-      'task_id' => (int)$task->getId(),
-      'subscriber_id' => (int)$failedSubscriber->getId(),
+      'task_id' => $taskId,
+      'subscriber_id' => $subscriberId,
     ]]);
     $this->assertIsArray($response);
     $this->assertArrayNotHasKey('code', $response);
 
-    $this->entityManager->refresh($failedTaskSubscriber);
-    $this->assertNull($failedTaskSubscriber->getError());
-    $this->assertEquals(0, $failedTaskSubscriber->getFailed());
-    $this->assertEquals(0, $failedTaskSubscriber->getProcessed());
+    // The failed row leaves the log and re-enters the queue as pending.
+    $logRow = $this->diContainer->get(ScheduledTaskSubscribersRepository::class)
+      ->findOneBy(['task' => $taskId, 'subscriber' => $subscriberId]);
+    $this->assertNull($logRow);
+    $queuedRow = $this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class)
+      ->findOneBy(['task' => $taskId, 'subscriber' => $subscriberId]);
+    $this->assertNotNull($queuedRow);
 
     $this->entityManager->refresh($newsletter);
     $this->assertSame(NewsletterEntity::STATUS_SENDING, $newsletter->getStatus());

--- a/mailpoet/tests/integration/Router/Endpoints/TrackTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/TrackTest.php
@@ -11,7 +11,6 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Router\Endpoints\Track;
 use MailPoet\Subscribers\LinkTokens;
@@ -71,8 +70,6 @@ class TrackTest extends \MailPoetTest {
       'link_hash' => $link->getHash(),
       'preview' => false,
     ];
-    $scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
-    $scheduledTaskSubscribersRepository->updateProcessedSubscribers($task, [(int)$subscriber->getId()]);
     // instantiate class
     $this->track = $this->diContainer->get(Track::class);
   }
@@ -186,9 +183,6 @@ class TrackTest extends \MailPoetTest {
     $this->entityManager->persist($scheduledTaskSubscriber);
     $this->entityManager->flush();
     $scheduledTaskEntity->getSubscribers()->add($scheduledTaskSubscriber);
-
-    $scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
-    $scheduledTaskSubscribersRepository->updateProcessedSubscribers($scheduledTaskEntity, [$this->subscriber->getId()]);
 
     $queue = $newsletter->getLatestQueue();
     $trackData = $this->trackData;

--- a/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
@@ -8,7 +8,7 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\InvalidStateException;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoet\Test\DataFactories\DynamicSegment;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
@@ -31,8 +31,8 @@ class SubscribersFinderTest extends \MailPoetTest {
   /** @var SegmentsRepository */
   private $segmentsRepository;
 
-  /** @var ScheduledTaskSubscribersRepository */
-  private $scheduledTaskSubscribersRepository;
+  /** @var ScheduledTaskQueuedSubscriberRepository */
+  private $scheduledTaskQueuedSubscriberRepository;
 
   public function _before() {
     parent::_before();
@@ -58,7 +58,7 @@ class SubscribersFinderTest extends \MailPoetTest {
     $this->scheduledTask = $scheduledTaskFactory->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->subscribersFinder = $this->diContainer->get(SubscribersFinder::class);
-    $this->scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
+    $this->scheduledTaskQueuedSubscriberRepository = $this->diContainer->get(ScheduledTaskQueuedSubscriberRepository::class);
   }
 
   public function testFindSubscribersInSegmentInSegmentDefaultSegment() {
@@ -76,7 +76,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->method('findSubscribersIdsInSegment')
       ->will($this->returnValue([$this->subscriber3->getId()]));
 
-    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager, $this->scheduledTaskSubscribersRepository);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager, $this->scheduledTaskQueuedSubscriberRepository);
     $subscribers = $finder->findSubscribersInSegments([$this->subscriber3->getId()], [$this->segment3->getId()]);
     verify($subscribers)->arrayCount(1);
     verify($subscribers)->arrayContains($this->subscriber3->getId());
@@ -90,7 +90,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->method('findSubscribersIdsInSegment')
       ->will($this->returnValue([$this->subscriber3->getId()]));
 
-    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager, $this->scheduledTaskSubscribersRepository);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager, $this->scheduledTaskQueuedSubscriberRepository);
     $subscribers = $finder->findSubscribersInSegments([$this->subscriber3->getId()], [$this->segment3->getId(), $this->segment3->getId()]);
     verify($subscribers)->arrayCount(1);
   }
@@ -103,7 +103,7 @@ class SubscribersFinderTest extends \MailPoetTest {
         (int)$this->segment2->getId(),
       ]
     );
-    $subscribersCount = $this->scheduledTask->getSubscribers()->count();
+    $subscribersCount = $this->scheduledTaskQueuedSubscriberRepository->countForTask($this->scheduledTask);
     verify($subscribersCount)->equals(1);
     $subscribersIds = $this->getScheduledTasksSubscribers((int)$this->scheduledTask->getId());
     verify($subscribersIds)->equals([$this->subscriber2->getId()]);
@@ -142,7 +142,7 @@ class SubscribersFinderTest extends \MailPoetTest {
         (int)$this->segment3->getId(),
       ]
     );
-    $subscribersCount = $this->scheduledTask->getSubscribers()->count();
+    $subscribersCount = $this->scheduledTaskQueuedSubscriberRepository->countForTask($this->scheduledTask);
     verify($subscribersCount)->equals(0);
   }
 
@@ -155,14 +155,14 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->will($this->returnValue([$this->subscriber1->getId()]));
     $this->segment2->setType(SegmentEntity::TYPE_DYNAMIC);
 
-    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager, $this->scheduledTaskSubscribersRepository);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager, $this->scheduledTaskQueuedSubscriberRepository);
     $finder->addSubscribersToTaskFromSegments(
       $this->scheduledTask,
       [
         (int)$this->segment2->getId(),
       ]
     );
-    $subscribersCount = $this->scheduledTask->getSubscribers()->count();
+    $subscribersCount = $this->scheduledTaskQueuedSubscriberRepository->countForTask($this->scheduledTask);
     verify($subscribersCount)->equals(1);
     $subscribersIds = $this->getScheduledTasksSubscribers((int)$this->scheduledTask->getId());
     verify($subscribersIds)->equals([$this->subscriber1->getId()]);
@@ -177,7 +177,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->will($this->returnValue([$this->subscriber2->getId()]));
     $this->segment3->setType(SegmentEntity::TYPE_DYNAMIC);
 
-    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager, $this->scheduledTaskSubscribersRepository);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager, $this->scheduledTaskQueuedSubscriberRepository);
     $finder->addSubscribersToTaskFromSegments(
       $this->scheduledTask,
       [
@@ -186,7 +186,7 @@ class SubscribersFinderTest extends \MailPoetTest {
         (int)$this->segment3->getId(),
       ]
     );
-    $subscribersCount = $this->scheduledTask->getSubscribers()->count();
+    $subscribersCount = $this->scheduledTaskQueuedSubscriberRepository->countForTask($this->scheduledTask);
     verify($subscribersCount)->equals(1);
     $subscribersIds = $this->getScheduledTasksSubscribers((int)$this->scheduledTask->getId());
     verify($subscribersIds)->equals([$this->subscriber2->getId()]);
@@ -208,23 +208,23 @@ class SubscribersFinderTest extends \MailPoetTest {
     // Without filtering
     $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
     $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$staticSegment->getId()]);
-    $staticCount = $task->getSubscribers()->count();
+    $staticCount = $this->scheduledTaskQueuedSubscriberRepository->countForTask($task);
     verify($staticCount)->equals(2);
 
     $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
     $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$dynamicSegment->getId()]);
-    $dynamicCount = $task->getSubscribers()->count();
+    $dynamicCount = $this->scheduledTaskQueuedSubscriberRepository->countForTask($task);
     verify($dynamicCount)->equals(4);
 
     // With filtering
     $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
     $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$staticSegment->getId()], $filterSegment->getId());
-    $staticCount = $task->getSubscribers()->count();
+    $staticCount = $this->scheduledTaskQueuedSubscriberRepository->countForTask($task);
     verify($staticCount)->equals(1);
 
     $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
     $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$dynamicSegment->getId()], $filterSegment->getId());
-    $dynamicCount = $task->getSubscribers()->count();
+    $dynamicCount = $this->scheduledTaskQueuedSubscriberRepository->countForTask($task);
     verify($dynamicCount)->equals(2);
   }
 
@@ -251,15 +251,7 @@ class SubscribersFinderTest extends \MailPoetTest {
   }
 
   private function getScheduledTasksSubscribers(int $taskId): array {
-    $scheduledTaskSubscribers = $this->scheduledTaskSubscribersRepository->findBy(['task' => $taskId]);
-    $subscribersIds = array_map(function($scheduledTaskSubscriber) {
-      $subscriber = $scheduledTaskSubscriber->getSubscriber();
-
-      if ($subscriber instanceof SubscriberEntity) {
-        return $subscriber->getId();
-      }
-    }, $scheduledTaskSubscribers);
-
-    return $subscribersIds;
+    // Sending tasks now enqueue pending recipients into the queue table.
+    return $this->scheduledTaskQueuedSubscriberRepository->getSubscriberIdsBatchForTask($taskId, 0, 1000);
   }
 }

--- a/mailpoet/tests/integration/Statistics/Track/UnsubscribesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/UnsubscribesTest.php
@@ -6,11 +6,11 @@ use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Statistics\StatisticsUnsubscribesRepository;
 use MailPoet\Statistics\Track\Unsubscribes;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as ScheduledTaskSubscriberFactory;
 use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 
@@ -43,11 +43,9 @@ class UnsubscribesTest extends \MailPoetTest {
       ->create();
 
     // create queue
-    $scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
     $scheduledTask = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, null);
     $this->sendingQueue = (new SendingQueueFactory())->create($scheduledTask, $newsletter);
-    $scheduledTaskSubscribersRepository->setSubscribers($scheduledTask, [$this->subscriber->getId()]);
-    $scheduledTaskSubscribersRepository->updateProcessedSubscribers($scheduledTask, [(int)$this->subscriber->getId()]);
+    (new ScheduledTaskSubscriberFactory())->createProcessed($scheduledTask, $this->subscriber);
 
     // instantiate class
     $this->unsubscribes = $this->diContainer->get(Unsubscribes::class);

--- a/mailpoet/tests/integration/Tasks/Subscribers/BatchIteratorTest.php
+++ b/mailpoet/tests/integration/Tasks/Subscribers/BatchIteratorTest.php
@@ -5,7 +5,7 @@ namespace MailPoet\Test\Tasks\Subscribers;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Tasks\Subscribers\BatchIterator;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
-use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as ScheduledTaskSubscriberFactory;
+use MailPoet\Test\DataFactories\ScheduledTaskQueuedSubscriber as ScheduledTaskQueuedSubscriberFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -24,12 +24,12 @@ class BatchIteratorTest extends \MailPoetTest {
     $task = $scheduledTaskFactory->create('some_task_type', ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
     $this->taskId = $task->getId();
 
-    $scheduledTaskSubscriberFactory = new ScheduledTaskSubscriberFactory();
+    $queuedSubscriberFactory = new ScheduledTaskQueuedSubscriberFactory();
 
     for ($i = 0; $i < $this->subscriberCount; $i++) {
       $subscriberFactory = new SubscriberFactory();
       $subscriber = $subscriberFactory->create();
-      $scheduledTaskSubscriberFactory->createUnprocessed($task, $subscriber);
+      $queuedSubscriberFactory->create($task, $subscriber);
     }
     $this->iterator = new BatchIterator($this->taskId, $this->batchSize);
   }

--- a/mailpoet/tests/integration/Util/DataInconsistency/DataInconsistencyRepositoryTest.php
+++ b/mailpoet/tests/integration/Util/DataInconsistency/DataInconsistencyRepositoryTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Util\DataInconsistency;
 
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -11,6 +12,7 @@ use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterLink;
 use MailPoet\Test\DataFactories\NewsletterPost;
 use MailPoet\Test\DataFactories\ScheduledTask;
+use MailPoet\Test\DataFactories\ScheduledTaskQueuedSubscriber;
 use MailPoet\Test\DataFactories\ScheduledTaskSubscriber;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\SendingQueue;
@@ -90,6 +92,39 @@ class DataInconsistencyRepositoryTest extends \MailPoetTest {
     // We keep the task and subscriber that was associated with the task we kept
     $taskSubscriberCount = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->count([]);
     verify($taskSubscriberCount)->equals(2);
+  }
+
+  public function testItHandlesOrphanedScheduledTaskQueuedSubscribers(): void {
+    $taskToKeep = (new ScheduledTask())->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $taskToDelete = (new ScheduledTask())->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $subscriberToKeep = (new Subscriber())->create();
+    $subscriberToDelete = (new Subscriber())->create();
+
+    $queuedSubscriberFactory = new ScheduledTaskQueuedSubscriber();
+    $queuedSubscriberFactory->create($taskToKeep, $subscriberToKeep); // valid
+    $queuedSubscriberFactory->create($taskToDelete, $subscriberToKeep); // orphan: task missing
+    $queuedSubscriberFactory->create($taskToKeep, $subscriberToDelete); // orphan: subscriber missing
+
+    $this->entityManager->remove($taskToDelete);
+    $this->entityManager->remove($subscriberToDelete);
+    $this->entityManager->flush();
+
+    $queuedCount = $this->entityManager->getRepository(ScheduledTaskQueuedSubscriberEntity::class)->count([]);
+    verify($queuedCount)->equals(3);
+
+    verify($this->repository->getOrphanedScheduledTaskQueuedSubscribersCount())->equals(2);
+    $this->repository->cleanupOrphanedScheduledTaskQueuedSubscribers();
+    verify($this->repository->getOrphanedScheduledTaskQueuedSubscribersCount())->equals(0);
+
+    // Only the valid queued recipient survives.
+    $queuedCount = $this->entityManager->getRepository(ScheduledTaskQueuedSubscriberEntity::class)->count([]);
+    verify($queuedCount)->equals(1);
+
+    // The kept task and subscriber are left intact.
+    $keptTask = $this->entityManager->find(ScheduledTaskEntity::class, (int)$taskToKeep->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $keptTask);
+    $keptSubscriber = $this->entityManager->find(SubscriberEntity::class, (int)$subscriberToKeep->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $keptSubscriber);
   }
 
   public function testItHandlesSendingQueuesWithoutNewsletter(): void {

--- a/mailpoet/tests/unit/API/JSON/ResponseBuilders/ScheduledTaskSubscriberResponseBuilderTest.php
+++ b/mailpoet/tests/unit/API/JSON/ResponseBuilders/ScheduledTaskSubscriberResponseBuilderTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\API\JSON\ResponseBuilders;
+
+use Codeception\Stub;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskQueuedSubscriberEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SubscriberEntity;
+
+class ScheduledTaskSubscriberResponseBuilderTest extends \MailPoetUnitTest {
+  public function testItProjectsAQueuedRowAsUnprocessed(): void {
+    $subscriber = Stub::make(SubscriberEntity::class, [
+      'getId' => 5,
+      'getEmail' => 'pending@example.com',
+      'getFirstName' => 'Pending',
+      'getLastName' => 'Pat',
+    ]);
+    $task = Stub::make(ScheduledTaskEntity::class, ['getId' => 9]);
+    $queuedSubscriber = Stub::make(ScheduledTaskQueuedSubscriberEntity::class, [
+      'getSubscriber' => $subscriber,
+      'getTask' => $task,
+    ]);
+
+    $item = (new ScheduledTaskSubscriberResponseBuilder())->buildQueued($queuedSubscriber);
+
+    // The queue has no processed/failed/error columns — they are synthesized.
+    verify($item['processed'])->equals(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED);
+    verify($item['failed'])->equals(ScheduledTaskSubscriberEntity::FAIL_STATUS_OK);
+    verify($item['error'])->null();
+    // Subscriber identity is mapped straight through.
+    verify($item['taskId'])->equals(9);
+    verify($item['subscriberId'])->equals(5);
+    verify($item['email'])->equals('pending@example.com');
+    verify($item['firstName'])->equals('Pending');
+    verify($item['lastName'])->equals('Pat');
+  }
+
+  public function testItBuildsAListOfQueuedItems(): void {
+    $queuedSubscriber = Stub::make(ScheduledTaskQueuedSubscriberEntity::class, [
+      'getSubscriber' => Stub::make(SubscriberEntity::class, ['getEmail' => 'a@example.com']),
+      'getTask' => Stub::make(ScheduledTaskEntity::class, ['getId' => 1]),
+    ]);
+
+    $items = (new ScheduledTaskSubscriberResponseBuilder())->buildForQueuedListing([$queuedSubscriber, $queuedSubscriber]);
+
+    verify($items)->arrayCount(2);
+    verify($items[0]['processed'])->equals(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED);
+  }
+}

--- a/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/Coupons/EmailContextBuilderTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/Coupons/EmailContextBuilderTest.php
@@ -5,19 +5,17 @@ namespace unit\EmailEditor\Integrations\MailPoet\Coupons;
 use MailPoet\EmailEditor\Integrations\MailPoet\Coupons\EmailContextBuilder;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\WP\Functions as WPFunctions;
-use MailPoetVendor\Doctrine\Common\Collections\ArrayCollection;
 
 class EmailContextBuilderTest extends \MailPoetUnitTest {
   public function testItMarksSingleRecipientAutomationAsRealSendWithoutValidRecipientEmail(): void {
-    $builder = new EmailContextBuilder($this->makeWpFunctions());
+    $builder = $this->makeBuilder();
 
     $context = $builder->build(
       $this->makeNewsletter(NewsletterEntity::TYPE_AUTOMATION),
-      $this->makeSendingQueue('not-an-email'),
+      $this->makeSendingQueue(1, 'not-an-email'),
       false
     );
 
@@ -29,17 +27,37 @@ class EmailContextBuilderTest extends \MailPoetUnitTest {
   }
 
   public function testItAddsRecipientEmailForSingleRecipientAutomationWithValidRecipientEmail(): void {
-    $builder = new EmailContextBuilder($this->makeWpFunctions());
+    $builder = $this->makeBuilder();
 
     $context = $builder->build(
       $this->makeNewsletter(NewsletterEntity::TYPE_AUTOMATION),
-      $this->makeSendingQueue('subscriber@example.com'),
+      $this->makeSendingQueue(1, 'subscriber@example.com'),
       false
     );
 
     verify($context['recipient_email'])->equals('subscriber@example.com');
     verify($context['is_real_send'])->true();
     verify($context['is_single_recipient'])->true();
+  }
+
+  public function testItDoesNotMarkAsSingleRecipientWhenTaskHasMultipleRecipients(): void {
+    // One recipient already sent (log) and one still pending (queue) => 2 recipients total,
+    // so this is not a 1:1 send and must not expose a single recipient email.
+    $builder = $this->makeBuilder();
+
+    $context = $builder->build(
+      $this->makeNewsletter(NewsletterEntity::TYPE_AUTOMATION),
+      $this->makeSendingQueue(2, 'subscriber@example.com'),
+      false
+    );
+
+    verify($context['is_single_recipient'])->false();
+    verify($context['subscriber_count'])->equals(2);
+    verify(isset($context['recipient_email']))->false();
+  }
+
+  private function makeBuilder(): EmailContextBuilder {
+    return new EmailContextBuilder($this->makeWpFunctions());
   }
 
   private function makeNewsletter(string $type): NewsletterEntity {
@@ -49,15 +67,15 @@ class EmailContextBuilderTest extends \MailPoetUnitTest {
     ]);
   }
 
-  private function makeSendingQueue(string $subscriberEmail): SendingQueueEntity {
+  private function makeSendingQueue(int $totalSubscribers = 1, ?string $recipientEmail = null): SendingQueueEntity {
     $subscriber = $this->make(SubscriberEntity::class, [
-      'getEmail' => $subscriberEmail,
-    ]);
-    $taskSubscriber = $this->make(ScheduledTaskSubscriberEntity::class, [
-      'getSubscriber' => $subscriber,
+      'getEmail' => $recipientEmail,
     ]);
     $task = $this->make(ScheduledTaskEntity::class, [
-      'getSubscribers' => new ArrayCollection([$taskSubscriber]),
+      'getId' => 5,
+      'getTotalSubscribersCount' => $totalSubscribers,
+      'getQueuedCount' => $totalSubscribers,
+      'getFirstQueuedSubscriber' => $recipientEmail !== null ? $subscriber : null,
     ]);
 
     return $this->make(SendingQueueEntity::class, [

--- a/mailpoet/tests/unit/WooCommerce/CouponPreProcessorTest.php
+++ b/mailpoet/tests/unit/WooCommerce/CouponPreProcessorTest.php
@@ -6,16 +6,16 @@ use Codeception\Stub;
 use Helper\WordPress;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
-use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\Coupon;
+use MailPoet\Newsletter\Sending\ScheduledTaskQueuedSubscriberRepository;
 use MailPoet\NewsletterProcessingException;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\WooCommerce\CouponPreProcessor;
 use MailPoet\WooCommerce\Helper;
 use MailPoet\WooCommerce\RandomCouponCodeGenerator;
-use MailPoetVendor\Doctrine\Common\Collections\ArrayCollection;
 
 class CouponPreProcessorTest extends \MailPoetUnitTest {
 
@@ -36,10 +36,9 @@ class CouponPreProcessorTest extends \MailPoetUnitTest {
       new \DateTimeZone('UTC');
     });
 
-    $this->processor = new CouponPreProcessor(
+    $this->processor = $this->makeProcessor(
       Stub::make(Helper::class),
-      Stub::make(NewslettersRepository::class),
-      new RandomCouponCodeGenerator()
+      Stub::make(NewslettersRepository::class)
     );
 
   }
@@ -64,12 +63,11 @@ class CouponPreProcessorTest extends \MailPoetUnitTest {
       'isWooCommerceActive' => true,
     ]);
 
-    $processor = new CouponPreProcessor(
+    $processor = $this->makeProcessor(
       $wcHelper,
       Stub::make(NewslettersRepository::class, [
         'flush' => Stub\Expected::never(), // for type = NewsletterEntity::TYPE_AUTOMATIC, the $newsletter->body shouldn't update
-      ], $this),
-      new RandomCouponCodeGenerator()
+      ], $this)
     );
 
     $newsletter = (new NewsletterEntity());
@@ -91,12 +89,11 @@ class CouponPreProcessorTest extends \MailPoetUnitTest {
       'isWooCommerceActive' => true,
     ]);
 
-    $processor = new CouponPreProcessor(
+    $processor = $this->makeProcessor(
       $wcHelper,
       Stub::make(NewslettersRepository::class, [
         'flush' => Stub\Expected::once(), // for type != NewsletterEntity::TYPE_AUTOMATIC, the $newsletter->body should update
-      ], $this),
-      new RandomCouponCodeGenerator()
+      ], $this)
     );
 
     $newsletter = (new NewsletterEntity());
@@ -119,12 +116,11 @@ class CouponPreProcessorTest extends \MailPoetUnitTest {
       'isWooCommerceActive' => true,
     ]);
 
-    $processor = new CouponPreProcessor(
+    $processor = $this->makeProcessor(
       $wcHelper,
       Stub::make(NewslettersRepository::class, [
         'flush' => Stub\Expected::never(),
-      ], $this),
-      new RandomCouponCodeGenerator()
+      ], $this)
     );
 
     $newsletter = (new NewsletterEntity());
@@ -148,12 +144,11 @@ class CouponPreProcessorTest extends \MailPoetUnitTest {
       'isWooCommerceActive' => false,
     ]);
 
-    $processor = new CouponPreProcessor(
+    $processor = $this->makeProcessor(
       $wcHelper,
       Stub::make(NewslettersRepository::class, [
         'flush' => Stub\Expected::never(),
-      ], $this),
-      new RandomCouponCodeGenerator()
+      ], $this)
     );
     $newsletter = (new NewsletterEntity());
 
@@ -174,12 +169,11 @@ class CouponPreProcessorTest extends \MailPoetUnitTest {
       'isWooCommerceActive' => true,
     ]);
 
-    $processor = new CouponPreProcessor(
+    $processor = $this->makeProcessor(
       $wcHelper,
       Stub::make(NewslettersRepository::class, [
         'flush' => Stub\Expected::never(),
-      ], $this),
-      new RandomCouponCodeGenerator()
+      ], $this)
     );
 
     [$newsletter, $blocks] = $this->createNewsletterAndBlockForType(NewsletterEntity::TYPE_STANDARD, 5);
@@ -196,16 +190,20 @@ class CouponPreProcessorTest extends \MailPoetUnitTest {
       'getEmail' => $subscriberEmail,
     ]);
 
-    $taskSubscriber = $this->make(ScheduledTaskSubscriberEntity::class, [
-      'getSubscriber' => $subscriber,
-    ]);
-
     $task = $this->make(ScheduledTaskEntity::class, [
-      'getSubscribers' => new ArrayCollection([$taskSubscriber]),
+      'getId' => 42,
+      'getTotalSubscribersCount' => 1,
     ]);
 
     $queue = $this->make(SendingQueueEntity::class, [
       'getTask' => $task,
+    ]);
+
+    $queueRepository = $this->make(ScheduledTaskQueuedSubscriberRepository::class, [
+      'getSubscriberIdsBatchForTask' => [42],
+    ]);
+    $subscribersRepository = $this->make(SubscribersRepository::class, [
+      'findOneById' => $subscriber,
     ]);
 
     $wcHelper = $this->make(Helper::class, [
@@ -213,10 +211,11 @@ class CouponPreProcessorTest extends \MailPoetUnitTest {
       'isWooCommerceActive' => true,
     ]);
 
-    $processor = new CouponPreProcessor(
+    $processor = $this->makeProcessor(
       $wcHelper,
       $this->make(NewslettersRepository::class),
-      new RandomCouponCodeGenerator()
+      $queueRepository,
+      $subscribersRepository
     );
 
     $newsletter = new NewsletterEntity();
@@ -249,6 +248,73 @@ class CouponPreProcessorTest extends \MailPoetUnitTest {
     // Test with additional emailRestrictions
     $blocks[0]['blocks'][0]['emailRestrictions'] = 'other@example.com';
     $processor->processCoupons($newsletter, $blocks, false, $queue);
+  }
+
+  public function testItDoesNotRestrictCouponToSubscriberWhenTaskHasMultipleRecipients(): void {
+    $wcCoupon = $this->createCouponMock();
+
+    // One pending (queue) + one already sent (log) => 2 recipients total, not a 1:1 send.
+    $task = $this->make(ScheduledTaskEntity::class, [
+      'getId' => 42,
+      'getTotalSubscribersCount' => 2,
+    ]);
+
+    $queue = $this->make(SendingQueueEntity::class, [
+      'getTask' => $task,
+    ]);
+
+    $wcHelper = $this->make(Helper::class, [
+      'createWcCoupon' => $wcCoupon,
+      'isWooCommerceActive' => true,
+    ]);
+
+    $processor = $this->makeProcessor(
+      $wcHelper,
+      $this->make(NewslettersRepository::class)
+    );
+
+    $newsletter = new NewsletterEntity();
+    $newsletter->setType(NewsletterEntity::TYPE_AUTOMATION);
+    $blocks = [
+      [
+        'type' => 'any',
+        'blocks' => [
+          [
+            'type' => Coupon::TYPE,
+            'discountType' => 'percent',
+            'amount' => '100',
+            'restrictToSubscriber' => true,
+          ],
+        ],
+      ],
+    ];
+    $newsletter->setBody(['blocks' => $blocks, 'content' => []]);
+
+    // The recipient email must not be injected for a multi-recipient send.
+    $wcCoupon->expects($this->once())
+      ->method('set_email_restrictions')
+      ->with([]);
+
+    $processor->processCoupons($newsletter, $blocks, false, $queue);
+  }
+
+  /**
+   * @param ScheduledTaskQueuedSubscriberRepository|null $queueRepository
+   * @param SubscribersRepository|null $subscribersRepository
+   */
+  private function makeProcessor(
+    Helper $wcHelper,
+    NewslettersRepository $newslettersRepository,
+    $queueRepository = null,
+    $subscribersRepository = null
+  ): CouponPreProcessor {
+    return new CouponPreProcessor(
+      $wcHelper,
+      $newslettersRepository,
+      new RandomCouponCodeGenerator(),
+      $queueRepository ?? Stub::make(ScheduledTaskQueuedSubscriberRepository::class),
+      $subscribersRepository ?? Stub::make(SubscribersRepository::class)
+    );
   }
 
   private function assertWCCouponReceivesCorrectValues($mockedWCCoupon, $expectedCouponId, $expiryDay) {


### PR DESCRIPTION
## Description

TODO

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

The data migration is forward-only — see the rollback note in the description.

## Screenshots or screencast

The two-tab Sending Status UI is exercised by `SendingStatusCest` (switches
Sent → Failed → Unprocessed and asserts the empty state). Happy to attach
screenshots if useful.

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:split-scheduled-taks-subscribers)

_The latest successful build from `split-scheduled-taks-subscribers` will be used. If none is available, the link won't work._