### PR TITLE
Fix subscriber email substring search

### DIFF
--- a/mailpoet/changelog/2026-06-18-19-56-50-fixed-restore-partial-email-address-search-on-the-subscr.md
+++ b/mailpoet/changelog/2026-06-18-19-56-50-fixed-restore-partial-email-address-search-on-the-subscr.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Restore partial email address search on the Subscribers page

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -258,9 +258,11 @@ class SubscriberListingRepository extends ListingRepository {
 
     $search = $definition->getSearch();
     if ($search && strlen(trim($search)) > 0 && trim($search) !== '*') {
+      $searchPatterns = $this->getSearchLikePatterns($search);
       $query
-        ->andWhere('(s.email LIKE :search OR s.first_name LIKE :search OR s.last_name LIKE :search)')
-        ->setParameter('search', Helpers::buildSearchLikePattern($search));
+        ->andWhere('(s.email LIKE :emailSearch OR s.first_name LIKE :nameSearch OR s.last_name LIKE :nameSearch)')
+        ->setParameter('emailSearch', $searchPatterns['email'])
+        ->setParameter('nameSearch', $searchPatterns['name']);
     }
 
     $filters = $definition->getFilters();
@@ -579,9 +581,22 @@ class SubscriberListingRepository extends ListingRepository {
     if (trim($search) === '*') {
       return;
     }
+    $searchPatterns = $this->getSearchLikePatterns($search);
     $queryBuilder
-      ->andWhere('s.email LIKE :search or s.firstName LIKE :search or s.lastName LIKE :search')
-      ->setParameter('search', Helpers::buildSearchLikePattern($search));
+      ->andWhere('s.email LIKE :emailSearch or s.firstName LIKE :nameSearch or s.lastName LIKE :nameSearch')
+      ->setParameter('emailSearch', $searchPatterns['email'])
+      ->setParameter('nameSearch', $searchPatterns['name']);
+  }
+
+  /**
+   * @return array{email: string, name: string}
+   */
+  private function getSearchLikePatterns(string $search): array {
+    $emailSearch = '%' . str_replace('*', '%', Helpers::escapeSearch($search)) . '%';
+    return [
+      'email' => $emailSearch,
+      'name' => Helpers::buildSearchLikePattern($search),
+    ];
   }
 
   protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
@@ -1026,9 +1041,11 @@ class SubscriberListingRepository extends ListingRepository {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $search = (string)$definition->getSearch();
     if (strlen(trim($search)) > 0 && trim($search) !== '*') {
+      $searchPatterns = $this->getSearchLikePatterns($search);
       $subscribersQuery
-        ->andWhere("$subscribersTable.email LIKE :search or $subscribersTable.first_name LIKE :search or $subscribersTable.last_name LIKE :search")
-        ->setParameter('search', Helpers::buildSearchLikePattern($search));
+        ->andWhere("$subscribersTable.email LIKE :emailSearch or $subscribersTable.first_name LIKE :nameSearch or $subscribersTable.last_name LIKE :nameSearch")
+        ->setParameter('emailSearch', $searchPatterns['email'])
+        ->setParameter('nameSearch', $searchPatterns['name']);
     }
     if ($definition->getGroup()) {
       if ($definition->getGroup() === 'trash') {

--- a/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
@@ -176,6 +176,27 @@ class SubscriberListingRepositoryTest extends \MailPoetTest {
     verify(count($data))->equals(7);
   }
 
+  public function testItSearchesSubscribersByEmailSubstring() {
+    $matchingSubscriber = (new Subscriber())
+      ->withEmail('john.doe@frankenstein.com')
+      ->withFirstName('John')
+      ->withLastName('Doe')
+      ->create();
+    (new Subscriber())
+      ->withEmail('jane.doe@example.com')
+      ->withFirstName('Jane')
+      ->withLastName('Doe')
+      ->create();
+
+    $this->listingData['search'] = 'frank';
+    $data = $this->repository->getData($this->getListingDefinition());
+    verify(count($data))->equals(1);
+    verify($data[0]->getEmail())->equals($matchingSubscriber->getEmail());
+    $count = $this->repository->getCount($this->getListingDefinition());
+    verify($count)->equals(1);
+    $this->listingData['search'] = '';
+  }
+
   public function testLoadSubscribersInDefaultSegment() {
     $list = $this->segmentRepository->createOrUpdate('Segment 5');
     $subscriberUnsubscribedFromAList = $this->createSubscriberEntity();
@@ -308,7 +329,7 @@ class SubscriberListingRepositoryTest extends \MailPoetTest {
     $this->entityManager->flush();
 
     $this->listingData['filter'] = ['segment' => $list->getId()];
-    $this->listingData['search'] = 'user-role-test2';
+    $this->listingData['search'] = 'test2';
     $data = $this->repository->getData($this->getListingDefinition());
     verify(count($data))->equals(1);
     verify($data[0]->getEmail())->equals($wpUserEmail2);


### PR DESCRIPTION
## Description

Restores partial email address search on MailPoet > Subscribers. Email searches now match substrings again, while first and last name search keeps the existing prefix behavior.

## Code review notes

_N/A_

## QA notes

Focused subscriber listing integration coverage, changed-file PHPCS, and Prettier passed.

Full `./do qa` did not complete: repository-wide PHPCS reported pre-existing violations in bundled test plugin files, then Robo exhausted memory while printing the massive report.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8197](https://linear.app/a8c/issue/STOMAIL-8197/restore-partial-email-search-on-subscribers-page)

Support thread: https://wordpress.org/support/topic/search-functionality-on-subscriber-page-bug/#post-18942572

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

| Before | After | 
| ---- | ---- | 
|  <img width="1032" height="515" alt="Screenshot 2026-06-19 at 08 38 30" src="https://github.com/user-attachments/assets/b6a05bc5-6b5e-41fd-8651-e2450496ddf1" /> | <img width="900" height="763" alt="Screenshot 2026-06-19 at 08 38 10" src="https://github.com/user-attachments/assets/60d44e41-184c-49aa-8389-fe272c16b249" /> |


## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8197-restore-partial-email-search-on-subscribers-page)

_The latest successful build from `stomail-8197-restore-partial-email-search-on-subscribers-page` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->