### PR TITLE
Add private action for public emails

### DIFF
--- a/mailpoet/assets/js/src/newsletters/listings/share-modal.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/share-modal.tsx
@@ -7,6 +7,7 @@ import { copyToClipboard } from 'utils';
 import { getShareLinks, ShareLink } from './share-links';
 
 export const SHARE_VISIBILITY_PUBLIC = 'public';
+export const SHARE_VISIBILITY_PRIVATE = 'private';
 
 type Props = {
   newsletter: NewsLetter;

--- a/mailpoet/assets/js/src/newsletters/listings/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.tsx
@@ -17,7 +17,11 @@ import {
   type NewsletterApiError,
   type NewsletterListingItem,
 } from '../api';
-import { NewsletterShareModal, SHARE_VISIBILITY_PUBLIC } from './share-modal';
+import {
+  NewsletterShareModal,
+  SHARE_VISIBILITY_PRIVATE,
+  SHARE_VISIBILITY_PUBLIC,
+} from './share-modal';
 import {
   STANDARD_NEWSLETTER_GROUPS,
   NewslettersListing,
@@ -187,6 +191,36 @@ function NewsletterListStandardComponent() {
     [],
   );
 
+  const makeNewsletterPrivate = useCallback(
+    async (item: NewsletterListingItem, refresh: () => void) => {
+      try {
+        await MailPoet.Ajax.post<{ data: NewsletterListingItem }>({
+          api_version: window.mailpoet_api_version,
+          endpoint: 'newsletters',
+          action: 'updateShareVisibility',
+          data: {
+            id: item.id,
+            share_visibility: SHARE_VISIBILITY_PRIVATE,
+          },
+        });
+        refresh();
+        MailPoet.Notice.success(
+          __('Email "%1$s" is now private.', 'mailpoet').replace(
+            '%1$s',
+            escapeHTML(item.campaign_name || item.subject),
+          ),
+        );
+        MailPoet.trackEvent('Emails > Share email made private');
+      } catch (response) {
+        const apiResponse = response as { errors?: { message?: string }[] };
+        if (apiResponse.errors && apiResponse.errors.length > 0) {
+          MailPoet.Notice.showApiErrorNotice(apiResponse, { scroll: true });
+        }
+      }
+    },
+    [],
+  );
+
   // `current_time` rides along with the listing response; the Statistics
   // column uses it to flag emails sent in the last few hours.
   const [currentTime, setCurrentTime] = useState<string | undefined>(undefined);
@@ -257,6 +291,20 @@ function NewsletterListStandardComponent() {
             },
           },
           {
+            id: 'make-private',
+            label: __('Make private', 'mailpoet'),
+            context: 'single',
+            supportsBulk: false,
+            isEligible: (item: NewsletterListingItem) =>
+              Boolean(item.can_share) &&
+              item.effective_share_visibility === SHARE_VISIBILITY_PUBLIC,
+            callback: (targets: NewsletterListingItem[]) => {
+              if (targets[0]) {
+                void makeNewsletterPrivate(targets[0], helpers.refresh);
+              }
+            },
+          },
+          {
             id: 'duplicate',
             label: __('Duplicate', 'mailpoet'),
             context: 'single',
@@ -288,7 +336,7 @@ function NewsletterListStandardComponent() {
         ],
         helpers.navigate,
       ) as Action<NewsletterListingItem>[],
-    [openShareModal],
+    [makeNewsletterPrivate, openShareModal],
   );
 
   const trackingHooksOk =

--- a/mailpoet/changelog/2026-06-19-07-41-00-added-option-to-mark-public-emails-as-private-from-the-e.md
+++ b/mailpoet/changelog/2026-06-19-07-41-00-added-option-to-mark-public-emails-as-private-from-the-e.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Option to mark public emails as private from the email listing

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -170,6 +170,29 @@ class NewslettersTest extends \MailPoetTest {
     verify($response->data['options'][NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE])->equals('0');
   }
 
+  public function testItCanUpdateShareVisibilityToPrivate(): void {
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->withOptions([
+        NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY => ShareVisibility::VISIBILITY_PUBLIC,
+      ])
+      ->create();
+
+    $response = $this->endpoint->updateShareVisibility([
+      'id' => $newsletter->getId(),
+      'share_visibility' => ShareVisibility::VISIBILITY_PRIVATE,
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['share_visibility'])->equals(ShareVisibility::VISIBILITY_PRIVATE);
+    verify($response->data['effective_share_visibility'])->equals(ShareVisibility::VISIBILITY_PRIVATE);
+    verify($response->data['can_share'])->false();
+
+    $this->newsletterRepository->refresh($newsletter);
+    verify($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY))
+      ->equals(ShareVisibility::VISIBILITY_PRIVATE);
+  }
+
   public function testItCanRestoreANewsletter() {
     $this->newsletterRepository->bulkTrash([$this->newsletter->getId()]);
     $this->entityManager->clear();


### PR DESCRIPTION
## Description

Adds a row action on the standard email listing to mark a public sent email as private. This switches it back to the private/view-in-browser behavior so the public share toolbar is no longer used.

## Code review notes

_N/A_

## QA notes

Passed focused integration coverage, JS QA, JS compile, Prettier, and PHPCS on the touched PHP test. Full `pnpm qa` was attempted, but local PHPCS scanned unrelated `tests/plugins/*` fixture/vendor files and exhausted memory after producing a large existing-violation report.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8198](https://linear.app/a8c/issue/STOMAIL-8198/allow-sent-public-emails-to-be-marked-private-from-listing-page)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="1384" height="635" alt="Screenshot 2026-06-19 at 09 53 17" src="https://github.com/user-attachments/assets/6f60c8d5-af6b-4bfe-a7e5-8922f4b0c724" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->