### PR TITLE
Treat unavailable filter fields as non-matching

### DIFF
--- a/mailpoet/changelog/2026-06-19-08-06-01-fixed-woocommerce-customer-conditions-for-subscribers-wi.md
+++ b/mailpoet/changelog/2026-06-19-08-06-01-fixed-woocommerce-customer-conditions-for-subscribers-wi.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+WooCommerce customer conditions for subscribers without customer records

--- a/mailpoet/lib/Automation/Engine/Control/FilterHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/FilterHandler.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Data\FilterGroup;
 use MailPoet\Automation\Engine\Data\Filters;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Exceptions\NotFoundException;
 use MailPoet\Automation\Engine\Integration\Filter;
 use MailPoet\Automation\Engine\Registry;
 
@@ -43,8 +44,15 @@ class FilterHandler {
     $operator = $group->getOperator();
     foreach ($group->getFilters() as $filterData) {
       $filter = $this->getFilter($filterData);
-      $value = $args->getFieldValue($filterData->getFieldKey(), $filter->getFieldParams($filterData));
-      $matches = $filter->matches($filterData, $value);
+      try {
+        $value = $args->getFieldValue($filterData->getFieldKey(), $filter->getFieldParams($filterData));
+        $matches = $filter->matches($filterData, $value);
+      } catch (NotFoundException $e) {
+        if (!$this->registry->getField($filterData->getFieldKey())) {
+          throw $e;
+        }
+        $matches = false;
+      }
       if ($operator === FilterGroup::OPERATOR_AND && !$matches) {
         return false;
       }

--- a/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
@@ -14,6 +14,7 @@ use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\Subject as SubjectData;
 use MailPoet\Automation\Engine\Data\SubjectEntry;
+use MailPoet\Automation\Engine\Exceptions\NotFoundException;
 use MailPoet\Automation\Engine\Integration\Filter;
 use MailPoet\Automation\Engine\Integration\Payload;
 use MailPoet\Automation\Engine\Integration\Subject;
@@ -148,6 +149,70 @@ class FilterHandlerTest extends MailPoetUnitTest {
       'test-param' => 'test-param-value',
       'test-param-data' => $filter,
     ], $fieldParams);
+  }
+
+  public function testItReturnsFalseWhenRegisteredFieldIsUnavailableForCurrentRun(): void {
+    $filter = new FilterData('f', Field::TYPE_STRING, 'test:unavailable-field', '', ['value' => 'abc']);
+    $filters = new Filters('and', [new FilterGroup('g1', 'and', [$filter])]);
+    $step = new Step('step', Step::TYPE_TRIGGER, 'test:step', [], [], $filters);
+    $subject = $this->createSubject('subject', [
+      new Field('test:available-field', Field::TYPE_STRING, 'Test field string', function () {
+        return 'abc';
+      }),
+    ]);
+
+    $stepRunArgs = new StepRunArgs(
+      $this->createMock(Automation::class),
+      $this->createMock(AutomationRun::class),
+      $step,
+      [new SubjectEntry($subject, new SubjectData($subject->getKey(), []))],
+      1
+    );
+
+    $registry = Stub::make(Registry::class, [
+      'filters' => [
+        Field::TYPE_STRING => $this->createFilter(Field::TYPE_STRING),
+      ],
+      'fields' => [
+        'test:unavailable-field' => new Field('test:unavailable-field', Field::TYPE_STRING, 'Unavailable field', function () {
+          return 'abc';
+        }),
+      ],
+    ]);
+
+    $handler = new FilterHandler($registry);
+    $this->assertFalse($handler->matchesFilters($stepRunArgs));
+  }
+
+  public function testItThrowsWhenFieldIsNotRegistered(): void {
+    $filter = new FilterData('f', Field::TYPE_STRING, 'test:unknown-field', '', ['value' => 'abc']);
+    $filters = new Filters('and', [new FilterGroup('g1', 'and', [$filter])]);
+    $step = new Step('step', Step::TYPE_TRIGGER, 'test:step', [], [], $filters);
+    $subject = $this->createSubject('subject', [
+      new Field('test:available-field', Field::TYPE_STRING, 'Test field string', function () {
+        return 'abc';
+      }),
+    ]);
+
+    $stepRunArgs = new StepRunArgs(
+      $this->createMock(Automation::class),
+      $this->createMock(AutomationRun::class),
+      $step,
+      [new SubjectEntry($subject, new SubjectData($subject->getKey(), []))],
+      1
+    );
+
+    $registry = Stub::make(Registry::class, [
+      'filters' => [
+        Field::TYPE_STRING => $this->createFilter(Field::TYPE_STRING),
+      ],
+      'fields' => [],
+    ]);
+
+    $handler = new FilterHandler($registry);
+    $this->expectException(NotFoundException::class);
+    $this->expectExceptionMessage("Field with key 'test:unknown-field' not found.");
+    $handler->matchesFilters($stepRunArgs);
   }
 
   public function dataForTestItFilters(): array {


### PR DESCRIPTION
## Description

Fixes If/Else filters so a valid field that is unavailable for the current automation run evaluates as no match instead of failing the step. This lets list-triggered automations route subscribers without WooCommerce customer data to the Else branch.

## Code review notes

The fallback is limited to fields registered in the automation registry; unknown field keys still throw.

## QA notes

Focused unit test, touched-file PHPCS/PHPStan, and Prettier passed. Full `./do qa` fails in PHPCS on unrelated bundled test plugin/vendor files, then exhausts memory.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8182

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8182-bug-ifelse-purchased-categories-step-fails-with-field-not)

_The latest successful build from `stomail-8182-bug-ifelse-purchased-categories-step-fails-with-field-not` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Issues Found: 1**

- **Bug**: If/Else filters in automation workflows fail when a valid filter field is not available during the automation run. The fix implements a fallback mechanism where unavailable registered fields now evaluate to a non-match instead of causing step failure, while unknown field keys continue to throw errors as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->