### PR TITLE
Fix abandoned cart block products

### DIFF
--- a/mailpoet/changelog/2026-06-19-21-55-15-fixed-abandoned-cart-products-not-showing-in-block-edito.md
+++ b/mailpoet/changelog/2026-06-19-21-55-15-fixed-abandoned-cart-products-not-showing-in-block-edito.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Abandoned cart products not showing in block editor emails

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -7,6 +7,7 @@ use MailPoet\Captcha\ReCaptchaHooks;
 use MailPoet\Captcha\TurnstileHooks;
 use MailPoet\Cron\CronTrigger;
 use MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockGenerator;
+use MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\ProductCollectionEmailRendererRegistrar;
 use MailPoet\Form\DisplayFormInWPContent;
 use MailPoet\Mailer\WordPress\WordpressMailerReplacer;
 use MailPoet\Newsletter\Scheduler\PostNotificationScheduler;
@@ -113,6 +114,8 @@ class Hooks {
 
   private CouponBlockGenerator $couponBlockGenerator;
 
+  private ProductCollectionEmailRendererRegistrar $productCollectionEmailRendererRegistrar;
+
   public function __construct(
     Form $subscriptionForm,
     Comment $subscriptionComment,
@@ -137,7 +140,8 @@ class Hooks {
     CronTrigger $cronTrigger,
     WooHelper $wooHelper,
     AdminUserSubscription $adminUserSubscription,
-    CouponBlockGenerator $couponBlockGenerator
+    CouponBlockGenerator $couponBlockGenerator,
+    ProductCollectionEmailRendererRegistrar $productCollectionEmailRendererRegistrar
   ) {
     $this->subscriptionForm = $subscriptionForm;
     $this->subscriptionComment = $subscriptionComment;
@@ -163,6 +167,7 @@ class Hooks {
     $this->wooHelper = $wooHelper;
     $this->adminUserSubscription = $adminUserSubscription;
     $this->couponBlockGenerator = $couponBlockGenerator;
+    $this->productCollectionEmailRendererRegistrar = $productCollectionEmailRendererRegistrar;
   }
 
   public function init() {
@@ -178,6 +183,7 @@ class Hooks {
     $this->setupPostNotifications();
     $this->setupWooCommerceSettings();
     $this->couponBlockGenerator->init();
+    $this->productCollectionEmailRendererRegistrar->init();
     $this->setupWoocommerceSystemInfo();
     $this->setupFooter();
     $this->setupSettingsLinkInPluginPage();

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -406,6 +406,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Coupons\EmailContextBuilder::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\ProductCollectionEmailRendererRegistrar::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Link::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\LinksToShortcodesConvertor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUrl::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Coupons/EmailContextBuilder.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Coupons/EmailContextBuilder.php
@@ -67,6 +67,10 @@ class EmailContextBuilder {
     // stand-in for everyone who will receive the email.
     $firstSubscriber = $subscribers ? $subscribers->first() : null;
     $subscriber = $firstSubscriber ? $firstSubscriber->getSubscriber() : null;
+    $wpUserId = $subscriber ? $subscriber->getWpUserId() : null;
+    if ($wpUserId) {
+      $context['user_id'] = (int)$wpUserId;
+    }
     $recipientEmail = $subscriber ? $subscriber->getEmail() : null;
     if (is_string($recipientEmail) && $this->wp->isEmail($recipientEmail)) {
       $context['recipient_email'] = $recipientEmail;

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/ProductCollection/OrderProductCollectionProcessor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/ProductCollection/OrderProductCollectionProcessor.php
@@ -2,9 +2,15 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection;
 
+use MailPoet\AutomaticEmails\WooCommerce\Events\AbandonedCart;
+use MailPoet\Entities\SendingQueueEntity;
+
 /**
- * Fills product collection blocks using one of the MailPoet order-aware
- * collections with products derived from the order that triggered the email.
+ * Fills product collection blocks from MailPoet automation context.
+ *
+ * Order-aware collections use products derived from the order that triggered
+ * the email. Abandoned-cart emails expose the queued cart product snapshot to
+ * WooCommerce's cart-contents collection during rendering.
  *
  * The collection slug stored in the block's `collection` attribute is the
  * marker — it is a declared block attribute, so it survives editing and
@@ -28,6 +34,7 @@ class OrderProductCollectionProcessor {
   ];
 
   private const PRODUCT_COLLECTION_BLOCK = 'woocommerce/product-collection';
+  private const PERSISTENT_CART_META_KEY_PREFIX = '_woocommerce_persistent_cart_';
   private const MAX_PRODUCTS = 24;
   private const RELATED_PRODUCTS_PER_ITEM = 8;
 
@@ -50,6 +57,49 @@ class OrderProductCollectionProcessor {
   }
 
   /**
+   * WooCommerce's cart-contents collection reads products from persistent cart
+   * user meta during email rendering. MailPoet already stores the abandoned cart
+   * snapshot on the queue, so expose that snapshot only while rendering the queue.
+   *
+   * @param array<string, mixed> $renderContext
+   */
+  public function createAbandonedCartPersistentCartFilter(
+    array $renderContext,
+    ?SendingQueueEntity $sendingQueue
+  ): ?callable {
+    $userId = isset($renderContext['user_id']) && is_numeric($renderContext['user_id'])
+      ? (int)$renderContext['user_id']
+      : 0;
+    if (!$userId || !$sendingQueue) {
+      return null;
+    }
+
+    $meta = $sendingQueue->getMeta() ?: [];
+    $productIds = $this->normalizeProductIds($meta[AbandonedCart::TASK_META_NAME] ?? []);
+    if (!$productIds) {
+      return null;
+    }
+
+    $persistentCart = $this->buildPersistentCart($productIds);
+    // Return a single-element value list. get_metadata_raw() unwraps it to
+    // $persistentCart for $single calls (its $check[0]) and hands it back as an
+    // array of values otherwise. WooCommerce reads the persistent cart with
+    // $single = true, so returning the bare cart here would make WP read index 0
+    // of an associative array and yield null.
+    return function($value, $objectId, $metaKey) use ($userId, $persistentCart) {
+      if (
+        (int)$objectId !== $userId
+        || !is_string($metaKey)
+        || strpos($metaKey, self::PERSISTENT_CART_META_KEY_PREFIX) !== 0
+      ) {
+        return $value;
+      }
+
+      return [$persistentCart];
+    };
+  }
+
+  /**
    * Set hand-picked products on every product collection block using one of the
    * order-aware collections, descending into inner blocks. Each collection is
    * resolved at most once per call.
@@ -60,6 +110,41 @@ class OrderProductCollectionProcessor {
   public function fillOrderCollections(array $blocks, \WC_Order $order): array {
     $resolvedIds = [];
     return $this->walkBlocks($blocks, $order, $resolvedIds);
+  }
+
+  /**
+   * @param mixed $productIds
+   * @return int[]
+   */
+  private function normalizeProductIds($productIds): array {
+    if (!is_array($productIds)) {
+      return [];
+    }
+
+    $normalized = [];
+    foreach ($productIds as $productId) {
+      if (!is_numeric($productId)) {
+        continue;
+      }
+      $productId = (int)$productId;
+      if ($productId > 0) {
+        $normalized[] = $productId;
+      }
+    }
+
+    return array_values(array_unique($normalized));
+  }
+
+  /**
+   * @param int[] $productIds
+   * @return array{cart: array<string, array{product_id: int}>}
+   */
+  private function buildPersistentCart(array $productIds): array {
+    $cart = [];
+    foreach ($productIds as $index => $productId) {
+      $cart['mailpoet_abandoned_cart_' . $index] = ['product_id' => $productId];
+    }
+    return ['cart' => $cart];
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/ProductCollection/ProductCollectionEmailRendererRegistrar.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/ProductCollection/ProductCollectionEmailRendererRegistrar.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection;
+
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\WooCommerce\Initializer as WooCommerceBlocksInitializer;
+use MailPoet\WP\Functions as WPFunctions;
+
+/**
+ * Wires WooCommerce's email block renderers when WooCommerce registers the
+ * blocks but leaves render_email_callback unset.
+ *
+ * WooCommerce sets render_email_callback through the block_type_metadata_settings
+ * filter while blocks register. On some builds the product blocks are registered
+ * before that filter is in place, so the email renderer never gets attached. The
+ * email editor then falls back to WooCommerce's frontend renderer, which resolves
+ * cart-contents and order collections against the live store state and renders the
+ * product blocks empty during a real send.
+ *
+ * Mirrors CouponBlockGenerator::registerEmailRenderer for product blocks.
+ */
+class ProductCollectionEmailRendererRegistrar {
+  private const PRODUCT_BLOCK_NAMES = [
+    'woocommerce/product-collection',
+    'woocommerce/product-image',
+    'woocommerce/product-price',
+    'woocommerce/product-button',
+    'woocommerce/product-sale-badge',
+  ];
+
+  private WPFunctions $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function init(): void {
+    if (!class_exists(Rendering_Context::class) || !class_exists(Email_Editor_Container::class)) {
+      return;
+    }
+
+    $this->wp->addAction('woocommerce_email_editor_render_start', [$this, 'registerEmailRenderers']);
+  }
+
+  public function registerEmailRenderers(): void {
+    if (!class_exists(\WP_Block_Type_Registry::class) || !class_exists(WooCommerceBlocksInitializer::class)) {
+      return;
+    }
+
+    $renderer = $this->getWooCommerceBlocksRenderer();
+    if (!$renderer) {
+      return;
+    }
+
+    $renderEmailCallbackProperty = 'render_email_callback';
+    $registry = \WP_Block_Type_Registry::get_instance();
+    foreach (self::PRODUCT_BLOCK_NAMES as $blockName) {
+      $blockType = $registry->get_registered($blockName);
+      if (!$blockType) {
+        continue;
+      }
+
+      $currentCallback = get_object_vars($blockType)[$renderEmailCallbackProperty] ?? null;
+      if (!$this->needsEmailRenderer($currentCallback)) {
+        continue;
+      }
+
+      // @phpstan-ignore-next-line -- WooCommerce email editor reads this dynamic block setting.
+      $blockType->{$renderEmailCallbackProperty} = [$renderer, 'render_block'];
+    }
+  }
+
+  private function getWooCommerceBlocksRenderer(): ?WooCommerceBlocksInitializer {
+    try {
+      return Email_Editor_Container::container()->get(WooCommerceBlocksInitializer::class);
+    } catch (\Throwable $e) {
+      return null;
+    }
+  }
+
+  /**
+   * Only fill the gap when no renderer is wired yet. An existing callback, whether
+   * WooCommerce's own or a custom one from another integration, is left untouched.
+   *
+   * @param mixed $currentCallback
+   */
+  public function needsEmailRenderer($currentCallback): bool {
+    return $currentCallback === null;
+  }
+}

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -111,9 +111,15 @@ class Renderer {
         return array_merge($context, $renderContext);
       };
       $orderProductsFilter = null;
+      $abandonedCartPersistentCartFilter = null;
 
       try {
         $this->wp->addFilter('woocommerce_email_editor_rendering_email_context', $filterCallback);
+        $abandonedCartPersistentCartFilter = $this->orderProductCollectionProcessor
+          ->createAbandonedCartPersistentCartFilter($renderContext, $sendingQueue);
+        if ($abandonedCartPersistentCartFilter) {
+          $this->wp->addFilter('get_user_metadata', $abandonedCartPersistentCartFilter, 10, 4);
+        }
         $orderProductsFilter = $this->orderProductCollectionProcessor->createBlocksFilter($renderContext);
         if ($orderProductsFilter) {
           $this->wp->addFilter('woocommerce_email_blocks_renderer_parsed_blocks', $orderProductsFilter);
@@ -134,6 +140,9 @@ class Renderer {
         $this->wp->removeFilter('woocommerce_email_editor_rendering_email_context', $filterCallback);
         if ($orderProductsFilter) {
           $this->wp->removeFilter('woocommerce_email_blocks_renderer_parsed_blocks', $orderProductsFilter);
+        }
+        if ($abandonedCartPersistentCartFilter) {
+          $this->wp->removeFilter('get_user_metadata', $abandonedCartPersistentCartFilter);
         }
         $this->couponBlockFailureCollector->clear();
       }

--- a/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/Coupons/EmailContextBuilderTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/Coupons/EmailContextBuilderTest.php
@@ -42,6 +42,18 @@ class EmailContextBuilderTest extends \MailPoetUnitTest {
     verify($context['is_single_recipient'])->true();
   }
 
+  public function testItAddsUserIdForSingleRecipientAutomationLinkedToWpUser(): void {
+    $builder = new EmailContextBuilder($this->makeWpFunctions());
+
+    $context = $builder->build(
+      $this->makeNewsletter(NewsletterEntity::TYPE_AUTOMATION),
+      $this->makeSendingQueue('subscriber@example.com', 123),
+      false
+    );
+
+    verify($context['user_id'])->equals(123);
+  }
+
   private function makeNewsletter(string $type): NewsletterEntity {
     return $this->make(NewsletterEntity::class, [
       'getId' => 1,
@@ -49,9 +61,10 @@ class EmailContextBuilderTest extends \MailPoetUnitTest {
     ]);
   }
 
-  private function makeSendingQueue(string $subscriberEmail): SendingQueueEntity {
+  private function makeSendingQueue(string $subscriberEmail, ?int $wpUserId = null): SendingQueueEntity {
     $subscriber = $this->make(SubscriberEntity::class, [
       'getEmail' => $subscriberEmail,
+      'getWpUserId' => $wpUserId,
     ]);
     $taskSubscriber = $this->make(ScheduledTaskSubscriberEntity::class, [
       'getSubscriber' => $subscriber,

--- a/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/ProductCollection/OrderProductCollectionProcessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/ProductCollection/OrderProductCollectionProcessorTest.php
@@ -2,7 +2,9 @@
 
 namespace unit\EmailEditor\Integrations\MailPoet\ProductCollection;
 
+use MailPoet\AutomaticEmails\WooCommerce\Events\AbandonedCart;
 use MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor;
+use MailPoet\Entities\SendingQueueEntity;
 
 class OrderProductCollectionProcessorTest extends \MailPoetUnitTest {
   /** @var OrderProductCollectionProcessor */
@@ -17,5 +19,69 @@ class OrderProductCollectionProcessorTest extends \MailPoetUnitTest {
     $this->assertNull($this->processor->createBlocksFilter([]));
     $this->assertNull($this->processor->createBlocksFilter(['order' => null]));
     $this->assertNull($this->processor->createBlocksFilter(['order' => new \stdClass()]));
+  }
+
+  public function testCreateAbandonedCartPersistentCartFilterReturnsNullWithoutUserId(): void {
+    $queue = $this->makeQueue([AbandonedCart::TASK_META_NAME => [11]]);
+
+    $this->assertNull($this->processor->createAbandonedCartPersistentCartFilter([], $queue));
+    $this->assertNull($this->processor->createAbandonedCartPersistentCartFilter(['user_id' => 0], $queue));
+  }
+
+  public function testCreateAbandonedCartPersistentCartFilterReturnsNullWithoutProducts(): void {
+    $this->assertNull($this->processor->createAbandonedCartPersistentCartFilter(['user_id' => 123], null));
+    $this->assertNull($this->processor->createAbandonedCartPersistentCartFilter(
+      ['user_id' => 123],
+      $this->makeQueue([])
+    ));
+    $this->assertNull($this->processor->createAbandonedCartPersistentCartFilter(
+      ['user_id' => 123],
+      $this->makeQueue([AbandonedCart::TASK_META_NAME => []])
+    ));
+  }
+
+  public function testAbandonedCartPersistentCartFilterExposesQueueProductIdsForMatchingUser(): void {
+    $filter = $this->processor->createAbandonedCartPersistentCartFilter(
+      ['user_id' => 123],
+      $this->makeQueue([AbandonedCart::TASK_META_NAME => ['11', 12, 'invalid', 0, 11]])
+    );
+    $this->assertIsCallable($filter);
+
+    $result = $filter(null, 123, '_woocommerce_persistent_cart_1', true);
+
+    // The filter returns a single-element value list. WooCommerce reads the
+    // persistent cart with $single = true, so get_metadata_raw() unwraps this
+    // to the cart via its $check[0] branch.
+    $this->assertSame([
+      [
+        'cart' => [
+          'mailpoet_abandoned_cart_0' => ['product_id' => 11],
+          'mailpoet_abandoned_cart_1' => ['product_id' => 12],
+        ],
+      ],
+    ], $result);
+  }
+
+  public function testAbandonedCartPersistentCartFilterLeavesUnrelatedMetadataUntouched(): void {
+    $filter = $this->processor->createAbandonedCartPersistentCartFilter(
+      ['user_id' => 123],
+      $this->makeQueue([AbandonedCart::TASK_META_NAME => [11]])
+    );
+    $this->assertIsCallable($filter);
+
+    $this->assertSame(
+      'existing',
+      $filter('existing', 456, '_woocommerce_persistent_cart_1', true)
+    );
+    $this->assertSame('existing', $filter('existing', 123, 'first_name', true));
+  }
+
+  /**
+   * @param array<string, mixed> $meta
+   */
+  private function makeQueue(array $meta): SendingQueueEntity {
+    return $this->make(SendingQueueEntity::class, [
+      'getMeta' => $meta,
+    ]);
   }
 }

--- a/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/ProductCollection/ProductCollectionEmailRendererRegistrarTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/ProductCollection/ProductCollectionEmailRendererRegistrarTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace unit\EmailEditor\Integrations\MailPoet\ProductCollection;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\ProductCollectionEmailRendererRegistrar;
+use MailPoet\WP\Functions as WPFunctions;
+
+class ProductCollectionEmailRendererRegistrarTest extends \MailPoetUnitTest {
+  /** @var ProductCollectionEmailRendererRegistrar */
+  private $registrar;
+
+  public function _before() {
+    parent::_before();
+    $this->registrar = new ProductCollectionEmailRendererRegistrar($this->makeEmpty(WPFunctions::class));
+  }
+
+  public function testItRegistersTheRendererOnlyWhenNoCallbackIsWired(): void {
+    verify($this->registrar->needsEmailRenderer(null))->true();
+  }
+
+  public function testItLeavesAnExistingCallbackUntouched(): void {
+    // A callback already set by WooCommerce or another integration must be preserved.
+    verify($this->registrar->needsEmailRenderer([$this, 'testItLeavesAnExistingCallbackUntouched']))->false();
+    verify($this->registrar->needsEmailRenderer('strlen'))->false();
+    verify($this->registrar->needsEmailRenderer(function () {
+    }))->false();
+  }
+}


### PR DESCRIPTION
## Description

Fixes abandoned cart block editor emails so the WooCommerce cart contents block can render the cart product snapshot captured by MailPoet.

## Code review notes

The cart contents collection slug is kept intact so WooCommerce still renders the checkout CTA. MailPoet exposes the queued cart products through a temporary persistent-cart metadata filter during rendering.

## QA notes

Targeted unit tests, Prettier, and changed-file PHPCS passed. Full `./do qa` was attempted; PHP lint passed, then PHPCS scanned pre-existing local `tests/plugins` fixtures and the QA wrapper exhausted memory while buffering that output.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8199

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

| Before | After | 
| ---- | ---- | 
| <img width="591" height="462" alt="Screenshot 2026-06-25 at 10 35 13" src="https://github.com/user-attachments/assets/e7a500f7-b880-45f5-9fef-9959ed22c156" /> | <img width="698" height="413" alt="Screenshot 2026-06-25 at 12 19 46" src="https://github.com/user-attachments/assets/646ae673-96e2-4090-a7d3-fa560704d09d" /> | 

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8199-fix-empty-abandoned-cart-products-in-block-editor-emails)

_The latest successful build from `stomail-8199-fix-empty-abandoned-cart-products-in-block-editor-emails` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->