### PR TITLE
Show automation email previews in a modal

### DIFF
--- a/mailpoet/assets/css/src/components-automation-integrations/mailpoet/_edit.scss
+++ b/mailpoet/assets/css/src/components-automation-integrations/mailpoet/_edit.scss
@@ -44,3 +44,42 @@
   display: block;
   margin-top: 8px;
 }
+
+.mailpoet-automation-email-preview-modal.components-modal__frame {
+  height: min(860px, calc(100vh - 64px));
+  max-height: calc(100vh - 64px);
+  max-width: calc(100vw - 64px);
+  width: min(960px, calc(100vw - 64px));
+
+  .components-modal__content {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    margin-top: 0;
+    padding: 0;
+  }
+}
+
+.mailpoet-automation-email-preview-modal-content {
+  background: #f0f0f1;
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
+.mailpoet-automation-email-preview-modal-spinner {
+  align-items: center;
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  position: absolute;
+}
+
+.mailpoet-automation-email-preview-modal-iframe {
+  background: #fff;
+  border: 0;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+}

--- a/mailpoet/assets/css/src/components-automation-integrations/mailpoet/_edit.scss
+++ b/mailpoet/assets/css/src/components-automation-integrations/mailpoet/_edit.scss
@@ -51,12 +51,21 @@
   max-width: calc(100vw - 64px);
   width: min(960px, calc(100vw - 64px));
 
+  .components-modal__header {
+    position: relative;
+  }
+
   .components-modal__content {
     display: flex;
     flex-direction: column;
     height: 100%;
     margin-top: 0;
     padding: 0;
+  }
+
+  .components-modal__children-container {
+    display: flex;
+    flex: 1;
   }
 }
 

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/context.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/context.ts
@@ -1,7 +1,7 @@
 import { select, dispatch, useSelect } from '@wordpress/data';
-import { FormTokenItem } from '../../editor/components';
-import { storeName } from '../../editor/store';
-import { SenderRestrictionsType } from '../../../common';
+import { storeName } from '../../editor/store/constants';
+import type { FormTokenItem } from '../../editor/components';
+import type { SenderRestrictionsType } from '../../../common';
 
 type Segment = FormTokenItem & {
   type: string;

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
@@ -435,6 +435,7 @@ export function EditNewsletter(): JSX.Element {
 
   useEffect(() => {
     setPreviewUrl(null);
+    setFetchingPreviewLink(false);
   }, [emailId]);
 
   const handleDuplicatedStep =

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
@@ -1,12 +1,13 @@
 import { dispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
+import { Modal, Spinner } from '@wordpress/components';
 import classnames from 'classnames';
-import { useCallback, useId, useState } from 'react';
+import { useCallback, useEffect, useId, useState } from 'react';
 import { store as noticesStore } from '@wordpress/notices';
 import { Button } from '../../../components/button';
 import { useSelectContext } from '../../../context';
-import { storeName } from '../../../../../editor/store';
+import { storeName } from '../../../../../editor/store/constants';
 import { MailPoet } from '../../../../../../mailpoet';
 import type {
   CreatedAutomationEmail,
@@ -24,8 +25,27 @@ type HandleDuplicatedStepType = {
   newEmailWpPostId?: number;
 };
 
-const emailPreviewLinkCache = {};
-const retrievePreviewLink = async (emailId) => {
+type EmailPreviewResponse = {
+  meta?: {
+    preview_url?: unknown;
+  };
+};
+
+const emailPreviewLinkCache: Record<number, string> = {};
+export const getPreviewUrlFromResponse = (
+  response: EmailPreviewResponse,
+): string =>
+  typeof response?.meta?.preview_url === 'string'
+    ? response.meta.preview_url
+    : '';
+
+export const retrievePreviewLink = async (
+  emailId?: number,
+): Promise<string> => {
+  if (!emailId) {
+    throw new Error('Missing email ID');
+  }
+
   if (
     emailPreviewLinkCache[emailId] &&
     emailPreviewLinkCache[emailId].length > 0
@@ -40,7 +60,11 @@ const retrievePreviewLink = async (emailId) => {
       id: emailId,
     },
   });
-  emailPreviewLinkCache[emailId] = response?.meta?.preview_url ?? '';
+  const previewUrl = getPreviewUrlFromResponse(response);
+  if (!previewUrl) {
+    throw new Error('Missing preview URL');
+  }
+  emailPreviewLinkCache[emailId] = previewUrl;
   return emailPreviewLinkCache[emailId];
 };
 
@@ -67,6 +91,39 @@ function EmailIdValidationMessage({
     <span className="mailpoet-automation-field-message" role="alert">
       {message}
     </span>
+  );
+}
+
+function EmailPreviewModal({
+  previewUrl,
+  onClose,
+}: {
+  previewUrl: string;
+  onClose: () => void;
+}): JSX.Element {
+  const [iframeLoaded, setIframeLoaded] = useState(false);
+
+  return (
+    <Modal
+      className="mailpoet-automation-email-preview-modal"
+      title={__('Email preview', 'mailpoet')}
+      onRequestClose={onClose}
+    >
+      <div className="mailpoet-automation-email-preview-modal-content">
+        {!iframeLoaded && (
+          <div className="mailpoet-automation-email-preview-modal-spinner">
+            <Spinner />
+          </div>
+        )}
+        <iframe
+          className="mailpoet-automation-email-preview-modal-iframe"
+          data-automation-id="automation_send_email_preview_iframe"
+          onLoad={() => setIframeLoaded(true)}
+          src={previewUrl}
+          title={__('Email preview', 'mailpoet')}
+        />
+      </div>
+    </Modal>
   );
 }
 
@@ -133,6 +190,7 @@ export function EditNewsletter(): JSX.Element {
   const [fetchingPreviewLink, setFetchingPreviewLink] = useState(false);
   const [isHandlingDuplicatedStep, setIsHandlingDuplicatedStep] =
     useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const blockEmailEditorHelpId = useId();
   const { block_email_editor_enabled: blockEmailEditorEnabled = false } =
     useSelectContext();
@@ -185,6 +243,16 @@ export function EditNewsletter(): JSX.Element {
     },
     [showEditorChoiceError],
   );
+
+  const showPreviewError = useCallback(() => {
+    void dispatch(noticesStore).createErrorNotice(
+      __(
+        'MailPoet could not open the email preview. Please make sure the email still exists and try again.',
+        'mailpoet',
+      ),
+      { explicitDismiss: true },
+    );
+  }, []);
 
   const redirectToEmailEditor = useCallback(
     (createdEmail: CreatedAutomationEmail, editorChoice: EditorChoice) => {
@@ -341,9 +409,18 @@ export function EditNewsletter(): JSX.Element {
 
   const retrievePreviewLinkForEmail = useCallback(async () => {
     setFetchingPreviewLink(true);
-    const link = await retrievePreviewLink(emailId);
-    window.open(link as string, '_blank');
-    setFetchingPreviewLink(false);
+    try {
+      const link = await retrievePreviewLink(emailId);
+      setPreviewUrl(link);
+    } catch {
+      showPreviewError();
+    } finally {
+      setFetchingPreviewLink(false);
+    }
+  }, [emailId, showPreviewError]);
+
+  useEffect(() => {
+    setPreviewUrl(null);
   }, [emailId]);
 
   const handleDuplicatedStep =
@@ -494,36 +571,44 @@ export function EditNewsletter(): JSX.Element {
   }
 
   return (
-    <div
-      className={classnames({
-        'mailpoet-automation-field__error': hasEmailIdError,
-      })}
-    >
-      <div className="mailpoet-automation-email-buttons">
-        <Button
-          variant="sidebar-primary"
-          centered
-          onClick={() => {
-            void handleEditContent();
-          }}
-          isBusy={isHandlingDuplicatedStep}
-          disabled={isHandlingDuplicatedStep}
-        >
-          {__('Edit content', 'mailpoet')}
-        </Button>
-        <Button
-          variant="secondary"
-          centered
-          isBusy={fetchingPreviewLink}
-          disabled={fetchingPreviewLink}
-          onClick={() => void retrievePreviewLinkForEmail()}
-        >
-          {__('Preview', 'mailpoet')}
-        </Button>
+    <>
+      <div
+        className={classnames({
+          'mailpoet-automation-field__error': hasEmailIdError,
+        })}
+      >
+        <div className="mailpoet-automation-email-buttons">
+          <Button
+            variant="sidebar-primary"
+            centered
+            onClick={() => {
+              void handleEditContent();
+            }}
+            isBusy={isHandlingDuplicatedStep}
+            disabled={isHandlingDuplicatedStep}
+          >
+            {__('Edit content', 'mailpoet')}
+          </Button>
+          <Button
+            variant="secondary"
+            centered
+            isBusy={fetchingPreviewLink}
+            disabled={fetchingPreviewLink}
+            onClick={() => void retrievePreviewLinkForEmail()}
+          >
+            {__('Preview', 'mailpoet')}
+          </Button>
+        </div>
+        {hasEmailIdError && (
+          <EmailIdValidationMessage message={emailIdErrorMessage} />
+        )}
       </div>
-      {hasEmailIdError && (
-        <EmailIdValidationMessage message={emailIdErrorMessage} />
+      {previewUrl && (
+        <EmailPreviewModal
+          previewUrl={previewUrl}
+          onClose={() => setPreviewUrl(null)}
+        />
       )}
-    </div>
+    </>
   );
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
@@ -3,7 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { Modal, Spinner } from '@wordpress/components';
 import classnames from 'classnames';
-import { useCallback, useEffect, useId, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { store as noticesStore } from '@wordpress/notices';
 import { Button } from '../../../components/button';
 import { useSelectContext } from '../../../context';
@@ -407,15 +407,29 @@ export function EditNewsletter(): JSX.Element {
     ],
   );
 
+  const emailIdRef = useRef(emailId);
+  useEffect(() => {
+    emailIdRef.current = emailId;
+  }, [emailId]);
+
   const retrievePreviewLinkForEmail = useCallback(async () => {
+    const requestedEmailId = emailId;
     setFetchingPreviewLink(true);
     try {
-      const link = await retrievePreviewLink(emailId);
+      const link = await retrievePreviewLink(requestedEmailId);
+      if (emailIdRef.current !== requestedEmailId) {
+        return;
+      }
       setPreviewUrl(link);
     } catch {
+      if (emailIdRef.current !== requestedEmailId) {
+        return;
+      }
       showPreviewError();
     } finally {
-      setFetchingPreviewLink(false);
+      if (emailIdRef.current === requestedEmailId) {
+        setFetchingPreviewLink(false);
+      }
     }
   }, [emailId, showPreviewError]);
 

--- a/mailpoet/changelog/2026-06-19-22-03-55-improved-preview-automation-emails-without-leaving-the-auto.md
+++ b/mailpoet/changelog/2026-06-19-22-03-55-improved-preview-automation-emails-without-leaving-the-auto.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Preview automation emails without leaving the automation editor

--- a/mailpoet/tests/javascript/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.spec.ts
+++ b/mailpoet/tests/javascript/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.spec.ts
@@ -285,6 +285,43 @@ describe('automation send email editor preview', function automationSendEmailEdi
     expect(windowOpenStub.notCalled).to.equal(true);
   });
 
+  it('re-enables the preview button when the email changes mid-request', async () => {
+    setSelectedStep(555);
+    let resolvePreview: (value: unknown) => void = () => undefined;
+    ajaxPostStub.returns(
+      new Promise((resolve) => {
+        resolvePreview = resolve;
+      }),
+    );
+    await renderEditNewsletter();
+
+    await clickPreview();
+
+    const findPreviewButton = () =>
+      Array.from(document.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Preview',
+      );
+    expect(findPreviewButton().disabled).to.equal(true);
+
+    setSelectedStep(999);
+    await React.act(async () => {
+      root.render(React.createElement(editNewsletter.EditNewsletter));
+    });
+
+    await React.act(async () => {
+      resolvePreview({ meta: { preview_url: '/mailpoet-preview' } });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(findPreviewButton().disabled).to.equal(false);
+    expect(
+      document.querySelector(
+        '[data-automation-id="automation_send_email_preview_iframe"]',
+      ),
+    ).to.equal(null);
+  });
+
   it('shows an error notice when the preview URL is missing', async () => {
     setSelectedStep(789);
     ajaxPostStub.resolves({ meta: {} });

--- a/mailpoet/tests/javascript/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.spec.ts
+++ b/mailpoet/tests/javascript/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.spec.ts
@@ -1,0 +1,305 @@
+import { JSDOM } from 'jsdom';
+import NodeModule from 'module';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import sinon from 'sinon';
+
+type Step = {
+  id: string;
+  type: string;
+  key: string;
+  args: Record<string, unknown>;
+  next_steps: unknown[];
+};
+
+type EditNewsletterModule = {
+  EditNewsletter: React.ComponentType;
+};
+
+type ModuleLoader = (
+  request: string,
+  parent: unknown,
+  isMain: boolean,
+) => unknown;
+
+type ModuleWithLoader = Record<string, ModuleLoader>;
+type FakeButtonProps = {
+  children?: React.ReactNode;
+  disabled?: boolean;
+  onClick?: () => void;
+};
+type FakeModalProps = {
+  children?: React.ReactNode;
+  onRequestClose?: () => void;
+  title?: string;
+};
+type SelectMapper = (select: () => ReturnType<typeof getSelectors>) => unknown;
+type TestRequire = (path: string) => unknown;
+
+const moduleLoadProperty = '_load';
+const testRequire = (
+  NodeModule as unknown as { createRequire: (path: string) => TestRequire }
+).createRequire(`${process.cwd()}/package.json`);
+const noticesStore = { name: 'notices' };
+let createErrorNoticeStub: sinon.SinonStub;
+let dom: JSDOM;
+let editNewsletter: EditNewsletterModule;
+let originalModuleLoad: ModuleLoader;
+let root: ReturnType<typeof createRoot>;
+let rootElement: HTMLDivElement;
+let selectedStep: Step;
+let ajaxPostStub: sinon.SinonStub;
+let windowOpenStub: sinon.SinonStub;
+
+const setupWindow = () => {
+  dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'https://example.com/wp-admin/admin.php',
+  });
+
+  global.window = dom.window as unknown as Window & typeof globalThis;
+  global.document = dom.window.document;
+  Object.defineProperty(global, 'navigator', {
+    configurable: true,
+    value: dom.window.navigator,
+  });
+  global.HTMLElement = dom.window.HTMLElement;
+  global.Element = dom.window.Element;
+  global.Node = dom.window.Node;
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+
+  Object.assign(window, {
+    mailpoet_api_version: 'v1',
+    mailpoet_feature_flags: {},
+  });
+};
+
+const getSelectors = () => ({
+  getAutomationData: () => ({ id: 12 }),
+  getContext: (key: string) =>
+    key === 'mailpoet' ? { block_email_editor_enabled: true } : undefined,
+  getSelectedStep: () => selectedStep,
+  getStepError: () => undefined,
+});
+
+const fakeMailPoet = {
+  Ajax: {
+    post: (...args: unknown[]): Promise<unknown> =>
+      ajaxPostStub(...args) as Promise<unknown>,
+  },
+  getBlockEmailEditorUrl: (postId: number) =>
+    `post.php?post=${postId}&action=edit`,
+  getNewsletterEditorUrl: (newsletterId: number, context: string) =>
+    `admin.php?page=mailpoet-newsletter-editor&id=${newsletterId}&context=${context}`,
+};
+
+function FakeButton({
+  children,
+  disabled = false,
+  onClick = undefined,
+}: FakeButtonProps): JSX.Element {
+  return React.createElement(
+    'button',
+    { disabled, onClick, type: 'button' },
+    children,
+  );
+}
+
+function FakeModal({
+  children,
+  onRequestClose = undefined,
+  title = '',
+}: FakeModalProps): JSX.Element {
+  return React.createElement(
+    'div',
+    { role: 'dialog' },
+    React.createElement('h1', {}, title),
+    React.createElement(
+      'button',
+      { onClick: onRequestClose, type: 'button' },
+      'Close',
+    ),
+    children,
+  );
+}
+
+function FakeSpinner(): JSX.Element {
+  return React.createElement('span', {
+    'data-automation-id': 'automation_send_email_preview_spinner',
+  });
+}
+
+const installModuleMocks = () => {
+  const moduleWithLoader = NodeModule as unknown as ModuleWithLoader;
+  originalModuleLoad = moduleWithLoader[moduleLoadProperty];
+  moduleWithLoader[moduleLoadProperty] = function loadModule(
+    request: string,
+    parent: unknown,
+    isMain: boolean,
+  ) {
+    if (request === '@wordpress/components') {
+      return { Button: FakeButton, Modal: FakeModal, Spinner: FakeSpinner };
+    }
+
+    if (request === '@wordpress/data') {
+      return {
+        dispatch: (store: unknown) =>
+          store === noticesStore
+            ? { createErrorNotice: createErrorNoticeStub }
+            : {
+                save: () => Promise.resolve({ saved: true }),
+                updateStepArgs: () => undefined,
+              },
+        select: () => getSelectors(),
+        useSelect: (mapSelect: SelectMapper) => mapSelect(() => getSelectors()),
+      };
+    }
+
+    if (request === '@wordpress/i18n') {
+      return { __: (text: string) => text };
+    }
+
+    if (request === '@wordpress/icons') {
+      return { plus: 'plus' };
+    }
+
+    if (request === '@wordpress/notices') {
+      return { store: noticesStore };
+    }
+
+    if (request === '../../../../../../mailpoet') {
+      return { MailPoet: fakeMailPoet };
+    }
+
+    return originalModuleLoad.apply(this, [request, parent, isMain]);
+  };
+};
+
+const restoreModuleMocks = () => {
+  (NodeModule as unknown as ModuleWithLoader)[moduleLoadProperty] =
+    originalModuleLoad;
+};
+
+const loadModules = async () => {
+  editNewsletter = testRequire(
+    './assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx',
+  ) as EditNewsletterModule;
+};
+
+const setSelectedStep = (emailId: number) => {
+  selectedStep = {
+    id: 'step-1',
+    type: 'action',
+    key: 'mailpoet:send-email',
+    args: {
+      email_id: emailId,
+      email_wp_post_id: 456,
+    },
+    next_steps: [],
+  };
+};
+
+const renderEditNewsletter = async () => {
+  rootElement = document.createElement('div');
+  document.body.appendChild(rootElement);
+  root = createRoot(rootElement);
+
+  await React.act(async () => {
+    root.render(React.createElement(editNewsletter.EditNewsletter));
+  });
+};
+
+const clickPreview = async () => {
+  const previewButton = Array.from(document.querySelectorAll('button')).find(
+    (button) => button.textContent === 'Preview',
+  );
+  expect(previewButton).to.not.equal(undefined);
+
+  await React.act(async () => {
+    previewButton.dispatchEvent(
+      new window.MouseEvent('click', {
+        bubbles: true,
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe('automation send email editor preview', function automationSendEmailEditorPreview() {
+  this.timeout(20000);
+
+  before(async () => {
+    setupWindow();
+    installModuleMocks();
+    await loadModules();
+    restoreModuleMocks();
+  });
+
+  beforeEach(() => {
+    createErrorNoticeStub = sinon.stub();
+    ajaxPostStub = sinon.stub();
+    windowOpenStub = sinon.stub(window, 'open');
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await React.act(async () => {
+        root.unmount();
+      });
+    }
+    sinon.restore();
+    document.body.innerHTML = '';
+  });
+
+  after(() => {
+    dom.window.close();
+    [
+      'document',
+      'Element',
+      'HTMLElement',
+      'IS_REACT_ACT_ENVIRONMENT',
+      'navigator',
+      'Node',
+      'window',
+    ].forEach((property) => Reflect.deleteProperty(global, property));
+  });
+
+  it('opens block-editor automation email previews in a modal iframe', async () => {
+    setSelectedStep(123);
+    ajaxPostStub.resolves({ meta: { preview_url: '/mailpoet-preview' } });
+    await renderEditNewsletter();
+
+    await clickPreview();
+
+    const iframe = document.querySelector(
+      '[data-automation-id="automation_send_email_preview_iframe"]',
+    );
+    expect(iframe).to.not.equal(null);
+    expect(iframe.getAttribute('src')).to.equal('/mailpoet-preview');
+    expect(ajaxPostStub.calledOnce).to.equal(true);
+    expect(ajaxPostStub.firstCall.args[0]).to.deep.include({
+      action: 'get',
+      endpoint: 'newsletters',
+    });
+    expect(ajaxPostStub.firstCall.args[0].data).to.deep.equal({ id: 123 });
+    expect(windowOpenStub.notCalled).to.equal(true);
+  });
+
+  it('shows an error notice when the preview URL is missing', async () => {
+    setSelectedStep(789);
+    ajaxPostStub.resolves({ meta: {} });
+    await renderEditNewsletter();
+
+    await clickPreview();
+
+    expect(
+      document.querySelector(
+        '[data-automation-id="automation_send_email_preview_iframe"]',
+      ),
+    ).to.equal(null);
+    expect(createErrorNoticeStub.calledOnce).to.equal(true);
+    expect(createErrorNoticeStub.firstCall.args[0]).to.equal(
+      'MailPoet could not open the email preview. Please make sure the email still exists and try again.',
+    );
+  });
+});


### PR DESCRIPTION
## Description

Previously, previewing an automation email opened the preview in a new browser tab. This change shows the preview in a modal directly inside the automation editor, so users no longer leave the editor.

The preview URL is loaded into an iframe inside a `Modal`, with a loading spinner until the iframe finishes loading. The cached preview URL resets when the selected email changes. Failures (missing email/preview URL) now surface a dismissible error notice instead of opening a blank tab.

## Code review notes

_N/A_

## QA notes

1. Open an automation with a send-email step.
2. Click **Preview** — preview opens in a modal (not a new tab), spinner shows until loaded.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8131

## Screenshots

<img width="1548" height="1046" alt="Screenshot 2026-06-20 at 21 08 50" src="https://github.com/user-attachments/assets/81af317c-6382-4bc0-8142-8d46a4013df3" />

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8131-preview-automation-emails-from-the-automation-editor)

_The latest successful build from `stomail-8131-preview-automation-emails-from-the-automation-editor` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

1 issue found:

**Bug:** The `EmailPreviewModal` component's iframe lacks an error handler. The iframe element has only an `onLoad` handler but no `onError` handler. If the iframe fails to load due to network errors, CORS issues, or other problems, the loading spinner will display indefinitely with no indication to the user that an error occurred. While the user can close the modal via the X button, they receive no feedback about the failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->