### PR TITLE
Preview automation template email content before activation

### DIFF
--- a/mailpoet/assets/css/src/components-automation-integrations/mailpoet/_edit.scss
+++ b/mailpoet/assets/css/src/components-automation-integrations/mailpoet/_edit.scss
@@ -92,3 +92,15 @@
   min-height: 0;
   width: 100%;
 }
+
+.mailpoet-automation-email-preview-modal-error {
+  align-items: center;
+  background: #f0f0f1;
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  margin: 0;
+  padding: 24px;
+  position: absolute;
+  text-align: center;
+}

--- a/mailpoet/assets/css/src/mailpoet-automation-templates.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-templates.scss
@@ -105,6 +105,48 @@
   }
 }
 
+.mailpoet-automation-template-email-previews {
+  margin-top: 32px;
+}
+
+.mailpoet-automation-template-email-previews-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 12px;
+}
+
+.mailpoet-automation-template-email-previews-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.mailpoet-automation-template-email-previews-item {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  margin: 0;
+
+  .components-button {
+    flex-shrink: 0;
+    margin-left: auto;
+  }
+}
+
+.mailpoet-automation-template-email-previews-name {
+  flex: 1;
+  font-weight: 500;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.mailpoet-automation-template-email-previews-error {
+  color: #d63638;
+  flex-basis: 100%;
+  font-size: 12px;
+}
+
 .mailpoet-automation-template-detail-preview-spinner {
   margin: auto;
 

--- a/mailpoet/assets/js/src/automation/components/email-preview-modal/index.tsx
+++ b/mailpoet/assets/js/src/automation/components/email-preview-modal/index.tsx
@@ -1,0 +1,83 @@
+import { Modal, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from 'react';
+
+const EMAIL_PREVIEW_LOAD_TIMEOUT = 15000;
+
+type Props = {
+  onClose: () => void;
+  title?: string;
+  // Provide exactly one source: a URL to load (`src`) or inline HTML (`srcDoc`).
+  src?: string;
+  srcDoc?: string;
+};
+
+export function EmailPreviewModal({
+  onClose,
+  title,
+  src,
+  srcDoc,
+}: Props): JSX.Element {
+  const [iframeLoaded, setIframeLoaded] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const modalTitle = title ?? __('Email preview', 'mailpoet');
+
+  // When the source changes, show the loading state again until the iframe
+  // reloads, instead of keeping the previous content's loaded/error state.
+  useEffect(() => {
+    setIframeLoaded(false);
+    setHasError(false);
+  }, [src, srcDoc]);
+
+  useEffect(() => {
+    if (iframeLoaded) {
+      return undefined;
+    }
+    const timeout = window.setTimeout(
+      () => setHasError(true),
+      EMAIL_PREVIEW_LOAD_TIMEOUT,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [iframeLoaded]);
+
+  return (
+    <Modal
+      className="mailpoet-automation-email-preview-modal"
+      title={modalTitle}
+      onRequestClose={onClose}
+    >
+      <div className="mailpoet-automation-email-preview-modal-content">
+        {hasError && (
+          <p
+            className="mailpoet-automation-email-preview-modal-error"
+            role="alert"
+          >
+            {__(
+              'MailPoet could not load the email preview. Please make sure the email still exists and try again.',
+              'mailpoet',
+            )}
+          </p>
+        )}
+        {!iframeLoaded && !hasError && (
+          <div className="mailpoet-automation-email-preview-modal-spinner">
+            <Spinner />
+          </div>
+        )}
+        {/* The iframe stays mounted while loading so a slow load is never torn
+            down; onLoad clears a timeout-triggered error if it eventually loads. */}
+        <iframe
+          className="mailpoet-automation-email-preview-modal-iframe"
+          data-automation-id="automation_send_email_preview_iframe"
+          onLoad={() => {
+            setIframeLoaded(true);
+            setHasError(false);
+          }}
+          onError={() => setHasError(true)}
+          src={src}
+          srcDoc={srcDoc}
+          title={modalTitle}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
@@ -1,11 +1,11 @@
 import { dispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
-import { Modal, Spinner } from '@wordpress/components';
 import classnames from 'classnames';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { store as noticesStore } from '@wordpress/notices';
 import { Button } from '../../../components/button';
+import { EmailPreviewModal } from '../../../../../components/email-preview-modal';
 import { useSelectContext } from '../../../context';
 import { storeName } from '../../../../../editor/store/constants';
 import { MailPoet } from '../../../../../../mailpoet';
@@ -91,39 +91,6 @@ function EmailIdValidationMessage({
     <span className="mailpoet-automation-field-message" role="alert">
       {message}
     </span>
-  );
-}
-
-function EmailPreviewModal({
-  previewUrl,
-  onClose,
-}: {
-  previewUrl: string;
-  onClose: () => void;
-}): JSX.Element {
-  const [iframeLoaded, setIframeLoaded] = useState(false);
-
-  return (
-    <Modal
-      className="mailpoet-automation-email-preview-modal"
-      title={__('Email preview', 'mailpoet')}
-      onRequestClose={onClose}
-    >
-      <div className="mailpoet-automation-email-preview-modal-content">
-        {!iframeLoaded && (
-          <div className="mailpoet-automation-email-preview-modal-spinner">
-            <Spinner />
-          </div>
-        )}
-        <iframe
-          className="mailpoet-automation-email-preview-modal-iframe"
-          data-automation-id="automation_send_email_preview_iframe"
-          onLoad={() => setIframeLoaded(true)}
-          src={previewUrl}
-          title={__('Email preview', 'mailpoet')}
-        />
-      </div>
-    </Modal>
   );
 }
 
@@ -620,7 +587,7 @@ export function EditNewsletter(): JSX.Element {
       </div>
       {previewUrl && (
         <EmailPreviewModal
-          previewUrl={previewUrl}
+          src={previewUrl}
           onClose={() => setPreviewUrl(null)}
         />
       )}

--- a/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-detail.tsx
@@ -13,6 +13,7 @@ import { chevronLeft, chevronRight, caution } from '@wordpress/icons';
 import { Tag } from '@woocommerce/components';
 import { addQueryArgs } from '@wordpress/url';
 import { TemplatePreview } from './template-preview';
+import { TemplateEmailPreviews } from './template-email-previews';
 import { AutomationTemplate, automationTemplateCategories } from '../config';
 import { MailPoet } from '../../../mailpoet';
 
@@ -85,6 +86,7 @@ export const TemplateDetail = forwardRef<HTMLDivElement, Props>(
             <Tag label={getCategory(template)} />
             <h1>{template.name}</h1>
             {template.description}
+            <TemplateEmailPreviews templateSlug={template.slug} />
           </div>
           <div className="mailpoet-automation-template-detail-preview">
             <TemplatePreview template={template} />

--- a/mailpoet/assets/js/src/automation/templates/components/template-email-previews.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-email-previews.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import { Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { storeName } from '../../editor/store';
+import { EmailPreviewModal } from '../../components/email-preview-modal';
+import { Step as StepData } from '../../editor/components/automation/types';
+
+const SEND_EMAIL_STEP_KEY = 'mailpoet:send-email';
+
+type PreviewableEmail = {
+  stepId: string;
+  name: string;
+  subject: string;
+  preheader: string;
+  pattern: string;
+};
+
+type Props = {
+  // Used to reset preview state when the detail modal switches templates.
+  templateSlug: string;
+};
+
+export function TemplateEmailPreviews({
+  templateSlug,
+}: Props): JSX.Element | null {
+  const requestVersionRef = useRef(0);
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null);
+  const [loadingStepId, setLoadingStepId] = useState<string | null>(null);
+  const [errorStepId, setErrorStepId] = useState<string | null>(null);
+
+  // Close any open preview and clear transient state when the template changes,
+  // so a stale modal/error from the previous template is never shown. Bumping
+  // the request version also invalidates any in-flight preview request.
+  useEffect(() => {
+    requestVersionRef.current += 1;
+    setPreviewHtml(null);
+    setLoadingStepId(null);
+    setErrorStepId(null);
+  }, [templateSlug]);
+
+  const emails = useSelect((select): PreviewableEmail[] => {
+    const store = select(storeName);
+    if (!store || typeof store.getAutomationData !== 'function') {
+      return [];
+    }
+    const steps: Record<string, StepData> =
+      store.getAutomationData()?.steps ?? {};
+    return Object.values(steps)
+      .filter(
+        (step) =>
+          step.key === SEND_EMAIL_STEP_KEY &&
+          typeof step.args?.pattern === 'string' &&
+          step.args.pattern !== '',
+      )
+      .map((step) => ({
+        stepId: step.id,
+        name: String(step.args?.name ?? ''),
+        subject: String(step.args?.subject ?? ''),
+        preheader: String(step.args?.preheader ?? ''),
+        pattern: String(step.args?.pattern ?? ''),
+      }));
+  }, []);
+
+  if (emails.length === 0) {
+    return null;
+  }
+
+  const openPreview = async (email: PreviewableEmail): Promise<void> => {
+    requestVersionRef.current += 1;
+    const requestVersion = requestVersionRef.current;
+    setLoadingStepId(email.stepId);
+    setErrorStepId(null);
+    // Drop any previously shown email so the modal never displays a stale
+    // preview while the new request is in flight.
+    setPreviewHtml(null);
+    try {
+      const path = addQueryArgs('/automation-template-email-preview', {
+        pattern: email.pattern,
+        subject: email.subject,
+        preheader: email.preheader,
+      });
+      const response = await apiFetch<{ data: { html: string } }>({
+        path,
+        method: 'GET',
+      });
+      // Ignore responses for a superseded template or preview request.
+      if (requestVersion !== requestVersionRef.current) {
+        return;
+      }
+      setPreviewHtml(response.data.html);
+    } catch (error) {
+      if (requestVersion !== requestVersionRef.current) {
+        return;
+      }
+      setErrorStepId(email.stepId);
+    } finally {
+      if (requestVersion === requestVersionRef.current) {
+        setLoadingStepId(null);
+      }
+    }
+  };
+
+  return (
+    <div className="mailpoet-automation-template-email-previews">
+      <h3 className="mailpoet-automation-template-email-previews-title">
+        {__('Email content', 'mailpoet')}
+      </h3>
+      <ul className="mailpoet-automation-template-email-previews-list">
+        {emails.map((email, index) => (
+          <li
+            key={email.stepId}
+            className="mailpoet-automation-template-email-previews-item"
+          >
+            <span className="mailpoet-automation-template-email-previews-name">
+              {email.name ||
+                // translators: %d is the position of the email in the template.
+                sprintf(__('Email %d', 'mailpoet'), index + 1)}
+            </span>
+            <Button
+              variant="secondary"
+              isBusy={loadingStepId === email.stepId}
+              disabled={loadingStepId !== null}
+              onClick={() => void openPreview(email)}
+            >
+              {__('Preview', 'mailpoet')}
+            </Button>
+            {errorStepId === email.stepId && (
+              <span
+                className="mailpoet-automation-template-email-previews-error"
+                role="alert"
+              >
+                {__(
+                  'Could not load the preview. Please try again.',
+                  'mailpoet',
+                )}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+      {previewHtml !== null && (
+        <EmailPreviewModal
+          srcDoc={previewHtml}
+          onClose={() => setPreviewHtml(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { Spinner } from '@wordpress/components';
-import { dispatch, useSelect } from '@wordpress/data';
+import { dispatch, select as wpSelect, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, caution } from '@wordpress/icons';
 import { Hooks } from 'wp-js-hooks';
@@ -76,6 +76,14 @@ export function TemplatePreview({ template }: Props): JSX.Element {
       initializeHooks();
       createStore();
       initializeIntegrations();
+
+      // Clear the previously loaded template's steps so the email preview list
+      // does not show stale emails while the new template is being fetched.
+      const currentAutomation = wpSelect(storeName).getAutomationData();
+      void dispatch(storeName).updateAutomation({
+        ...currentAutomation,
+        steps: {},
+      });
 
       try {
         const path = addQueryArgs(`/automation-templates/${template.slug}`, {

--- a/mailpoet/changelog/2026-06-20-21-06-39-added-preview-of-an-automation-templates-pre-built-email.md
+++ b/mailpoet/changelog/2026-06-20-21-06-39-added-preview-of-an-automation-templates-pre-built-email.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Preview of an automation template's pre-built email content before starting to build

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationTemplateEmailPreviewEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationTemplateEmailPreviewEndpoint.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Endpoints\Automations;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Integrations\MailPoet\Templates\TemplateEmailPreviewRenderer;
+use MailPoet\Validator\Builder;
+
+class AutomationTemplateEmailPreviewEndpoint extends Endpoint {
+  /** @var TemplateEmailPreviewRenderer */
+  private $previewRenderer;
+
+  public function __construct(
+    TemplateEmailPreviewRenderer $previewRenderer
+  ) {
+    $this->previewRenderer = $previewRenderer;
+  }
+
+  public function handle(Request $request): Response {
+    /** @var string|null $patternParam - for PHPStan because strval() doesn't accept a value of mixed */
+    $patternParam = $request->getParam('pattern');
+    $pattern = strval($patternParam);
+    /** @var string|null $subjectParam */
+    $subjectParam = $request->getParam('subject');
+    $subject = strval($subjectParam ?? '');
+    /** @var string|null $preheaderParam */
+    $preheaderParam = $request->getParam('preheader');
+    $preheader = strval($preheaderParam ?? '');
+
+    $html = $this->previewRenderer->render($pattern, $subject, $preheader);
+    if ($html === null) {
+      throw Exceptions::automationTemplateEmailPatternNotFound($pattern);
+    }
+
+    return new Response(['html' => $html]);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'pattern' => Builder::string()->required(),
+      'subject' => Builder::string(),
+      'preheader' => Builder::string(),
+    ];
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -10,6 +10,7 @@ use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsDeleteEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsDuplicateEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsGetEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsPutEndpoint;
+use MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplateEmailPreviewEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplateGetEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplatesGetEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationVersionsGetEndpoint;
@@ -86,6 +87,7 @@ class Engine {
       $api->registerPostRoute('automations/(?P<id>\d+)/duplicate', AutomationsDuplicateEndpoint::class);
       $api->registerPostRoute('automations/create-from-template', AutomationsCreateFromTemplateEndpoint::class);
       $api->registerGetRoute('automation-templates', AutomationTemplatesGetEndpoint::class);
+      $api->registerGetRoute('automation-template-email-preview', AutomationTemplateEmailPreviewEndpoint::class);
       $api->registerGetRoute('automation-templates/(?P<slug>.+)', AutomationTemplateGetEndpoint::class);
     });
   }

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -37,6 +37,7 @@ class Exceptions {
   private const MISSING_REQUIRED_SUBJECTS = 'mailpoet_automation_missing_required_subjects';
   private const AUTOMATION_NOT_TRASHED = 'mailpoet_automation_not_trashed';
   private const AUTOMATION_TEMPLATE_NOT_FOUND = 'mailpoet_automation_template_not_found';
+  private const AUTOMATION_TEMPLATE_EMAIL_PATTERN_NOT_FOUND = 'mailpoet_automation_template_email_pattern_not_found';
   private const AUTOMATION_STEP_NOT_STARTED = 'mailpoet_automation_step_not_started';
   private const AUTOMATION_STEP_NOT_RUNNING = 'mailpoet_automation_step_not_running';
   private const AUTOMATION_STEP_ACTION_PROCESSED = 'mailpoet_automation_step_action_processed';
@@ -279,6 +280,13 @@ class Exceptions {
       ->withErrorCode(self::AUTOMATION_TEMPLATE_NOT_FOUND)
       // translators: %d is the ID of the automation template.
       ->withMessage(sprintf(__("Automation template with ID '%d' not found.", 'mailpoet'), $id));
+  }
+
+  public static function automationTemplateEmailPatternNotFound(string $pattern): NotFoundException {
+    return NotFoundException::create()
+      ->withErrorCode(self::AUTOMATION_TEMPLATE_EMAIL_PATTERN_NOT_FOUND)
+      // translators: %s is the name of the automation template email pattern.
+      ->withMessage(sprintf(__("Automation template email pattern '%s' not found.", 'mailpoet'), $pattern));
   }
 
   public static function stepNotStarted(string $id, int $runId): InvalidStateException {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplateEmailPreviewRenderer.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplateEmailPreviewRenderer.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet\Templates;
+
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Engine\Personalizer;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer as GutenbergRenderer;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController;
+use MailPoet\EmailEditor\Integrations\MailPoet\Templates\TemplatesController;
+use MailPoet\WP\Functions as WPFunctions;
+
+/**
+ * Renders an automation template's pre-built email pattern to HTML for previewing
+ * in the template library, without persisting a newsletter or mailpoet_email post.
+ *
+ * The block-editor renderer resolves post content through the core/post-content
+ * block, which reads the post via get_post(). To render without a database write
+ * we prime the WordPress object cache with an in-memory post under an unused ID,
+ * render, then remove it again. Nothing is written to the database.
+ */
+class TemplateEmailPreviewRenderer {
+  // High, implausible-to-exist post ID range used only to back the in-memory
+  // preview post. A fresh ID is drawn per render so concurrent previews can't
+  // clobber each other's cache entry when a persistent object cache is in use.
+  private const PREVIEW_POST_ID_MIN = 2000000000;
+  private const PREVIEW_POST_ID_MAX = 2147483646;
+
+  private PatternsController $patternsController;
+  private TemplatesController $templatesController;
+  private WPFunctions $wp;
+
+  public function __construct(
+    PatternsController $patternsController,
+    TemplatesController $templatesController,
+    WPFunctions $wp
+  ) {
+    $this->patternsController = $patternsController;
+    $this->templatesController = $templatesController;
+    $this->wp = $wp;
+  }
+
+  public function patternExists(string $patternName): bool {
+    return $this->patternsController->getPatternPreviewContent($patternName) !== null;
+  }
+
+  public function render(string $patternName, string $subject = '', string $preheader = ''): ?string {
+    $content = $this->patternsController->getPatternPreviewContent($patternName);
+    if ($content === null) {
+      return null;
+    }
+
+    $previewPostId = random_int(self::PREVIEW_POST_ID_MIN, self::PREVIEW_POST_ID_MAX);
+    $post = new \WP_Post((object)[
+      'ID' => $previewPostId,
+      'post_author' => 0,
+      'post_date' => '2024-01-01 00:00:00',
+      'post_date_gmt' => '2024-01-01 00:00:00',
+      'post_content' => $content,
+      'post_title' => $subject,
+      'post_status' => 'publish',
+      'post_name' => 'mailpoet-automation-template-email-preview',
+      'post_type' => 'mailpoet_email',
+      'post_modified' => '2024-01-01 00:00:00',
+      'post_modified_gmt' => '2024-01-01 00:00:00',
+      'filter' => 'raw',
+    ]);
+
+    $contextFilter = function (array $context): array {
+      return array_merge($context, [
+        'integration' => 'mailpoet',
+        'newsletter_id' => 0,
+        'queue_id' => 0,
+        'email_type' => 'automation',
+        'is_real_send' => false,
+        'is_preview' => true,
+        'is_single_recipient' => false,
+        'subscriber_count' => 0,
+        'mailpoet_is_automation' => true,
+      ]);
+    };
+
+    $this->wp->wpCacheSet($previewPostId, $post, 'posts');
+    $this->wp->addFilter('woocommerce_email_editor_rendering_email_context', $contextFilter);
+    try {
+      $rendered = $this->getRenderer()->render(
+        $post,
+        $subject,
+        $preheader,
+        (string)$this->wp->getBloginfo('language'),
+        '<meta name="robots" content="noindex, nofollow" />',
+        $this->templatesController->getDefaultTemplateSlug()
+      );
+    } finally {
+      $this->wp->removeFilter('woocommerce_email_editor_rendering_email_context', $contextFilter);
+      $this->wp->wpCacheDelete($previewPostId, 'posts');
+    }
+
+    $html = is_string($rendered['html'] ?? null) ? $rendered['html'] : null;
+    if ($html === null) {
+      return null;
+    }
+
+    // Replace personalization tags (e.g. <!--[mailpoet/site-title]-->) with their
+    // preview values; without this they render as empty placeholders.
+    $personalizer = $this->getPersonalizer();
+    $personalizer->set_context([
+      'recipient_email' => null,
+      'is_user_preview' => true,
+      'newsletter_id' => 0,
+      'queue_id' => null,
+    ]);
+    return $personalizer->personalize_content($html);
+  }
+
+  private function getRenderer(): GutenbergRenderer {
+    return Email_Editor_Container::container()->get(GutenbergRenderer::class);
+  }
+
+  private function getPersonalizer(): Personalizer {
+    return Email_Editor_Container::container()->get(Personalizer::class);
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -927,6 +927,7 @@ class TemplatesFactory {
     ];
 
     if ($preview) {
+      $args['pattern'] = $pattern;
       return $args;
     }
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -212,6 +212,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\CustomerSubjectToSubscriberSubjectTransformer::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Templates\TemplatesFactory::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Templates\EmailFactory::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Templates\TemplateEmailPreviewRenderer::class)->setPublic(true);
 
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\AbandonedCart\AbandonedCartTrigger::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\AbandonedCart\AbandonedCartHandler::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -168,6 +168,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationsGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationVersionsGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplateGetEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplateEmailPreviewEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplatesGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationsPutEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationsCreateFromTemplateEndpoint::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -93,6 +93,43 @@ class PatternsController {
     return null;
   }
 
+  /**
+   * Get the static preview content of a pattern by name.
+   *
+   * Returns the placeholder content (get_content()) shown in the editor's
+   * pattern preview rather than the dynamic email content. This is suitable for
+   * previewing automation template emails before an automation exists, when no
+   * cart/order context is available to populate dynamic blocks.
+   *
+   * @param string $patternName The pattern name (e.g., 'welcome-email-content')
+   * @return string|null The static pattern content or null if not found
+   */
+  public function getPatternPreviewContent(string $patternName): ?string {
+    $this->ensurePatternsInitialized();
+
+    foreach ($this->patterns as $pattern) {
+      if ($pattern->get_name() === $patternName) {
+        // Apply the same filter used in registerPatterns so integrations that
+        // modify pattern properties stay consistent with registered patterns.
+        $patternData = $this->wp->applyFilters('mailpoet_email_editor_integration_register_pattern', [
+          'name' => $pattern->get_namespace() . '/' . $pattern->get_name(),
+          'properties' => $pattern->get_properties(),
+          'email_content' => $pattern->get_email_content(),
+        ], $pattern);
+
+        if (!is_array($patternData)) {
+          return null;
+        }
+
+        $properties = $patternData['properties'] ?? null;
+        $content = is_array($properties) ? ($properties['content'] ?? null) : null;
+        return is_string($content) ? $content : null;
+      }
+    }
+
+    return null;
+  }
+
   private function ensurePatternsInitialized(): void {
     if (!empty($this->patterns)) {
       return;

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -727,6 +727,15 @@ class Functions {
     return wp_trim_words($text, $numWords, $more);
   }
 
+  public function wpCacheSet($key, $data, $group = '', $expire = 0) {
+    // phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined -- generic wrapper, expiry is controlled by callers.
+    return wp_cache_set($key, $data, $group, $expire);
+  }
+
+  public function wpCacheDelete($key, $group = '') {
+    return wp_cache_delete($key, $group);
+  }
+
   public function wpUploadDir($time = null, $createDir = true, $refreshCache = false) {
     return wp_upload_dir($time, $createDir, $refreshCache);
   }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplateEmailPreviewRendererTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplateEmailPreviewRendererTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\MailPoet\Templates;
+
+use MailPoet\Automation\Integrations\MailPoet\Templates\TemplateEmailPreviewRenderer;
+use MailPoetTest;
+
+class TemplateEmailPreviewRendererTest extends MailPoetTest {
+  /** @var TemplateEmailPreviewRenderer */
+  private $renderer;
+
+  public function _before(): void {
+    parent::_before();
+    $this->renderer = $this->diContainer->get(TemplateEmailPreviewRenderer::class);
+  }
+
+  public function testItRendersPatternContentToHtml(): void {
+    $html = $this->renderer->render('welcome-email-content', 'Welcome subject', 'Preheader');
+    verify($html)->notNull();
+    verify($html)->stringContainsString('<!DOCTYPE html>');
+    verify($html)->stringContainsString('Welcome to');
+  }
+
+  public function testItWrapsContentInTheEmailTemplate(): void {
+    $html = (string)$this->renderer->render('welcome-email-content', 'Welcome subject', 'Preheader');
+    // The default email template adds a footer with an unsubscribe link; the bare
+    // fallback template (email-general) does not.
+    verify(stripos($html, 'unsubscribe') !== false)->true();
+  }
+
+  public function testItRendersPersonalizationTags(): void {
+    $html = (string)$this->renderer->render('welcome-email-content', 'Welcome subject', 'Preheader');
+    verify($html)->stringNotContainsString('<!--[mailpoet/');
+  }
+
+  public function testItDoesNotPersistAnyPost(): void {
+    $countBefore = $this->countPreviewPosts();
+    $this->renderer->render('welcome-email-content', 'Welcome subject', 'Preheader');
+    $countAfter = $this->countPreviewPosts();
+    verify($countAfter)->equals(0);
+    verify($countAfter)->equals($countBefore);
+  }
+
+  public function testItReturnsNullForUnknownPattern(): void {
+    verify($this->renderer->render('this-pattern-does-not-exist'))->null();
+  }
+
+  public function testPatternExistsReflectsAvailability(): void {
+    verify($this->renderer->patternExists('welcome-email-content'))->true();
+    verify($this->renderer->patternExists('this-pattern-does-not-exist'))->false();
+  }
+
+  private function countPreviewPosts(): int {
+    global $wpdb;
+    return (int)$wpdb->get_var(
+      $wpdb->prepare(
+        "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_name = %s",
+        'mailpoet-automation-template-email-preview'
+      )
+    );
+  }
+}

--- a/mailpoet/tests/javascript/automation/components/email-preview-modal.spec.ts
+++ b/mailpoet/tests/javascript/automation/components/email-preview-modal.spec.ts
@@ -1,0 +1,162 @@
+import { JSDOM } from 'jsdom';
+import NodeModule from 'module';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+type ModalModule = {
+  EmailPreviewModal: React.ComponentType<{
+    onClose: () => void;
+    src?: string;
+    srcDoc?: string;
+  }>;
+};
+
+type ModuleLoader = (
+  request: string,
+  parent: unknown,
+  isMain: boolean,
+) => unknown;
+type ModuleWithLoader = Record<string, ModuleLoader>;
+type TestRequire = (path: string) => unknown;
+
+const moduleLoadProperty = '_load';
+const testRequire = (
+  NodeModule as unknown as { createRequire: (path: string) => TestRequire }
+).createRequire(`${process.cwd()}/package.json`);
+
+let dom: JSDOM;
+let modalModule: ModalModule;
+let originalModuleLoad: ModuleLoader;
+let root: ReturnType<typeof createRoot>;
+let rootElement: HTMLDivElement;
+
+const setupWindow = () => {
+  dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'https://example.com/wp-admin/admin.php',
+  });
+  global.window = dom.window as unknown as Window & typeof globalThis;
+  global.document = dom.window.document;
+  Object.defineProperty(global, 'navigator', {
+    configurable: true,
+    value: dom.window.navigator,
+  });
+  global.HTMLElement = dom.window.HTMLElement;
+  global.Element = dom.window.Element;
+  global.Node = dom.window.Node;
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+};
+
+function FakeModal({ children }: { children?: React.ReactNode }): JSX.Element {
+  return React.createElement('div', { role: 'dialog' }, children);
+}
+
+function FakeSpinner(): JSX.Element {
+  return React.createElement('span', {
+    'data-automation-id': 'email_preview_spinner',
+  });
+}
+
+const installModuleMocks = () => {
+  const moduleWithLoader = NodeModule as unknown as ModuleWithLoader;
+  originalModuleLoad = moduleWithLoader[moduleLoadProperty];
+  moduleWithLoader[moduleLoadProperty] = function loadModule(
+    request: string,
+    parent: unknown,
+    isMain: boolean,
+  ) {
+    if (request === '@wordpress/components') {
+      return { Modal: FakeModal, Spinner: FakeSpinner };
+    }
+    if (request === '@wordpress/i18n') {
+      return { __: (text: string) => text };
+    }
+    return originalModuleLoad.apply(this, [request, parent, isMain]);
+  };
+};
+
+const restoreModuleMocks = () => {
+  (NodeModule as unknown as ModuleWithLoader)[moduleLoadProperty] =
+    originalModuleLoad;
+};
+
+const renderModal = async (srcDoc: string) => {
+  rootElement = document.createElement('div');
+  document.body.appendChild(rootElement);
+  root = createRoot(rootElement);
+  await React.act(async () => {
+    root.render(
+      React.createElement(modalModule.EmailPreviewModal, {
+        onClose: () => undefined,
+        srcDoc,
+      }),
+    );
+  });
+};
+
+const spinner = () =>
+  document.querySelector('[data-automation-id="email_preview_spinner"]');
+
+const iframe = () =>
+  document.querySelector(
+    '[data-automation-id="automation_send_email_preview_iframe"]',
+  );
+
+const fireIframeLoad = async () => {
+  await React.act(async () => {
+    iframe().dispatchEvent(new window.Event('load'));
+    await Promise.resolve();
+  });
+};
+
+describe('email preview modal', function emailPreviewModal() {
+  this.timeout(20000);
+
+  before(() => {
+    setupWindow();
+    installModuleMocks();
+    modalModule = testRequire(
+      './assets/js/src/automation/components/email-preview-modal/index.tsx',
+    ) as ModalModule;
+    restoreModuleMocks();
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await React.act(async () => {
+        root.unmount();
+      });
+    }
+    document.body.innerHTML = '';
+  });
+
+  after(() => {
+    dom.window.close();
+    [
+      'document',
+      'Element',
+      'HTMLElement',
+      'IS_REACT_ACT_ENVIRONMENT',
+      'navigator',
+      'Node',
+      'window',
+    ].forEach((property) => Reflect.deleteProperty(global, property));
+  });
+
+  it('shows the spinner again when the source changes', async () => {
+    await renderModal('<p>a</p>');
+    await fireIframeLoad();
+    expect(spinner()).to.equal(null);
+
+    // Swap the content on the already-mounted modal.
+    await React.act(async () => {
+      root.render(
+        React.createElement(modalModule.EmailPreviewModal, {
+          onClose: () => undefined,
+          srcDoc: '<p>b</p>',
+        }),
+      );
+    });
+
+    expect(spinner()).to.not.equal(null);
+  });
+});

--- a/mailpoet/tests/javascript/automation/templates/components/template-email-previews.spec.ts
+++ b/mailpoet/tests/javascript/automation/templates/components/template-email-previews.spec.ts
@@ -1,0 +1,329 @@
+import { JSDOM } from 'jsdom';
+import NodeModule from 'module';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import sinon from 'sinon';
+
+type Step = {
+  id: string;
+  type: string;
+  key: string;
+  args: Record<string, unknown>;
+  next_steps: unknown[];
+};
+
+type TemplateEmailPreviewsModule = {
+  TemplateEmailPreviews: React.ComponentType<{ templateSlug: string }>;
+};
+
+type ModuleLoader = (
+  request: string,
+  parent: unknown,
+  isMain: boolean,
+) => unknown;
+type ModuleWithLoader = Record<string, ModuleLoader>;
+type TestRequire = (path: string) => unknown;
+
+type FakeButtonProps = {
+  children?: React.ReactNode;
+  disabled?: boolean;
+  onClick?: () => void;
+};
+
+const moduleLoadProperty = '_load';
+const testRequire = (
+  NodeModule as unknown as { createRequire: (path: string) => TestRequire }
+).createRequire(`${process.cwd()}/package.json`);
+
+let dom: JSDOM;
+let previewsModule: TemplateEmailPreviewsModule;
+let originalModuleLoad: ModuleLoader;
+let root: ReturnType<typeof createRoot>;
+let rootElement: HTMLDivElement;
+let apiFetchStub: sinon.SinonStub;
+let automationSteps: Record<string, Step>;
+
+const setupWindow = () => {
+  dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'https://example.com/wp-admin/admin.php',
+  });
+  global.window = dom.window as unknown as Window & typeof globalThis;
+  global.document = dom.window.document;
+  Object.defineProperty(global, 'navigator', {
+    configurable: true,
+    value: dom.window.navigator,
+  });
+  global.HTMLElement = dom.window.HTMLElement;
+  global.Element = dom.window.Element;
+  global.Node = dom.window.Node;
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+};
+
+const fakeSelectors = {
+  getAutomationData: () => ({ steps: automationSteps }),
+};
+
+function FakeButton({
+  children,
+  disabled = false,
+  onClick = undefined,
+}: FakeButtonProps): JSX.Element {
+  return React.createElement(
+    'button',
+    { disabled, onClick, type: 'button' },
+    children,
+  );
+}
+
+function FakeEmailPreviewModal({
+  srcDoc,
+  onClose,
+}: {
+  srcDoc?: string;
+  onClose: () => void;
+}): JSX.Element {
+  return React.createElement(
+    'div',
+    { role: 'dialog' },
+    React.createElement('iframe', {
+      'data-automation-id': 'template_email_preview_iframe',
+      srcDoc,
+      title: 'preview',
+    }),
+    React.createElement(
+      'button',
+      { onClick: onClose, type: 'button' },
+      'Close',
+    ),
+  );
+}
+
+const installModuleMocks = () => {
+  const moduleWithLoader = NodeModule as unknown as ModuleWithLoader;
+  originalModuleLoad = moduleWithLoader[moduleLoadProperty];
+  moduleWithLoader[moduleLoadProperty] = function loadModule(
+    request: string,
+    parent: unknown,
+    isMain: boolean,
+  ) {
+    if (request === '@wordpress/components') {
+      return { Button: FakeButton };
+    }
+    if (request === '@wordpress/data') {
+      return {
+        useSelect: (
+          mapSelect: (select: () => typeof fakeSelectors) => unknown,
+        ) => mapSelect(() => fakeSelectors),
+      };
+    }
+    if (request === '@wordpress/i18n') {
+      return {
+        __: (text: string) => text,
+        sprintf: (format: string, ...args: unknown[]) =>
+          format.replace(/%d|%s/g, () => String(args.shift())),
+      };
+    }
+    if (request === '@wordpress/api-fetch') {
+      return (...args: unknown[]) => apiFetchStub(...args) as Promise<unknown>;
+    }
+    if (request === '@wordpress/url') {
+      return {
+        addQueryArgs: (path: string, args: Record<string, string>) => {
+          const query = String(new dom.window.URLSearchParams(args));
+          return query ? `${path}?${query}` : path;
+        },
+      };
+    }
+    if (request === '../../editor/store') {
+      return { storeName: 'mailpoet-automation-editor' };
+    }
+    if (request === '../../components/email-preview-modal') {
+      return { EmailPreviewModal: FakeEmailPreviewModal };
+    }
+    return originalModuleLoad.apply(this, [request, parent, isMain]);
+  };
+};
+
+const restoreModuleMocks = () => {
+  (NodeModule as unknown as ModuleWithLoader)[moduleLoadProperty] =
+    originalModuleLoad;
+};
+
+const sendEmailStep = (id: string, args: Record<string, unknown>): Step => ({
+  id,
+  type: 'action',
+  key: 'mailpoet:send-email',
+  args,
+  next_steps: [],
+});
+
+const render = async (templateSlug = 'welcome-series') => {
+  rootElement = document.createElement('div');
+  document.body.appendChild(rootElement);
+  root = createRoot(rootElement);
+  await React.act(async () => {
+    root.render(
+      React.createElement(previewsModule.TemplateEmailPreviews, {
+        templateSlug,
+      }),
+    );
+  });
+};
+
+const previewButtons = () =>
+  Array.from(document.querySelectorAll('button')).filter(
+    (button) => button.textContent === 'Preview',
+  );
+
+describe('automation template email previews', function templateEmailPreviews() {
+  this.timeout(20000);
+
+  before(async () => {
+    setupWindow();
+    installModuleMocks();
+    previewsModule = testRequire(
+      './assets/js/src/automation/templates/components/template-email-previews.tsx',
+    ) as TemplateEmailPreviewsModule;
+    restoreModuleMocks();
+  });
+
+  beforeEach(() => {
+    apiFetchStub = sinon.stub();
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await React.act(async () => {
+        root.unmount();
+      });
+    }
+    sinon.restore();
+    document.body.innerHTML = '';
+  });
+
+  after(() => {
+    dom.window.close();
+    [
+      'document',
+      'Element',
+      'HTMLElement',
+      'IS_REACT_ACT_ENVIRONMENT',
+      'navigator',
+      'Node',
+      'window',
+    ].forEach((property) => Reflect.deleteProperty(global, property));
+  });
+
+  it('shows a preview button only for send email steps with a pattern', async () => {
+    automationSteps = {
+      'step-1': sendEmailStep('step-1', {
+        name: 'Welcome',
+        pattern: 'welcome-email-content',
+      }),
+      'step-2': sendEmailStep('step-2', { name: 'No pattern' }),
+      'step-3': {
+        id: 'step-3',
+        type: 'trigger',
+        key: 'mailpoet:someone-subscribes',
+        args: { pattern: 'should-be-ignored' },
+        next_steps: [],
+      },
+    };
+
+    await render();
+
+    expect(previewButtons().length).to.equal(1);
+  });
+
+  it('renders nothing when no email has a pattern', async () => {
+    automationSteps = {
+      'step-1': sendEmailStep('step-1', { name: 'No pattern' }),
+    };
+
+    await render();
+
+    expect(rootElement.textContent).to.equal('');
+    expect(previewButtons().length).to.equal(0);
+  });
+
+  it('fetches the rendered email and shows it in the modal', async () => {
+    automationSteps = {
+      'step-1': sendEmailStep('step-1', {
+        name: 'Welcome',
+        subject: 'Welcome subject',
+        preheader: 'Preheader',
+        pattern: 'welcome-email-content',
+      }),
+    };
+    apiFetchStub.resolves({ data: { html: '<p>Preview body</p>' } });
+
+    await render();
+
+    await React.act(async () => {
+      previewButtons()[0].dispatchEvent(
+        new window.MouseEvent('click', { bubbles: true }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(apiFetchStub.calledOnce).to.equal(true);
+    expect(apiFetchStub.firstCall.args[0].path).to.contain(
+      'automation-template-email-preview',
+    );
+    expect(apiFetchStub.firstCall.args[0].path).to.contain(
+      'pattern=welcome-email-content',
+    );
+
+    const iframe = document.querySelector(
+      '[data-automation-id="template_email_preview_iframe"]',
+    );
+    expect(iframe).to.not.equal(null);
+    expect(iframe.getAttribute('srcdoc')).to.equal('<p>Preview body</p>');
+  });
+
+  it('ignores a preview response after the template changed', async () => {
+    automationSteps = {
+      'step-1': sendEmailStep('step-1', {
+        name: 'Welcome',
+        pattern: 'welcome-email-content',
+      }),
+    };
+    let resolvePreview: (value: unknown) => void = () => undefined;
+    apiFetchStub.returns(
+      new Promise((resolve) => {
+        resolvePreview = resolve;
+      }),
+    );
+
+    await render('template-a');
+
+    await React.act(async () => {
+      previewButtons()[0].dispatchEvent(
+        new window.MouseEvent('click', { bubbles: true }),
+      );
+      await Promise.resolve();
+    });
+
+    // Switch to another template while the request is in flight.
+    await React.act(async () => {
+      root.render(
+        React.createElement(previewsModule.TemplateEmailPreviews, {
+          templateSlug: 'template-b',
+        }),
+      );
+    });
+
+    await React.act(async () => {
+      resolvePreview({ data: { html: '<p>Stale</p>' } });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(
+      document.querySelector(
+        '[data-automation-id="template_email_preview_iframe"]',
+      ),
+    ).to.equal(null);
+  });
+});


### PR DESCRIPTION
## Description

Adds an email-content preview to the automation template library. When a template's Send email steps have pre-built content, the template detail modal lists each email with a **Preview** action so users can see the rendered email before clicking **Start building**. Multi-email templates expose each email separately; steps without content are omitted.

Rendering creates no newsletter or `mailpoet_email` post: an in-memory `WP_Post` is primed into the object cache, rendered through the email template wrapper, personalized, then discarded. The send-email step's preview modal is extracted into a shared `EmailPreviewModal`.

## Code review notes

- The no-persist render relies on priming the object cache with an in-memory `WP_Post`: the WC email renderer resolves content via `core/post-content` → `get_post()`, so a detached post renders empty. Documented in `TemplateEmailPreviewRenderer`.
- Preview uses the pattern's static `get_content()` (placeholder products), not dynamic `get_email_content()`, which renders empty without WooCommerce cart context.

## QA notes

- Automation → Templates → open a template with Send email steps (e.g. Welcome series) → click **Preview** on each email.
- Verify the email template wrapper (header/footer), themed content background, and resolved personalization tags (e.g. site title).
- Confirm no `mailpoet_email` post is created (check phpMyAdmin / listing).

## Linked PRs

Premium: mailpoet/mailpoet-premium#1105

## Linked tickets

STOMAIL-8130

## Screenshots

| Before | After | 
| ---- | ----- | 
| <img width="832" height="748" alt="Screenshot 2026-06-21 at 14 45 25" src="https://github.com/user-attachments/assets/0b25df5d-45c3-4e05-a7df-53fd1504a02e" /> | <img width="838" height="744" alt="Screenshot 2026-06-21 at 14 45 18" src="https://github.com/user-attachments/assets/9e4cef58-86b2-4525-af02-f8c2033c64e0" /> | 


**Email preview from automation template preview (this PR):**
<img width="1800" height="1169" alt="Screenshot 2026-06-21 at 12 40 12" src="https://github.com/user-attachments/assets/8a10781d-dd74-424d-b224-fb7956567790" />

**Email preview from automation email editor (from https://github.com/mailpoet/mailpoet/pull/6896):**
<img width="1800" height="1169" alt="Screenshot 2026-06-21 at 12 40 24" src="https://github.com/user-attachments/assets/9d57a82f-b3b7-41f9-b1f4-cc1939118be4" />

**Email editor:**
<img width="1800" height="1169" alt="Screenshot 2026-06-21 at 12 40 33" src="https://github.com/user-attachments/assets/7905b484-223d-4223-a754-2e1a266f4b81" />

**Email preview in new tab from editor:**
<img width="1800" height="1169" alt="Screenshot 2026-06-21 at 12 40 42" src="https://github.com/user-attachments/assets/abede6e2-9447-4158-8393-29919f7fee65" />


## Tasks

- [x] I have added a changelog entry
- [x] I followed best practices for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8130-preview-automation-template-email-content)

_The latest successful build from `add/stomail-8130-preview-automation-template-email-content` will be used. If none is available, the link won't work._