### PR TITLE
Revert subscriber search wildcard changes

### DIFF
--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -621,62 +621,14 @@ function SubscriberFilters({
   );
 }
 
-function NoItemsFound({
-  group,
-  search,
-  onWildcardSearch,
-}: {
-  group: Group;
-  search?: string;
-  onWildcardSearch: (search: string) => void;
-}) {
-  const term = search?.trim();
-  if (!term || term.includes('*')) {
-    return <>{__('No items found.', 'mailpoet')}</>;
-  }
-  const wildcardTerm = `*${term}`;
-  return (
-    <>
-      {createInterpolateElement(
-        sprintf(
-          // translators: %1$s is the search term the user typed, %2$s is the same term prefixed with the * wildcard.
-          __(
-            'No items found that begin with „%1$s“. Tip: use * to match anywhere, e.g. <link>%2$s</link>.',
-            'mailpoet',
-          ),
-          term,
-          wildcardTerm,
-        ),
-        {
-          link: (
-            <a
-              href={`#/group[${group}]/search[${encodeURIComponent(
-                wildcardTerm,
-              )}]`}
-              onClick={(event) => {
-                event.preventDefault();
-                onWildcardSearch(wildcardTerm);
-              }}
-            >
-              {wildcardTerm}
-            </a>
-          ),
-        },
-      )}
-    </>
-  );
-}
-
 function EmptyContent({
   group,
   search,
   onCheckTrash,
-  onWildcardSearch,
 }: {
   group: Group;
   search?: string;
   onCheckTrash: () => void;
-  onWildcardSearch: (search: string) => void;
 }) {
   if (
     group === 'bounced' &&
@@ -702,14 +654,10 @@ function EmptyContent({
   if (group !== 'trash' && search) {
     return (
       <p>
-        <NoItemsFound
-          group={group}
-          search={search}
-          onWildcardSearch={onWildcardSearch}
-        />
-        <br />
+        {__('No items found.', 'mailpoet')}{' '}
         <a
           href={`#/group[trash]/search[${encodeURIComponent(search)}]`}
+          className="button button-link"
           onClick={(event) => {
             event.preventDefault();
             onCheckTrash();
@@ -720,15 +668,7 @@ function EmptyContent({
       </p>
     );
   }
-  return (
-    <div>
-      <NoItemsFound
-        group={group}
-        search={search}
-        onWildcardSearch={onWildcardSearch}
-      />
-    </div>
-  );
+  return <div>{__('No items found.', 'mailpoet')}</div>;
 }
 
 function SubscriberList() {
@@ -1238,12 +1178,6 @@ function SubscriberList() {
     setView((currentView) => ({ ...currentView, page: 1 }));
   };
 
-  const handleWildcardSearch = (search: string): void => {
-    setSelection([]);
-    clearLoadError();
-    setView((currentView) => ({ ...currentView, search, page: 1 }));
-  };
-
   const groupsToRender = useMemo(
     () =>
       (groups ?? [])
@@ -1388,7 +1322,6 @@ function SubscriberList() {
               group={group}
               search={view.search}
               onCheckTrash={handleCheckTrash}
-              onWildcardSearch={handleWildcardSearch}
             />
           }
         >

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -257,12 +257,11 @@ class SubscriberListingRepository extends ListingRepository {
     }
 
     $search = $definition->getSearch();
-    if ($search && strlen(trim($search)) > 0 && trim($search) !== '*') {
-      $searchPatterns = $this->getSearchLikePatterns($search);
+    if ($search && strlen(trim($search)) > 0) {
+      $search = Helpers::escapeSearch($search);
       $query
-        ->andWhere('(s.email LIKE :emailSearch OR s.first_name LIKE :nameSearch OR s.last_name LIKE :nameSearch)')
-        ->setParameter('emailSearch', $searchPatterns['email'])
-        ->setParameter('nameSearch', $searchPatterns['name']);
+        ->andWhere('(s.email LIKE :search OR s.first_name LIKE :search OR s.last_name LIKE :search)')
+        ->setParameter('search', "%$search%");
     }
 
     $filters = $definition->getFilters();
@@ -578,25 +577,10 @@ class SubscriberListingRepository extends ListingRepository {
   }
 
   protected function applySearch(QueryBuilder $queryBuilder, string $search, array $parameters = []) {
-    if (trim($search) === '*') {
-      return;
-    }
-    $searchPatterns = $this->getSearchLikePatterns($search);
+    $search = Helpers::escapeSearch($search);
     $queryBuilder
-      ->andWhere('s.email LIKE :emailSearch or s.firstName LIKE :nameSearch or s.lastName LIKE :nameSearch')
-      ->setParameter('emailSearch', $searchPatterns['email'])
-      ->setParameter('nameSearch', $searchPatterns['name']);
-  }
-
-  /**
-   * @return array{email: string, name: string}
-   */
-  private function getSearchLikePatterns(string $search): array {
-    $emailSearch = '%' . str_replace('*', '%', Helpers::escapeSearch($search)) . '%';
-    return [
-      'email' => $emailSearch,
-      'name' => Helpers::buildSearchLikePattern($search),
-    ];
+      ->andWhere('s.email LIKE :search or s.firstName LIKE :search or s.lastName LIKE :search')
+      ->setParameter('search', "%$search%");
   }
 
   protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
@@ -1039,13 +1023,11 @@ class SubscriberListingRepository extends ListingRepository {
     $subscribersQuery = $this->dynamicSegmentsFilter->apply($subscribersQuery, $segment);
     // Apply group, search to fetch only necessary ids
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    $search = (string)$definition->getSearch();
-    if (strlen(trim($search)) > 0 && trim($search) !== '*') {
-      $searchPatterns = $this->getSearchLikePatterns($search);
+    if ($definition->getSearch()) {
+      $search = Helpers::escapeSearch((string)$definition->getSearch());
       $subscribersQuery
-        ->andWhere("$subscribersTable.email LIKE :emailSearch or $subscribersTable.first_name LIKE :nameSearch or $subscribersTable.last_name LIKE :nameSearch")
-        ->setParameter('emailSearch', $searchPatterns['email'])
-        ->setParameter('nameSearch', $searchPatterns['name']);
+        ->andWhere("$subscribersTable.email LIKE :search or $subscribersTable.first_name LIKE :search or $subscribersTable.last_name LIKE :search")
+        ->setParameter('search', "%$search%");
     }
     if ($definition->getGroup()) {
       if ($definition->getGroup() === 'trash') {

--- a/mailpoet/lib/Util/Helpers.php
+++ b/mailpoet/lib/Util/Helpers.php
@@ -115,19 +115,6 @@ class Helpers {
     return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], trim($search)); // escape for 'LIKE'
   }
 
-  /**
-   * Build a prefix-anchored LIKE pattern for subscriber search.
-   *
-   * LIKE metacharacters typed by the user are escaped first, so a literal '%'
-   * or '_' matches itself. The user-facing wildcard is '*', which is then
-   * translated to a SQL '%'. A trailing '%' keeps the match prefix-anchored.
-   * e.g. "*se*arch" => "%se%arch%"
-   */
-  public static function buildSearchLikePattern(string $search): string {
-    $escaped = self::escapeSearch($search);
-    return str_replace('*', '%', $escaped) . '%';
-  }
-
   public static function extractEmailDomain(string $email = ''): string {
     $arrayOfItems = explode('@', trim($email));
     return strtolower(array_pop($arrayOfItems));

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -549,7 +549,7 @@ class SubscribersListingCest {
     $i->searchFor('noresultsexpected_xyz');
 
     // Should stay in trash — not redirect to All
-    $i->waitForText('No items found that begin with');
+    $i->waitForText('No items found.');
     $i->seeInCurrentURL(urlencode('group[trash]'));
   }
 

--- a/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
@@ -75,7 +75,7 @@ class SubscribersEndpointsTest extends Test {
 
     $response = $this->get(self::LISTING_PATH, ['query' => [
       'per_page' => 100,
-      'search' => "rest-search-needle-{$suffix}",
+      'search' => "needle-{$suffix}",
     ]]);
     $this->assertIsArray($response);
     $payload = $response['data'];
@@ -85,19 +85,6 @@ class SubscribersEndpointsTest extends Test {
     $emails = array_column($items, 'email');
     $this->assertContains("rest-search-needle-{$suffix}@example.com", $emails);
     $this->assertNotContains("rest-search-other-{$suffix}@example.com", $emails);
-
-    $wildcardResponse = $this->get(self::LISTING_PATH, ['query' => [
-      'per_page' => 100,
-      'search' => "*needle-{$suffix}",
-    ]]);
-    $this->assertIsArray($wildcardResponse);
-    $wildcardPayload = $wildcardResponse['data'];
-    $this->assertIsArray($wildcardPayload);
-    $wildcardItems = $wildcardPayload['items'];
-    $this->assertIsArray($wildcardItems);
-    $wildcardEmails = array_column($wildcardItems, 'email');
-    $this->assertContains("rest-search-needle-{$suffix}@example.com", $wildcardEmails);
-    $this->assertNotContains("rest-search-other-{$suffix}@example.com", $wildcardEmails);
   }
 
   public function testBulkTrashMovesSelectionToTrash(): void {

--- a/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
@@ -329,7 +329,7 @@ class SubscriberListingRepositoryTest extends \MailPoetTest {
     $this->entityManager->flush();
 
     $this->listingData['filter'] = ['segment' => $list->getId()];
-    $this->listingData['search'] = 'test2';
+    $this->listingData['search'] = 'user-role-test2';
     $data = $this->repository->getData($this->getListingDefinition());
     verify(count($data))->equals(1);
     verify($data[0]->getEmail())->equals($wpUserEmail2);

--- a/mailpoet/tests/unit/Util/HelpersTest.php
+++ b/mailpoet/tests/unit/Util/HelpersTest.php
@@ -69,18 +69,4 @@ class HelpersTest extends \MailPoetUnitTest {
     verify(Helpers::escapeSearch('He_llo'))->equals('He\_llo');
     verify(Helpers::escapeSearch('He\\llo'))->equals('He\\\llo');
   }
-
-  public function testItBuildsSearchLikePattern() {
-    // prefix-anchored by default (trailing %)
-    verify(Helpers::buildSearchLikePattern('Hello'))->equals('Hello%');
-    verify(Helpers::buildSearchLikePattern(' Hello '))->equals('Hello%');
-    // '*' is the user-facing wildcard, translated to SQL '%'
-    verify(Helpers::buildSearchLikePattern('*search'))->equals('%search%');
-    verify(Helpers::buildSearchLikePattern('*se*arch'))->equals('%se%arch%');
-    verify(Helpers::buildSearchLikePattern('se*arch'))->equals('se%arch%');
-    // literal LIKE metacharacters typed by the user stay escaped
-    verify(Helpers::buildSearchLikePattern('He%llo'))->equals('He\%llo%');
-    verify(Helpers::buildSearchLikePattern('He_llo'))->equals('He\_llo%');
-    verify(Helpers::buildSearchLikePattern('*He%llo*'))->equals('%He\%llo%%');
-  }
 }


### PR DESCRIPTION
## Description

Subscriber search ended up in a confusing state after #6836 restricted default matching to prefixes and introduced `*`, then #6889 restored unrestricted email substring matching.

This PR reverts both PRs' search behavior back to the previous unrestricted `LIKE` matching and removes the wildcard UI/tests. The #6889 changelog entry is intentionally kept so users still see that partial email address search was restored. The #6889 email-substring integration test is also kept as regression coverage.

## Code review notes

This is a behavior revert rather than a full file reset, so later unrelated subscriber-listing changes are preserved.

## QA notes

Tested search locally.

## Linked PRs

- Reverts https://github.com/mailpoet/mailpoet/pull/6836
- Reverts behavior from https://github.com/mailpoet/mailpoet/pull/6889 while keeping its changelog entry and email-substring test

## Linked tickets

- STOMAIL-8156
- STOMAIL-8197

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:revert-search-improvements)

_The latest successful build from `revert-search-improvements` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

This PR reverts subscriber search functionality to restore previous behavior. It is not addressing specific bugs or issues, but rather reverting conflicting changes from PRs `#6836` and `#6889` that left the search behavior in a confusing state. The work involves restoring the unrestricted `LIKE` matching approach, removing wildcard UI components and associated tests, while preserving the changelog entry and integration test coverage for email substring search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->