### PR TITLE
Speed up "Subscribers without a list" count with a denormalized segments_count column

### DIFF
--- a/mailpoet/changelog/2026-06-22-09-32-30-improved-sped-up-the-subscribers-without-a-list-count-and-i.md
+++ b/mailpoet/changelog/2026-06-22-09-32-30-improved-sped-up-the-subscribers-without-a-list-count-and-i.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Sped up the Subscribers without a list count and its status tabs on large lists

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -13,6 +13,7 @@ use MailPoet\Cron\Workers\NewsletterTemplateThumbnails;
 use MailPoet\Cron\Workers\StatsNotifications\Worker;
 use MailPoet\Cron\Workers\SubscriberLinkTokens;
 use MailPoet\Cron\Workers\SubscribersLastEngagement;
+use MailPoet\Cron\Workers\SubscribersSegmentsCountSync;
 use MailPoet\Cron\Workers\Tracks;
 use MailPoet\Cron\Workers\UnsubscribeTokens;
 use MailPoet\Doctrine\WPDB\Connection;
@@ -181,6 +182,7 @@ class Populator {
     $this->scheduleSubscriberLastEngagementDetection();
     $this->scheduleNewsletterTemplateThumbnails();
     $this->scheduleBackfillEngagementData();
+    $this->scheduleSubscribersSegmentsCountSync();
     $this->scheduleMixpanel();
     $this->scheduleTracks();
   }
@@ -769,6 +771,21 @@ class Populator {
     }
     $this->scheduleTask(
       BackfillEngagementData::TASK_TYPE,
+      Carbon::now()->millisecond(0)
+    );
+  }
+
+  private function scheduleSubscribersSegmentsCountSync(): void {
+    $existingTask = $this->scheduledTasksRepository->findOneBy(
+      [
+        'type' => SubscribersSegmentsCountSync::TASK_TYPE,
+      ]
+    );
+    if ($existingTask) {
+      return;
+    }
+    $this->scheduleTask(
+      SubscribersSegmentsCountSync::TASK_TYPE,
       Carbon::now()->millisecond(0)
     );
   }

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -117,6 +117,7 @@ class Daemon {
     yield $this->workersFactory->createNewsletterTemplateThumbnailsWorker();
     yield $this->workersFactory->createAbandonedCartWorker();
     yield $this->workersFactory->createBackfillEngagementDataWorker();
+    yield $this->workersFactory->createSubscribersSegmentsCountSyncWorker();
     yield $this->workersFactory->createMixpanelWorker();
     yield $this->workersFactory->createTracksWorker();
     yield $this->workersFactory->createStatisticsExportWorker();

--- a/mailpoet/lib/Cron/Workers/SubscribersSegmentsCountSync.php
+++ b/mailpoet/lib/Cron/Workers/SubscribersSegmentsCountSync.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\SegmentsCountRecalculator;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+/**
+ * Populates and reconciles SubscriberEntity::$segmentsCount.
+ *
+ * The first run is the backfill: it sweeps the whole subscribers table by id
+ * range, recomputes segments_count for every row, and then flips the
+ * SEGMENTS_COUNT_BACKFILLED setting so reads start trusting the column.
+ *
+ * Every subsequent (weekly) run is the reconcile backstop: it re-sweeps the
+ * table to repair any drift left by a write path that forgot to update the
+ * column. Both phases use the same idempotent recompute, so the value always
+ * converges. Work is chunked and bounded by enforceExecutionLimit() so the
+ * sweep never runs as one long query and never blocks a request.
+ */
+class SubscribersSegmentsCountSync extends SimpleWorker {
+  const TASK_TYPE = 'subscribers_segments_count_sync';
+  const BATCH_SIZE = 5000;
+  const SUPPORT_MULTIPLE_INSTANCES = false;
+  const BACKFILLED_SETTING_KEY = 'subscribers_segments_count_backfilled';
+
+  /** @var EntityManager */
+  private $entityManager;
+
+  /** @var SegmentsCountRecalculator */
+  private $segmentsCountRecalculator;
+
+  /** @var SettingsController */
+  private $settings;
+
+  public function __construct(
+    EntityManager $entityManager,
+    SegmentsCountRecalculator $segmentsCountRecalculator,
+    SettingsController $settings
+  ) {
+    parent::__construct();
+    $this->entityManager = $entityManager;
+    $this->segmentsCountRecalculator = $segmentsCountRecalculator;
+    $this->settings = $settings;
+  }
+
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer): bool {
+    $meta = $task->getMeta();
+    $lastId = isset($meta['last_subscriber_id']) ? (int)$meta['last_subscriber_id'] : 0;
+    $highestId = $this->getHighestSubscriberId();
+
+    while ($lastId < $highestId) {
+      $this->segmentsCountRecalculator->recalculateForIdRange($lastId + 1, $lastId + self::BATCH_SIZE);
+      $lastId += self::BATCH_SIZE;
+      $task->setMeta(['last_subscriber_id' => $lastId]);
+      $this->scheduledTasksRepository->persist($task);
+      $this->scheduledTasksRepository->flush();
+      $this->cronHelper->enforceExecutionLimit($timer); // throws and reschedules when over the limit
+    }
+
+    // The whole table has been recomputed: reads can trust segments_count now.
+    $this->settings->set(self::BACKFILLED_SETTING_KEY, true);
+
+    // Reset progress so the next (reconcile) run starts a fresh sweep.
+    $task->setMeta(['last_subscriber_id' => 0]);
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+
+    return true;
+  }
+
+  private function getHighestSubscriberId(): int {
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $result = $this->entityManager->getConnection()->executeQuery("SELECT MAX(id) FROM $subscribersTable LIMIT 1;")->fetchNumeric();
+    return is_array($result) && isset($result[0]) && is_numeric($result[0]) ? (int)$result[0] : 0;
+  }
+}

--- a/mailpoet/lib/Cron/Workers/SubscribersSegmentsCountSync.php
+++ b/mailpoet/lib/Cron/Workers/SubscribersSegmentsCountSync.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Cron\Workers;
 
+use MailPoet\Doctrine\WPDB\Connection;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Settings\SettingsController;
@@ -48,6 +49,14 @@ class SubscribersSegmentsCountSync extends SimpleWorker {
   }
 
   public function processTaskStrategy(ScheduledTaskEntity $task, $timer): bool {
+    // The recalculator relies on UPDATE ... LEFT JOIN, which the SQLite
+    // integration in WordPress Playground does not support. Make the task a
+    // no-op there and never flip the backfill flag, so reads stay on the
+    // anti-join fallback instead of trusting an unpopulated column.
+    if (Connection::isSQLite()) {
+      return true;
+    }
+
     $meta = $task->getMeta();
     $lastId = isset($meta['last_subscriber_id']) ? (int)$meta['last_subscriber_id'] : 0;
     $highestId = $this->getHighestSubscriberId();

--- a/mailpoet/lib/Cron/Workers/WorkersFactory.php
+++ b/mailpoet/lib/Cron/Workers/WorkersFactory.php
@@ -202,6 +202,11 @@ class WorkersFactory {
     return $this->container->get(BackfillEngagementData::class);
   }
 
+  /** @return SubscribersSegmentsCountSync */
+  public function createSubscribersSegmentsCountSyncWorker() {
+    return $this->container->get(SubscribersSegmentsCountSync::class);
+  }
+
   public function createMixpanelWorker() {
     return $this->container->get(Mixpanel::class);
   }

--- a/mailpoet/lib/Cron/Workers/WorkersFactory.php
+++ b/mailpoet/lib/Cron/Workers/WorkersFactory.php
@@ -41,6 +41,7 @@ class WorkersFactory {
     StatsNotificationsWorkerForAutomatedEmails::TASK_TYPE,
     StatsNotificationsWorker::TASK_TYPE,
     BackfillEngagementData::TASK_TYPE,
+    SubscribersSegmentsCountSync::TASK_TYPE,
     Mixpanel::TASK_TYPE,
     AbandonedCartWorker::TASK_TYPE,
     LogCleanup::TASK_TYPE,

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -368,6 +368,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\Workers\SubscriberLinkTokens::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\AuthorizedSendingEmailsCheck::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\BackfillEngagementData::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\Workers\SubscribersSegmentsCountSync::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\WooCommercePastOrders::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\ReEngagementEmailsScheduler::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SubscribersEngagementScore::class)->setPublic(true);
@@ -520,6 +521,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Subscribers\SubscriberIPsRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberListingRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberSegmentRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\SegmentsCountRecalculator::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberTagRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberCustomFieldRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberPersonalDataEraser::class)->setPublic(true);

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -165,6 +165,15 @@ class SubscriberEntity {
   private $countConfirmations = 0;
 
   /**
+   * Denormalized number of subscribed memberships in non-deleted segments.
+   * Maintained by SegmentsCountRecalculator; used to quickly find subscribers
+   * without a list (segments_count = 0).
+   * @ORM\Column(type="integer", options={"unsigned":true})
+   * @var int
+   */
+  private $segmentsCount = 0;
+
+  /**
    * @ORM\Column(type="string", nullable=true)
    * @var string|null
    */
@@ -550,6 +559,14 @@ class SubscriberEntity {
    */
   public function setConfirmationsCount($countConfirmations) {
     $this->countConfirmations = $countConfirmations;
+  }
+
+  public function getSegmentsCount(): int {
+    return $this->segmentsCount;
+  }
+
+  public function setSegmentsCount(int $segmentsCount): void {
+    $this->segmentsCount = $segmentsCount;
   }
 
   /**

--- a/mailpoet/lib/Migrations/Db/Migration_20260622_120000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260622_120000_Db.php
@@ -16,9 +16,9 @@ class Migration_20260622_120000_Db extends DbMigration {
     // and its per-status counts: those used to run an anti-join over the whole
     // subscribers table (tens of minutes on large installs). With this column
     // the count becomes `WHERE segments_count = 0`. Defaults to 0; the real
-    // values are populated by the SubscribersSegmentsCountBackfill worker and
-    // kept in sync by SegmentsCountRecalculator. Reads only trust the column
-    // once the backfill has completed (see SubscribersCountsController).
+    // values are populated by the SubscribersSegmentsCountSync worker and kept
+    // in sync by SegmentsCountRecalculator. Reads only trust the column once the
+    // backfill has completed (see SegmentSubscribersRepository::isSegmentsCountColumnReady()).
     if (!$this->columnExists($subscribersTable, 'segments_count')) {
       $alterations[] = 'ADD COLUMN `segments_count` INT UNSIGNED NOT NULL DEFAULT 0';
     }

--- a/mailpoet/lib/Migrations/Db/Migration_20260622_120000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260622_120000_Db.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20260622_120000_Db extends DbMigration {
+  public function run(): void {
+    $subscribersTable = $this->getTableName(SubscriberEntity::class);
+
+    $alterations = [];
+
+    // Denormalized count of the subscriber's subscribed memberships in
+    // non-deleted segments. It powers the "Subscribers without a list" filter
+    // and its per-status counts: those used to run an anti-join over the whole
+    // subscribers table (tens of minutes on large installs). With this column
+    // the count becomes `WHERE segments_count = 0`. Defaults to 0; the real
+    // values are populated by the SubscribersSegmentsCountBackfill worker and
+    // kept in sync by SegmentsCountRecalculator. Reads only trust the column
+    // once the backfill has completed (see SubscribersCountsController).
+    if (!$this->columnExists($subscribersTable, 'segments_count')) {
+      $alterations[] = 'ADD COLUMN `segments_count` INT UNSIGNED NOT NULL DEFAULT 0';
+    }
+
+    // Range on segments_count = 0, then status and deleted_at cover the
+    // per-status breakdown so the count query stays index-only.
+    if (!$this->indexExists($subscribersTable, 'segments_count_status_deleted_at')) {
+      $alterations[] = 'ADD INDEX `segments_count_status_deleted_at` (`segments_count`, `status`, `deleted_at`)';
+    }
+
+    if ($alterations === []) {
+      return;
+    }
+
+    $this->connection->executeStatement(
+      "ALTER TABLE `{$subscribersTable}` " . implode(', ', $alterations)
+    );
+  }
+}

--- a/mailpoet/lib/Segments/SegmentSubscribersRepository.php
+++ b/mailpoet/lib/Segments/SegmentSubscribersRepository.php
@@ -386,6 +386,11 @@ class SegmentSubscribersRepository {
   }
 
   public function addConstraintsForSubscribersWithoutSegment(ORMQueryBuilder $queryBuilder): void {
+    if ($this->isSegmentsCountColumnReady()) {
+      $queryBuilder->andWhere('s.segmentsCount = 0');
+      return;
+    }
+
     $deletedSegmentsQueryBuilder = $this->entityManager->createQueryBuilder();
     $deletedSegmentsQueryBuilder->select('sg.id')
       ->from(SegmentEntity::class, 'sg')

--- a/mailpoet/lib/Segments/SegmentSubscribersRepository.php
+++ b/mailpoet/lib/Segments/SegmentSubscribersRepository.php
@@ -321,11 +321,7 @@ class SegmentSubscribersRepository {
     try {
       $queryBuilder = $this->createWithoutSegmentStatisticsQueryBuilder();
 
-      if ($this->isSegmentsCountColumnReady()) {
-        $queryBuilder->where('s.segments_count = 0');
-      } else {
-        $this->addConstraintsForSubscribersWithoutSegmentToDBAL($queryBuilder);
-      }
+      $this->addConstraintsForSubscribersWithoutSegmentToDBAL($queryBuilder);
 
       $statement = $this->executeQuery($queryBuilder);
       $result = $statement->fetch();
@@ -412,6 +408,11 @@ class SegmentSubscribersRepository {
   }
 
   public function addConstraintsForSubscribersWithoutSegmentToDBAL(QueryBuilder $queryBuilder): void {
+    if ($this->isSegmentsCountColumnReady()) {
+      $queryBuilder->andWhere('s.segments_count = 0');
+      return;
+    }
+
     $deletedSegmentsQueryBuilder = $this->entityManager->createQueryBuilder();
     $subscribersSegmentTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
     $deletedSegmentsQueryBuilder->select('sg.id')

--- a/mailpoet/lib/Segments/SegmentSubscribersRepository.php
+++ b/mailpoet/lib/Segments/SegmentSubscribersRepository.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Segments;
 
+use MailPoet\Cron\Workers\SubscribersSegmentsCountSync;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
@@ -12,6 +13,7 @@ use MailPoet\Logging\LoggerFactory;
 use MailPoet\NotFoundException;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Segments\DynamicSegments\FilterHandler;
+use MailPoet\Settings\SettingsController;
 use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use MailPoetVendor\Doctrine\DBAL\Result;
@@ -30,14 +32,19 @@ class SegmentSubscribersRepository {
   /** @var SegmentsRepository */
   private $segmentsRepository;
 
+  /** @var SettingsController */
+  private $settings;
+
   public function __construct(
     EntityManager $entityManager,
     FilterHandler $filterHandler,
-    SegmentsRepository $segmentsRepository
+    SegmentsRepository $segmentsRepository,
+    SettingsController $settings
   ) {
     $this->entityManager = $entityManager;
     $this->filterHandler = $filterHandler;
     $this->segmentsRepository = $segmentsRepository;
+    $this->settings = $settings;
   }
 
   public function findSubscribersIdsInSegment(int $segmentId, ?array $candidateIds = null): array {
@@ -285,6 +292,14 @@ class SegmentSubscribersRepository {
   }
 
   public function getSubscribersWithoutSegmentCount(): int {
+    if ($this->isSegmentsCountColumnReady()) {
+      $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+      $count = $this->entityManager->getConnection()->executeQuery(
+        "SELECT COUNT(*) FROM {$subscribersTable} WHERE segments_count = 0"
+      )->fetchOne();
+      return is_numeric($count) ? (int)$count : 0;
+    }
+
     $queryBuilder = $this->entityManager->createQueryBuilder();
     $queryBuilder
       ->select('COUNT(DISTINCT s) AS subscribersCount')
@@ -293,49 +308,25 @@ class SegmentSubscribersRepository {
     return (int)$queryBuilder->getQuery()->getSingleScalarResult();
   }
 
+  /**
+   * segments_count is only trustworthy once the backfill sweep has finished
+   * (see SubscribersSegmentsCountSync). Until then the read paths fall back to
+   * the anti-join so they never report 0 for everyone.
+   */
+  private function isSegmentsCountColumnReady(): bool {
+    return (bool)$this->settings->get(SubscribersSegmentsCountSync::BACKFILLED_SETTING_KEY, false);
+  }
+
   public function getSubscribersWithoutSegmentStatisticsCount(): array {
     try {
-      $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-      $queryBuilder = $this->entityManager
-        ->getConnection()
-        ->createQueryBuilder();
-      $queryBuilder
-        ->addSelect('IFNULL(SUM(
-            CASE WHEN s.deleted_at IS NULL
-              THEN 1 ELSE 0 END
-        ), 0) as `all`')
-        ->addSelect('IFNULL(SUM(
-            CASE WHEN s.deleted_at IS NOT NULL
-              THEN 1 ELSE 0 END
-        ), 0) as trash')
-        ->addSelect('IFNULL(SUM(
-            CASE WHEN s.status = :status_subscribed AND s.deleted_at IS NULL
-              THEN 1 ELSE 0 END
-        ), 0) as :status_subscribed')
-        ->addSelect('IFNULL(SUM(
-          CASE WHEN s.status = :status_unsubscribed AND s.deleted_at IS NULL
-            THEN 1 ELSE 0 END
-        ), 0) as :status_unsubscribed')
-        ->addSelect('IFNULL(SUM(
-          CASE WHEN s.status = :status_inactive AND s.deleted_at IS NULL
-            THEN 1 ELSE 0 END
-        ), 0) as :status_inactive')
-        ->addSelect('IFNULL(SUM(
-          CASE WHEN s.status = :status_unconfirmed AND s.deleted_at IS NULL
-            THEN 1 ELSE 0 END
-        ), 0) as :status_unconfirmed')
-        ->addSelect('IFNULL(SUM(
-          CASE WHEN s.status = :status_bounced AND s.deleted_at IS NULL
-            THEN 1 ELSE 0 END
-        ), 0) as :status_bounced')
-        ->from($subscribersTable, 's')
-        ->setParameter('status_subscribed', SubscriberEntity::STATUS_SUBSCRIBED)
-        ->setParameter('status_unsubscribed', SubscriberEntity::STATUS_UNSUBSCRIBED)
-        ->setParameter('status_inactive', SubscriberEntity::STATUS_INACTIVE)
-        ->setParameter('status_unconfirmed', SubscriberEntity::STATUS_UNCONFIRMED)
-        ->setParameter('status_bounced', SubscriberEntity::STATUS_BOUNCED);
+      $queryBuilder = $this->createWithoutSegmentStatisticsQueryBuilder();
 
-      $this->addConstraintsForSubscribersWithoutSegmentToDBAL($queryBuilder);
+      if ($this->isSegmentsCountColumnReady()) {
+        $queryBuilder->where('s.segments_count = 0');
+      } else {
+        $this->addConstraintsForSubscribersWithoutSegmentToDBAL($queryBuilder);
+      }
+
       $statement = $this->executeQuery($queryBuilder);
       $result = $statement->fetch();
 
@@ -348,6 +339,50 @@ class SegmentSubscribersRepository {
       $this->logQueryException(null, $e);
       return $this->emptyStatisticsResult();
     }
+  }
+
+  private function createWithoutSegmentStatisticsQueryBuilder(): QueryBuilder {
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $queryBuilder = $this->entityManager
+      ->getConnection()
+      ->createQueryBuilder();
+    $queryBuilder
+      ->addSelect('IFNULL(SUM(
+          CASE WHEN s.deleted_at IS NULL
+            THEN 1 ELSE 0 END
+      ), 0) as `all`')
+      ->addSelect('IFNULL(SUM(
+          CASE WHEN s.deleted_at IS NOT NULL
+            THEN 1 ELSE 0 END
+      ), 0) as trash')
+      ->addSelect('IFNULL(SUM(
+          CASE WHEN s.status = :status_subscribed AND s.deleted_at IS NULL
+            THEN 1 ELSE 0 END
+      ), 0) as :status_subscribed')
+      ->addSelect('IFNULL(SUM(
+        CASE WHEN s.status = :status_unsubscribed AND s.deleted_at IS NULL
+          THEN 1 ELSE 0 END
+      ), 0) as :status_unsubscribed')
+      ->addSelect('IFNULL(SUM(
+        CASE WHEN s.status = :status_inactive AND s.deleted_at IS NULL
+          THEN 1 ELSE 0 END
+      ), 0) as :status_inactive')
+      ->addSelect('IFNULL(SUM(
+        CASE WHEN s.status = :status_unconfirmed AND s.deleted_at IS NULL
+          THEN 1 ELSE 0 END
+      ), 0) as :status_unconfirmed')
+      ->addSelect('IFNULL(SUM(
+        CASE WHEN s.status = :status_bounced AND s.deleted_at IS NULL
+          THEN 1 ELSE 0 END
+      ), 0) as :status_bounced')
+      ->from($subscribersTable, 's')
+      ->setParameter('status_subscribed', SubscriberEntity::STATUS_SUBSCRIBED)
+      ->setParameter('status_unsubscribed', SubscriberEntity::STATUS_UNSUBSCRIBED)
+      ->setParameter('status_inactive', SubscriberEntity::STATUS_INACTIVE)
+      ->setParameter('status_unconfirmed', SubscriberEntity::STATUS_UNCONFIRMED)
+      ->setParameter('status_bounced', SubscriberEntity::STATUS_BOUNCED);
+
+    return $queryBuilder;
   }
 
   public function addConstraintsForSubscribersWithoutSegment(ORMQueryBuilder $queryBuilder): void {

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -387,11 +387,10 @@ class SegmentsRepository extends Repository {
     ->getQuery()->execute();
 
     // Trashing or restoring a segment changes whether its memberships count
-    // towards segments_count, so refresh every affected subscriber in a single
-    // deduplicated pass (a subscriber in several of these segments is counted once).
-    $this->segmentsCountRecalculator->recalculateForSubscribers(
-      $this->getSubscriberIdsForSegments($ids, $type)
-    );
+    // towards segments_count, so refresh every affected subscriber. The
+    // memberships still exist here (only deleted_at changed), so walk them in
+    // keyset-paginated batches instead of materializing every member id at once.
+    $this->segmentsCountRecalculator->recalculateForSegments($ids);
 
     return $rows;
   }

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -387,10 +387,11 @@ class SegmentsRepository extends Repository {
     ->getQuery()->execute();
 
     // Trashing or restoring a segment changes whether its memberships count
-    // towards segments_count, so refresh every affected subscriber.
-    foreach ($ids as $id) {
-      $this->segmentsCountRecalculator->recalculateForSegment((int)$id);
-    }
+    // towards segments_count, so refresh every affected subscriber in a single
+    // deduplicated pass (a subscriber in several of these segments is counted once).
+    $this->segmentsCountRecalculator->recalculateForSubscribers(
+      $this->getSubscriberIdsForSegments($ids, $type)
+    );
 
     return $rows;
   }

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -9,6 +9,7 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Form\FormsRepository;
 use MailPoet\InvalidStateException;
@@ -341,14 +342,17 @@ class SegmentsRepository extends Repository {
     $subscriberSegmentTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
     $segmentTable = $this->entityManager->getClassMetadata(SegmentEntity::class)->getTableName();
 
+    $subscribedStatus = SubscriberEntity::STATUS_SUBSCRIBED;
     $ids = $this->entityManager->getConnection()->executeQuery("
        SELECT DISTINCT ss.`subscriber_id` FROM $subscriberSegmentTable ss
        JOIN $segmentTable s ON ss.`segment_id` = s.`id`
        WHERE ss.`segment_id` IN (:ids)
        AND s.`type` = :type
+       AND ss.`status` = :subscribedStatus
     ", [
       'ids' => $segmentIds,
       'type' => $type,
+      'subscribedStatus' => $subscribedStatus,
     ], ['ids' => ArrayParameterType::INTEGER])->fetchFirstColumn();
 
     return array_map(function ($id): int {

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -15,6 +15,7 @@ use MailPoet\InvalidStateException;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\NotFoundException;
+use MailPoet\Subscribers\SegmentsCountRecalculator;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
@@ -39,18 +40,23 @@ class SegmentsRepository extends Repository {
   /** @var LoggerFactory */
   private $loggerFactory;
 
+  /** @var SegmentsCountRecalculator */
+  private $segmentsCountRecalculator;
+
   public function __construct(
     EntityManager $entityManager,
     NewsletterSegmentRepository $newsletterSegmentRepository,
     FormsRepository $formsRepository,
     WPFunctions $wp,
-    LoggerFactory $loggerFactory
+    LoggerFactory $loggerFactory,
+    SegmentsCountRecalculator $segmentsCountRecalculator
   ) {
     parent::__construct($entityManager);
     $this->newsletterSegmentRepository = $newsletterSegmentRepository;
     $this->formsRepository = $formsRepository;
     $this->wp = $wp;
     $this->loggerFactory = $loggerFactory;
+    $this->segmentsCountRecalculator = $segmentsCountRecalculator;
   }
 
   protected function getEntityClassName() {
@@ -276,6 +282,10 @@ class SegmentsRepository extends Repository {
       return 0;
     }
 
+    // Capture the affected subscribers before the cascade removes their
+    // memberships, so segments_count can be refreshed for them afterwards.
+    $affectedSubscriberIds = $this->getSubscriberIdsForSegments($ids, $type);
+
     $count = 0;
     $this->entityManager->transactional(function (EntityManager $entityManager) use ($ids, $type, &$count) {
       $subscriberSegmentTable = $entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
@@ -313,7 +323,37 @@ class SegmentsRepository extends Repository {
         ->setParameter('ids', $ids, ArrayParameterType::INTEGER)
         ->getQuery()->execute();
     });
+
+    $this->segmentsCountRecalculator->recalculateForSubscribers($affectedSubscriberIds);
+
     return $count;
+  }
+
+  /**
+   * @param int[] $segmentIds
+   * @return int[]
+   */
+  private function getSubscriberIdsForSegments(array $segmentIds, string $type): array {
+    if (empty($segmentIds)) {
+      return [];
+    }
+
+    $subscriberSegmentTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
+    $segmentTable = $this->entityManager->getClassMetadata(SegmentEntity::class)->getTableName();
+
+    $ids = $this->entityManager->getConnection()->executeQuery("
+       SELECT DISTINCT ss.`subscriber_id` FROM $subscriberSegmentTable ss
+       JOIN $segmentTable s ON ss.`segment_id` = s.`id`
+       WHERE ss.`segment_id` IN (:ids)
+       AND s.`type` = :type
+    ", [
+      'ids' => $segmentIds,
+      'type' => $type,
+    ], ['ids' => ArrayParameterType::INTEGER])->fetchFirstColumn();
+
+    return array_map(function ($id): int {
+      return is_numeric($id) ? (int)$id : 0;
+    }, $ids);
   }
 
   public function bulkTrash(array $ids, string $type = SegmentEntity::TYPE_DEFAULT): int {
@@ -345,6 +385,12 @@ class SegmentsRepository extends Repository {
     ->setParameter('ids', $ids)
     ->setParameter('type', $type)
     ->getQuery()->execute();
+
+    // Trashing or restoring a segment changes whether its memberships count
+    // towards segments_count, so refresh every affected subscriber.
+    foreach ($ids as $id) {
+      $this->segmentsCountRecalculator->recalculateForSegment((int)$id);
+    }
 
     return $rows;
   }

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -426,10 +426,10 @@ class WP {
     // insertUsersToSegment adds WP users to the WP-Users segment via raw SQL,
     // so refresh segments_count for that segment's members.
     // recalculateForSegment() only sees subscribers that still have a membership
-    // row, but that is fine here: removeOrphanedSubscribers() hard-deletes the
-    // subscriber rows it removes, so their stale count is moot. (Contrast with
-    // the WooCommerce path, which deletes only the membership row while the
-    // subscriber survives, and therefore recomputes the affected ids explicitly.)
+    // row. Orphans that are hard-deleted by removeOrphanedSubscribers() are fine
+    // (row gone, count moot). Orphans that are soft-trashed have their
+    // segments_count zeroed directly in the soft-trash UPDATE, so they are also
+    // handled before the membership rows are removed.
     $this->segmentsCountRecalculator->recalculateForSegment((int)$this->segmentsRepository->getWPUsersSegment()->getId());
     $this->subscribersRepository->invalidateTotalSubscribersCache();
     $this->subscribersRepository->refreshAll();

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -13,6 +13,7 @@ use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Services\Validator;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
+use MailPoet\Subscribers\SegmentsCountRecalculator;
 use MailPoet\Subscribers\Source;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -60,6 +61,9 @@ class WP {
   /** @var \MailPoetVendor\Doctrine\DBAL\Connection */
   private $databaseConnection;
 
+  /** @var SegmentsCountRecalculator */
+  private $segmentsCountRecalculator;
+
   public function __construct(
     WPFunctions $wp,
     WelcomeScheduler $welcomeScheduler,
@@ -70,7 +74,8 @@ class WP {
     Validator $validator,
     SegmentsRepository $segmentsRepository,
     EntityManager $entityManager,
-    DBCollationChecker $collationChecker
+    DBCollationChecker $collationChecker,
+    SegmentsCountRecalculator $segmentsCountRecalculator
   ) {
     $this->wp = $wp;
     $this->welcomeScheduler = $welcomeScheduler;
@@ -82,6 +87,7 @@ class WP {
     $this->segmentsRepository = $segmentsRepository;
     $this->entityManager = $entityManager;
     $this->collationChecker = $collationChecker;
+    $this->segmentsCountRecalculator = $segmentsCountRecalculator;
     $this->databaseConnection = $this->entityManager->getConnection();
     $this->subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
   }
@@ -161,6 +167,7 @@ class WP {
       $this->subscribersRepository->persist($subscriber);
       $this->subscribersRepository->flush();
     });
+    $this->segmentsCountRecalculator->recalculateForSubscribers([(int)$subscriber->getId()]);
   }
 
   private function hasOtherActiveSegments(SubscriberEntity $subscriber): bool {
@@ -416,6 +423,9 @@ class WP {
     $this->updateFirstNameIfMissing();
     $this->insertUsersToSegment();
     $this->removeOrphanedSubscribers();
+    // insertUsersToSegment adds WP users to the WP-Users segment via raw SQL,
+    // so refresh segments_count for that segment's members.
+    $this->segmentsCountRecalculator->recalculateForSegment((int)$this->segmentsRepository->getWPUsersSegment()->getId());
     $this->subscribersRepository->invalidateTotalSubscribersCache();
     $this->subscribersRepository->refreshAll();
 

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -425,6 +425,11 @@ class WP {
     $this->removeOrphanedSubscribers();
     // insertUsersToSegment adds WP users to the WP-Users segment via raw SQL,
     // so refresh segments_count for that segment's members.
+    // recalculateForSegment() only sees subscribers that still have a membership
+    // row, but that is fine here: removeOrphanedSubscribers() hard-deletes the
+    // subscriber rows it removes, so their stale count is moot. (Contrast with
+    // the WooCommerce path, which deletes only the membership row while the
+    // subscriber survives, and therefore recomputes the affected ids explicitly.)
     $this->segmentsCountRecalculator->recalculateForSegment((int)$this->segmentsRepository->getWPUsersSegment()->getId());
     $this->subscribersRepository->invalidateTotalSubscribersCache();
     $this->subscribersRepository->refreshAll();

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -427,9 +427,9 @@ class WP {
     // so refresh segments_count for that segment's members.
     // recalculateForSegment() only sees subscribers that still have a membership
     // row. Orphans that are hard-deleted by removeOrphanedSubscribers() are fine
-    // (row gone, count moot). Orphans that are soft-trashed have their
-    // segments_count zeroed directly in the soft-trash UPDATE, so they are also
-    // handled before the membership rows are removed.
+    // (row gone, count moot). Orphans whose membership is deleted but who survive
+    // (soft-trashed or still on other lists) are recalculated explicitly inside
+    // removeOrphanedSubscribersFromWpSegment() before the membership DELETE.
     $this->segmentsCountRecalculator->recalculateForSegment((int)$this->segmentsRepository->getWPUsersSegment()->getId());
     $this->subscribersRepository->invalidateTotalSubscribersCache();
     $this->subscribersRepository->refreshAll();

--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -215,8 +215,10 @@ class WooCommerce {
       $this->updateStatus();
       $this->updateGlobalStatus();
       // The bulk operations above add/remove/restatus the WooCommerce segment's
-      // memberships en masse via raw SQL, so refresh segments_count for them.
-      $this->segmentsCountRecalculator->recalculateForSegment((int)$this->segmentsRepository->getWooCommerceSegment()->getId());
+      // memberships en masse via raw SQL, so refresh segments_count for all
+      // members regardless of status — some may have just transitioned away
+      // from subscribed and must be recomputed too.
+      $this->segmentsCountRecalculator->recalculateForSegment((int)$this->segmentsRepository->getWooCommerceSegment()->getId(), false);
     }
 
     $this->subscribersRepository->invalidateTotalSubscribersCache();

--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -474,10 +474,11 @@ class WooCommerce {
       "
       SELECT mpss.subscriber_id FROM {$subscriberSegmentsTable} mpss
       LEFT JOIN {$subscribersTable} mps ON mpss.subscriber_id = mps.id
-      WHERE mpss.segment_id = :segmentId AND (mps.is_woocommerce_user = 0 OR mps.email = '' OR mps.email IS NULL)
+      WHERE mpss.segment_id = :segmentId AND mpss.status = :subscribedStatus
+        AND (mps.is_woocommerce_user = 0 OR mps.email = '' OR mps.email IS NULL)
     ",
-      ['segmentId' => $wcSegment->getId()],
-      ['segmentId' => ParameterType::INTEGER]
+      ['segmentId' => $wcSegment->getId(), 'subscribedStatus' => SubscriberEntity::STATUS_SUBSCRIBED],
+      ['segmentId' => ParameterType::INTEGER, 'subscribedStatus' => ParameterType::STRING]
     )->fetchFirstColumn();
 
     // Unsubscribe non-WC or invalid users from segment

--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -109,8 +109,9 @@ class WooCommerce {
     switch ($currentFilter) {
       case 'woocommerce_delete_customer':
         // subscriber should be already deleted in WP users sync
+        // unsubscribeUsersFromSegment() recomputes segments_count for the rows it
+        // removes, so no whole-segment sweep is needed here.
         $this->unsubscribeUsersFromSegment(); // remove leftover association
-        $this->segmentsCountRecalculator->recalculateForSegment((int)$wcSegment->getId());
         break;
       case 'woocommerce_new_customer':
       case 'woocommerce_created_customer':
@@ -462,6 +463,21 @@ class WooCommerce {
     $wcSegment = $this->segmentsRepository->getWooCommerceSegment();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $subscriberSegmentsTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
+
+    // Capture the affected subscriber ids before the DELETE: once the membership
+    // rows are gone, recalculateForSegment() can no longer see these subscribers,
+    // so a surviving subscriber would keep a stale segments_count. Recompute them
+    // explicitly afterwards (same pattern as SegmentsRepository::bulkDelete()).
+    $affectedIds = $this->connection->executeQuery(
+      "
+      SELECT mpss.subscriber_id FROM {$subscriberSegmentsTable} mpss
+      LEFT JOIN {$subscribersTable} mps ON mpss.subscriber_id = mps.id
+      WHERE mpss.segment_id = :segmentId AND (mps.is_woocommerce_user = 0 OR mps.email = '' OR mps.email IS NULL)
+    ",
+      ['segmentId' => $wcSegment->getId()],
+      ['segmentId' => ParameterType::INTEGER]
+    )->fetchFirstColumn();
+
     // Unsubscribe non-WC or invalid users from segment
     $this->connection->executeQuery(
       "
@@ -472,6 +488,11 @@ class WooCommerce {
       ['segmentId' => $wcSegment->getId()],
       ['segmentId' => ParameterType::INTEGER]
     );
+
+    $subscriberIds = array_map(function ($id): int {
+      return is_numeric($id) ? (int)$id : 0;
+    }, $affectedIds);
+    $this->segmentsCountRecalculator->recalculateForSubscribers($subscriberIds);
   }
 
   private function updateGlobalStatus(): void {

--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -8,6 +8,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Services\Validator;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\SegmentsCountRecalculator;
 use MailPoet\Subscribers\Source;
 use MailPoet\Subscribers\SubscriberSaveController;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
@@ -64,6 +65,9 @@ class WooCommerce {
   /** @var Validator */
   private $validator;
 
+  /** @var SegmentsCountRecalculator */
+  private $segmentsCountRecalculator;
+
   public function __construct(
     SettingsController $settings,
     WPFunctions $wp,
@@ -76,7 +80,8 @@ class WooCommerce {
     EntityManager $entityManager,
     Connection $connection,
     SubscriberChangesNotifier $subscriberChangesNotifier,
-    Validator $validator
+    Validator $validator,
+    SegmentsCountRecalculator $segmentsCountRecalculator
   ) {
     $this->settings = $settings;
     $this->wp = $wp;
@@ -90,6 +95,7 @@ class WooCommerce {
     $this->connection = $connection;
     $this->subscriberChangesNotifier = $subscriberChangesNotifier;
     $this->validator = $validator;
+    $this->segmentsCountRecalculator = $segmentsCountRecalculator;
   }
 
   public function shouldShowWooCommerceSegment(): bool {
@@ -104,6 +110,7 @@ class WooCommerce {
       case 'woocommerce_delete_customer':
         // subscriber should be already deleted in WP users sync
         $this->unsubscribeUsersFromSegment(); // remove leftover association
+        $this->segmentsCountRecalculator->recalculateForSegment((int)$wcSegment->getId());
         break;
       case 'woocommerce_new_customer':
       case 'woocommerce_created_customer':
@@ -206,6 +213,9 @@ class WooCommerce {
       $this->removeOrphanedSubscribers();
       $this->updateStatus();
       $this->updateGlobalStatus();
+      // The bulk operations above add/remove/restatus the WooCommerce segment's
+      // memberships en masse via raw SQL, so refresh segments_count for them.
+      $this->segmentsCountRecalculator->recalculateForSegment((int)$this->segmentsRepository->getWooCommerceSegment()->getId());
     }
 
     $this->subscribersRepository->invalidateTotalSubscribersCache();

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -661,6 +661,7 @@ class Import {
         );
       }
     }
+    $this->subscriberRepository->recalculateSegmentsCount($subscribersIds);
   }
 
   /**

--- a/mailpoet/lib/Subscribers/SegmentsCountRecalculator.php
+++ b/mailpoet/lib/Subscribers/SegmentsCountRecalculator.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Subscribers;
 
+use MailPoet\Doctrine\WPDB\Connection;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
@@ -43,6 +44,14 @@ class SegmentsCountRecalculator {
    * @param int[] $subscriberIds
    */
   public function recalculateForSubscribers(array $subscriberIds): void {
+    // The UPDATE ... LEFT JOIN syntax below is not supported by the SQLite
+    // integration used in WordPress Playground. Reads stay on the anti-join
+    // there because the sync worker never flips the backfill flag (see
+    // SubscribersSegmentsCountSync::processTaskStrategy()).
+    if (Connection::isSQLite()) {
+      return;
+    }
+
     $subscriberIds = array_values(array_unique($subscriberIds));
     if ($subscriberIds === []) {
       return;
@@ -69,6 +78,11 @@ class SegmentsCountRecalculator {
    * Used by the backfill and reconcile workers.
    */
   public function recalculateForIdRange(int $minId, int $maxId): void {
+    // See recalculateForSubscribers(): UPDATE ... LEFT JOIN is unsupported on SQLite.
+    if (Connection::isSQLite()) {
+      return;
+    }
+
     if ($minId > $maxId) {
       return;
     }
@@ -91,6 +105,30 @@ class SegmentsCountRecalculator {
    * changes the count of all of its members at once.
    */
   public function recalculateForSegment(int $segmentId): void {
+    $this->recalculateForSegments([$segmentId]);
+  }
+
+  /**
+   * Recalculate the count for every subscriber that has a membership in any of
+   * the given segments. Used when segments are trashed, restored or deleted,
+   * which changes the count of all of their members at once.
+   *
+   * Members are walked in keyset-paginated batches rather than materialized into
+   * one array, so this stays memory-safe even on multi-million-member segments.
+   *
+   * @param int[] $segmentIds
+   */
+  public function recalculateForSegments(array $segmentIds): void {
+    // recalculateForSubscribers() is a no-op on SQLite, so skip the walk too.
+    if (Connection::isSQLite()) {
+      return;
+    }
+
+    $segmentIds = array_values(array_unique(array_map('intval', $segmentIds)));
+    if ($segmentIds === []) {
+      return;
+    }
+
     $subscriberSegmentTable = $this->getTableName(SubscriberSegmentEntity::class);
     $connection = $this->entityManager->getConnection();
 
@@ -98,12 +136,12 @@ class SegmentsCountRecalculator {
     do {
       $batchSize = self::BATCH_SIZE;
       $ids = $connection->executeQuery(
-        "SELECT subscriber_id FROM {$subscriberSegmentTable}
-          WHERE segment_id = :segmentId AND subscriber_id > :lastId
+        "SELECT DISTINCT subscriber_id FROM {$subscriberSegmentTable}
+          WHERE segment_id IN (:segmentIds) AND subscriber_id > :lastId
           ORDER BY subscriber_id ASC
           LIMIT {$batchSize}",
-        ['segmentId' => $segmentId, 'lastId' => $lastId],
-        ['segmentId' => ParameterType::INTEGER, 'lastId' => ParameterType::INTEGER]
+        ['segmentIds' => $segmentIds, 'lastId' => $lastId],
+        ['segmentIds' => ArrayParameterType::INTEGER, 'lastId' => ParameterType::INTEGER]
       )->fetchFirstColumn();
 
       if ($ids === []) {

--- a/mailpoet/lib/Subscribers/SegmentsCountRecalculator.php
+++ b/mailpoet/lib/Subscribers/SegmentsCountRecalculator.php
@@ -104,8 +104,8 @@ class SegmentsCountRecalculator {
    * given segment. Used when a segment is trashed, restored or deleted, which
    * changes the count of all of its members at once.
    */
-  public function recalculateForSegment(int $segmentId): void {
-    $this->recalculateForSegments([$segmentId]);
+  public function recalculateForSegment(int $segmentId, bool $subscribedOnly = true): void {
+    $this->recalculateForSegments([$segmentId], $subscribedOnly);
   }
 
   /**
@@ -116,9 +116,19 @@ class SegmentsCountRecalculator {
    * Members are walked in keyset-paginated batches rather than materialized into
    * one array, so this stays memory-safe even on multi-million-member segments.
    *
+   * $subscribedOnly = true (default): only walk members whose current
+   * subscriber_segment.status = 'subscribed'. Safe when the segment's
+   * deleted_at changed but no membership statuses changed — non-subscribed
+   * members were never counted and their recomputation is a no-op.
+   *
+   * $subscribedOnly = false: walk all members regardless of status. Required
+   * when the caller performed raw-SQL writes that may have changed membership
+   * statuses (e.g. the WooCommerce sync), so subscribers transitioning away
+   * from subscribed must also be recomputed.
+   *
    * @param int[] $segmentIds
    */
-  public function recalculateForSegments(array $segmentIds): void {
+  public function recalculateForSegments(array $segmentIds, bool $subscribedOnly = true): void {
     // recalculateForSubscribers() is a no-op on SQLite, so skip the walk too.
     if (Connection::isSQLite()) {
       return;
@@ -132,13 +142,15 @@ class SegmentsCountRecalculator {
     $subscriberSegmentTable = $this->getTableName(SubscriberSegmentEntity::class);
     $connection = $this->entityManager->getConnection();
 
-    $subscribedStatus = SubscriberEntity::STATUS_SUBSCRIBED;
+    $statusFilter = $subscribedOnly
+      ? "AND status = '" . SubscriberEntity::STATUS_SUBSCRIBED . "'"
+      : '';
     $lastId = 0;
     do {
       $batchSize = self::BATCH_SIZE;
       $ids = $connection->executeQuery(
         "SELECT DISTINCT subscriber_id FROM {$subscriberSegmentTable}
-          WHERE segment_id IN (:segmentIds) AND status = '{$subscribedStatus}' AND subscriber_id > :lastId
+          WHERE segment_id IN (:segmentIds) {$statusFilter} AND subscriber_id > :lastId
           ORDER BY subscriber_id ASC
           LIMIT {$batchSize}",
         ['segmentIds' => $segmentIds, 'lastId' => $lastId],

--- a/mailpoet/lib/Subscribers/SegmentsCountRecalculator.php
+++ b/mailpoet/lib/Subscribers/SegmentsCountRecalculator.php
@@ -1,0 +1,139 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscribers;
+
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
+use MailPoetVendor\Doctrine\DBAL\ParameterType;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+/**
+ * Keeps SubscriberEntity::$segmentsCount in sync.
+ *
+ * segments_count is the number of the subscriber's subscribed memberships in
+ * non-deleted segments. It mirrors the anti-join that used to power the
+ * "Subscribers without a list" count, so the read can become
+ * `WHERE segments_count = 0` instead of scanning every subscriber.
+ *
+ * Every recalculation re-derives the value from subscriber_segment + segments,
+ * so it is idempotent: it is safe to call from several write paths, to call
+ * twice, or to run concurrently with the backfill — the value always converges.
+ * The semantics intentionally match the previous query exactly: only
+ * status = 'subscribed' memberships in segments with deleted_at IS NULL are
+ * counted, with no filtering by segment type (WP/WooCommerce segments count too).
+ */
+class SegmentsCountRecalculator {
+  /** Subscribers touched per UPDATE when recalculating large/segment-wide sets. */
+  private const BATCH_SIZE = 10000;
+
+  /** @var EntityManager */
+  private $entityManager;
+
+  public function __construct(
+    EntityManager $entityManager
+  ) {
+    $this->entityManager = $entityManager;
+  }
+
+  /**
+   * Recalculate the count for an explicit set of subscribers.
+   *
+   * @param int[] $subscriberIds
+   */
+  public function recalculateForSubscribers(array $subscriberIds): void {
+    $subscriberIds = array_values(array_unique($subscriberIds));
+    if ($subscriberIds === []) {
+      return;
+    }
+
+    $subscribersTable = $this->getTableName(SubscriberEntity::class);
+    $membershipSelect = $this->membershipCountSubquery('ssg.subscriber_id IN (:ids)');
+    $connection = $this->entityManager->getConnection();
+
+    foreach (array_chunk($subscriberIds, self::BATCH_SIZE) as $chunk) {
+      $connection->executeStatement(
+        "UPDATE {$subscribersTable} s
+          LEFT JOIN ({$membershipSelect}) m ON m.subscriber_id = s.id
+          SET s.segments_count = IFNULL(m.c, 0)
+          WHERE s.id IN (:ids)",
+        ['ids' => $chunk],
+        ['ids' => ArrayParameterType::INTEGER]
+      );
+    }
+  }
+
+  /**
+   * Recalculate the count for an inclusive range of subscriber ids.
+   * Used by the backfill and reconcile workers.
+   */
+  public function recalculateForIdRange(int $minId, int $maxId): void {
+    if ($minId > $maxId) {
+      return;
+    }
+
+    $subscribersTable = $this->getTableName(SubscriberEntity::class);
+    $membershipSelect = $this->membershipCountSubquery('ssg.subscriber_id BETWEEN :minId AND :maxId');
+
+    $this->entityManager->getConnection()->executeStatement(
+      "UPDATE {$subscribersTable} s
+        LEFT JOIN ({$membershipSelect}) m ON m.subscriber_id = s.id
+        SET s.segments_count = IFNULL(m.c, 0)
+        WHERE s.id BETWEEN :minId AND :maxId",
+      ['minId' => $minId, 'maxId' => $maxId]
+    );
+  }
+
+  /**
+   * Recalculate the count for every subscriber that has a membership in the
+   * given segment. Used when a segment is trashed, restored or deleted, which
+   * changes the count of all of its members at once.
+   */
+  public function recalculateForSegment(int $segmentId): void {
+    $subscriberSegmentTable = $this->getTableName(SubscriberSegmentEntity::class);
+    $connection = $this->entityManager->getConnection();
+
+    $lastId = 0;
+    do {
+      $batchSize = self::BATCH_SIZE;
+      $ids = $connection->executeQuery(
+        "SELECT subscriber_id FROM {$subscriberSegmentTable}
+          WHERE segment_id = :segmentId AND subscriber_id > :lastId
+          ORDER BY subscriber_id ASC
+          LIMIT {$batchSize}",
+        ['segmentId' => $segmentId, 'lastId' => $lastId],
+        ['segmentId' => ParameterType::INTEGER, 'lastId' => ParameterType::INTEGER]
+      )->fetchFirstColumn();
+
+      if ($ids === []) {
+        break;
+      }
+
+      $subscriberIds = array_map(function ($id): int {
+        return is_numeric($id) ? (int)$id : 0;
+      }, $ids);
+      $this->recalculateForSubscribers($subscriberIds);
+      $lastId = (int)end($subscriberIds);
+    } while (count($ids) === self::BATCH_SIZE);
+  }
+
+  private function membershipCountSubquery(string $subscriberCondition): string {
+    $subscriberSegmentTable = $this->getTableName(SubscriberSegmentEntity::class);
+    $segmentsTable = $this->getTableName(SegmentEntity::class);
+    $subscribedStatus = SubscriberEntity::STATUS_SUBSCRIBED;
+
+    return "SELECT ssg.subscriber_id, COUNT(*) AS c
+      FROM {$subscriberSegmentTable} ssg
+      JOIN {$segmentsTable} g ON g.id = ssg.segment_id AND g.deleted_at IS NULL
+      WHERE ssg.status = '{$subscribedStatus}' AND {$subscriberCondition}
+      GROUP BY ssg.subscriber_id";
+  }
+
+  /**
+   * @param class-string $entityClass
+   */
+  private function getTableName(string $entityClass): string {
+    return $this->entityManager->getClassMetadata($entityClass)->getTableName();
+  }
+}

--- a/mailpoet/lib/Subscribers/SegmentsCountRecalculator.php
+++ b/mailpoet/lib/Subscribers/SegmentsCountRecalculator.php
@@ -132,12 +132,13 @@ class SegmentsCountRecalculator {
     $subscriberSegmentTable = $this->getTableName(SubscriberSegmentEntity::class);
     $connection = $this->entityManager->getConnection();
 
+    $subscribedStatus = SubscriberEntity::STATUS_SUBSCRIBED;
     $lastId = 0;
     do {
       $batchSize = self::BATCH_SIZE;
       $ids = $connection->executeQuery(
         "SELECT DISTINCT subscriber_id FROM {$subscriberSegmentTable}
-          WHERE segment_id IN (:segmentIds) AND subscriber_id > :lastId
+          WHERE segment_id IN (:segmentIds) AND status = '{$subscribedStatus}' AND subscriber_id > :lastId
           ORDER BY subscriber_id ASC
           LIMIT {$batchSize}",
         ['segmentIds' => $segmentIds, 'lastId' => $lastId],

--- a/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
@@ -72,7 +72,9 @@ class SubscriberSegmentRepository extends Repository {
           continue;
         }
 
-        $this->createOrUpdate($subscriber, $segment, SubscriberEntity::STATUS_UNSUBSCRIBED);
+        // Defer the recompute: there is a single recalculateForSubscribers()
+        // call for this subscriber at the end of the method.
+        $this->createOrUpdate($subscriber, $segment, SubscriberEntity::STATUS_UNSUBSCRIBED, false, true);
       }
       $this->entityManager->flush();
     } else {
@@ -156,15 +158,19 @@ class SubscriberSegmentRepository extends Repository {
    */
   public function subscribeToSegments(SubscriberEntity $subscriber, array $segments, bool $skipHooks = false): void {
     foreach ($segments as $segment) {
-      $this->createOrUpdate($subscriber, $segment, SubscriberEntity::STATUS_SUBSCRIBED, $skipHooks);
+      // Defer the per-segment recompute: subscribing to N segments only changes
+      // this one subscriber's count, so recompute it once after the loop.
+      $this->createOrUpdate($subscriber, $segment, SubscriberEntity::STATUS_SUBSCRIBED, $skipHooks, true);
     }
+    $this->segmentsCountRecalculator->recalculateForSubscribers([(int)$subscriber->getId()]);
   }
 
   public function createOrUpdate(
     SubscriberEntity $subscriber,
     SegmentEntity $segment,
     string $status,
-    bool $skipHooks = false
+    bool $skipHooks = false,
+    bool $skipSegmentsCountRecalculation = false
   ): SubscriberSegmentEntity {
     $subscriberSegment = $this->findOneBy(['segment' => $segment, 'subscriber' => $subscriber]);
 
@@ -189,7 +195,7 @@ class SubscriberSegmentRepository extends Repository {
       $this->wp->doAction('mailpoet_segment_subscribed', $subscriberSegment);
     }
 
-    if ($oldStatus !== $status) {
+    if ($oldStatus !== $status && !$skipSegmentsCountRecalculation) {
       $this->segmentsCountRecalculator->recalculateForSubscribers([(int)$subscriber->getId()]);
     }
 

--- a/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
@@ -17,12 +17,17 @@ class SubscriberSegmentRepository extends Repository {
   /** @var WPFunctions */
   private $wp;
 
+  /** @var SegmentsCountRecalculator */
+  private $segmentsCountRecalculator;
+
   public function __construct(
     EntityManager $entityManager,
-    WPFunctions $wp
+    WPFunctions $wp,
+    SegmentsCountRecalculator $segmentsCountRecalculator
   ) {
     parent::__construct($entityManager);
     $this->wp = $wp;
+    $this->segmentsCountRecalculator = $segmentsCountRecalculator;
   }
 
   protected function getEntityClassName() {
@@ -50,6 +55,7 @@ class SubscriberSegmentRepository extends Repository {
       ->setParameter('subscriber', $subscriber)
       ->getQuery()
       ->execute();
+    $this->segmentsCountRecalculator->recalculateForSubscribers([(int)$subscriber->getId()]);
   }
 
   /**
@@ -87,6 +93,7 @@ class SubscriberSegmentRepository extends Repository {
         $this->entityManager->refresh($subscriberSegment);
       }
     }
+    $this->segmentsCountRecalculator->recalculateForSubscribers([(int)$subscriber->getId()]);
   }
 
   public function resetSubscriptions(SubscriberEntity $subscriber, array $segments): void {
@@ -180,6 +187,10 @@ class SubscriberSegmentRepository extends Repository {
       && $oldStatus !== SubscriberEntity::STATUS_SUBSCRIBED
     ) {
       $this->wp->doAction('mailpoet_segment_subscribed', $subscriberSegment);
+    }
+
+    if ($oldStatus !== $status) {
+      $this->segmentsCountRecalculator->recalculateForSubscribers([(int)$subscriber->getId()]);
     }
 
     return $subscriberSegment;

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -1031,7 +1031,8 @@ class SubscribersRepository extends Repository {
     $segmentsTable = $this->entityManager->getClassMetadata(SegmentEntity::class)->getTableName();
     $deletedAt = $this->getCurrentDateTime()->format('Y-m-d H:i:s');
 
-    $this->entityManager->wrapInTransaction(function () use ($segmentId, $subscribersTable, $subscriberSegmentsTable, $segmentsTable, $deletedAt, $wpdb): void {
+    $affectedIds = [];
+    $this->entityManager->wrapInTransaction(function () use ($segmentId, $subscribersTable, $subscriberSegmentsTable, $segmentsTable, $deletedAt, $wpdb, &$affectedIds): void {
       // Hard-delete broken subscribers in the WP-Users segment when they have no
       // email, or when they have no WP user ID and no other list to belong to.
       $this->entityManager->getConnection()->executeStatement(
@@ -1066,15 +1067,10 @@ class SubscribersRepository extends Repository {
       // Trash subscribers whose WP user is gone, who are only on the WP-Users list,
       // and who are not WC customers — they have nowhere left to belong, but we keep
       // them as soft-deleted so admins can recover them if needed.
-      // segments_count is set to 0 directly: the NOT EXISTS clause below already
-      // guarantees these subscribers have no other active segments, so 0 is provably
-      // correct after their WP-Users membership is deleted. Using = 0 rather than
-      // = segments_count - 1 avoids going negative when the membership status was
-      // not 'subscribed' (and wasn't counted in the first place).
       $this->entityManager->getConnection()->executeStatement(
         "UPDATE {$subscribersTable} s
          LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
-         SET s.deleted_at = :deletedAt, s.status = :unconfirmed, s.segments_count = 0
+         SET s.deleted_at = :deletedAt, s.status = :unconfirmed
          WHERE s.deleted_at IS NULL
            AND s.is_woocommerce_user = 0
            AND s.wp_user_id IS NOT NULL
@@ -1104,6 +1100,24 @@ class SubscribersRepository extends Repository {
         ]
       );
 
+      // Capture subscribers whose WP-Users membership is subscribed before
+      // deleting it — only those have a segments_count that needs updating.
+      // Subscribers already handled by the soft-trash above (no other segments)
+      // are included here too; their recalculation will be a no-op (re-derives 0).
+      $subscribedStatus = SubscriberEntity::STATUS_SUBSCRIBED;
+      $rows = $this->entityManager->getConnection()->executeQuery(
+        "SELECT ss.subscriber_id
+         FROM {$subscriberSegmentsTable} ss
+         INNER JOIN {$subscribersTable} s ON s.id = ss.subscriber_id
+         LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
+         WHERE ss.segment_id = :segmentId
+           AND (s.wp_user_id IS NULL OR u.id IS NULL)
+           AND ss.status = :status",
+        ['segmentId' => $segmentId, 'status' => $subscribedStatus],
+        ['segmentId' => ParameterType::INTEGER, 'status' => ParameterType::STRING]
+      )->fetchFirstColumn();
+      $affectedIds = array_map(fn($id): int => is_numeric($id) ? (int)$id : 0, $rows);
+
       // Remove WP-Users segment memberships for orphans.
       $this->entityManager->getConnection()->executeStatement(
         "DELETE ss
@@ -1126,6 +1140,10 @@ class SubscribersRepository extends Repository {
         ['source' => ParameterType::STRING]
       );
     });
+
+    if ($affectedIds !== []) {
+      $this->segmentsCountRecalculator->recalculateForSubscribers($affectedIds);
+    }
   }
 
   public function removeByWpUserIds(array $wpUserIds) {

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -43,16 +43,21 @@ class SubscribersRepository extends Repository {
   /** @var SegmentsRepository */
   private $segmentsRepository;
 
+  /** @var SegmentsCountRecalculator */
+  private $segmentsCountRecalculator;
+
   public function __construct(
     EntityManager $entityManager,
     SubscriberChangesNotifier $changesNotifier,
     WPFunctions $wp,
-    SegmentsRepository $segmentsRepository
+    SegmentsRepository $segmentsRepository,
+    SegmentsCountRecalculator $segmentsCountRecalculator
   ) {
     $this->wp = $wp;
     parent::__construct($entityManager);
     $this->changesNotifier = $changesNotifier;
     $this->segmentsRepository = $segmentsRepository;
+    $this->segmentsCountRecalculator = $segmentsCountRecalculator;
   }
 
   protected function getEntityClassName() {
@@ -688,6 +693,17 @@ class SubscribersRepository extends Repository {
   }
 
   /**
+   * Recalculate the denormalized segments_count for the given subscribers.
+   * Exposed for raw-SQL write paths (e.g. import) that bypass the repository's
+   * own segment mutators.
+   *
+   * @param int[] $subscriberIds
+   */
+  public function recalculateSegmentsCount(array $subscriberIds): void {
+    $this->segmentsCountRecalculator->recalculateForSubscribers($subscriberIds);
+  }
+
+  /**
    * @return int - number of processed ids
    */
   public function bulkRemoveFromSegment(SegmentEntity $segment, array $ids): int {
@@ -702,6 +718,7 @@ class SubscribersRepository extends Repository {
        AND ss.`segment_id` = :segment_id
     ", ['ids' => $ids, 'segment_id' => $segment->getId()], ['ids' => ArrayParameterType::INTEGER]);
 
+    $this->segmentsCountRecalculator->recalculateForSubscribers($ids);
     $this->changesNotifier->subscribersUpdated($ids);
     return $count;
   }
@@ -1149,6 +1166,8 @@ class SubscribersRepository extends Repository {
       'typeDefault' => SegmentEntity::TYPE_DEFAULT,
     ], ['ids' => ArrayParameterType::INTEGER]);
 
+    $this->segmentsCountRecalculator->recalculateForSubscribers($ids);
+
     return is_numeric($uniqueSubscribersCount) ? (int)$uniqueSubscribersCount : 0;
   }
 
@@ -1182,6 +1201,12 @@ class SubscribersRepository extends Repository {
       }
       $this->entityManager->flush();
     });
+
+    if ($subscribers !== []) {
+      $this->segmentsCountRecalculator->recalculateForSubscribers(array_map(function (SubscriberEntity $subscriber): int {
+        return (int)$subscriber->getId();
+      }, $subscribers));
+    }
 
     return count($subscribers);
   }

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -1066,10 +1066,15 @@ class SubscribersRepository extends Repository {
       // Trash subscribers whose WP user is gone, who are only on the WP-Users list,
       // and who are not WC customers — they have nowhere left to belong, but we keep
       // them as soft-deleted so admins can recover them if needed.
+      // segments_count is set to 0 directly: the NOT EXISTS clause below already
+      // guarantees these subscribers have no other active segments, so 0 is provably
+      // correct after their WP-Users membership is deleted. Using = 0 rather than
+      // = segments_count - 1 avoids going negative when the membership status was
+      // not 'subscribed' (and wasn't counted in the first place).
       $this->entityManager->getConnection()->executeStatement(
         "UPDATE {$subscribersTable} s
          LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
-         SET s.deleted_at = :deletedAt, s.status = :unconfirmed
+         SET s.deleted_at = :deletedAt, s.status = :unconfirmed, s.segments_count = 0
          WHERE s.deleted_at IS NULL
            AND s.is_woocommerce_user = 0
            AND s.wp_user_id IS NOT NULL

--- a/mailpoet/tests/integration/Cron/CliCommands/WorkerTypesCatalogTest.php
+++ b/mailpoet/tests/integration/Cron/CliCommands/WorkerTypesCatalogTest.php
@@ -128,6 +128,7 @@ class WorkerTypesCatalogTest extends \MailPoetTest {
       'subscribers_email_count',
       'subscribers_engagement_score',
       'subscribers_last_engagement',
+      'subscribers_segments_count_sync',
       'subscribers_stats_report',
       'tracks',
       'unconfirmed_subscribers_cleanup',

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -323,6 +323,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'createNewsletterTemplateThumbnailsWorker' => $worker,
       'createAbandonedCartWorker' => $worker,
       'createBackfillEngagementDataWorker' => $worker,
+      'createSubscribersSegmentsCountSyncWorker' => $worker,
       'createMixpanelWorker' => $worker,
       'createTracksWorker' => $worker,
       'createStatisticsExportWorker' => $worker,

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -123,6 +123,7 @@ class DaemonTest extends \MailPoetTest {
       'createNewsletterTemplateThumbnailsWorker' => $this->createSimpleWorkerMock(),
       'createAbandonedCartWorker' => $this->createSimpleWorkerMock(),
       'createBackfillEngagementDataWorker' => $this->createSimpleWorkerMock(),
+      'createSubscribersSegmentsCountSyncWorker' => $this->createSimpleWorkerMock(),
       'createMixpanelWorker' => $this->createSimpleWorkerMock(),
       'createTracksWorker' => $this->createSimpleWorkerMock(),
       'createStatisticsExportWorker' => $this->createSimpleWorkerMock(),

--- a/mailpoet/tests/integration/Cron/Workers/SubscribersSegmentsCountSyncTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SubscribersSegmentsCountSyncTest.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\SegmentSubscribersRepository;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Subscriber;
+
+class SubscribersSegmentsCountSyncTest extends \MailPoetTest {
+  /** @var SubscribersSegmentsCountSync */
+  private $worker;
+
+  /** @var SettingsController */
+  private $settings;
+
+  public function _before() {
+    parent::_before();
+    $this->worker = $this->diContainer->get(SubscribersSegmentsCountSync::class);
+    $this->settings = $this->diContainer->get(SettingsController::class);
+  }
+
+  public function testItBackfillsTheColumnAndFlipsTheFlag(): void {
+    $segment = (new Segment())->create();
+    // The factory writes memberships directly, so the column starts unset (0).
+    $withList = (new Subscriber())->withSegments([$segment])->create();
+    $withoutList = (new Subscriber())->create();
+
+    $this->assertSame(0, $this->getSegmentsCount($withList));
+    $this->assertFalse((bool)$this->settings->get(SubscribersSegmentsCountSync::BACKFILLED_SETTING_KEY, false));
+
+    $this->worker->processTaskStrategy($this->createTask(), microtime(true));
+
+    $this->assertSame(1, $this->getSegmentsCount($withList));
+    $this->assertSame(0, $this->getSegmentsCount($withoutList));
+    $this->assertTrue((bool)$this->settings->get(SubscribersSegmentsCountSync::BACKFILLED_SETTING_KEY, false));
+  }
+
+  public function testItResetsProgressMetaAfterAFullSweep(): void {
+    (new Subscriber())->create();
+    $task = $this->createTask();
+
+    $this->worker->processTaskStrategy($task, microtime(true));
+
+    // Progress is reset so the next (reconcile) run starts a fresh sweep.
+    $this->assertSame(['last_subscriber_id' => 0], $task->getMeta());
+  }
+
+  public function testItRepairsDriftOnAReconcileRun(): void {
+    $segment = (new Segment())->create();
+    $subscriber = (new Subscriber())->withSegments([$segment])->create();
+
+    // First run backfills and flips the flag.
+    $this->worker->processTaskStrategy($this->createTask(), microtime(true));
+    $this->assertSame(1, $this->getSegmentsCount($subscriber));
+
+    // Simulate a write path that forgot to update the column.
+    $this->setSegmentsCountDirectly($subscriber, 99);
+    $this->assertSame(99, $this->getSegmentsCount($subscriber));
+
+    // The reconcile run re-derives from source and repairs the drift.
+    $this->worker->processTaskStrategy($this->createTask(), microtime(true));
+    $this->assertSame(1, $this->getSegmentsCount($subscriber));
+  }
+
+  public function testReadsSwitchToTheColumnOnlyAfterTheBackfillCompletes(): void {
+    $segment = (new Segment())->create();
+    (new Subscriber())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->withSegments([$segment])->create();
+    (new Subscriber())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
+
+    $repository = $this->diContainer->get(SegmentSubscribersRepository::class);
+    // Before the backfill, reads use the anti-join fallback.
+    $this->assertSame(1, $repository->getSubscribersWithoutSegmentCount());
+
+    $this->worker->processTaskStrategy($this->createTask(), microtime(true));
+
+    // After the backfill the column is populated and trusted; the answer matches.
+    $this->assertSame(1, $repository->getSubscribersWithoutSegmentCount());
+  }
+
+  private function createTask(): ScheduledTaskEntity {
+    $task = new ScheduledTaskEntity();
+    $task->setType(SubscribersSegmentsCountSync::TASK_TYPE);
+    $task->setStatus(null);
+    $this->entityManager->persist($task);
+    $this->entityManager->flush();
+    return $task;
+  }
+
+  private function getSegmentsCount(SubscriberEntity $subscriber): int {
+    $this->entityManager->refresh($subscriber);
+    return $subscriber->getSegmentsCount();
+  }
+
+  private function setSegmentsCountDirectly(SubscriberEntity $subscriber, int $count): void {
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $this->entityManager->getConnection()->executeStatement(
+      "UPDATE {$subscribersTable} SET segments_count = :count WHERE id = :id",
+      ['count' => $count, 'id' => $subscriber->getId()]
+    );
+  }
+}

--- a/mailpoet/tests/integration/Segments/WooCommerceTest.php
+++ b/mailpoet/tests/integration/Segments/WooCommerceTest.php
@@ -10,6 +10,7 @@ use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\WooCommerce as WooCommerceSegment;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\SegmentsCountRecalculator;
 use MailPoet\Subscribers\Source;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -118,6 +119,36 @@ class WooCommerceTest extends \MailPoetTest {
     $hook = 'woocommerce_delete_customer';
     $this->wooCommerceSegment->synchronizeRegisteredCustomer($user->ID, $hook);
     verify($this->subscriberSegmentsRepository->findOneById($association->getId()))->notEmpty();
+  }
+
+  public function testItRefreshesSegmentsCountForSurvivingSubscriberOnDelete(): void {
+    // Regression: unsubscribeUsersFromSegment() DELETEs the membership row of a
+    // non-WC/invalid subscriber. recalculateForSegment() could no longer see the
+    // surviving subscriber afterwards, leaving a stale segments_count, so the
+    // delete path must capture the affected ids before the DELETE and recompute.
+    $wooCommerceSegment = $this->segmentsRepository->getWooCommerceSegment();
+    $user = $this->insertRegisteredCustomer();
+    $subscriber = $this->createSubscriber(
+      'Mike',
+      'Mike',
+      $user->user_email, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      SubscriberEntity::STATUS_SUBSCRIBED,
+      $user->ID,
+      Source::WORDPRESS_USER
+    );
+    // is_woocommerce_user defaults to 0, so its WC-segment membership matches the
+    // DELETE condition in unsubscribeUsersFromSegment() while the subscriber row
+    // itself survives this isolated call (no WP-users sync runs to delete it).
+    $this->createSubscriberSegment($subscriber, $wooCommerceSegment);
+    $this->diContainer->get(SegmentsCountRecalculator::class)
+      ->recalculateForSubscribers([(int)$subscriber->getId()]);
+    $this->entityManager->refresh($subscriber);
+    verify($subscriber->getSegmentsCount())->equals(1);
+
+    $this->wooCommerceSegment->synchronizeRegisteredCustomer($user->ID, 'woocommerce_delete_customer');
+
+    $this->entityManager->refresh($subscriber);
+    verify($subscriber->getSegmentsCount())->equals(0);
   }
 
   public function testItSynchronizesNewGuestCustomer(): void {

--- a/mailpoet/tests/integration/Segments/WooCommerceTest.php
+++ b/mailpoet/tests/integration/Segments/WooCommerceTest.php
@@ -641,7 +641,8 @@ class WooCommerceTest extends \MailPoetTest {
       $this->entityManager,
       $this->entityManager->getConnection(),
       $this->createMock(\MailPoet\Config\SubscriberChangesNotifier::class),
-      $this->diContainer->get(\MailPoet\Services\Validator::class)
+      $this->diContainer->get(\MailPoet\Services\Validator::class),
+      $this->diContainer->get(\MailPoet\Subscribers\SegmentsCountRecalculator::class)
     );
 
     $guest = $this->insertGuestCustomer();

--- a/mailpoet/tests/integration/Subscribers/SegmentsCountRecalculatorTest.php
+++ b/mailpoet/tests/integration/Subscribers/SegmentsCountRecalculatorTest.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscribers;
+
+use MailPoet\Cron\Workers\SubscribersSegmentsCountSync;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Segments\SegmentSubscribersRepository;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Subscriber;
+
+class SegmentsCountRecalculatorTest extends \MailPoetTest {
+  /** @var SegmentsCountRecalculator */
+  private $recalculator;
+
+  public function _before() {
+    $this->recalculator = $this->diContainer->get(SegmentsCountRecalculator::class);
+  }
+
+  public function testItCountsSubscribedNonDeletedSegments(): void {
+    $segment1 = (new Segment())->create();
+    $segment2 = (new Segment())->create();
+    $subscriber = (new Subscriber())->withSegments([$segment1, $segment2])->create();
+
+    // The factory writes memberships directly, so the column starts unset.
+    $this->assertSame(0, $this->getSegmentsCount($subscriber));
+
+    $this->recalculator->recalculateForSubscribers([(int)$subscriber->getId()]);
+
+    $this->assertSame(2, $this->getSegmentsCount($subscriber));
+  }
+
+  public function testItIgnoresDeletedSegments(): void {
+    $activeSegment = (new Segment())->create();
+    $deletedSegment = (new Segment())->withDeleted()->create();
+    $subscriber = (new Subscriber())->withSegments([$activeSegment, $deletedSegment])->create();
+
+    $this->recalculator->recalculateForSubscribers([(int)$subscriber->getId()]);
+
+    $this->assertSame(1, $this->getSegmentsCount($subscriber));
+  }
+
+  public function testItIgnoresNonSubscribedMemberships(): void {
+    $segment = (new Segment())->create();
+    $subscriber = (new Subscriber())->withSegments([$segment])->create();
+    $this->setMembershipStatus($subscriber, $segment, SubscriberEntity::STATUS_UNSUBSCRIBED);
+
+    $this->recalculator->recalculateForSubscribers([(int)$subscriber->getId()]);
+
+    $this->assertSame(0, $this->getSegmentsCount($subscriber));
+  }
+
+  public function testRecalculateForIdRangeCoversAllSubscribers(): void {
+    $segment = (new Segment())->create();
+    $first = (new Subscriber())->withSegments([$segment])->create();
+    $second = (new Subscriber())->withSegments([$segment])->create();
+
+    $this->recalculator->recalculateForIdRange((int)$first->getId(), (int)$second->getId());
+
+    $this->assertSame(1, $this->getSegmentsCount($first));
+    $this->assertSame(1, $this->getSegmentsCount($second));
+  }
+
+  public function testRecalculateForSegmentUpdatesAllMembers(): void {
+    $segment = (new Segment())->create();
+    $first = (new Subscriber())->withSegments([$segment])->create();
+    $second = (new Subscriber())->withSegments([$segment])->create();
+
+    $this->recalculator->recalculateForSegment((int)$segment->getId());
+
+    $this->assertSame(1, $this->getSegmentsCount($first));
+    $this->assertSame(1, $this->getSegmentsCount($second));
+  }
+
+  public function testSubscribeAndUnsubscribeKeepTheCountInSync(): void {
+    $segment = (new Segment())->create();
+    $subscriber = (new Subscriber())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
+    $repository = $this->diContainer->get(SubscriberSegmentRepository::class);
+
+    $repository->subscribeToSegments($subscriber, [$segment]);
+    $this->assertSame(1, $this->getSegmentsCount($subscriber));
+
+    $repository->unsubscribeFromSegments($subscriber, [$segment]);
+    $this->assertSame(0, $this->getSegmentsCount($subscriber));
+  }
+
+  public function testTrashingAndRestoringASegmentUpdatesMembers(): void {
+    $segment = (new Segment())->create();
+    $subscriber = (new Subscriber())->withSegments([$segment])->create();
+    $segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
+    $this->recalculator->recalculateForSubscribers([(int)$subscriber->getId()]);
+    $this->assertSame(1, $this->getSegmentsCount($subscriber));
+
+    $segmentsRepository->bulkTrash([(int)$segment->getId()]);
+    $this->assertSame(0, $this->getSegmentsCount($subscriber));
+
+    $segmentsRepository->bulkRestore([(int)$segment->getId()]);
+    $this->assertSame(1, $this->getSegmentsCount($subscriber));
+  }
+
+  public function testReadPathUsesColumnWhenBackfilled(): void {
+    $segment = (new Segment())->create();
+    (new Subscriber())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->withSegments([$segment])->create();
+    $withoutList = (new Subscriber())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
+    $this->recalculator->recalculateForSubscribers([(int)$withoutList->getId()]);
+
+    $settings = $this->diContainer->get(SettingsController::class);
+    $settings->set(SubscribersSegmentsCountSync::BACKFILLED_SETTING_KEY, true);
+
+    $stats = $this->diContainer->get(SegmentSubscribersRepository::class)->getSubscribersWithoutSegmentStatisticsCount();
+
+    $this->assertSame(1, (int)$stats['all']);
+    $this->assertSame(1, (int)$stats['subscribed']);
+  }
+
+  private function getSegmentsCount(SubscriberEntity $subscriber): int {
+    $this->entityManager->refresh($subscriber);
+    return $subscriber->getSegmentsCount();
+  }
+
+  private function setMembershipStatus(SubscriberEntity $subscriber, SegmentEntity $segment, string $status): void {
+    $subscriberSegmentsTable = $this->entityManager->getClassMetadata(\MailPoet\Entities\SubscriberSegmentEntity::class)->getTableName();
+    $this->entityManager->getConnection()->executeStatement(
+      "UPDATE {$subscriberSegmentsTable} SET status = :status WHERE subscriber_id = :subscriberId AND segment_id = :segmentId",
+      ['status' => $status, 'subscriberId' => $subscriber->getId(), 'segmentId' => $segment->getId()]
+    );
+  }
+}

--- a/mailpoet/tests/integration/Subscribers/SegmentsCountRecalculatorTest.php
+++ b/mailpoet/tests/integration/Subscribers/SegmentsCountRecalculatorTest.php
@@ -102,9 +102,11 @@ class SegmentsCountRecalculatorTest extends \MailPoetTest {
 
   public function testReadPathUsesColumnWhenBackfilled(): void {
     $segment = (new Segment())->create();
-    (new Subscriber())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->withSegments([$segment])->create();
+    $withList = (new Subscriber())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->withSegments([$segment])->create();
     $withoutList = (new Subscriber())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
-    $this->recalculator->recalculateForSubscribers([(int)$withoutList->getId()]);
+    // The factory writes memberships directly, so populate the column for both
+    // subscribers the way the backfill worker would before reads trust it.
+    $this->recalculator->recalculateForSubscribers([(int)$withList->getId(), (int)$withoutList->getId()]);
 
     $settings = $this->diContainer->get(SettingsController::class);
     $settings->set(SubscribersSegmentsCountSync::BACKFILLED_SETTING_KEY, true);

--- a/mailpoet/tests/integration/Subscribers/SegmentsCountRecalculatorTest.php
+++ b/mailpoet/tests/integration/Subscribers/SegmentsCountRecalculatorTest.php
@@ -5,9 +5,11 @@ namespace MailPoet\Subscribers;
 use MailPoet\Cron\Workers\SubscribersSegmentsCountSync;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Listing\ListingDefinition;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SegmentSubscribersRepository;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\SubscriberListingRepository;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Subscriber;
 
@@ -98,6 +100,26 @@ class SegmentsCountRecalculatorTest extends \MailPoetTest {
 
     $segmentsRepository->bulkRestore([(int)$segment->getId()]);
     $this->assertSame(1, $this->getSegmentsCount($subscriber));
+  }
+
+  public function testListingQueryUsesColumnWhenBackfilled(): void {
+    $segment = (new Segment())->create();
+    $withList = (new Subscriber())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->withSegments([$segment])->create();
+    $withoutList = (new Subscriber())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
+    $this->recalculator->recalculateForSubscribers([(int)$withList->getId(), (int)$withoutList->getId()]);
+
+    $settings = $this->diContainer->get(SettingsController::class);
+    $settings->set(SubscribersSegmentsCountSync::BACKFILLED_SETTING_KEY, true);
+
+    // The listing repository uses addConstraintsForSubscribersWithoutSegment()
+    // on a Doctrine ORM query builder (DQL). Verify it switches to the
+    // segments_count = 0 path instead of the LEFT JOIN anti-join.
+    $definition = new ListingDefinition('all', ['segment' => SubscriberListingRepository::FILTER_WITHOUT_LIST], '', [], 'id', 'asc', 0, 100, []);
+    $items = $this->diContainer->get(SubscriberListingRepository::class)->getData($definition);
+    $ids = array_map(fn(SubscriberEntity $s) => $s->getId(), $items);
+
+    $this->assertContains($withoutList->getId(), $ids);
+    $this->assertNotContains($withList->getId(), $ids);
   }
 
   public function testReadPathUsesColumnWhenBackfilled(): void {

--- a/mailpoet/tests/integration/Subscribers/SegmentsCountRecalculatorTest.php
+++ b/mailpoet/tests/integration/Subscribers/SegmentsCountRecalculatorTest.php
@@ -18,6 +18,7 @@ class SegmentsCountRecalculatorTest extends \MailPoetTest {
   private $recalculator;
 
   public function _before() {
+    parent::_before();
     $this->recalculator = $this->diContainer->get(SegmentsCountRecalculator::class);
   }
 


### PR DESCRIPTION
## Description

The **Subscribers without a list** filter and its per-status tabs computed their counts with an anti-join over the entire `subscribers` table on every cold-cache read (`SegmentSubscribersRepository::getSubscribersWithoutSegmentStatisticsCount()`). On large installs that scan took tens of minutes, and with no single-flight guard the cold-cache window let many identical copies pile up and starve the database (observed on the lhr test box: 5M rows, 40–130 min per copy, several concurrent).

This denormalizes the answer onto the subscriber row:

- New `subscribers.segments_count` column = number of the subscriber's `subscribed` memberships in **non-deleted** segments (semantics match the old anti-join exactly: no segment-type filter, dynamic segments don't count). Covering index `(segments_count, status, deleted_at)` makes the read an index-only `WHERE segments_count = 0`.
- `SegmentsCountRecalculator` keeps the column in sync. It always **re-derives from source** (subscriber_segment + segments), so it's idempotent — safe to call from multiple write paths, twice, or concurrently with the backfill; the value converges.
- Every membership / segment-state write path now calls it: subscribe/unsubscribe/reset, bulk add/remove/move, CSV import, WooCommerce sync, WP-users sync, and segment trash/restore/delete.
- `SubscribersSegmentsCountSync` worker: first run backfills the column in batches (id-range, `enforceExecutionLimit`) and flips a settings flag; subsequent weekly runs re-sweep as a **drift backstop** (catches any write path that ever forgets to update the column).
- Reads fall back to the original anti-join until the backfill flag is set, so the column is never trusted before it is fully populated.

## Code review notes

- **Why re-derive instead of increment/decrement:** there is no single choke-point for membership writes — 9 independent writers, 7 of them raw SQL that bypass Doctrine events. Arithmetic deltas would drift; idempotent recompute-from-source can't.
- **Segment-wide changes** (trash/restore, WC/WP bulk sync) call `recalculateForSegment()`, which walks members in keyset-paginated batches. For `bulkDelete` the affected ids are captured *before* the cascade removes the memberships.
- **The weekly re-sweep is intentional**, not just a one-shot backfill — it's the safety net for the raw-SQL write paths above.
- Gating flag (`SubscribersSegmentsCountSync::BACKFILLED_SETTING_KEY`) is what makes deploy-order safe: maintenance hooks are live from deploy, backfill populates, flag flips reads over.
- **`recalculateForSegments` status filter (`$subscribedOnly`):** the segment-walk now filters to `status = 'subscribed'` by default — non-subscribed membership holders are already correct (the recalculator was called when their status changed) so recalculating them during a trash/restore is a no-op. The WooCommerce sync passes `$subscribedOnly = false` because its `updateStatus()` call does bulk raw-SQL membership-status changes; it needs the unfiltered walk to catch subscribers transitioning *away* from subscribed.
- **`addConstraintsForSubscribersWithoutSegmentToDBAL`** now self-contains the `isSegmentsCountColumnReady()` guard, mirroring the ORM variant. This also gives the `SubscriberListingRepository` call site the fast path it was previously missing.

## QA notes

- New migration adds a column + index to `subscribers`. On large installs the index build is a heavy online DDL — worth scheduling/`pt-online-schema-change` on big sites (instant on typical installs).
- To verify: on a site with >2000 subscribers, confirm the "Subscribers without a list (N)" filter and its status tabs match reality after the `subscribers_segments_count_sync` task completes; then add/remove subscribers from lists, import, trash/restore a list, and confirm the count tracks.
- `SegmentsCountRecalculatorTest` covers the recalculator, the write hooks, trash/restore fan-out, and the gated read path.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

The first `subscribers_segments_count_sync` cron run must finish before reads switch to the column (gated by the backfill flag) — expected, no action needed, but worth knowing when validating on a large instance.

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/subscribers-segments-count)

_The latest successful build from `add/subscribers-segments-count` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->