### PR TITLE
Default Woo-backed revenue reporting on via filter

### DIFF
--- a/mailpoet/changelog.txt
+++ b/mailpoet/changelog.txt
@@ -8,7 +8,6 @@
 * Added: Order-aware product recommendations in post-purchase automation emails: cross-sells of the purchased products, products with the same tag, or products from the same category;
 * Added: Email campaign attribution on WooCommerce orders;
 * Added: Per-user listing preferences and sorting across MailPoet list pages;
-* Added: Personal data export and erasure for email attribution data stored on WooCommerce orders;
 * Improved: Speed up sorting the subscribers list by subscription date on large lists;
 * Improved: Reduce JavaScript size in the admin area;
 * Improved: Performance when WooCommerce is inactive by hiding the WooCommerce Customers list instead of running a slow database check;

--- a/mailpoet/changelog/2026-06-22-14-37-40-changed-woocommerce-revenue-reporting-now-matches-woo-anal.md
+++ b/mailpoet/changelog/2026-06-22-14-37-40-changed-woocommerce-revenue-reporting-now-matches-woo-anal.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+WooCommerce revenue reporting now matches Woo Analytics by counting orders WooCommerce attributes to the mailpoet source, with the mailpoet_woo_backed_revenue_reporting filter to opt back to the previous MailPoet reporting

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -7,14 +7,12 @@ use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 class FeaturesController {
   const FEATURE_BRAND_TEMPLATES = 'brand_templates';
   const FEATURE_SEND_BY_TIMEZONE = 'send_by_timezone';
-  const FEATURE_WOO_BACKED_REVENUE_REPORTING = 'woo_backed_revenue_reporting';
 
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::FEATURE_BRAND_TEMPLATES => false,
     self::FEATURE_SEND_BY_TIMEZONE => false,
-    self::FEATURE_WOO_BACKED_REVENUE_REPORTING => false,
   ];
 
   /** @var array|null */

--- a/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
+++ b/mailpoet/lib/WooCommerce/OrderAttributionRevenueReader.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\WooCommerce;
 
-use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\Sending\NewsletterReplayMetadata;
 use MailPoet\WP\Functions as WPFunctions;
 use WC_Order;
@@ -12,9 +11,6 @@ use WC_Order;
  * @phpstan-type AttributionRow array{order_id: int, date_created_gmt: string, newsletter_id: string, subscriber_id: string|null, queue_id: string|null}
  */
 class OrderAttributionRevenueReader {
-  /** @var FeaturesController */
-  private $featuresController;
-
   /** @var Helper */
   private $wooHelper;
 
@@ -22,11 +18,9 @@ class OrderAttributionRevenueReader {
   private $wp;
 
   public function __construct(
-    FeaturesController $featuresController,
     Helper $wooHelper,
     WPFunctions $wp
   ) {
-    $this->featuresController = $featuresController;
     $this->wooHelper = $wooHelper;
     $this->wp = $wp;
   }
@@ -136,7 +130,7 @@ class OrderAttributionRevenueReader {
     if (!$this->wooHelper->isWooCommerceActive()) {
       return null;
     }
-    if (!$this->featuresController->isSupported(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING)) {
+    if (!$this->wp->applyFilters('mailpoet_woo_backed_revenue_reporting', true)) {
       return null;
     }
 

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
@@ -6,14 +6,12 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\Sending\NewsletterReplayMetadata;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
-use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterLink;
 use MailPoet\Test\DataFactories\StatisticsClicks;
@@ -54,8 +52,7 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
   public function _before() {
     $this->testee = $this->diContainer->get(NewsletterStatisticsRepository::class);
     $this->revenueRepository = $this->diContainer->get(StatisticsWooCommercePurchasesRepository::class);
-    (new Features())->withFeatureDisabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
-    $this->diContainer->get(FeaturesController::class)->resetCache();
+    add_filter('mailpoet_woo_backed_revenue_reporting', '__return_false');
     delete_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
     $this->newsletter = (new Newsletter())->withSendingQueue()->create();
     $this->assertInstanceOf(NewsletterEntity::class, $this->newsletter);
@@ -192,8 +189,7 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
   }
 
   private function enableWooBackedRevenueReadModel(): void {
-    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
-    $this->diContainer->get(FeaturesController::class)->resetCache();
+    remove_filter('mailpoet_woo_backed_revenue_reporting', '__return_false');
     update_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION, gmdate('Y-m-d H:i:s', time() - HOUR_IN_SECONDS));
   }
 

--- a/mailpoet/tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberStatisticsRepositoryTest.php
@@ -4,11 +4,9 @@ namespace MailPoet\Subscribers\Statistics;
 
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
-use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterLink;
 use MailPoet\Test\DataFactories\StatisticsClicks;
@@ -35,8 +33,7 @@ class SubscriberStatisticsRepositoryTest extends \MailPoetTest {
     parent::_before();
     $this->repository = $this->diContainer->get(SubscriberStatisticsRepository::class);
     $this->settings = SettingsController::getInstance();
-    (new Features())->withFeatureDisabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
-    $this->diContainer->get(FeaturesController::class)->resetCache();
+    add_filter('mailpoet_woo_backed_revenue_reporting', '__return_false');
     delete_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION);
   }
 
@@ -274,8 +271,7 @@ class SubscriberStatisticsRepositoryTest extends \MailPoetTest {
   }
 
   private function enableWooBackedRevenueReadModel(): void {
-    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
-    $this->diContainer->get(FeaturesController::class)->resetCache();
+    remove_filter('mailpoet_woo_backed_revenue_reporting', '__return_false');
     update_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION, gmdate('Y-m-d H:i:s', time() - HOUR_IN_SECONDS));
   }
 

--- a/mailpoet/tests/integration/WooCommerce/OrderAttributionCompatibilityTest.php
+++ b/mailpoet/tests/integration/WooCommerce/OrderAttributionCompatibilityTest.php
@@ -12,13 +12,11 @@ use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\StatisticsClicksRepository;
 use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
 use MailPoet\Subscribers\SubscribersRepository;
-use MailPoet\Test\DataFactories\Features;
 use MailPoet\Util\Cookies;
 use MailPoet\WP\Functions as WPFunctions;
 use WC_Order;
@@ -133,8 +131,6 @@ class OrderAttributionCompatibilityTest extends \MailPoetTest {
 
   public function testWooBackedRevenueMatchesWooMailPoetSourceForArbitratedOrders(): void {
     $this->settings->set('tracking.level', TrackingConfig::LEVEL_FULL);
-    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
-    $this->diContainer->get(FeaturesController::class)->resetCache();
     update_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION, '2000-01-01 00:00:00');
 
     $click = $this->createClick($this->link, $this->subscriber);
@@ -247,8 +243,6 @@ class OrderAttributionCompatibilityTest extends \MailPoetTest {
    * @return OrderRow[]
    */
   private function readNewsletterOrderRows(): array {
-    (new Features())->withFeatureEnabled(FeaturesController::FEATURE_WOO_BACKED_REVENUE_REPORTING);
-    $this->diContainer->get(FeaturesController::class)->resetCache();
     update_option(OrderAttributionWriter::WRITES_STARTED_AT_OPTION, '2000-01-01 00:00:00');
 
     $reader = $this->diContainer->get(OrderAttributionRevenueReader::class);


### PR DESCRIPTION
## Description

Make Woo-backed revenue reporting the default for all stores.

The read model previously sat behind the off-by-default `woo_backed_revenue_reporting` feature flag (toggled on the experimental page). This replaces that flag with a code-only `mailpoet_woo_backed_revenue_reporting` filter that defaults to `true`, so post-boundary MailPoet revenue reads orders WooCommerce attributes to the `mailpoet` source — matching Woo Analytics — recovering per-newsletter / per-subscriber detail from MailPoet's own tables.

A site can opt back to the legacy reporting in code (no UI):

```php
add_filter( 'mailpoet_woo_backed_revenue_reporting', '__return_false' );
```

Switching is **lossless and reversible**: the standard-source write and the legacy `statistics_woocommerce_purchases` engine both run regardless of the filter, so both read models stay available at all times.

Also removes the 5.30.0 "Added" changelog line for the attribution privacy exporter/eraser (reverted in STOMAIL-8200) and adds a `Changed` entry.

## Code review notes

- The filter replaces a DB feature flag, so this feature's experimental-page toggle is gone by design — the issue calls for a code-only switch.
- Tests drive the filter with `add_filter`/`remove_filter` and need no teardown: the integration base `tearDown()` restores `wp_filter` from a clean snapshot.

## QA notes

PHPStan (free + premium) and PHPCS clean on changed files. Integration tests pass: `OrderAttributionCompatibilityTest` (10), `NewsletterStatisticsRepositoryTest` (7), `SubscriberStatisticsRepositoryTest` (12), premium `OrderStatisticsTest` (5).

Manual check: with no filter set, post-boundary newsletter/subscriber revenue reads the Woo path; `add_filter('mailpoet_woo_backed_revenue_reporting', '__return_false')` falls back to legacy reads with identical pre-boundary numbers.

## Linked PRs

Premium: mailpoet/mailpoet-premium#1106

## Linked tickets

STOMAIL-8139

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I added sufficient test coverage

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/stomail-8139-woo-backed-revenue-reporting-default-on)

_The latest successful build from `update/stomail-8139-woo-backed-revenue-reporting-default-on` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->