### PR TITLE
Add Manage Subscription block

### DIFF
--- a/mailpoet/assets/js/src/post-editor-block/blocks.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/blocks.jsx
@@ -1,2 +1,3 @@
 import './subscription-form/form-block.jsx';
 import './newsletter/newsletter-block.jsx';
+import './manage-subscription/manage-subscription-block.jsx';

--- a/mailpoet/assets/js/src/post-editor-block/manage-subscription/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/manage-subscription/edit.jsx
@@ -1,0 +1,19 @@
+/* eslint-disable react/react-in-jsx-scope */
+const wp = window.wp;
+const { Disabled } = wp.components;
+const { useBlockProps } = wp.blockEditor;
+const ServerSideRender = wp.serverSideRender;
+
+function Edit() {
+  const blockProps = useBlockProps();
+
+  return (
+    <div {...blockProps}>
+      <Disabled>
+        <ServerSideRender block="mailpoet/manage-subscription-block-render" />
+      </Disabled>
+    </div>
+  );
+}
+
+export { Edit };

--- a/mailpoet/assets/js/src/post-editor-block/manage-subscription/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/manage-subscription/edit.jsx
@@ -10,7 +10,10 @@ function Edit() {
   return (
     <div {...blockProps}>
       <Disabled>
-        <ServerSideRender block="mailpoet/manage-subscription-block-render" />
+        <ServerSideRender
+          block="mailpoet/manage-subscription-block-render"
+          attributes={{ preview: true }}
+        />
       </Disabled>
     </div>
   );

--- a/mailpoet/assets/js/src/post-editor-block/manage-subscription/manage-subscription-block.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/manage-subscription/manage-subscription-block.jsx
@@ -1,0 +1,30 @@
+import { Edit } from './edit.jsx';
+import { Icon } from '../subscription-form/icon.jsx';
+
+const wp = window.wp;
+const { registerBlockType } = wp.blocks;
+
+const locale = window.mailpoetManageSubscriptionBlock || {};
+const title = locale.title || 'MailPoet Manage Subscription';
+
+// Inserter-hidden block that is server-rendered for the editor preview.
+registerBlockType('mailpoet/manage-subscription-block-render', {
+  title,
+  apiVersion: 3,
+  supports: {
+    inserter: false,
+  },
+});
+
+registerBlockType('mailpoet/manage-subscription-block', {
+  title,
+  description: locale.description || '',
+  apiVersion: 3,
+  icon: Icon,
+  category: 'widgets',
+  example: {},
+  edit: Edit,
+  save() {
+    return null;
+  },
+});

--- a/mailpoet/assets/js/src/post-editor-block/manage-subscription/manage-subscription-block.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/manage-subscription/manage-subscription-block.jsx
@@ -11,6 +11,12 @@ const title = locale.title || 'MailPoet Manage Subscription';
 registerBlockType('mailpoet/manage-subscription-block-render', {
   title,
   apiVersion: 3,
+  attributes: {
+    preview: {
+      type: 'boolean',
+      default: false,
+    },
+  },
   supports: {
     inserter: false,
   },

--- a/mailpoet/changelog/2026-06-23-14-08-50-added-add-a-manage-subscription-block-that-renders-the-m.md
+++ b/mailpoet/changelog/2026-06-23-14-08-50-added-add-a-manage-subscription-block-that-renders-the-m.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Add a Manage Subscription block that renders the manage-subscription form (modern style) without requiring the shortcode or URL parameters

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -300,7 +300,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\PostEditorBlocks\PostEditorBlock::class);
     $container->autowire(\MailPoet\PostEditorBlocks\SubscriptionFormBlock::class);
     $container->autowire(\MailPoet\PostEditorBlocks\NewsletterBlock::class)->setPublic(true);
-    $container->autowire(\MailPoet\PostEditorBlocks\ManageSubscriptionBlock::class);
+    $container->autowire(\MailPoet\PostEditorBlocks\ManageSubscriptionBlock::class)->setPublic(true);
     $container->autowire(\MailPoet\PostEditorBlocks\WooCommerceBlocksIntegration::class);
     // Subscribers import CLI
     $container->autowire(\MailPoet\Subscribers\ImportExport\Import\Cli::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -300,6 +300,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\PostEditorBlocks\PostEditorBlock::class);
     $container->autowire(\MailPoet\PostEditorBlocks\SubscriptionFormBlock::class);
     $container->autowire(\MailPoet\PostEditorBlocks\NewsletterBlock::class)->setPublic(true);
+    $container->autowire(\MailPoet\PostEditorBlocks\ManageSubscriptionBlock::class);
     $container->autowire(\MailPoet\PostEditorBlocks\WooCommerceBlocksIntegration::class);
     // Subscribers import CLI
     $container->autowire(\MailPoet\Subscribers\ImportExport\Import\Cli::class)->setPublic(true);

--- a/mailpoet/lib/PostEditorBlocks/ManageSubscriptionBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/ManageSubscriptionBlock.php
@@ -64,9 +64,13 @@ class ManageSubscriptionBlock {
     $this->assetsController->setupFrontEndDependencies();
 
     // Make sure the Pages service has its internal state initialised (notably
-    // $data) before rendering, so it resolves the current logged-in user as a
-    // subscriber on any page or the WooCommerce My Account page.
-    $this->subscriptionPages->init();
+    // $data, which isPreview() reads and which is null until init()) before
+    // rendering, so it resolves the current logged-in user as a subscriber on
+    // any page or the WooCommerce My Account page. Guarded so we don't clobber
+    // an already-initialised shared instance (e.g. the router subscription page).
+    if (!$this->subscriptionPages->isInitialized()) {
+      $this->subscriptionPages->init();
+    }
 
     return (string)$this->subscriptionPages->getManageContent();
   }

--- a/mailpoet/lib/PostEditorBlocks/ManageSubscriptionBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/ManageSubscriptionBlock.php
@@ -58,7 +58,7 @@ class ManageSubscriptionBlock {
     ]);
   }
 
-  public function renderManageSubscription(): string {
+  public function renderManageSubscription(array $attributes = []): string {
     // getManageContent() does not enqueue the front-end form assets itself
     // (the subscription page flow does that separately), so load them here.
     $this->assetsController->setupFrontEndDependencies();

--- a/mailpoet/lib/PostEditorBlocks/ManageSubscriptionBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/ManageSubscriptionBlock.php
@@ -1,0 +1,73 @@
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+
+namespace MailPoet\PostEditorBlocks;
+
+use MailPoet\Form\AssetsController;
+use MailPoet\Subscription\Pages as SubscriptionPages;
+use MailPoet\WP\Functions as WPFunctions;
+
+// phpcs:disable Generic.Files.InlineHTML
+class ManageSubscriptionBlock {
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var SubscriptionPages */
+  private $subscriptionPages;
+
+  /** @var AssetsController */
+  private $assetsController;
+
+  public function __construct(
+    WPFunctions $wp,
+    SubscriptionPages $subscriptionPages,
+    AssetsController $assetsController
+  ) {
+    $this->wp = $wp;
+    $this->subscriptionPages = $subscriptionPages;
+    $this->assetsController = $assetsController;
+  }
+
+  public function init() {
+    // Registered in every context (including REST) so the editor's
+    // ServerSideRender preview can render this block.
+    $this->wp->registerBlockType('mailpoet/manage-subscription-block-render', [
+      'render_callback' => [$this, 'renderManageSubscription'],
+    ]);
+  }
+
+  public function initAdmin() {
+    $this->wp->registerBlockType('mailpoet/manage-subscription-block', [
+      'editor_script' => 'mailpoet/manage-subscription-block',
+    ]);
+
+    $this->wp->addAction('admin_head', function() {
+      ?>
+      <script type="text/javascript">
+        window.mailpoetManageSubscriptionBlock = {
+          title: '<?php echo esc_js(__('MailPoet Manage Subscription', 'mailpoet')); ?>',
+          description: '<?php echo esc_js(__('Lets logged-in subscribers manage their lists and subscription status.', 'mailpoet')); ?>',
+        };
+      </script>
+      <?php
+    });
+  }
+
+  public function initFrontend() {
+    $this->wp->registerBlockType('mailpoet/manage-subscription-block', [
+      'render_callback' => [$this, 'renderManageSubscription'],
+    ]);
+  }
+
+  public function renderManageSubscription(): string {
+    // getManageContent() does not enqueue the front-end form assets itself
+    // (the subscription page flow does that separately), so load them here.
+    $this->assetsController->setupFrontEndDependencies();
+
+    // Make sure the Pages service has its internal state initialised (notably
+    // $data) before rendering, so it resolves the current logged-in user as a
+    // subscriber on any page or the WooCommerce My Account page.
+    $this->subscriptionPages->init();
+
+    return (string)$this->subscriptionPages->getManageContent();
+  }
+}

--- a/mailpoet/lib/PostEditorBlocks/ManageSubscriptionBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/ManageSubscriptionBlock.php
@@ -31,6 +31,12 @@ class ManageSubscriptionBlock {
     // Registered in every context (including REST) so the editor's
     // ServerSideRender preview can render this block.
     $this->wp->registerBlockType('mailpoet/manage-subscription-block-render', [
+      'attributes' => [
+        'preview' => [
+          'type' => 'boolean',
+          'default' => false,
+        ],
+      ],
       'render_callback' => [$this, 'renderManageSubscription'],
     ]);
   }
@@ -63,12 +69,24 @@ class ManageSubscriptionBlock {
     // (the subscription page flow does that separately), so load them here.
     $this->assetsController->setupFrontEndDependencies();
 
-    // Make sure the Pages service has its internal state initialised (notably
-    // $data, which isPreview() reads and which is null until init()) before
-    // rendering, so it resolves the current logged-in user as a subscriber on
-    // any page or the WooCommerce My Account page. Guarded so we don't clobber
-    // an already-initialised shared instance (e.g. the router subscription page).
-    if (!$this->subscriptionPages->isInitialized()) {
+    if (!empty($attributes['preview']) && $this->wp->currentUserCan('edit_posts')) {
+      // The editor's ServerSideRender preview passes preview=true so it shows a
+      // representative demo form instead of the current admin's own subscription
+      // (or the "subscribers only" message when the admin isn't a subscriber).
+      // Force the demo regardless of any prior Pages state. WordPress passes
+      // attributes that a block type doesn't register through to the render
+      // callback verbatim, so hand-written block markup in content can carry
+      // preview=true; the capability check (the same one the block-renderer
+      // REST endpoint enforces) keeps visitors from forcing the demo form.
+      $this->subscriptionPages->init(false, ['preview' => true]);
+    } elseif (!$this->subscriptionPages->isInitialized()) {
+      // Make sure the Pages instance has its internal state initialised (notably
+      // $data, which isPreview() reads and which is null until init()) before
+      // rendering, so it resolves the current logged-in user as a subscriber on
+      // any page or the WooCommerce My Account page. Pages is registered
+      // non-shared, so this instance belongs to this block alone and persists
+      // only across renders within a single request; the guard just avoids
+      // re-initialising it on repeated renders.
       $this->subscriptionPages->init();
     }
 

--- a/mailpoet/lib/PostEditorBlocks/PostEditorBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/PostEditorBlock.php
@@ -19,21 +19,27 @@ class PostEditorBlock {
   /** @var NewsletterBlock */
   private $newsletterBlock;
 
+  /** @var ManageSubscriptionBlock */
+  private $manageSubscriptionBlock;
+
   public function __construct(
     Renderer $renderer,
     WPFunctions $wp,
     SubscriptionFormBlock $subscriptionFormBlock,
-    NewsletterBlock $newsletterBlock
+    NewsletterBlock $newsletterBlock,
+    ManageSubscriptionBlock $manageSubscriptionBlock
   ) {
     $this->renderer = $renderer;
     $this->wp = $wp;
     $this->subscriptionFormBlock = $subscriptionFormBlock;
     $this->newsletterBlock = $newsletterBlock;
+    $this->manageSubscriptionBlock = $manageSubscriptionBlock;
   }
 
   public function init() {
     $this->subscriptionFormBlock->init();
     $this->newsletterBlock->init();
+    $this->manageSubscriptionBlock->init();
 
     if ($this->wp->isAdmin()) {
       $this->initAdmin();
@@ -46,6 +52,7 @@ class PostEditorBlock {
     $this->wp->addAction('enqueue_block_editor_assets', [$this, 'enqueueAssets']);
     $this->subscriptionFormBlock->initAdmin();
     $this->newsletterBlock->initAdmin();
+    $this->manageSubscriptionBlock->initAdmin();
   }
 
   public function enqueueAssets() {
@@ -77,5 +84,6 @@ class PostEditorBlock {
   private function initFrontend() {
     $this->subscriptionFormBlock->initFrontend();
     $this->newsletterBlock->initFrontend();
+    $this->manageSubscriptionBlock->initFrontend();
   }
 }

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -159,6 +159,10 @@ class Pages {
     return $this;
   }
 
+  public function isInitialized(): bool {
+    return $this->data !== null;
+  }
+
   private function isPreview() {
     return (array_key_exists('preview', $_GET) || array_key_exists('preview', $this->data));
   }

--- a/mailpoet/tests/integration/PostEditorBlocks/ManageSubscriptionBlockTest.php
+++ b/mailpoet/tests/integration/PostEditorBlocks/ManageSubscriptionBlockTest.php
@@ -2,7 +2,10 @@
 
 namespace MailPoet\PostEditorBlocks;
 
+use MailPoet\Form\AssetsController;
+use MailPoet\Subscription\Pages as SubscriptionPages;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\WP\Functions as WPFunctions;
 
 class ManageSubscriptionBlockTest extends \MailPoetTest {
   /** @var ManageSubscriptionBlock */
@@ -10,7 +13,15 @@ class ManageSubscriptionBlockTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->block = $this->diContainer->get(ManageSubscriptionBlock::class);
+    // The block service keeps its Pages instance, whose init() leaves sticky
+    // state ($data, $subscriber). Pages is registered non-shared, so wiring
+    // the block manually gives each test a fresh Pages and keeps results
+    // independent of test order.
+    $this->block = new ManageSubscriptionBlock(
+      $this->diContainer->get(WPFunctions::class),
+      $this->diContainer->get(SubscriptionPages::class),
+      $this->diContainer->get(AssetsController::class)
+    );
   }
 
   public function testItRendersTheManageFormForALoggedInSubscriber(): void {
@@ -34,5 +45,28 @@ class ManageSubscriptionBlockTest extends \MailPoetTest {
       'Subscription management form is only available to mailing lists subscribers.',
       $this->block->renderManageSubscription()
     );
+  }
+
+  public function testItRendersTheDemoFormInPreviewModeForEditors(): void {
+    $wpUser = get_users()[0];
+    wp_set_current_user((int)$wpUser->ID);
+    $html = $this->block->renderManageSubscription(['preview' => true]);
+    wp_set_current_user(0);
+
+    // Preview renders the demo form, not the current user's own subscription.
+    $this->assertStringContainsString('mailpoet_subscription_update', $html);
+    $this->assertStringContainsString(SubscriptionPages::DEMO_EMAIL, $html);
+  }
+
+  public function testItIgnoresThePreviewAttributeForGuests(): void {
+    wp_set_current_user(0);
+    // WordPress passes unregistered attributes from post content through to
+    // the render callback, so preview=true must not work without edit_posts.
+    $html = $this->block->renderManageSubscription(['preview' => true]);
+    $this->assertStringContainsString(
+      'Subscription management form is only available to mailing lists subscribers.',
+      $html
+    );
+    $this->assertStringNotContainsString(SubscriptionPages::DEMO_EMAIL, $html);
   }
 }

--- a/mailpoet/tests/integration/PostEditorBlocks/ManageSubscriptionBlockTest.php
+++ b/mailpoet/tests/integration/PostEditorBlocks/ManageSubscriptionBlockTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\PostEditorBlocks;
+
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+
+class ManageSubscriptionBlockTest extends \MailPoetTest {
+  /** @var ManageSubscriptionBlock */
+  private $block;
+
+  public function _before() {
+    parent::_before();
+    $this->block = $this->diContainer->get(ManageSubscriptionBlock::class);
+  }
+
+  public function testItRendersTheManageFormForALoggedInSubscriber(): void {
+    $wpUser = get_users()[0];
+    (new SubscriberFactory())
+      ->withEmail($wpUser->user_email) // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      ->withWpUserId((int)$wpUser->ID)
+      ->create();
+
+    wp_set_current_user((int)$wpUser->ID);
+    $html = $this->block->renderManageSubscription();
+    wp_set_current_user(0);
+
+    // The manage-subscription form posts to admin-post.php with this action.
+    $this->assertStringContainsString('mailpoet_subscription_update', $html);
+  }
+
+  public function testItReturnsTheSubscribersOnlyMessageForGuests(): void {
+    wp_set_current_user(0);
+    $this->assertStringContainsString(
+      'Subscription management form is only available to mailing lists subscribers.',
+      $this->block->renderManageSubscription()
+    );
+  }
+}


### PR DESCRIPTION
## Description

Adds a mailpoet/manage-subscription block that renders the manage-subscription form via `Pages::getManageContent()`, reusing the existing renderer including the modern style. 

This gives a native, block-based alternative to the `[mailpoet_manage_subscription]` shortcode, which works on any page for logged-in subscribers, without the router's email/token URL parameters or custom CSS.

Mirrors `SubscriptionFormBlock`: an inserter-hidden *-render block (registered in init() for the editor ServerSideRender preview), plus the user-facing block registered for the editor and frontend.

## Code review notes:
  - Reuses Subscription\Pages::getManageContent() — no rendering logic duplicated.
  - Mirrors SubscriptionFormBlock: a *-render block registered in init() (so the editor's ServerSideRender preview works) plus the user-facing block for editor, and frontend; reuses the existing subscription-form icon.
  - renderManageSubscription() calls Pages::init() defensively (isPreview() reads $data, which is null until init(); on a normal page this is a no-op re-init) and enqueues the form assets via AssetsController::setupFrontEndDependencies(), which getManageContent() does not do on its own.

## QA notes:
  1. Settings → set manage-subscription style to Modern.
  2. Add the "MailPoet Manage Subscription" block to a page; publish.
  3. Logged in as a subscriber → Modern form renders (no URL params needed).
  4. Logged out → "...only available to mailing lists subscribers" (unchanged). Covered by tests/integration/PostEditorBlocks/ManageSubscriptionBlockTest.php.

## Linked tickets
11194294-zen

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="800" height="557" alt="A8C 2026-06-23 at 14 08 29" src="https://github.com/user-attachments/assets/67e245f6-166b-4f38-b4ef-beadbc109a9e" /> | <img width="800" height="483" alt="A8C 2026-06-23 at 14 10 08" src="https://github.com/user-attachments/assets/31f23a97-8b83-4399-b157-129763dba3b3" /> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

Note: Editor JS follows the existing post-editor-block convention (.jsx, window.wp globals) for consistency with the sibling blocks."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->