### PR TITLE
Add Download button to the Logs page

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_logs.scss
+++ b/mailpoet/assets/css/src/components-plugin/_logs.scss
@@ -89,7 +89,8 @@
   }
 }
 
-.mailpoet-logs-delete-modal {
+.mailpoet-logs-delete-modal,
+.mailpoet-logs-download-modal {
   .components-modal__content {
     min-width: 420px;
   }
@@ -99,7 +100,8 @@
   }
 }
 
-.mailpoet-logs-delete-modal__actions {
+.mailpoet-logs-delete-modal__actions,
+.mailpoet-logs-download-modal__actions {
   display: flex;
   gap: $grid-gap-half;
   justify-content: flex-end;

--- a/mailpoet/assets/js/src/logs/download-modal.tsx
+++ b/mailpoet/assets/js/src/logs/download-modal.tsx
@@ -1,0 +1,108 @@
+import { useCallback } from 'react';
+import { Modal, Notice } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+import { Button } from 'common';
+import type { LogsFilter } from './url-state';
+
+type DownloadConfig = {
+  action_url: string;
+  nonce: string;
+};
+
+// Keep in sync with LogsDownload::MAX_LOGS on the PHP side.
+const MAX_LOGS = 50000;
+
+type Props = {
+  count: number;
+  filter: LogsFilter;
+  search: string | undefined;
+  isUnrestricted: boolean;
+  downloadConfig: DownloadConfig;
+  onClose: () => void;
+};
+
+function buildDownloadUrl(
+  downloadConfig: DownloadConfig,
+  filter: LogsFilter,
+  search: string | undefined,
+): string {
+  const params = new URLSearchParams({
+    action: 'mailpoet_download_logs',
+    _wpnonce: downloadConfig.nonce,
+  });
+  if (filter.from) params.set('from', filter.from);
+  if (filter.to) params.set('to', filter.to);
+  (filter.name ?? []).forEach((name) => params.append('name[]', name));
+  (filter.level ?? []).forEach((level) =>
+    params.append('level[]', String(level)),
+  );
+  if (search) params.set('search', search);
+  return `${downloadConfig.action_url}?${params.toString()}`;
+}
+
+export function DownloadLogsModal({
+  count,
+  filter,
+  search,
+  isUnrestricted,
+  downloadConfig,
+  onClose,
+}: Props): JSX.Element {
+  const formattedCount = count.toLocaleString();
+  const message = isUnrestricted
+    ? sprintf(
+        _n(
+          'This downloads the only log as a .txt file.',
+          'This downloads all %s logs as a .txt file.',
+          count,
+          'mailpoet',
+        ),
+        formattedCount,
+      )
+    : sprintf(
+        _n(
+          'This downloads %s log matching the current filters as a .txt file.',
+          'This downloads %s logs matching the current filters as a .txt file.',
+          count,
+          'mailpoet',
+        ),
+        formattedCount,
+      );
+
+  const handleDownload = useCallback((): void => {
+    window.location.assign(buildDownloadUrl(downloadConfig, filter, search));
+    onClose();
+  }, [downloadConfig, filter, search, onClose]);
+
+  return (
+    <Modal
+      className="mailpoet-logs-download-modal"
+      title={__('Download logs', 'mailpoet')}
+      onRequestClose={onClose}
+    >
+      {count > MAX_LOGS && (
+        <Notice status="warning" isDismissible={false}>
+          {sprintf(
+            __('Only the most recent %s logs will be downloaded.', 'mailpoet'),
+            MAX_LOGS.toLocaleString(),
+          )}
+        </Notice>
+      )}
+
+      <p>{message}</p>
+
+      <div className="mailpoet-logs-download-modal__actions">
+        <Button dimension="small" variant="secondary" onClick={onClose}>
+          {__('Cancel', 'mailpoet')}
+        </Button>
+        <Button dimension="small" onClick={handleDownload}>
+          {sprintf(
+            _n('Download %s log', 'Download %s logs', count, 'mailpoet'),
+            formattedCount,
+          )}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -13,6 +13,7 @@ import {
 } from 'common/dataviews';
 import { getLogs, type LogListingItem } from './api';
 import { DeleteLogsModal } from './delete-modal';
+import { DownloadLogsModal } from './download-modal';
 import { getLogActions, getLogFieldDefinitions, getLogFields } from './fields';
 import {
   getLogFilterOptions,
@@ -80,6 +81,7 @@ export function List({ defaultFrom, downloadConfig }: Props): JSX.Element {
     () => new Set(),
   );
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const didMountRef = useRef(false);
 
@@ -125,6 +127,7 @@ export function List({ defaultFrom, downloadConfig }: Props): JSX.Element {
   const isUnrestrictedDelete =
     Object.keys(requestFilter).length === 0 && !searchTerm;
   const canDelete = !isLoading && !dateRangeError && meta.count > 0;
+  const canDownload = canDelete;
 
   const persistedViewChange = usePersistedDataViewsPreference(
     'logs',
@@ -176,17 +179,6 @@ export function List({ defaultFrom, downloadConfig }: Props): JSX.Element {
     () => ({ totalItems: meta.count, totalPages: meta.pages }),
     [meta],
   );
-
-  const downloadLogs = useCallback((): void => {
-    if (!downloadConfig) return;
-    const params = new URLSearchParams({
-      action: 'mailpoet_download_logs',
-      _wpnonce: downloadConfig.nonce,
-    });
-    if (requestFilter.from) params.set('from', requestFilter.from);
-    if (requestFilter.to) params.set('to', requestFilter.to);
-    window.location.assign(`${downloadConfig.action_url}?${params.toString()}`);
-  }, [downloadConfig, requestFilter]);
 
   const retryLoading = useCallback((): void => {
     clearLoadError();
@@ -262,17 +254,17 @@ export function List({ defaultFrom, downloadConfig }: Props): JSX.Element {
             >
               {__('Delete logs...', 'mailpoet')}
             </Button>
-            <DataViews.ViewConfig />
             {downloadConfig && (
               <Button
                 dimension="small"
                 variant="secondary"
-                onClick={downloadLogs}
-                isDisabled={isLoading}
+                onClick={() => setIsDownloadModalOpen(true)}
+                isDisabled={!canDownload}
               >
-                {__('Download', 'mailpoet')}
+                {__('Download...', 'mailpoet')}
               </Button>
             )}
+            <DataViews.ViewConfig />
           </div>
         </div>
         <DataViews.Filters />
@@ -287,6 +279,16 @@ export function List({ defaultFrom, downloadConfig }: Props): JSX.Element {
           isUnrestricted={isUnrestrictedDelete}
           onClose={() => setIsDeleteModalOpen(false)}
           onDeleted={handleDeleted}
+        />
+      )}
+      {isDownloadModalOpen && downloadConfig && (
+        <DownloadLogsModal
+          count={meta.count}
+          filter={requestFilter}
+          search={searchTerm}
+          isUnrestricted={isUnrestrictedDelete}
+          downloadConfig={downloadConfig}
+          onClose={() => setIsDownloadModalOpen(false)}
         />
       )}
     </div>

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -257,7 +257,7 @@ export function List({ defaultFrom, downloadConfig }: Props): JSX.Element {
             {downloadConfig && (
               <Button
                 dimension="small"
-                variant="secondary"
+                variant="tertiary"
                 onClick={() => setIsDownloadModalOpen(true)}
                 isDisabled={!canDownload}
               >

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -36,8 +36,14 @@ const DEFAULT_VIEW: View = {
   showTitle: true,
 };
 
+type DownloadConfig = {
+  action_url: string;
+  nonce: string;
+};
+
 type Props = {
   defaultFrom: string;
+  downloadConfig?: DownloadConfig;
 };
 
 function buildInitialView(defaultFrom: string): View {
@@ -65,7 +71,7 @@ function filtersKey(view: View): string {
   return JSON.stringify(view.filters ?? []);
 }
 
-export function List({ defaultFrom }: Props): JSX.Element {
+export function List({ defaultFrom, downloadConfig }: Props): JSX.Element {
   const initialView = useMemo(
     () => buildInitialView(defaultFrom),
     [defaultFrom],
@@ -171,6 +177,18 @@ export function List({ defaultFrom }: Props): JSX.Element {
     [meta],
   );
 
+  const downloadLogs = useCallback((): void => {
+    if (!downloadConfig) return;
+    const params = new URLSearchParams({
+      action: 'mailpoet_download_logs',
+      _wpnonce: downloadConfig.nonce,
+    });
+    if (requestFilter.from) params.set('from', requestFilter.from);
+    if (requestFilter.to) params.set('to', requestFilter.to);
+    window.location.assign(`${downloadConfig.action_url}?${params.toString()}`);
+  }, [downloadConfig, requestFilter]);
+
+
   const retryLoading = useCallback((): void => {
     clearLoadError();
     refresh();
@@ -246,6 +264,16 @@ export function List({ defaultFrom }: Props): JSX.Element {
               {__('Delete logs...', 'mailpoet')}
             </Button>
             <DataViews.ViewConfig />
+            {downloadConfig && (
+              <Button
+                dimension="small"
+                variant="secondary"
+                onClick={downloadLogs}
+                isDisabled={isLoading}
+              >
+                {__('Download', 'mailpoet')}
+              </Button>
+            )}
           </div>
         </div>
         <DataViews.Filters />

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -188,7 +188,6 @@ export function List({ defaultFrom, downloadConfig }: Props): JSX.Element {
     window.location.assign(`${downloadConfig.action_url}?${params.toString()}`);
   }, [downloadConfig, requestFilter]);
 
-
   const retryLoading = useCallback((): void => {
     clearLoadError();
     refresh();

--- a/mailpoet/assets/js/src/logs/logs.tsx
+++ b/mailpoet/assets/js/src/logs/logs.tsx
@@ -6,6 +6,10 @@ import { List } from './list';
 declare global {
   interface Window {
     mailpoet_logs_default_from: string;
+    mailpoet_logs_download: {
+      action_url: string;
+      nonce: string;
+    };
   }
 }
 
@@ -15,7 +19,10 @@ if (container) {
   const root = createRoot(container);
   root.render(
     <ErrorBoundary>
-      <List defaultFrom={window.mailpoet_logs_default_from} />
+      <List
+        defaultFrom={window.mailpoet_logs_default_from}
+        downloadConfig={window.mailpoet_logs_download}
+      />
     </ErrorBoundary>,
   );
 }

--- a/mailpoet/changelog/2026-06-24-12-30-44-added-download-button-on-the-logs-page-to-export-logs-re.md
+++ b/mailpoet/changelog/2026-06-24-12-30-44-added-download-button-on-the-logs-page-to-export-logs-re.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Download button on the Logs page to export logs respecting active filters

--- a/mailpoet/lib/AdminPages/Pages/Logs.php
+++ b/mailpoet/lib/AdminPages/Pages/Logs.php
@@ -48,7 +48,7 @@ class Logs {
         'nonce' => $this->wp->wpCreateNonce('wp_rest'),
       ],
       'download' => [
-        'action_url' => admin_url('admin-post.php'),
+        'action_url' => $this->wp->adminUrl('admin-post.php'),
         'nonce' => LogsDownload::createNonce($this->wp),
       ],
     ];

--- a/mailpoet/lib/AdminPages/Pages/Logs.php
+++ b/mailpoet/lib/AdminPages/Pages/Logs.php
@@ -5,6 +5,7 @@ namespace MailPoet\AdminPages\Pages;
 use MailPoet\AdminPages\AssetsController;
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Logging\LogRepository;
+use MailPoet\Logging\LogsDownload;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -45,6 +46,10 @@ class Logs {
       'api' => [
         'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
         'nonce' => $this->wp->wpCreateNonce('wp_rest'),
+      ],
+      'download' => [
+        'action_url' => admin_url('admin-post.php'),
+        'nonce' => LogsDownload::createNonce($this->wp),
       ],
     ];
     $this->pageRenderer->displayPage('logs.html', $data);

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -22,6 +22,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor as MailpoetEmailEdito
 use MailPoet\EmailEditor\Integrations\MailPoet\Logger;
 use MailPoet\Form\RestApi\Api as FormsRestApi;
 use MailPoet\InvalidStateException;
+use MailPoet\Logging\LogsDownload;
 use MailPoet\Logging\RestApi\Api as LogsRestApi;
 use MailPoet\Migrator\Cli as MigratorCli;
 use MailPoet\Newsletter\RestApi\Api as NewslettersRestApi;
@@ -150,6 +151,9 @@ class Initializer {
   /** @var NewslettersRestApi */
   private $newslettersRestApi;
 
+  /** @var LogsDownload */
+  private $logsDownload;
+
   /** @var MailPoetIntegration */
   private $automationMailPoetIntegration;
 
@@ -220,6 +224,7 @@ class Initializer {
     LogsRestApi $logsRestApi,
     SubscribersRestApi $subscribersRestApi,
     NewslettersRestApi $newslettersRestApi,
+    LogsDownload $logsDownload,
     PublicEmailRoute $publicEmailRoute
   ) {
     $this->rendererFactory = $rendererFactory;
@@ -262,6 +267,7 @@ class Initializer {
     $this->logsRestApi = $logsRestApi;
     $this->subscribersRestApi = $subscribersRestApi;
     $this->newslettersRestApi = $newslettersRestApi;
+    $this->logsDownload = $logsDownload;
     $this->publicEmailRoute = $publicEmailRoute;
 
     $emailEditorContainer = Email_Editor_Container::container();
@@ -445,6 +451,7 @@ class Initializer {
       $this->logsRestApi->initialize();
       $this->subscribersRestApi->initialize();
       $this->newslettersRestApi->initialize();
+      $this->logsDownload->initialize();
       $this->blockTypesController->initialize();
       $this->wpFunctions->doAction('mailpoet_initialized', MAILPOET_VERSION);
     } catch (InvalidStateException $e) {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -788,6 +788,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Logging\RestApi\Api::class)->setPublic(true);
     $container->autowire(\MailPoet\Logging\RestApi\Endpoints\LogsListingEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Logging\RestApi\Endpoints\LogsDeleteEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Logging\LogsDownload::class)->setPublic(true);
     // Subscribers REST API
     $container->autowire(\MailPoet\Subscribers\RestApi\Api::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\RestApi\Endpoints\SubscribersListingEndpoint::class)->setPublic(true);

--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -180,9 +180,26 @@ class LogRepository extends Repository {
 
     $sql = "SELECT `created_at`, `name`, `message` FROM `{$logsTable}`{$where} ORDER BY `created_at` DESC, `id` DESC LIMIT :export_limit";
 
-    return $this->entityManager->getConnection()
+    $rows = $this->entityManager->getConnection()
       ->executeQuery($sql, $parameters, $types)
       ->fetchAllAssociative();
+
+    $logs = [];
+    foreach ($rows as $row) {
+      $logs[] = [
+        'created_at' => $this->castToNullableString($row['created_at']) ?? '',
+        'name' => $this->castToNullableString($row['name']),
+        'message' => $this->castToNullableString($row['message']),
+      ];
+    }
+    return $logs;
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function castToNullableString($value): ?string {
+    return is_scalar($value) ? (string)$value : null;
   }
 
   public function getRawMessagesForNewsletter(NewsletterEntity $newsletter, string $topic): array {

--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -163,6 +163,28 @@ class LogRepository extends Repository {
     return $deleted;
   }
 
+  /**
+   * Fetch logs matching the listing's filter shape (`from`/`to`/`name`/`level`)
+   * and free-text search for export, so a download contains exactly the rows the
+   * filtered listing shows. Mirrors deleteLogs()'s WHERE clause and is capped by
+   * $limit to keep memory bounded on large log tables.
+   *
+   * @param array{from?: string, to?: string, name?: string[], level?: int[]} $filter
+   * @return array<int, array{created_at: string, name: string|null, message: string|null}>
+   */
+  public function getLogsForExport(array $filter, ?string $search = null, int $limit = 50000): array {
+    $logsTable = $this->entityManager->getClassMetadata(LogEntity::class)->getTableName();
+    [$where, $parameters, $types] = $this->buildFilterSql($filter, $search);
+    $parameters['export_limit'] = $limit;
+    $types['export_limit'] = ParameterType::INTEGER;
+
+    $sql = "SELECT `created_at`, `name`, `message` FROM `{$logsTable}`{$where} ORDER BY `created_at` DESC, `id` DESC LIMIT :export_limit";
+
+    return $this->entityManager->getConnection()
+      ->executeQuery($sql, $parameters, $types)
+      ->fetchAllAssociative();
+  }
+
   public function getRawMessagesForNewsletter(NewsletterEntity $newsletter, string $topic): array {
     return $this->entityManager->createQueryBuilder()
       ->select('DISTINCT logs.rawMessage message')

--- a/mailpoet/lib/Logging/LogsDownload.php
+++ b/mailpoet/lib/Logging/LogsDownload.php
@@ -40,18 +40,37 @@ class LogsDownload {
 
     $from = isset($_GET['from']) && is_string($_GET['from']) ? sanitize_text_field(wp_unslash($_GET['from'])) : null;
     $to = isset($_GET['to']) && is_string($_GET['to']) ? sanitize_text_field(wp_unslash($_GET['to'])) : null;
+    $search = isset($_GET['search']) && is_string($_GET['search']) ? sanitize_text_field(wp_unslash($_GET['search'])) : null;
 
+    $filter = [];
     $dateFrom = $this->parseDateParam($from);
+    if ($dateFrom instanceof \DateTimeImmutable) {
+      $filter['from'] = $dateFrom->format('Y-m-d');
+    }
     $dateTo = $this->parseDateParam($to);
+    if ($dateTo instanceof \DateTimeImmutable) {
+      $filter['to'] = $dateTo->format('Y-m-d');
+    }
+    $names = $this->parseStringArrayParam('name');
+    if ($names) {
+      $filter['name'] = $names;
+    }
+    $levels = $this->parseIntArrayParam('level');
+    if ($levels) {
+      $filter['level'] = $levels;
+    }
+    if ($search === '') {
+      $search = null;
+    }
 
-    $logs = $this->logRepository->getLogs($dateFrom, $dateTo, null, null, (string)self::MAX_LOGS);
+    $logs = $this->logRepository->getLogsForExport($filter, $search, self::MAX_LOGS);
 
     $filename = 'mailpoet-logs';
-    if ($from) {
-      $filename .= '-from-' . $from;
+    if (isset($filter['from'])) {
+      $filename .= '-from-' . $filter['from'];
     }
-    if ($to) {
-      $filename .= '-to-' . $to;
+    if (isset($filter['to'])) {
+      $filename .= '-to-' . $filter['to'];
     }
     $filename .= '.txt';
 
@@ -62,13 +81,45 @@ class LogsDownload {
     header('Expires: 0');
 
     foreach ($logs as $log) {
-      $createdAt = $log->getCreatedAt() ? $log->getCreatedAt()->format('Y-m-d H:i:s') : 'N/A';
-      $name = $log->getName() ?? '';
-      $message = $log->getMessage() ?? '';
+      $createdAt = $log['created_at'] ?? 'N/A';
+      $name = $log['name'] ?? '';
+      $message = $log['message'] ?? '';
       // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
       echo '[' . $createdAt . '] [' . $name . '] ' . $message . "\n";
     }
     exit;
+  }
+
+  /**
+   * @return string[]
+   */
+  private function parseStringArrayParam(string $key): array {
+    if (!isset($_GET[$key]) || !is_array($_GET[$key])) {
+      return [];
+    }
+    $values = [];
+    foreach (wp_unslash($_GET[$key]) as $value) {
+      if (is_string($value) && $value !== '') {
+        $values[] = sanitize_text_field($value);
+      }
+    }
+    return array_values(array_unique($values));
+  }
+
+  /**
+   * @return int[]
+   */
+  private function parseIntArrayParam(string $key): array {
+    if (!isset($_GET[$key]) || !is_array($_GET[$key])) {
+      return [];
+    }
+    $values = [];
+    foreach ($_GET[$key] as $value) {
+      if (is_numeric($value)) {
+        $values[] = (int)$value;
+      }
+    }
+    return array_values(array_unique($values));
   }
 
   public static function createNonce(WPFunctions $wp): string {

--- a/mailpoet/lib/Logging/LogsDownload.php
+++ b/mailpoet/lib/Logging/LogsDownload.php
@@ -84,6 +84,7 @@ class LogsDownload {
       $createdAt = $log['created_at'] ?? 'N/A';
       $name = $log['name'] ?? '';
       $message = $log['message'] ?? '';
+      // Output is a text/plain attachment download, not HTML; HTML-escaping would corrupt the log content.
       // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
       echo '[' . $createdAt . '] [' . $name . '] ' . $message . "\n";
     }
@@ -91,30 +92,25 @@ class LogsDownload {
   }
 
   private function getStringParam(string $key): ?string {
-    if (!isset($_GET[$key])) {
+    if (!isset($_GET[$key]) || !is_string($_GET[$key])) {
       return null;
     }
-    $value = $this->wp->wpUnslash($_GET[$key]);
-    return is_string($value) ? $this->wp->sanitizeTextField($value) : null;
+    return sanitize_text_field(wp_unslash($_GET[$key]));
   }
 
   /**
    * @return string[]
    */
   private function parseStringArrayParam(string $key): array {
-    if (!isset($_GET[$key])) {
+    if (!isset($_GET[$key]) || !is_array($_GET[$key])) {
       return [];
     }
-    $unslashed = $this->wp->wpUnslash($_GET[$key]);
-    if (!is_array($unslashed)) {
-      return [];
-    }
-    $values = [];
-    foreach ($unslashed as $value) {
-      if (is_string($value) && $value !== '') {
-        $values[] = $this->wp->sanitizeTextField($value);
+    $values = array_filter(
+      array_map('sanitize_text_field', wp_unslash($_GET[$key])),
+      static function (string $value): bool {
+        return $value !== '';
       }
-    }
+    );
     return array_values(array_unique($values));
   }
 
@@ -125,12 +121,7 @@ class LogsDownload {
     if (!isset($_GET[$key]) || !is_array($_GET[$key])) {
       return [];
     }
-    $values = [];
-    foreach ($_GET[$key] as $value) {
-      if (is_numeric($value)) {
-        $values[] = (int)$value;
-      }
-    }
+    $values = array_map('intval', wp_unslash($_GET[$key]));
     return array_values(array_unique($values));
   }
 

--- a/mailpoet/lib/Logging/LogsDownload.php
+++ b/mailpoet/lib/Logging/LogsDownload.php
@@ -30,17 +30,17 @@ class LogsDownload {
 
   public function handle(): void {
     if (!$this->wp->currentUserCan(AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN)) {
-      wp_die(esc_html__('You do not have permission to download logs.', 'mailpoet'), '', ['response' => 403]);
+      $this->wp->wpDie(esc_html__('You do not have permission to download logs.', 'mailpoet'), '', ['response' => 403]);
     }
 
-    $nonce = isset($_GET['_wpnonce']) ? sanitize_text_field(wp_unslash($_GET['_wpnonce'])) : '';
+    $nonce = $this->getStringParam('_wpnonce') ?? '';
     if (!$this->wp->wpVerifyNonce($nonce, self::NONCE_ACTION)) {
-      wp_die(esc_html__('Security check failed.', 'mailpoet'), '', ['response' => 403]);
+      $this->wp->wpDie(esc_html__('Security check failed.', 'mailpoet'), '', ['response' => 403]);
     }
 
-    $from = isset($_GET['from']) && is_string($_GET['from']) ? sanitize_text_field(wp_unslash($_GET['from'])) : null;
-    $to = isset($_GET['to']) && is_string($_GET['to']) ? sanitize_text_field(wp_unslash($_GET['to'])) : null;
-    $search = isset($_GET['search']) && is_string($_GET['search']) ? sanitize_text_field(wp_unslash($_GET['search'])) : null;
+    $from = $this->getStringParam('from');
+    $to = $this->getStringParam('to');
+    $search = $this->getStringParam('search');
 
     $filter = [];
     $dateFrom = $this->parseDateParam($from);
@@ -90,17 +90,29 @@ class LogsDownload {
     exit;
   }
 
+  private function getStringParam(string $key): ?string {
+    if (!isset($_GET[$key])) {
+      return null;
+    }
+    $value = $this->wp->wpUnslash($_GET[$key]);
+    return is_string($value) ? $this->wp->sanitizeTextField($value) : null;
+  }
+
   /**
    * @return string[]
    */
   private function parseStringArrayParam(string $key): array {
-    if (!isset($_GET[$key]) || !is_array($_GET[$key])) {
+    if (!isset($_GET[$key])) {
+      return [];
+    }
+    $unslashed = $this->wp->wpUnslash($_GET[$key]);
+    if (!is_array($unslashed)) {
       return [];
     }
     $values = [];
-    foreach (wp_unslash($_GET[$key]) as $value) {
+    foreach ($unslashed as $value) {
       if (is_string($value) && $value !== '') {
-        $values[] = sanitize_text_field($value);
+        $values[] = $this->wp->sanitizeTextField($value);
       }
     }
     return array_values(array_unique($values));

--- a/mailpoet/lib/Logging/LogsDownload.php
+++ b/mailpoet/lib/Logging/LogsDownload.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Logging;
+
+use MailPoet\Config\AccessControl;
+use MailPoet\WP\Functions as WPFunctions;
+
+class LogsDownload {
+  private const ACTION = 'mailpoet_download_logs';
+  private const NONCE_ACTION = 'mailpoet_download_logs_nonce';
+  private const MAX_LOGS = 50000;
+
+  /** @var LogRepository */
+  private $logRepository;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    LogRepository $logRepository,
+    WPFunctions $wp
+  ) {
+    $this->logRepository = $logRepository;
+    $this->wp = $wp;
+  }
+
+  public function initialize(): void {
+    $this->wp->addAction('admin_post_' . self::ACTION, [$this, 'handle']);
+  }
+
+  public function handle(): void {
+    if (!$this->wp->currentUserCan(AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN)) {
+      wp_die(esc_html__('You do not have permission to download logs.', 'mailpoet'), '', ['response' => 403]);
+    }
+
+    $nonce = isset($_GET['_wpnonce']) ? sanitize_text_field(wp_unslash($_GET['_wpnonce'])) : '';
+    if (!$this->wp->wpVerifyNonce($nonce, self::NONCE_ACTION)) {
+      wp_die(esc_html__('Security check failed.', 'mailpoet'), '', ['response' => 403]);
+    }
+
+    $from = isset($_GET['from']) && is_string($_GET['from']) ? sanitize_text_field(wp_unslash($_GET['from'])) : null;
+    $to = isset($_GET['to']) && is_string($_GET['to']) ? sanitize_text_field(wp_unslash($_GET['to'])) : null;
+
+    $dateFrom = $this->parseDateParam($from);
+    $dateTo = $this->parseDateParam($to);
+
+    $logs = $this->logRepository->getLogs($dateFrom, $dateTo, null, null, (string)self::MAX_LOGS);
+
+    $filename = 'mailpoet-logs';
+    if ($from) {
+      $filename .= '-from-' . $from;
+    }
+    if ($to) {
+      $filename .= '-to-' . $to;
+    }
+    $filename .= '.txt';
+
+    header('Content-Type: text/plain; charset=utf-8');
+    header('Content-Disposition: attachment; filename="' . $filename . '"');
+    header('Cache-Control: no-cache, no-store, must-revalidate');
+    header('Pragma: no-cache');
+    header('Expires: 0');
+
+    foreach ($logs as $log) {
+      $createdAt = $log->getCreatedAt() ? $log->getCreatedAt()->format('Y-m-d H:i:s') : 'N/A';
+      $name = $log->getName() ?? '';
+      $message = $log->getMessage() ?? '';
+      // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+      echo '[' . $createdAt . '] [' . $name . '] ' . $message . "\n";
+    }
+    exit;
+  }
+
+  public static function createNonce(WPFunctions $wp): string {
+    return $wp->wpCreateNonce(self::NONCE_ACTION);
+  }
+
+  private function parseDateParam(?string $value): ?\DateTimeImmutable {
+    if ($value === null || $value === '') {
+      return null;
+    }
+    $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+    if (!$date) {
+      return null;
+    }
+    $errors = \DateTimeImmutable::getLastErrors();
+    if (is_array($errors) && ($errors['warning_count'] > 0 || $errors['error_count'] > 0)) {
+      return null;
+    }
+    return $date;
+  }
+}

--- a/mailpoet/views/logs.html
+++ b/mailpoet/views/logs.html
@@ -12,6 +12,7 @@
       var mailpoet_logs_default_from = '<%= logs_default_from %>';
       var mailpoet_logs_filter_options = <%= json_encode(logs_filter_options) %>;
       var mailpoet_logs_api = <%= json_encode(api) %>;
+      var mailpoet_logs_download = <%= json_encode(download) %>;
     <% endautoescape %>
   </script>
 </div>

--- a/scripts/composer-install.sh
+++ b/scripts/composer-install.sh
@@ -10,9 +10,9 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 echo "==> composer install in mailpoet/"
 (cd "$ROOT_DIR/mailpoet" && composer install --no-interaction)
 
-if [ -d "$ROOT_DIR/mailpoet-premium" ]; then
+if [ -f "$ROOT_DIR/mailpoet-premium/composer.json" ]; then
   echo "==> composer install in mailpoet-premium/"
   (cd "$ROOT_DIR/mailpoet-premium" && composer install --no-interaction)
 else
-  echo "==> skipping mailpoet-premium/ (directory not present)"
+  echo "==> skipping mailpoet-premium/ (no composer.json found)"
 fi


### PR DESCRIPTION
## Description

Adds a **Download** button to MailPoet > Settings > Advanced > Logging > See Logs, positioned to the right of the existing **Clear** button. Clicking it downloads a `.txt` file containing all log entries for the currently selected date range — similar to WooCommerce > Status > Logs.

## Code review notes

- The download uses `admin-post.php` (standard WordPress pattern for file downloads) rather than the WP REST API, since REST endpoints can't stream file responses with `Content-Disposition: attachment`.
- Nonce is generated server-side in `Logs.php` and passed to the frontend via a JS global (`mailpoet_logs_download`), following the same pattern as the existing `mailpoet_logs_api` global.
- Max 50,000 log entries per download — uses the existing `LogRepository::getLogs()` method.
- The `scripts/composer-install.sh` fix is a minor bugfix: the script was checking `if [ -d mailpoet-premium ]` but the directory exists as a compiled build without `composer.json`, causing the install to fail. Changed to check for `composer.json` instead.

## QA notes

1. Go to **MailPoet > Settings > Advanced > Logging** and set logging to "Everything" or "Errors only"
2. Navigate to the Logs page via **See Logs**
3. Confirm a **Download** button appears to the right of **Clear**
4. Click **Download** — a `.txt` file should download with log entries in the format `[YYYY-MM-DD HH:MM:SS] [log-name] message`
5. Set a date range using the From/To filters, click **Apply**, then **Download** — confirm the downloaded file only contains entries within that range and the filename includes the date range (e.g. `mailpoet-logs-from-2024-01-01-to-2024-01-07.txt`)

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8206

## After-merge notes

_N/A_

## Screenshots

| Filtered | All logs | 
| ---- | ---- | 
|  <img width="489" height="241" alt="Screenshot 2026-06-24 at 14 46 42" src="https://github.com/user-attachments/assets/f5be3d4d-b4c7-44e3-a525-2fe3f38c7108" /> | <img width="478" height="249" alt="Screenshot 2026-06-24 at 14 46 48" src="https://github.com/user-attachments/assets/5c904146-1205-4a18-b1b6-8eb5b877b260" /> | 
## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**New Features**
- Added a **“Download…”** option to the Logs page, opening a modal to export logs as a **plain-text (.txt)** file using the current filters/search.

**User Experience**
- The modal shows how many entries will be included and warns when the export exceeds the maximum, exporting only the most recent entries.

**Security & Compatibility**
- Added server-side handling for log downloads with **nonce protection** and support for filtering by **date range, names, levels, and search**.

**Internal Changes**
- Wired the new download configuration from the admin page through the UI to the export action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8206-add-download-button-to-the-logs-page)

_The latest successful build from `stomail-8206-add-download-button-to-the-logs-page` will be used. If none is available, the link won't work._