### PR TITLE
Hide activity event-type dropdown for premium

### DIFF
--- a/mailpoet/assets/js/src/subscribers/stats/activity-shell.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/activity-shell.tsx
@@ -33,12 +33,20 @@ const EVENT_TYPE_OPTIONS: Array<{ label: string; value: ActivityEventType }> = [
   { label: __('Unsubscribes', 'mailpoet'), value: 'unsubscribe' },
 ];
 
+function isDetailedAnalyticsRestricted(): boolean {
+  const capability = MailPoet.capabilities?.detailedAnalytics;
+  return !capability || capability.isRestricted;
+}
+
 export function ActivityShell({
   lastEngagementAt,
   location,
   params,
 }: Props): JSX.Element {
   const [eventType, setEventType] = useState<ActivityEventType>('all');
+  // Premium replaces this dropdown with a native DataViews event-type filter, so
+  // only restricted/free users (who see the upsell) need the control here.
+  const showEventTypeFilter = isDetailedAnalyticsRestricted();
   const subtitle = lastEngagementAt
     ? sprintf(
         // translators: %s is a date and time when the subscriber was last seen.
@@ -64,14 +72,16 @@ export function ActivityShell({
               </div>
             </div>
           </FlexBlock>
-          <SelectControl
-            className="mailpoet-subscriber-stats-activity-filter"
-            hideLabelFromVision
-            label={__('Activity event type', 'mailpoet')}
-            onChange={(value) => setEventType(value as ActivityEventType)}
-            options={EVENT_TYPE_OPTIONS}
-            value={eventType}
-          />
+          {showEventTypeFilter && (
+            <SelectControl
+              className="mailpoet-subscriber-stats-activity-filter"
+              hideLabelFromVision
+              label={__('Activity event type', 'mailpoet')}
+              onChange={(value) => setEventType(value as ActivityEventType)}
+              options={EVENT_TYPE_OPTIONS}
+              value={eventType}
+            />
+          )}
         </Flex>
       </CardHeader>
       <CardBody className="mailpoet-subscriber-stats-activity-body">


### PR DESCRIPTION
## Description

Free half of STOMAIL-8175. The subscriber activity feed's event-type `SelectControl` lives in the free plugin but is consumed by premium. Premium now replaces it with a native DataViews event-type filter, so this dropdown is only rendered for restricted/free users who see the upsell.

Requires the premium PR to ship together.

## Code review notes

- Visibility is gated on `MailPoet.capabilities.detailedAnalytics.isRestricted`: shown for restricted/free (drives upsell), hidden for premium where the native filter takes over.

## QA notes

1. Without premium: open a subscriber → Statistics → Activity; the event-type dropdown is still shown.
2. With premium active: the dropdown is hidden (premium renders its own native filter).

## Linked PRs

mailpoet/mailpoet-premium#1110

## Linked tickets

STOMAIL-8175

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8175-dataviews-native-filters-sorting-for-premium-subscriber)

_The latest successful build from `add/stomail-8175-dataviews-native-filters-sorting-for-premium-subscriber` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->