### PR TITLE
Pass newsletter to premium clicked-links and reasons stats filters

### DIFF
--- a/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
@@ -168,6 +168,7 @@ export function CampaignStatsPage() {
               'mailpoet_newsletters_clicked_links_table',
               <PremiumBanner />,
               newsletter.clicked_links,
+              newsletter,
             )}
           </Tab>
 
@@ -225,6 +226,7 @@ export function CampaignStatsPage() {
               'mailpoet_newsletters_unsubscribe_reasons',
               <PremiumBanner />,
               newsletter.statistics.unsubscribeReasons,
+              newsletter,
             )}
           </Tab>
         </Tabs>


### PR DESCRIPTION
## Description

Premium moves the Clicked Links and Unsubscribe Reasons campaign-stats tables server-side (STOMAIL-8174). To build their REST requests those tables need the newsletter (for its id), so this passes `newsletter` into the `mailpoet_newsletters_clicked_links_table` and `mailpoet_newsletters_unsubscribe_reasons` filter hooks alongside the existing pre-loaded data.

## Code review notes

_N/A_

## QA notes

No user-facing change on its own — it only widens two filter-hook payloads. Test together with the premium PR (recompile both plugins): without this change the premium clicked-links / unsubscribe-reasons tables can't resolve the newsletter id and error out. Behaviour is exercised by the premium acceptance and integration tests.

## Linked PRs

mailpoet/mailpoet-premium#1111

## Linked tickets

STOMAIL-8174

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->