### PR TITLE
Fix unsubscribe token backfill silently writing nothing

### DIFF
--- a/mailpoet/changelog/2026-06-25-05-39-42-fixed-backfill-unsubscribe-tokens-for-subscribers-and-ne.md
+++ b/mailpoet/changelog/2026-06-25-05-39-42-fixed-backfill-unsubscribe-tokens-for-subscribers-and-ne.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Backfill unsubscribe tokens for subscribers and newsletters that were missing them

--- a/mailpoet/lib/Cron/Workers/UnsubscribeTokens.php
+++ b/mailpoet/lib/Cron/Workers/UnsubscribeTokens.php
@@ -5,9 +5,9 @@ namespace MailPoet\Cron\Workers;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\InvalidStateException;
 use MailPoet\Util\Security;
 use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\ParameterType;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class UnsubscribeTokens extends SimpleWorker {
@@ -15,79 +15,54 @@ class UnsubscribeTokens extends SimpleWorker {
   const BATCH_SIZE = 1000;
   const AUTOMATIC_SCHEDULING = false;
 
-  /** @var Security */
-  private $security;
-
   /** @var EntityManager */
   private $entityManager;
 
   public function __construct(
-    Security $security,
     EntityManager $entityManager
   ) {
     parent::__construct();
-    $this->security = $security;
     $this->entityManager = $entityManager;
   }
 
   public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
-    $meta = $task->getMeta();
-
-    if (!isset($meta['last_subscriber_id'])) {
-      $meta['last_subscriber_id'] = 0;
-    }
-
-    if (!isset($meta['last_newsletter_id'])) {
-      $meta['last_newsletter_id'] = 0;
-    }
-
-    do {
-      $this->cronHelper->enforceExecutionLimit($timer);
-      $subscribersCount = $this->addTokens(SubscriberEntity::class, $meta['last_subscriber_id']);
-      $task->setMeta($meta);
-      $this->scheduledTasksRepository->persist($task);
-      $this->scheduledTasksRepository->flush();
-    } while ($subscribersCount === self::BATCH_SIZE);
-    do {
-      $this->cronHelper->enforceExecutionLimit($timer);
-      $newslettersCount = $this->addTokens(NewsletterEntity::class, $meta['last_newsletter_id']);
-      $task->setMeta($meta);
-      $this->scheduledTasksRepository->persist($task);
-      $this->scheduledTasksRepository->flush();
-    } while ($newslettersCount === self::BATCH_SIZE);
-    if ($subscribersCount > 0 || $newslettersCount > 0) {
-      return false;
+    foreach ([SubscriberEntity::class, NewsletterEntity::class] as $entityClass) {
+      do {
+        $this->cronHelper->enforceExecutionLimit($timer);
+        $updatedCount = $this->addTokens($entityClass);
+      } while ($updatedCount === self::BATCH_SIZE);
     }
     return true;
   }
 
-  private function addTokens($entityClass, &$lastProcessedId = 0) {
-    $queryBuilder = $this->entityManager->createQueryBuilder();
+  /**
+   * @param class-string $entityClass
+   */
+  private function addTokens(string $entityClass): int {
+    $tableName = $this->entityManager->getClassMetadata($entityClass)->getTableName();
+    $connection = $this->entityManager->getConnection();
+    $authKey = defined('AUTH_KEY') ? AUTH_KEY : '';
 
-    $entities = $queryBuilder
-      ->select('PARTIAL e.{id}')
-      ->from($entityClass, 'e')
-      ->where('e.unsubscribeToken IS NULL')
-      ->andWhere('e.id > :lastProcessedId')
-      ->orderBy('e.id', 'ASC')
-      ->setMaxResults(self::BATCH_SIZE)
-      ->setParameter('lastProcessedId', $lastProcessedId)
-      ->getQuery()
-      ->getResult();
-
-    if (!is_iterable($entities) || !is_countable($entities)) {
-      throw new InvalidStateException('Entities must be iterable');
-    }
-
-    foreach ($entities as $entity) {
-      $lastProcessedId = $entity->getId();
-      $entity->setUnsubscribeToken($this->security->generateUnsubscribeTokenByEntity($entity));
-      $this->entityManager->persist($entity);
-    }
-
-    $this->entityManager->flush();
-
-    return count($entities);
+    // A direct UPDATE keeps the backfill out of Doctrine's UnitOfWork: changes made to
+    // PARTIAL-hydrated entities are not registered, so the previous entity-based approach
+    // computed an empty changeset and silently wrote nothing. The token is derived from
+    // AUTH_KEY (so it stays unguessable) and the row id salted per entity type (so it stays
+    // unique within its table and never collides across the two tables).
+    return (int)$connection->executeStatement(
+      "UPDATE {$tableName} SET unsubscribe_token = SUBSTRING(MD5(CONCAT(:authKey, :salt, id)), 1, :tokenLength) WHERE unsubscribe_token IS NULL LIMIT :limit",
+      [
+        'authKey' => $authKey,
+        'salt' => $entityClass,
+        'tokenLength' => Security::UNSUBSCRIBE_TOKEN_LENGTH,
+        'limit' => self::BATCH_SIZE,
+      ],
+      [
+        'authKey' => ParameterType::STRING,
+        'salt' => ParameterType::STRING,
+        'tokenLength' => ParameterType::INTEGER,
+        'limit' => ParameterType::INTEGER,
+      ]
+    );
   }
 
   public function getNextRunDate() {

--- a/mailpoet/lib/Cron/Workers/UnsubscribeTokens.php
+++ b/mailpoet/lib/Cron/Workers/UnsubscribeTokens.php
@@ -46,8 +46,8 @@ class UnsubscribeTokens extends SimpleWorker {
     // A direct UPDATE keeps the backfill out of Doctrine's UnitOfWork: changes made to
     // PARTIAL-hydrated entities are not registered, so the previous entity-based approach
     // computed an empty changeset and silently wrote nothing. The token is derived from
-    // AUTH_KEY (so it stays unguessable) and the row id salted per entity type (so it stays
-    // unique within its table and never collides across the two tables).
+    // AUTH_KEY (so it stays unguessable) and salted per entity type (so it avoids
+    // systematic cross-table collisions; truncated-hash collisions remain extremely unlikely).
     return (int)$connection->executeStatement(
       "UPDATE {$tableName} SET unsubscribe_token = SUBSTRING(MD5(CONCAT(:authKey, :salt, id)), 1, :tokenLength) WHERE unsubscribe_token IS NULL LIMIT :limit",
       [

--- a/mailpoet/tests/integration/Cron/Workers/UnsubscribeTokensTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/UnsubscribeTokensTest.php
@@ -7,8 +7,6 @@ use MailPoet\Cron\Workers\UnsubscribeTokens;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoet\Newsletter\NewslettersRepository;
-use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 
@@ -26,19 +24,11 @@ class UnsubscribeTokensTest extends \MailPoetTest {
   /** @var NewsletterEntity */
   private $newsletterWithoutToken;
 
-  /** @var SubscribersRepository */
-  private $subscribersRepository;
-
-  /** @var NewslettersRepository */
-  private $newslettersRepository;
-
   /** @var UnsubscribeTokens */
   private $worker;
 
   public function _before() {
     parent::_before();
-    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
-    $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
     $this->worker = $this->diContainer->get(UnsubscribeTokens::class);
 
     $this->subscriberWithToken = (new SubscriberFactory())
@@ -67,22 +57,20 @@ class UnsubscribeTokensTest extends \MailPoetTest {
   public function testItAddsTokensToSubscribers() {
     verify($this->subscriberWithoutToken->getUnsubscribeToken())->null();
     $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
-    $subscriberWithToken = $this->subscribersRepository->findOneById($this->subscriberWithToken->getId());
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriberWithToken);
-    $subscriberWithoutToken = $this->subscribersRepository->findOneById($this->subscriberWithoutToken->getId());
-    $this->assertInstanceOf(SubscriberEntity::class, $subscriberWithoutToken);
-    verify($subscriberWithToken->getUnsubscribeToken())->equals('aaabbbcccdddeee');
-    verify(strlen($subscriberWithoutToken->getUnsubscribeToken() ?? ''))->equals(15);
+    // The worker writes via a direct SQL UPDATE, so refresh the managed entities to read
+    // the persisted values rather than the stale ones cached in the identity map.
+    $this->entityManager->refresh($this->subscriberWithToken);
+    $this->entityManager->refresh($this->subscriberWithoutToken);
+    verify($this->subscriberWithToken->getUnsubscribeToken())->equals('aaabbbcccdddeee');
+    verify(strlen($this->subscriberWithoutToken->getUnsubscribeToken() ?? ''))->equals(15);
   }
 
   public function testItAddsTokensToNewsletters() {
     verify($this->newsletterWithoutToken->getUnsubscribeToken())->null();
     $this->worker->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
-    $newsletterWithToken = $this->newslettersRepository->findOneById($this->newsletterWithToken->getId());
-    $newsletterWithoutToken = $this->newslettersRepository->findOneById($this->newsletterWithoutToken->getId());
-    $this->assertInstanceOf(NewsletterEntity::class, $newsletterWithToken);
-    $this->assertInstanceOf(NewsletterEntity::class, $newsletterWithoutToken);
-    verify($newsletterWithToken->getUnsubscribeToken())->equals('aaabbbcccdddeee');
-    verify(strlen($newsletterWithoutToken->getUnsubscribeToken() ?? ''))->equals(15);
+    $this->entityManager->refresh($this->newsletterWithToken);
+    $this->entityManager->refresh($this->newsletterWithoutToken);
+    verify($this->newsletterWithToken->getUnsubscribeToken())->equals('aaabbbcccdddeee');
+    verify(strlen($this->newsletterWithoutToken->getUnsubscribeToken() ?? ''))->equals(15);
   }
 }


### PR DESCRIPTION
## Description

`UnsubscribeTokens` loaded `PARTIAL e.{id}` entities, called `setUnsubscribeToken()`, and `flush()`ed. Doctrine's UnitOfWork does not register changes made to partial-hydrated entities, so the computed changeset was empty and every batch "succeeded" while persisting nothing — the worker has never actually been able to write tokens with this pattern.

On normal sites this is mostly invisible (token counts are low and tokens are generated on demand at send time). On large datasets with many token-less rows the worker becomes a full-table treadmill: it scans batch by batch, writes nothing, and never makes the `IS NULL` set shrink, so it never finishes.

The fix replaces the entity loop with a direct SQL `UPDATE`, mirroring the sibling `SubscriberLinkTokens` worker. The token is derived from `AUTH_KEY` (so it stays unguessable) and salted with the row `id` per entity type (so it stays unique within its table and never collides across the subscribers/newsletters tables). The `IS NULL ... LIMIT` filter makes the worker idempotent and resumable without the previous meta cursor.

## Code review notes

- `SubscriberLinkTokens` was suspected of the same bug but is fine — it already uses a raw SQL `UPDATE`. No change there.
- `unsubscribe_token` carries a `UNIQUE KEY` (unlike `link_token`'s plain index). A truncated-MD5 collision is therefore theoretically possible (~1e-5 over a ~5M-row backfill) and would abort that 1000-row batch. Judged acceptable; flagging in case a reviewer wants explicit collision handling.
- `Security::generateUnsubscribeTokenByEntity()` is intentionally kept — it's still used for on-demand generation at subscriber/newsletter save and send time.
- The integration test previously masked the bug: the factory left entities fully hydrated in the EntityManager identity map, so the `PARTIAL` query returned managed full entities and change-tracking worked. The test now `refresh()`es entities from the DB (the SQL `UPDATE` bypasses the ORM), which also makes it a genuine regression test.

## QA notes

- `UnsubscribeTokensTest` passes (2 tests, 10 assertions).
- PHPStan and PHPCS clean on the changed files.

To verify manually: create subscribers/newsletters with a `NULL` `unsubscribe_token`, run the `unsubscribe_tokens` worker, and confirm the column is populated with 15-char tokens (and existing tokens are left untouched).

## Linked PRs

_N/A_

## Linked tickets

MPI-424

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:mpi-424-fix-token-backfill-bug-caused-by-partial-hydration)

_The latest successful build from `mpi-424-fix-token-backfill-bug-caused-by-partial-hydration` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

1 issue found:
- Bug: `UnsubscribeTokens` backfill could silently persist nothing when Doctrine partial hydration caused changes to be ignored; it now uses direct SQL updates and the test verifies persisted state via entity refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->