### PR TITLE
Fix MAX_JOIN_SIZE fatal in WP user sync on restrictive hosts

### DIFF
--- a/mailpoet/changelog/2026-06-25-09-38-27-fixed-critical-error-during-wordpress-user-synchronizati.md
+++ b/mailpoet/changelog/2026-06-25-09-38-27-fixed-critical-error-during-wordpress-user-synchronizati.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Critical error during WordPress user synchronization on hosts that enforce a low database MAX_JOIN_SIZE limit

--- a/mailpoet/lib/Doctrine/Middlewares/PostConnectMiddleware.php
+++ b/mailpoet/lib/Doctrine/Middlewares/PostConnectMiddleware.php
@@ -4,11 +4,20 @@ namespace MailPoet\Doctrine\Middlewares;
 
 use MailPoetVendor\Doctrine\DBAL\Driver\Connection;
 use MailPoetVendor\Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use Throwable;
 
 class PostConnectMiddleware extends AbstractDriverMiddleware {
   public function connect(array $params): Connection {
     $connection = parent::connect($params);
     $connection->exec('SET time_zone = "+00:00"');
+    // Lift the session MAX_JOIN_SIZE limit so large best-effort joins (e.g. the WP user
+    // synchronization on sites with many users/subscribers) don't fatal on hosts that
+    // enforce a low MAX_JOIN_SIZE. Best-effort: some hosts/engines may disallow it.
+    try {
+      $connection->exec('SET SESSION SQL_BIG_SELECTS=1');
+    } catch (Throwable $e) {
+      // Ignore — keep the connection usable even if the host rejects this statement.
+    }
     return $connection;
   }
 }

--- a/mailpoet/tests/integration/Doctrine/Middlewares/PostConnectMiddlewareTest.php
+++ b/mailpoet/tests/integration/Doctrine/Middlewares/PostConnectMiddlewareTest.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Doctrine\Middlewares;
+
+use MailPoet\Doctrine\ConnectionFactory;
+
+class PostConnectMiddlewareTest extends \MailPoetTest {
+  public function testItEnablesBigSelectsOnConnect() {
+    $connection = (new ConnectionFactory())->createConnection();
+    $bigSelects = $connection->fetchOne('SELECT @@SESSION.sql_big_selects');
+    verify($bigSelects)->equals('1');
+  }
+
+  public function testItEnablesBigSelectsOnTheRuntimeConnection() {
+    $bigSelects = $this->entityManager->getConnection()->fetchOne('SELECT @@SESSION.sql_big_selects');
+    verify($bigSelects)->equals('1');
+  }
+}


### PR DESCRIPTION
## Description

On shared hosts that enforce a low `MAX_JOIN_SIZE`, MailPoet throws an uncaught fatal:

```
QueryException: The SELECT would examine more than MAX_JOIN_SIZE rows; check your
WHERE and use SET SQL_BIG_SELECTS=1 ... in .../Doctrine/WPDB/Connection.php
```

The crash comes from the WP-users → MailPoet-subscribers sync (`Segments\WP::insertSubscribers`), which runs on **every activation/update**. Because activation retries on each page load until it succeeds, the site is fully locked out with a critical error.

Root cause: `insertSubscribers()` gained an email-on-email join (`wp_users.user_email = subscribers.email`, text columns, collation-forced, no usable index) in 5.26.0, so MySQL examines ~`wp_users × subscribers` rows. This explains affected users reporting "ran fine for years, nothing changed on our server."

Fix: set `SET SESSION SQL_BIG_SELECTS=1` once per MailPoet DB connection in `PostConnectMiddleware` (next to the existing `SET time_zone`). MailPoet runs every query through the global `$wpdb` connection, so one connection-level statement covers all query paths — this sync, segment statistics, and future code — without touching any query logic. It's best-effort (wrapped) so hosts/engines that reject the statement keep a usable connection.

## Code review notes

- This generalizes the narrower fix from STOMAIL-7899 / #6575, which only wrapped `SegmentSubscribersRepository::executeQuery`. That per-query `SET` is now redundant but left in place to keep this change surgical — happy to remove it in a follow-up.
- Not paired with a query rewrite: lifting the limit removes the fatal without behavioral risk. Optimizing the `insertSubscribers()` cross-join is tracked as a separate follow-up so the urgent crash fix can ship on its own.

## QA notes

Customer-side stop-gap while this ships (mu-plugin, loads before MailPoet's bootstrap on the same `$wpdb` connection):

```php
<?php // wp-content/mu-plugins/zzz-sql-big-selects.php
add_action('muplugins_loaded', function () {
    global $wpdb;
    $wpdb->query('SET SESSION SQL_BIG_SELECTS=1');
});
```

Automated: `tests/integration/Doctrine/Middlewares/PostConnectMiddlewareTest.php` asserts `@@SESSION.sql_big_selects = 1` on both a fresh and the runtime EntityManager connection. `Segments/WPTest.php` (47 tests) still passes — no sync behavior change.

## Linked PRs

_N/A_

## Linked tickets

- STOMAIL-8210
- Zendesk #11350658

## After-merge notes

Follow-up: optimize the `insertSubscribers()` email cross-join so the sync doesn't scan that many rows in the first place.

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8210-max-join-size-fatal-in-wp-user-sync-on-restrictive-hosts)

_The latest successful build from `fix/stomail-8210-max-join-size-fatal-in-wp-user-sync-on-restrictive-hosts` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->