### PR TITLE
Add Latest Posts block to email editor

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/block.json
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/block.json
@@ -1,0 +1,43 @@
+{
+  "name": "mailpoet/latest-posts",
+  "version": "1.0.0",
+  "title": "Latest Posts",
+  "description": "Automatically displays your most recent posts in the email when it is sent.",
+  "category": "mailpoet",
+  "keywords": ["posts", "latest", "blog", "automated", "dynamic"],
+  "textdomain": "mailpoet",
+  "icon": "list-view",
+  "supports": {
+    "html": false,
+    "reusable": false,
+    "email": true,
+    "align": false
+  },
+  "apiVersion": 3,
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "attributes": {
+    "query": {
+      "type": "object",
+      "default": {
+        "selectionMode": "latest",
+        "perPage": 3,
+        "postType": "post",
+        "order": "newest",
+        "offset": 0,
+        "terms": [],
+        "inclusionType": "include",
+        "posts": []
+      }
+    },
+    "displayLayout": {
+      "type": "object",
+      "default": {
+        "columns": 1
+      }
+    }
+  },
+  "providesContext": {
+    "mailpoet/latestPostsQuery": "query",
+    "mailpoet/latestPostsDisplayLayout": "displayLayout"
+  }
+}

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/constants.ts
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/constants.ts
@@ -3,3 +3,6 @@ export const TEMPLATE_BLOCK_NAME = 'mailpoet/latest-posts-template';
 
 export const QUERY_CONTEXT = 'mailpoet/latestPostsQuery';
 export const DISPLAY_LAYOUT_CONTEXT = 'mailpoet/latestPostsDisplayLayout';
+
+// Mirrors LatestPosts::MAX_POSTS on the server and the WP REST per_page cap.
+export const MAX_POSTS = 100;

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/constants.ts
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/constants.ts
@@ -1,0 +1,5 @@
+export const LATEST_POSTS_BLOCK_NAME = 'mailpoet/latest-posts';
+export const TEMPLATE_BLOCK_NAME = 'mailpoet/latest-posts-template';
+
+export const QUERY_CONTEXT = 'mailpoet/latestPostsQuery';
+export const DISPLAY_LAYOUT_CONTEXT = 'mailpoet/latestPostsDisplayLayout';

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/edit.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/edit.tsx
@@ -228,43 +228,39 @@ export function Edit({
             />
           )}
           {!isManual && (
-            <RangeControl
-              label={__('Number of posts', 'mailpoet')}
-              value={query.perPage}
-              min={1}
-              max={10}
-              onChange={(value) => updateQuery({ perPage: value ?? 1 })}
-              __nextHasNoMarginBottom
-            />
-          )}
-          {!isManual && (
-            <SelectControl
-              label={__('Order', 'mailpoet')}
-              value={query.order}
-              options={ORDER_OPTIONS}
-              onChange={(value) => updateQuery({ order: value })}
-              __nextHasNoMarginBottom
-            />
-          )}
-          {!isManual && (
-            <BaseControl>
-              <TermControl
-                value={query.terms ?? []}
-                onChange={(terms) => updateQuery({ terms })}
+            <>
+              <RangeControl
+                label={__('Number of posts', 'mailpoet')}
+                value={query.perPage}
+                min={1}
+                max={10}
+                onChange={(value) => updateQuery({ perPage: value ?? 1 })}
+                __nextHasNoMarginBottom
               />
-            </BaseControl>
-          )}
-          {!isManual && (
-            <ToggleControl
-              label={__('Exclude selected categories & tags', 'mailpoet')}
-              checked={query.inclusionType === 'exclude'}
-              onChange={(exclude) =>
-                updateQuery({
-                  inclusionType: exclude ? 'exclude' : 'include',
-                })
-              }
-              __nextHasNoMarginBottom
-            />
+              <SelectControl
+                label={__('Order', 'mailpoet')}
+                value={query.order}
+                options={ORDER_OPTIONS}
+                onChange={(value) => updateQuery({ order: value })}
+                __nextHasNoMarginBottom
+              />
+              <BaseControl>
+                <TermControl
+                  value={query.terms ?? []}
+                  onChange={(terms) => updateQuery({ terms })}
+                />
+              </BaseControl>
+              <ToggleControl
+                label={__('Exclude selected categories & tags', 'mailpoet')}
+                checked={query.inclusionType === 'exclude'}
+                onChange={(exclude) =>
+                  updateQuery({
+                    inclusionType: exclude ? 'exclude' : 'include',
+                  })
+                }
+                __nextHasNoMarginBottom
+              />
+            </>
           )}
         </PanelBody>
         <PanelBody title={__('Layout', 'mailpoet')}>

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/edit.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/edit.tsx
@@ -16,7 +16,7 @@ import {
   ToggleControl,
   FormTokenField,
 } from '@wordpress/components';
-import { TEMPLATE_BLOCK_NAME } from './constants';
+import { MAX_POSTS, TEMPLATE_BLOCK_NAME } from './constants';
 
 type Term = { id: number; taxonomy: string };
 
@@ -141,7 +141,7 @@ function ManualPostsControl({
         selectedPosts: value.length
           ? ((getEntityRecords('postType', postType, {
               include: value,
-              per_page: value.length,
+              per_page: Math.min(value.length, MAX_POSTS),
               orderby: 'include',
             }) ?? []) as unknown as PostRecord[])
           : ([] as PostRecord[]),

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/edit.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/edit.tsx
@@ -150,20 +150,36 @@ function ManualPostsControl({
     [search, postType, value.join(',')],
   );
 
-  const titleToId = new Map<string, number>();
-  [...selectedPosts, ...searchResults].forEach((post) => {
-    titleToId.set(postTitle(post), post.id);
+  // FormTokenField identifies tokens by their label, so posts that share a
+  // title (e.g. several "(no title)") would collide. Suffix the post ID only
+  // for titles that actually repeat, keeping unique titles clean.
+  const uniquePosts = [
+    ...new Map(
+      [...selectedPosts, ...searchResults].map((post) => [post.id, post]),
+    ).values(),
+  ];
+  const titleCounts = new Map<string, number>();
+  uniquePosts.forEach((post) => {
+    const title = postTitle(post);
+    titleCounts.set(title, (titleCounts.get(title) ?? 0) + 1);
   });
+  const labelFor = (post: PostRecord): string => {
+    const title = postTitle(post);
+    return (titleCounts.get(title) ?? 0) > 1 ? `${title} (#${post.id})` : title;
+  };
 
-  const selectedTitles = value
+  const labelToId = new Map<string, number>();
+  uniquePosts.forEach((post) => labelToId.set(labelFor(post), post.id));
+
+  const selectedLabels = value
     .map((id) => selectedPosts.find((post) => post.id === id))
     .filter((post): post is PostRecord => Boolean(post))
-    .map(postTitle);
+    .map(labelFor);
 
   const handleChange = (tokens: (string | { value: string })[]): void => {
     const ids = tokens
       .map((token) => (typeof token === 'string' ? token : token.value))
-      .map((title) => titleToId.get(title))
+      .map((label) => labelToId.get(label))
       .filter((id): id is number => typeof id === 'number');
     onChange(ids);
   };
@@ -171,8 +187,8 @@ function ManualPostsControl({
   return (
     <FormTokenField
       label={__('Choose posts', 'mailpoet')}
-      value={selectedTitles}
-      suggestions={searchResults.map(postTitle)}
+      value={selectedLabels}
+      suggestions={searchResults.map(labelFor)}
       onInputChange={setSearch}
       onChange={handleChange}
       __experimentalExpandOnFocus
@@ -190,13 +206,15 @@ export function Edit({
   const innerBlocksProps = useInnerBlocksProps(blockProps, {
     allowedBlocks: [TEMPLATE_BLOCK_NAME],
     template: INNER_TEMPLATE,
-    templateLock: false,
+    templateLock: 'insert',
   });
 
   const updateQuery = (next: Partial<LatestPostsQuery>): void =>
     setAttributes({ query: { ...query, ...next } });
 
   const isManual = query.selectionMode === 'manual';
+  // Categories and tags are post-only taxonomies.
+  const supportsTerms = query.postType === 'post';
 
   return (
     <>
@@ -244,22 +262,26 @@ export function Edit({
                 onChange={(value) => updateQuery({ order: value })}
                 __nextHasNoMarginBottom
               />
-              <BaseControl>
-                <TermControl
-                  value={query.terms ?? []}
-                  onChange={(terms) => updateQuery({ terms })}
-                />
-              </BaseControl>
-              <ToggleControl
-                label={__('Exclude selected categories & tags', 'mailpoet')}
-                checked={query.inclusionType === 'exclude'}
-                onChange={(exclude) =>
-                  updateQuery({
-                    inclusionType: exclude ? 'exclude' : 'include',
-                  })
-                }
-                __nextHasNoMarginBottom
-              />
+              {supportsTerms && (
+                <>
+                  <BaseControl>
+                    <TermControl
+                      value={query.terms ?? []}
+                      onChange={(terms) => updateQuery({ terms })}
+                    />
+                  </BaseControl>
+                  <ToggleControl
+                    label={__('Exclude selected categories & tags', 'mailpoet')}
+                    checked={query.inclusionType === 'exclude'}
+                    onChange={(exclude) =>
+                      updateQuery({
+                        inclusionType: exclude ? 'exclude' : 'include',
+                      })
+                    }
+                    __nextHasNoMarginBottom
+                  />
+                </>
+              )}
             </>
           )}
         </PanelBody>

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/edit.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/edit.tsx
@@ -1,0 +1,285 @@
+import type { BlockEditProps } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import {
+  useBlockProps,
+  useInnerBlocksProps,
+  InspectorControls,
+} from '@wordpress/block-editor';
+import {
+  PanelBody,
+  BaseControl,
+  RangeControl,
+  SelectControl,
+  ToggleControl,
+  FormTokenField,
+} from '@wordpress/components';
+import { TEMPLATE_BLOCK_NAME } from './constants';
+
+type Term = { id: number; taxonomy: string };
+
+type LatestPostsQuery = {
+  selectionMode: 'latest' | 'manual';
+  perPage: number;
+  postType: string;
+  order: string;
+  offset: number;
+  terms: Term[];
+  inclusionType: 'include' | 'exclude';
+  posts: number[];
+};
+
+type Attributes = {
+  query: LatestPostsQuery;
+  displayLayout: { columns: number };
+};
+
+type TermRecord = { id: number; name: string; taxonomy: string };
+type PostRecord = { id: number; title?: { rendered?: string } };
+
+// Lock the single template child so it cannot be removed or moved, while still
+// letting users edit (and add to) the blocks composed inside it.
+const INNER_TEMPLATE: Array<[string, Record<string, unknown>]> = [
+  [TEMPLATE_BLOCK_NAME, { lock: { move: true, remove: true } }],
+];
+
+const MODE_OPTIONS: { label: string; value: string }[] = [
+  { label: __('Latest posts', 'mailpoet'), value: 'latest' },
+  { label: __('Manual selection', 'mailpoet'), value: 'manual' },
+];
+
+const POST_TYPE_OPTIONS: { label: string; value: string }[] = [
+  { label: __('Posts', 'mailpoet'), value: 'post' },
+  { label: __('Pages', 'mailpoet'), value: 'page' },
+];
+
+const ORDER_OPTIONS: { label: string; value: string }[] = [
+  { label: __('Newest to oldest', 'mailpoet'), value: 'newest' },
+  { label: __('Oldest to newest', 'mailpoet'), value: 'oldest' },
+];
+
+const postTitle = (post: PostRecord): string =>
+  post.title?.rendered?.trim() || __('(no title)', 'mailpoet');
+
+function TermControl({
+  value,
+  onChange,
+}: {
+  value: Term[];
+  onChange: (terms: Term[]) => void;
+}): JSX.Element {
+  const records = useSelect((select) => {
+    const { getEntityRecords } = select(coreStore);
+    const restQuery = { per_page: -1, orderby: 'name', order: 'asc' };
+    const categories = (getEntityRecords('taxonomy', 'category', restQuery) ??
+      []) as unknown as TermRecord[];
+    const tags = (getEntityRecords('taxonomy', 'post_tag', restQuery) ??
+      []) as unknown as TermRecord[];
+    return [...categories, ...tags];
+  }, []);
+
+  const labelFor = (record: TermRecord): string =>
+    record.taxonomy === 'post_tag'
+      ? `${record.name} ${__('(tag)', 'mailpoet')}`
+      : record.name;
+
+  const labelToTerm = new Map<string, Term>();
+  const idToLabel = new Map<string, string>();
+  records.forEach((record) => {
+    const label = labelFor(record);
+    labelToTerm.set(label, { id: record.id, taxonomy: record.taxonomy });
+    idToLabel.set(`${record.taxonomy}:${record.id}`, label);
+  });
+
+  const selectedLabels = value
+    .map((term) => idToLabel.get(`${term.taxonomy}:${term.id}`))
+    .filter((label): label is string => Boolean(label));
+
+  const handleChange = (tokens: (string | { value: string })[]): void => {
+    const terms = tokens
+      .map((token) => (typeof token === 'string' ? token : token.value))
+      .map((label) => labelToTerm.get(label))
+      .filter((term): term is Term => Boolean(term));
+    onChange(terms);
+  };
+
+  return (
+    <FormTokenField
+      label={__('Categories & tags', 'mailpoet')}
+      value={selectedLabels}
+      suggestions={[...labelToTerm.keys()]}
+      onChange={handleChange}
+      __experimentalExpandOnFocus
+      __nextHasNoMarginBottom
+    />
+  );
+}
+
+function ManualPostsControl({
+  postType,
+  value,
+  onChange,
+}: {
+  postType: string;
+  value: number[];
+  onChange: (posts: number[]) => void;
+}): JSX.Element {
+  const [search, setSearch] = useState('');
+
+  const { searchResults, selectedPosts } = useSelect(
+    (select) => {
+      const { getEntityRecords } = select(coreStore);
+      return {
+        searchResults: search
+          ? ((getEntityRecords('postType', postType, {
+              search,
+              per_page: 20,
+            }) ?? []) as unknown as PostRecord[])
+          : ([] as PostRecord[]),
+        selectedPosts: value.length
+          ? ((getEntityRecords('postType', postType, {
+              include: value,
+              per_page: value.length,
+              orderby: 'include',
+            }) ?? []) as unknown as PostRecord[])
+          : ([] as PostRecord[]),
+      };
+    },
+    [search, postType, value.join(',')],
+  );
+
+  const titleToId = new Map<string, number>();
+  [...selectedPosts, ...searchResults].forEach((post) => {
+    titleToId.set(postTitle(post), post.id);
+  });
+
+  const selectedTitles = value
+    .map((id) => selectedPosts.find((post) => post.id === id))
+    .filter((post): post is PostRecord => Boolean(post))
+    .map(postTitle);
+
+  const handleChange = (tokens: (string | { value: string })[]): void => {
+    const ids = tokens
+      .map((token) => (typeof token === 'string' ? token : token.value))
+      .map((title) => titleToId.get(title))
+      .filter((id): id is number => typeof id === 'number');
+    onChange(ids);
+  };
+
+  return (
+    <FormTokenField
+      label={__('Choose posts', 'mailpoet')}
+      value={selectedTitles}
+      suggestions={searchResults.map(postTitle)}
+      onInputChange={setSearch}
+      onChange={handleChange}
+      __experimentalExpandOnFocus
+      __nextHasNoMarginBottom
+    />
+  );
+}
+
+export function Edit({
+  attributes,
+  setAttributes,
+}: BlockEditProps<Attributes>): JSX.Element {
+  const { query, displayLayout } = attributes;
+  const blockProps = useBlockProps();
+  const innerBlocksProps = useInnerBlocksProps(blockProps, {
+    allowedBlocks: [TEMPLATE_BLOCK_NAME],
+    template: INNER_TEMPLATE,
+    templateLock: false,
+  });
+
+  const updateQuery = (next: Partial<LatestPostsQuery>): void =>
+    setAttributes({ query: { ...query, ...next } });
+
+  const isManual = query.selectionMode === 'manual';
+
+  return (
+    <>
+      <InspectorControls>
+        <PanelBody title={__('Posts', 'mailpoet')}>
+          <SelectControl
+            label={__('Selection', 'mailpoet')}
+            value={query.selectionMode}
+            options={MODE_OPTIONS}
+            onChange={(value) =>
+              updateQuery({
+                selectionMode: value === 'manual' ? 'manual' : 'latest',
+              })
+            }
+            __nextHasNoMarginBottom
+          />
+          <SelectControl
+            label={__('Content type', 'mailpoet')}
+            value={query.postType}
+            options={POST_TYPE_OPTIONS}
+            onChange={(value) => updateQuery({ postType: value })}
+            __nextHasNoMarginBottom
+          />
+          {isManual && (
+            <ManualPostsControl
+              postType={query.postType}
+              value={query.posts ?? []}
+              onChange={(posts) => updateQuery({ posts })}
+            />
+          )}
+          {!isManual && (
+            <RangeControl
+              label={__('Number of posts', 'mailpoet')}
+              value={query.perPage}
+              min={1}
+              max={10}
+              onChange={(value) => updateQuery({ perPage: value ?? 1 })}
+              __nextHasNoMarginBottom
+            />
+          )}
+          {!isManual && (
+            <SelectControl
+              label={__('Order', 'mailpoet')}
+              value={query.order}
+              options={ORDER_OPTIONS}
+              onChange={(value) => updateQuery({ order: value })}
+              __nextHasNoMarginBottom
+            />
+          )}
+          {!isManual && (
+            <BaseControl>
+              <TermControl
+                value={query.terms ?? []}
+                onChange={(terms) => updateQuery({ terms })}
+              />
+            </BaseControl>
+          )}
+          {!isManual && (
+            <ToggleControl
+              label={__('Exclude selected categories & tags', 'mailpoet')}
+              checked={query.inclusionType === 'exclude'}
+              onChange={(exclude) =>
+                updateQuery({
+                  inclusionType: exclude ? 'exclude' : 'include',
+                })
+              }
+              __nextHasNoMarginBottom
+            />
+          )}
+        </PanelBody>
+        <PanelBody title={__('Layout', 'mailpoet')}>
+          <RangeControl
+            label={__('Columns', 'mailpoet')}
+            value={displayLayout.columns}
+            min={1}
+            max={2}
+            onChange={(value) =>
+              setAttributes({ displayLayout: { columns: value ?? 1 } })
+            }
+          />
+        </PanelBody>
+      </InspectorControls>
+      <div {...innerBlocksProps} />
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/index.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/index.tsx
@@ -1,0 +1,26 @@
+import './style.scss';
+import { registerBlockType } from '@wordpress/blocks';
+import type { BlockEditProps } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/block-editor';
+import { layout } from '@wordpress/icons';
+import latestPostsMetadata from './block.json';
+import postTemplateMetadata from './post-template/block.json';
+import { Edit as LatestPostsEdit } from './edit';
+import { Edit as PostTemplateEdit } from './post-template/edit';
+
+const saveInnerBlocks = (): JSX.Element => <InnerBlocks.Content />;
+
+registerBlockType(latestPostsMetadata, {
+  edit: LatestPostsEdit as React.ComponentType<
+    BlockEditProps<Record<string, unknown>>
+  >,
+  save: saveInnerBlocks,
+});
+
+registerBlockType(postTemplateMetadata, {
+  icon: { src: layout },
+  edit: PostTemplateEdit as unknown as React.ComponentType<
+    BlockEditProps<Record<string, unknown>>
+  >,
+  save: saveInnerBlocks,
+});

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/index.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/index.tsx
@@ -2,7 +2,7 @@ import './style.scss';
 import { registerBlockType } from '@wordpress/blocks';
 import type { BlockEditProps } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/block-editor';
-import { layout } from '@wordpress/icons';
+import { layout, postList } from '@wordpress/icons';
 import latestPostsMetadata from './block.json';
 import postTemplateMetadata from './post-template/block.json';
 import { Edit as LatestPostsEdit } from './edit';
@@ -11,6 +11,7 @@ import { Edit as PostTemplateEdit } from './post-template/edit';
 const saveInnerBlocks = (): JSX.Element => <InnerBlocks.Content />;
 
 registerBlockType(latestPostsMetadata, {
+  icon: { src: postList },
   edit: LatestPostsEdit as React.ComponentType<
     BlockEditProps<Record<string, unknown>>
   >,

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/index.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/index.tsx
@@ -2,11 +2,13 @@ import './style.scss';
 import { registerBlockType } from '@wordpress/blocks';
 import type { BlockEditProps } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/block-editor';
-import { layout, postList } from '@wordpress/icons';
+import { layout, postContent, postList } from '@wordpress/icons';
 import latestPostsMetadata from './block.json';
 import postTemplateMetadata from './post-template/block.json';
+import postContentMetadata from './post-content/block.json';
 import { Edit as LatestPostsEdit } from './edit';
 import { Edit as PostTemplateEdit } from './post-template/edit';
+import { Edit as PostContentEdit } from './post-content/edit';
 
 const saveInnerBlocks = (): JSX.Element => <InnerBlocks.Content />;
 
@@ -24,4 +26,12 @@ registerBlockType(postTemplateMetadata, {
     BlockEditProps<Record<string, unknown>>
   >,
   save: saveInnerBlocks,
+});
+
+registerBlockType(postContentMetadata, {
+  icon: { src: postContent },
+  edit: PostContentEdit as unknown as React.ComponentType<
+    BlockEditProps<Record<string, unknown>>
+  >,
+  save: () => null,
 });

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/block.json
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/block.json
@@ -1,0 +1,18 @@
+{
+  "name": "mailpoet/post-content",
+  "version": "1.0.0",
+  "title": "Post Content",
+  "description": "Displays the full content of each post. Blocks that cannot be rendered in emails are left out when the email is sent.",
+  "category": "mailpoet",
+  "parent": ["mailpoet/latest-posts-template"],
+  "textdomain": "mailpoet",
+  "icon": "align-left",
+  "supports": {
+    "html": false,
+    "reusable": false,
+    "email": true
+  },
+  "usesContext": ["postId", "postType"],
+  "apiVersion": 3,
+  "$schema": "https://schemas.wp.org/trunk/block.json"
+}

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/edit.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/edit.tsx
@@ -1,0 +1,60 @@
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { useBlockProps } from '@wordpress/block-editor';
+import { Spinner } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+
+type EditProps = {
+  context: {
+    postId?: number;
+    postType?: string;
+  };
+};
+
+type ContentRecord = { content?: { rendered?: string } };
+
+export function Edit({ context }: EditProps): JSX.Element {
+  const { postId, postType } = context;
+  const blockProps = useBlockProps({
+    className: 'mailpoet-latest-posts__post-content',
+  });
+
+  const record = useSelect(
+    (select) => {
+      if (!postId || !postType) {
+        return null;
+      }
+      return select(coreStore).getEntityRecord(
+        'postType',
+        postType,
+        postId,
+      ) as ContentRecord | null;
+    },
+    [postId, postType],
+  );
+
+  if (!postId || !postType) {
+    return (
+      <div {...blockProps}>
+        <p>{__('Displays the content of each post.', 'mailpoet')}</p>
+      </div>
+    );
+  }
+
+  if (!record) {
+    return (
+      <div {...blockProps}>
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      {...blockProps}
+      // Read-only preview using the rendered content from the site's own REST API.
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: record.content?.rendered ?? '' }}
+    />
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/edit.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/edit.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
@@ -19,16 +19,22 @@ export function Edit({ context }: EditProps): JSX.Element {
     className: 'mailpoet-latest-posts__post-content',
   });
 
-  const record = useSelect(
+  const { record, hasResolved } = useSelect(
     (select) => {
       if (!postId || !postType) {
-        return null;
+        return { record: null, hasResolved: false };
       }
-      return select(coreStore).getEntityRecord(
-        'postType',
-        postType,
-        postId,
-      ) as ContentRecord | null;
+      return {
+        record: select(coreStore).getEntityRecord(
+          'postType',
+          postType,
+          postId,
+        ) as ContentRecord | null,
+        hasResolved: select(coreStore).hasFinishedResolution(
+          'getEntityRecord',
+          ['postType', postType, postId],
+        ),
+      };
     },
     [postId, postType],
   );
@@ -41,10 +47,24 @@ export function Edit({ context }: EditProps): JSX.Element {
     );
   }
 
-  if (!record) {
+  if (!hasResolved) {
     return (
       <div {...blockProps}>
         <Spinner />
+      </div>
+    );
+  }
+
+  if (!record) {
+    return (
+      <div {...blockProps}>
+        <p>
+          {sprintf(
+            // translators: %d is the post ID.
+            __('Could not load the post (ID: %d). Was it deleted?', 'mailpoet'),
+            postId,
+          )}
+        </p>
       </div>
     );
   }

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/block.json
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/block.json
@@ -1,0 +1,24 @@
+{
+  "name": "mailpoet/latest-posts-template",
+  "version": "1.0.0",
+  "title": "Post Template",
+  "description": "Block layout that repeats for each of the latest posts.",
+  "category": "mailpoet",
+  "parent": ["mailpoet/latest-posts"],
+  "textdomain": "mailpoet",
+  "icon": "layout",
+  "supports": {
+    "html": false,
+    "reusable": false,
+    "inserter": false,
+    "email": true
+  },
+  "usesContext": [
+    "mailpoet/latestPostsQuery",
+    "mailpoet/latestPostsDisplayLayout",
+    "postId",
+    "postType"
+  ],
+  "apiVersion": 3,
+  "$schema": "https://schemas.wp.org/trunk/block.json"
+}

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/edit.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/edit.tsx
@@ -194,7 +194,9 @@ export function Edit({ clientId, context }: EditProps): JSX.Element {
         perPage,
         offset,
         order,
-        terms,
+        // Categories and tags only apply to posts; ignore stale terms after a
+        // switch to pages so the preview matches the server-side query.
+        terms: postType === 'post' ? terms : [],
         inclusionType,
       });
 

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/edit.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/edit.tsx
@@ -1,10 +1,11 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { __ } from '@wordpress/i18n';
 import { memo, useMemo, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import * as BlockEditor from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { QUERY_CONTEXT, DISPLAY_LAYOUT_CONTEXT } from '../constants';
+import { QUERY_CONTEXT, DISPLAY_LAYOUT_CONTEXT, MAX_POSTS } from '../constants';
 
 const {
   useBlockProps,
@@ -99,7 +100,7 @@ function buildRestQuery({
     return manualPosts.length
       ? {
           include: manualPosts,
-          per_page: manualPosts.length,
+          per_page: Math.min(manualPosts.length, MAX_POSTS),
           orderby: 'include',
         }
       : { include: [0], per_page: 1 };
@@ -148,14 +149,21 @@ function TemplateBlockPreview({
 
   const handleOnClick = (): void => setActiveBlockContextId(blockContextId);
 
+  const handleOnKeyDown = (event: ReactKeyboardEvent): void => {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+    event.preventDefault();
+    handleOnClick();
+  };
+
   return (
     <div
       {...blockPreviewProps}
       tabIndex={0}
       role="button"
       onClick={handleOnClick}
-      onKeyDown={handleOnClick}
-      onKeyUp={handleOnClick}
+      onKeyDown={handleOnKeyDown}
       style={{ display: isHidden ? 'none' : undefined }}
     />
   );

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/edit.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/edit.tsx
@@ -30,7 +30,7 @@ const { BlockContextProvider } = BlockEditor as unknown as {
 const castBlockEditor = BlockEditor as unknown as {
   __experimentalUseBlockPreview: UseBlockPreview;
 };
-// eslint-disable-next-line no-underscore-dangle -- WordPress exposes this experimental hook under a dunder-prefixed name.
+// eslint-disable-next-line no-underscore-dangle
 const useBlockPreview = castBlockEditor.__experimentalUseBlockPreview;
 
 type Term = { id: number; taxonomy: string };
@@ -59,8 +59,7 @@ type EditProps = {
 type PostRecord = { id: number; type: string };
 type BlockContext = { postId: number; postType: string };
 
-// Default per-post layout. Users can add, remove and reorder these inner
-// blocks; the server renders whatever they compose, once per selected post.
+// This is the default layout for each post. Users can customize it by adding, removing, or rearranging the inner blocks below.
 const POST_TEMPLATE: Array<[string, Record<string, unknown>?]> = [
   ['core/post-featured-image'],
   ['core/post-title', { level: 3, isLink: true }],
@@ -155,7 +154,8 @@ function TemplateBlockPreview({
       tabIndex={0}
       role="button"
       onClick={handleOnClick}
-      onKeyPress={handleOnClick}
+      onKeyDown={handleOnClick}
+      onKeyUp={handleOnClick}
       style={{ display: isHidden ? 'none' : undefined }}
     />
   );

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/edit.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/edit.tsx
@@ -1,0 +1,268 @@
+import { __ } from '@wordpress/i18n';
+import { memo, useMemo, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import * as BlockEditor from '@wordpress/block-editor';
+import { Spinner } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { QUERY_CONTEXT, DISPLAY_LAYOUT_CONTEXT } from '../constants';
+
+const {
+  useBlockProps,
+  useInnerBlocksProps,
+  store: blockEditorStore,
+} = BlockEditor;
+
+// BlockContextProvider and __experimentalUseBlockPreview exist at runtime in
+// @wordpress/block-editor but are missing from the bundled type definitions,
+// so we access them through a narrow typed cast.
+type BlockContextProviderType = React.ComponentType<{
+  value: Record<string, unknown>;
+  children: React.ReactNode;
+}>;
+type UseBlockPreview = (args: {
+  blocks: unknown;
+  props?: Record<string, unknown>;
+}) => Record<string, unknown>;
+
+const { BlockContextProvider } = BlockEditor as unknown as {
+  BlockContextProvider: BlockContextProviderType;
+};
+const castBlockEditor = BlockEditor as unknown as {
+  __experimentalUseBlockPreview: UseBlockPreview;
+};
+// eslint-disable-next-line no-underscore-dangle -- WordPress exposes this experimental hook under a dunder-prefixed name.
+const useBlockPreview = castBlockEditor.__experimentalUseBlockPreview;
+
+type Term = { id: number; taxonomy: string };
+
+type LatestPostsQuery = {
+  selectionMode?: 'latest' | 'manual';
+  perPage?: number;
+  postType?: string;
+  order?: string;
+  offset?: number;
+  terms?: Term[];
+  inclusionType?: 'include' | 'exclude';
+  posts?: number[];
+};
+
+type TemplateContext = {
+  [QUERY_CONTEXT]?: LatestPostsQuery;
+  [DISPLAY_LAYOUT_CONTEXT]?: { columns?: number };
+};
+
+type EditProps = {
+  clientId: string;
+  context: TemplateContext;
+};
+
+type PostRecord = { id: number; type: string };
+type BlockContext = { postId: number; postType: string };
+
+// Default per-post layout. Users can add, remove and reorder these inner
+// blocks; the server renders whatever they compose, once per selected post.
+const POST_TEMPLATE: Array<[string, Record<string, unknown>?]> = [
+  ['core/post-featured-image'],
+  ['core/post-title', { level: 3, isLink: true }],
+  ['core/post-excerpt'],
+];
+
+function TemplateInnerBlocks(): JSX.Element {
+  const innerBlocksProps = useInnerBlocksProps(
+    { className: 'mailpoet-latest-posts__item' },
+    { template: POST_TEMPLATE, templateLock: false },
+  );
+  return <div {...innerBlocksProps} />;
+}
+
+// Translates the block's query attributes into a WP REST query, mirroring the
+// server-side BlockPostQuery so the editor preview matches the sent email.
+function buildRestQuery({
+  isManual,
+  manualPosts,
+  perPage,
+  offset,
+  order,
+  terms,
+  inclusionType,
+}: {
+  isManual: boolean;
+  manualPosts: number[];
+  perPage: number;
+  offset: number;
+  order: string;
+  terms: Term[];
+  inclusionType: 'include' | 'exclude';
+}): Record<string, unknown> {
+  if (isManual) {
+    // include: [0] resolves to no posts, so an empty manual selection previews
+    // as "no posts" instead of falling back to the latest ones.
+    return manualPosts.length
+      ? {
+          include: manualPosts,
+          per_page: manualPosts.length,
+          orderby: 'include',
+        }
+      : { include: [0], per_page: 1 };
+  }
+
+  const restQuery: Record<string, unknown> = {
+    per_page: perPage,
+    offset,
+    order: order === 'oldest' ? 'asc' : 'desc',
+    orderby: 'date',
+  };
+
+  const categoryIds = terms
+    .filter((term) => term.taxonomy === 'category')
+    .map((term) => term.id);
+  const tagIds = terms
+    .filter((term) => term.taxonomy === 'post_tag')
+    .map((term) => term.id);
+
+  const isExclude = inclusionType === 'exclude';
+  if (categoryIds.length) {
+    restQuery[isExclude ? 'categories_exclude' : 'categories'] = categoryIds;
+  }
+  if (tagIds.length) {
+    restQuery[isExclude ? 'tags_exclude' : 'tags'] = tagIds;
+  }
+
+  return restQuery;
+}
+
+function TemplateBlockPreview({
+  blocks,
+  blockContextId,
+  isHidden,
+  setActiveBlockContextId,
+}: {
+  blocks: unknown;
+  blockContextId: number;
+  isHidden: boolean;
+  setActiveBlockContextId: (id: number) => void;
+}): JSX.Element {
+  const blockPreviewProps = useBlockPreview({
+    blocks,
+    props: { className: 'mailpoet-latest-posts__item' },
+  });
+
+  const handleOnClick = (): void => setActiveBlockContextId(blockContextId);
+
+  return (
+    <div
+      {...blockPreviewProps}
+      tabIndex={0}
+      role="button"
+      onClick={handleOnClick}
+      onKeyPress={handleOnClick}
+      style={{ display: isHidden ? 'none' : undefined }}
+    />
+  );
+}
+
+const MemoizedTemplateBlockPreview = memo(TemplateBlockPreview);
+
+export function Edit({ clientId, context }: EditProps): JSX.Element {
+  const query = context[QUERY_CONTEXT] || {};
+  const displayLayout = context[DISPLAY_LAYOUT_CONTEXT] || {};
+  const {
+    selectionMode = 'latest',
+    perPage = 3,
+    postType = 'post',
+    order = 'newest',
+    offset = 0,
+    terms = [],
+    inclusionType = 'include',
+    posts: manualPosts = [],
+  } = query;
+  const columns = displayLayout.columns || 1;
+  const [activeBlockContextId, setActiveBlockContextId] = useState<number>();
+
+  const isManual = selectionMode === 'manual';
+
+  const { posts, blocks } = useSelect(
+    (select) => {
+      const { getEntityRecords } = select(coreStore);
+      const { getBlocks } = select(blockEditorStore) as unknown as {
+        getBlocks: (clientId: string) => unknown[];
+      };
+
+      const restQuery = buildRestQuery({
+        isManual,
+        manualPosts,
+        perPage,
+        offset,
+        order,
+        terms,
+        inclusionType,
+      });
+
+      return {
+        posts: getEntityRecords('postType', postType, restQuery) as unknown as
+          | PostRecord[]
+          | null,
+        blocks: getBlocks(clientId),
+      };
+    },
+    [
+      isManual,
+      manualPosts.join(','),
+      perPage,
+      postType,
+      order,
+      offset,
+      JSON.stringify(terms),
+      inclusionType,
+      clientId,
+    ],
+  );
+
+  const blockContexts = useMemo<BlockContext[]>(
+    () =>
+      posts?.map((post) => ({
+        postId: post.id,
+        postType: post.type,
+      })) ?? [],
+    [posts],
+  );
+
+  const blockProps = useBlockProps({
+    className:
+      columns > 1
+        ? `mailpoet-latest-posts columns-${columns}`
+        : 'mailpoet-latest-posts',
+  });
+
+  if (!posts) {
+    return (
+      <p {...blockProps}>
+        <Spinner />
+      </p>
+    );
+  }
+
+  if (!posts.length) {
+    return <p {...blockProps}>{__('No posts found.', 'mailpoet')}</p>;
+  }
+
+  const activeContextId = activeBlockContextId || blockContexts[0]?.postId;
+
+  return (
+    <div {...blockProps}>
+      {blockContexts.map((blockContext) => (
+        <BlockContextProvider key={blockContext.postId} value={blockContext}>
+          {blockContext.postId === activeContextId ? (
+            <TemplateInnerBlocks />
+          ) : null}
+          <MemoizedTemplateBlockPreview
+            blocks={blocks}
+            blockContextId={blockContext.postId}
+            setActiveBlockContextId={setActiveBlockContextId}
+            isHidden={blockContext.postId === activeContextId}
+          />
+        </BlockContextProvider>
+      ))}
+    </div>
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/style.scss
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/style.scss
@@ -1,6 +1,6 @@
 .mailpoet-latest-posts {
   display: grid;
-  gap: 20px;
+  gap: var(--wp--style--block-gap, 20px);
 }
 
 .mailpoet-latest-posts.columns-2 {

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/style.scss
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/style.scss
@@ -1,0 +1,13 @@
+.mailpoet-latest-posts {
+  display: grid;
+  gap: 20px;
+}
+
+.mailpoet-latest-posts.columns-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.mailpoet-latest-posts__item {
+  margin: 0;
+  min-width: 0;
+}

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/style.scss
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/style.scss
@@ -11,3 +11,8 @@
   margin: 0;
   min-width: 0;
 }
+
+.mailpoet-latest-posts__post-content img {
+  height: auto;
+  max-width: 100%;
+}

--- a/mailpoet/changelog/2026-06-22-11-38-47-added-latest-posts-content-block-for-email-editor.md
+++ b/mailpoet/changelog/2026-06-22-11-38-47-added-latest-posts-content-block-for-email-editor.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Latest posts block for the email editor with a composable per-post layout, category and tag filtering, and manual post selection

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -398,6 +398,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypesController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\AutomationEmailContextProvider::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\AutomationEmailPreviewOrderProvider::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes\LatestPosts::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes\PoweredByMailpoet::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockDetector::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Coupons\CouponBlockFailureTranslator::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -2,7 +2,13 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Process_Manager;
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Engine\Theme_Controller;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Column as ColumnRenderer;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Columns as ColumnsRenderer;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Image as ImageRenderer;
 use MailPoet\Config\Env;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterPostEntity;
@@ -15,13 +21,10 @@ use MailPoet\WP\Functions as WPFunctions;
 /**
  * Renders the MailPoet "Latest posts" block for the email editor.
  *
- * Modeled on WooCommerce's Product Collection block: a curated container
- * (mailpoet/latest-posts) holds a template block (mailpoet/latest-posts-template)
- * whose inner blocks (featured image, title, excerpt, ...) are the composable,
- * repeating unit. Selection controls (how many posts, post type, order, columns)
- * live on the container. At render time we select posts dynamically (reusing the
- * legacy AutomatedLatestContent engine) and render the template's inner blocks
- * once per post, so the markup stays consistent with the rest of the editor.
+ * There are two blocks working together here: the container (mailpoet/latest-posts)
+ * is where you pick which posts to show, and it wraps a template block
+ * (mailpoet/latest-posts-template) that defines how a single post looks. When we
+ * render, we fetch the posts and repeat the template's inner blocks for each one.
  */
 class LatestPosts extends AbstractBlock {
   protected $blockName = 'latest-posts';
@@ -29,13 +32,10 @@ class LatestPosts extends AbstractBlock {
   private const TEMPLATE_BLOCK = 'mailpoet/latest-posts-template';
   private const DEFAULT_COLUMNS = 1;
   private const MAX_COLUMNS = 2;
-  private const COLUMN_GAP_PX = 20;
-  private const DEFAULT_BLOCK_GAP = '28px';
+  private const DEFAULT_BLOCK_GAP = '20px';
+  private const DEFAULT_CONTENT_WIDTH_PX = 600;
 
-  /**
-   * Core blocks that the template is composed of. They are not email-enabled by
-   * default, so we opt them in to keep them usable inside the email editor.
-   */
+  /** Template blocks. Not email-enabled by default, so we opt them in. */
   private const TEMPLATE_CORE_BLOCKS = [
     'core/post-featured-image',
     'core/post-title',
@@ -48,6 +48,16 @@ class LatestPosts extends AbstractBlock {
     'core/post-terms',
     'core/avatar',
     'core/read-more',
+  ];
+
+  /**
+   * Image blocks core renders as a bare <figure>/<img> that email clients
+   * handle poorly. We route them through the core/image renderer for
+   * table-wrapped, properly sized output.
+   */
+  private const IMAGE_CORE_BLOCKS = [
+    'core/post-featured-image',
+    'core/avatar',
   ];
 
   /** @var array<int, int[]> */
@@ -81,8 +91,8 @@ class LatestPosts extends AbstractBlock {
   }
 
   /**
-   * The block is email-only; it produces no output outside the email rendering
-   * pipeline, where renderEmail (render_email_callback) takes over.
+   * Email-only block: renders nothing outside the email pipeline, where
+   * renderEmail() takes over.
    *
    * @param array<string, mixed>|\WP_Block $attributes
    */
@@ -108,12 +118,10 @@ class LatestPosts extends AbstractBlock {
   }
 
   /**
-   * WordPress styles element link colors (e.g. the "Read more" link in
-   * core/post-excerpt) with a `:where(:not(.wp-element-button))` selector. The
-   * email CSS inliner (Emogrifier) cannot parse `:where()`, so the colour is
-   * dropped from the sent email even though the editor (a real browser) honours
-   * it. Rewriting it to the equivalent `:not()` selector keeps the same meaning
-   * while being inlineable. `:not()` with a single class is supported.
+   * The email CSS inliner (Emogrifier) cannot parse the `:where()` selector
+   * WordPress uses for element link colors (e.g. the "Read more" link), so the
+   * colour is dropped from the sent email. Rewriting it to the equivalent
+   * `:not()` keeps the same meaning while being inlineable.
    */
   public function makeLinkColorStylesInlineable(string $styles): string {
     return str_replace(':where(:not(.wp-element-button))', ':not(.wp-element-button)', $styles);
@@ -130,6 +138,9 @@ class LatestPosts extends AbstractBlock {
         $settings['supports'] = [];
       }
       $settings['supports']['email'] = true;
+    }
+    if (in_array($name, self::IMAGE_CORE_BLOCKS, true)) {
+      $settings['render_email_callback'] = [$this, 'renderImageBlockForEmail'];
     }
     return $settings;
   }
@@ -148,7 +159,82 @@ class LatestPosts extends AbstractBlock {
       return $this->renderNoPostsMessage();
     }
 
-    return $this->renderPosts($posts, $innerBlocks, $this->getColumns($attrs), $renderingContext);
+    $availableWidth = $this->getAvailableWidth($parsedBlock, $renderingContext);
+
+    // render_email_callback blocks skip add_spacer, so the margin-top the engine
+    // assigned us (spacing from the block above) is never rendered. We apply it
+    // to the first row ourselves.
+    $blockMarginTop = $this->getBlockMarginTop($parsedBlock);
+
+    return $this->renderPosts($posts, $innerBlocks, $this->getColumns($attrs), $renderingContext, $availableWidth, $blockMarginTop);
+  }
+
+  /**
+   * Renders an image block (featured image, avatar) like core/image for email:
+   * a clean <figure><img> passed through the email image renderer.
+   *
+   * @param array<string, mixed> $parsedBlock
+   */
+  public function renderImageBlockForEmail(string $blockContent, array $parsedBlock, Rendering_Context $renderingContext): string {
+    if (trim($blockContent) === '') {
+      return '';
+    }
+
+    $blockName = isset($parsedBlock['blockName']) && is_string($parsedBlock['blockName']) ? $parsedBlock['blockName'] : '';
+    $attrs = isset($parsedBlock['attrs']) && is_array($parsedBlock['attrs']) ? $parsedBlock['attrs'] : [];
+
+    // The avatar has a fixed pixel size; preserve it so it does not stretch to
+    // the full container width (the featured image fills the width like a normal
+    // image).
+    if ($blockName === 'core/avatar' && !isset($attrs['width'])) {
+      $width = $this->getRenderedImageWidth($blockContent);
+      if ($width !== null) {
+        $attrs['width'] = $width . 'px';
+        $parsedBlock['attrs'] = $attrs;
+      }
+    }
+
+    $figure = $this->normalizeToImageFigure($blockContent);
+    if ($figure === null) {
+      return $blockContent;
+    }
+
+    return (new ImageRenderer())->render($figure, $parsedBlock, $renderingContext);
+  }
+
+  /**
+   * Normalizes image markup into a clean core/image-style <figure><img>,
+   * dropping email-hostile attributes (height, object-fit, srcset, ...) so the
+   * image scales by width and keeps its aspect ratio.
+   */
+  private function normalizeToImageFigure(string $html): ?string {
+    $processor = new \WP_HTML_Tag_Processor($html);
+    if (!$processor->next_tag('img')) {
+      return null;
+    }
+    foreach (['height', 'width', 'style', 'srcset', 'sizes', 'loading', 'decoding'] as $attribute) {
+      $processor->remove_attribute($attribute);
+    }
+    $html = $processor->get_updated_html();
+
+    if (stripos($html, '<figure') === false) {
+      $html = '<figure class="wp-block-image">' . $html . '</figure>';
+    }
+
+    return $html;
+  }
+
+  private function getRenderedImageWidth(string $html): ?int {
+    $processor = new \WP_HTML_Tag_Processor($html);
+    if (!$processor->next_tag('img')) {
+      return null;
+    }
+    $width = $processor->get_attribute('width');
+    if (!is_string($width) || !is_numeric($width)) {
+      return null;
+    }
+    $width = (int)$width;
+    return $width > 0 ? $width : null;
   }
 
   private function registerTemplateBlock(): void {
@@ -173,9 +259,8 @@ class LatestPosts extends AbstractBlock {
     if (!$blockType instanceof \WP_Block_Type) {
       return;
     }
-    $renderEmailCallbackProperty = 'render_email_callback';
     // @phpstan-ignore-next-line -- WooCommerce email editor reads this dynamic block setting.
-    $blockType->{$renderEmailCallbackProperty} = [$this, 'renderEmail'];
+    $blockType->render_email_callback = [$this, 'renderEmail']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
   private function enableEmailSupportForRegisteredCoreBlocks(): void {
@@ -187,6 +272,11 @@ class LatestPosts extends AbstractBlock {
       $supports = is_array($blockType->supports) ? $blockType->supports : [];
       $supports['email'] = true;
       $blockType->supports = $supports;
+
+      if (in_array($blockName, self::IMAGE_CORE_BLOCKS, true)) {
+        // @phpstan-ignore-next-line -- WooCommerce email editor reads this dynamic block setting.
+        $blockType->render_email_callback = [$this, 'renderImageBlockForEmail']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      }
     }
   }
 
@@ -313,9 +403,8 @@ class LatestPosts extends AbstractBlock {
   }
 
   /**
-   * Returns the inner blocks rendered once per post. When the block is used
-   * without a composed template (e.g. inserted by a pattern or template as a
-   * self-closing block), we fall back to a sensible default layout.
+   * Inner blocks rendered once per post, falling back to a default layout when
+   * the block has no composed template.
    *
    * @param array<string, mixed> $parentBlock
    * @return array<int, mixed>
@@ -348,77 +437,201 @@ class LatestPosts extends AbstractBlock {
    * @param \WP_Post[] $posts
    * @param array<int, mixed> $innerBlocks
    */
-  private function renderPosts(array $posts, array $innerBlocks, int $columns, ?Rendering_Context $renderingContext): string {
+  private function renderPosts(array $posts, array $innerBlocks, int $columns, ?Rendering_Context $renderingContext, int $availableWidth, string $blockMarginTop = ''): string {
+    $renderingContext = $this->resolveRenderingContext($renderingContext);
+    $blockGap = $this->getBlockGap($renderingContext);
+
     if ($columns === 1) {
+      $preparedBlocks = $this->preprocessBlocks($this->normalizeInnerBlocks($innerBlocks), $availableWidth, $renderingContext);
       $html = '';
-      $blockGap = $this->getBlockGap($renderingContext);
-      $lastIndex = count($posts) - 1;
       foreach ($posts as $index => $post) {
-        $marginBottom = $index < $lastIndex ? $blockGap : '0';
-        $html .= sprintf(
-          '<div style="margin:0 0 %s;">%s</div>',
-          $this->wp->escAttr($marginBottom),
-          $this->renderPostItem($post, $innerBlocks)
-        );
+        // The first post inherits the block's own top margin (from the block
+        // above); the rest use the inter-post gap.
+        $gap = $index > 0 ? $blockGap : $blockMarginTop;
+        $blocks = $gap !== '' ? $this->withTopGap($preparedBlocks, $gap) : $preparedBlocks;
+        $html .= $this->renderInnerBlocks($post, $blocks);
       }
       return $html;
     }
 
+    $rows = array_chunk($posts, max(1, $columns));
     $html = '';
-    foreach (array_chunk($posts, max(1, $columns)) as $row) {
-      $html .= $this->renderPostsRow($row, $innerBlocks, $columns, $renderingContext);
+    foreach ($rows as $rowIndex => $row) {
+      // The first row inherits the block's own top margin; the rest use the gap.
+      $marginTop = $rowIndex > 0 ? $blockGap : $blockMarginTop;
+      $html .= $this->renderColumnsRow($row, $innerBlocks, $columns, $availableWidth, $renderingContext, $marginTop);
     }
     return $html;
   }
 
   /**
+   * Renders a row of posts as a real core/columns block: build the
+   * core/columns > core/column tree, run it through the email preprocessors,
+   * then render with the core Columns/Column renderers.
+   *
+   * The engine adds the column gap as padding on top of the column widths, so
+   * equal columns would overflow the row by the total gap. We pre-shrink the
+   * width handed to the splitter so columns plus gaps fit the available width.
+   *
    * @param \WP_Post[] $posts
    * @param array<int, mixed> $innerBlocks
    */
-  private function renderPostsRow(array $posts, array $innerBlocks, int $columns, ?Rendering_Context $renderingContext): string {
-    $startSide = $this->getStartSide($renderingContext);
-    $endSide = $startSide === 'right' ? 'left' : 'right';
-    $cellWidth = (int)floor(100 / $columns);
-    $gapHalf = (int)floor(self::COLUMN_GAP_PX / 2);
-
-    $html = sprintf(
-      '<table role="presentation" width="100%%" border="0" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 %s;"><tr>',
-      $this->wp->escAttr($this->getBlockGap($renderingContext))
-    );
-
-    foreach ($posts as $columnIndex => $post) {
-      $paddingSide = $columnIndex === 0 ? $endSide : $startSide;
-      $html .= sprintf(
-        '<td valign="top" width="%1$d%%" style="width:%1$d%%;padding-%2$s:%3$dpx;">%4$s</td>',
-        $cellWidth,
-        $this->wp->escAttr($paddingSide),
-        $gapHalf,
-        $this->renderPostItem($post, $innerBlocks)
-      );
+  private function renderColumnsRow(array $posts, array $innerBlocks, int $columns, int $availableWidth, ?Rendering_Context $renderingContext, string $marginTop = ''): string {
+    if ($renderingContext === null) {
+      return $this->renderStackedFallback($posts, $innerBlocks, $availableWidth, $renderingContext, $marginTop);
     }
 
-    $missingCells = $columns - count($posts);
-    for ($i = 0; $i < $missingCells; $i++) {
-      $html .= sprintf('<td valign="top" width="%1$d%%" style="width:%1$d%%;"></td>', $cellWidth);
+    $gapPx = $this->parsePx($this->getBlockGap($renderingContext));
+    $splitWidth = $gapPx > 0 ? max(1, $availableWidth - ($gapPx * ($columns - 1))) : $availableWidth;
+
+    $columnsAttrs = [];
+    if ($gapPx > 0) {
+      // Pin the gap to a pixel value so it matches the width we subtracted (the
+      // theme gap may otherwise be a preset reference).
+      $columnsAttrs['style'] = ['spacing' => ['blockGap' => ['top' => $gapPx . 'px', 'left' => $gapPx . 'px']]];
     }
 
-    $html .= '</tr></table>';
+    $columnBlocks = [];
+    for ($i = 0; $i < $columns; $i++) {
+      $hasPost = isset($posts[$i]);
+      $columnBlocks[] = [
+        'blockName' => 'core/column',
+        'attrs' => [],
+        'innerHTML' => '',
+        'innerContent' => [],
+        'innerBlocks' => $hasPost ? $this->normalizeInnerBlocks($innerBlocks) : [],
+      ];
+    }
+    $columnsTree = [
+      'blockName' => 'core/columns',
+      'attrs' => $columnsAttrs,
+      'innerHTML' => '',
+      'innerContent' => [],
+      'innerBlocks' => $columnBlocks,
+    ];
+
+    $preprocessed = $this->preprocessBlocks([$columnsTree], $splitWidth, $renderingContext);
+    $columnsBlock = $preprocessed[0] ?? $columnsTree;
+    if (!is_array($columnsBlock)) {
+      $columnsBlock = $columnsTree;
+    }
+    if ($marginTop !== '') {
+      $emailAttrs = isset($columnsBlock['email_attrs']) && is_array($columnsBlock['email_attrs']) ? $columnsBlock['email_attrs'] : [];
+      $emailAttrs['margin-top'] = $marginTop;
+      $columnsBlock['email_attrs'] = $emailAttrs;
+    }
+    $preparedColumns = isset($columnsBlock['innerBlocks']) && is_array($columnsBlock['innerBlocks']) ? $columnsBlock['innerBlocks'] : [];
+
+    $columnRenderer = new ColumnRenderer();
+    $cells = '';
+    foreach ($preparedColumns as $i => $columnBlock) {
+      if (!is_array($columnBlock)) {
+        continue;
+      }
+      $post = $posts[$i] ?? null;
+      $columnInnerBlocks = isset($columnBlock['innerBlocks']) && is_array($columnBlock['innerBlocks']) ? $columnBlock['innerBlocks'] : [];
+      $inner = $post instanceof \WP_Post ? $this->renderInnerBlocks($post, $columnInnerBlocks) : '';
+      $columnContent = '<div class="wp-block-column">' . $inner . '</div>';
+      $cells .= $columnRenderer->render($columnContent, $columnBlock, $renderingContext);
+    }
+
+    $columnsContent = '<div class="wp-block-columns">' . $cells . '</div>';
+    return (new ColumnsRenderer())->render($columnsContent, $columnsBlock, $renderingContext);
+  }
+
+  /**
+   * Fallback when the email engine services are unavailable (e.g. rendering
+   * outside the editor pipeline): stack posts vertically so nothing is dropped.
+   *
+   * @param \WP_Post[] $posts
+   * @param array<int, mixed> $innerBlocks
+   */
+  private function renderStackedFallback(array $posts, array $innerBlocks, int $contentWidth, ?Rendering_Context $renderingContext, string $marginTop = ''): string {
+    $preparedBlocks = $this->preprocessBlocks($this->normalizeInnerBlocks($innerBlocks), $contentWidth, $renderingContext);
+    $blockGap = $this->getBlockGap($renderingContext);
+    $html = '';
+    foreach ($posts as $index => $post) {
+      $gap = $index > 0 ? $blockGap : $marginTop;
+      $blocks = $gap !== '' ? $this->withTopGap($preparedBlocks, $gap) : $preparedBlocks;
+      $html .= $this->renderInnerBlocks($post, $blocks);
+    }
     return $html;
   }
 
   /**
-   * Renders the per-post inner blocks (featured image, title, excerpt, ...)
-   * once for the given post, matching how core/post-template renders its loop.
+   * Sets a top gap on the first block so its renderer emits the standard
+   * `email-block-layout` margin-top spacer, the way the engine spaces siblings.
    *
-   * We use render_block() (not WP_Block::render directly) on purpose: it applies
-   * the render_block_data filter, which is where WordPress registers block
-   * supports such as element/link colors. Skipping it would render the markup
-   * but drop the matching styles (e.g. the "Read more" link colour). Post context
-   * is provided through the render_block_context filter, exactly like core.
+   * @param array<int, mixed> $blocks
+   * @return array<int, mixed>
+   */
+  private function withTopGap(array $blocks, string $gap): array {
+    foreach ($blocks as $index => $block) {
+      if (!is_array($block)) {
+        continue;
+      }
+      $emailAttrs = isset($block['email_attrs']) && is_array($block['email_attrs']) ? $block['email_attrs'] : [];
+      $emailAttrs['margin-top'] = $gap;
+      $block['email_attrs'] = $emailAttrs;
+      $blocks[$index] = $block;
+      break;
+    }
+    return $blocks;
+  }
+
+  /**
+   * Runs blocks through the email preprocessors so each block (and any nested
+   * image) gets its email_attrs width/spacing for the given available width.
+   *
+   * @param array<int, mixed> $blocks
+   * @return array<int, mixed>
+   */
+  private function preprocessBlocks(array $blocks, int $contentWidth, ?Rendering_Context $renderingContext): array {
+    $processManager = $this->getEmailEditorService(Process_Manager::class);
+    $themeController = $this->getEmailEditorService(Theme_Controller::class);
+    if (!$processManager instanceof Process_Manager || !$themeController instanceof Theme_Controller) {
+      return $blocks;
+    }
+
+    $styles = $themeController->get_styles();
+    unset($styles['spacing']['padding']['left'], $styles['spacing']['padding']['right']);
+    $styles['__variables_map'] = $themeController->get_variables_values_map();
+
+    $layout = $themeController->get_layout_settings();
+    $layout['contentSize'] = $contentWidth . 'px';
+
+    return $processManager->preprocess($blocks, $layout, $styles, $renderingContext);
+  }
+
+  /**
+   * Normalizes a list of parsed blocks so they have the full shape the engine
+   * preprocessors and WP_Block expect.
+   *
+   * @param array<int, mixed> $innerBlocks
+   * @return array<int, array<string, mixed>>
+   */
+  private function normalizeInnerBlocks(array $innerBlocks): array {
+    $normalized = [];
+    foreach ($innerBlocks as $innerBlock) {
+      if (is_array($innerBlock)) {
+        $normalized[] = $this->normalizeBlock($innerBlock);
+      }
+    }
+    return $normalized;
+  }
+
+  /**
+   * Renders the per-post inner blocks once for the given post, like
+   * core/post-template's loop.
+   *
+   * Uses render_block() (not WP_Block::render) so the render_block_data filter
+   * applies block supports such as element/link colors; skipping it would drop
+   * those styles (e.g. the "Read more" link colour). Post context is provided
+   * via the render_block_context filter, like core.
    *
    * @param array<int, mixed> $innerBlocks
    */
-  private function renderPostItem(\WP_Post $templatePost, array $innerBlocks): string {
+  private function renderInnerBlocks(\WP_Post $templatePost, array $innerBlocks): string {
     global $post, $wp_query;
 
     $previousPost = $post;
@@ -453,13 +666,14 @@ class LatestPosts extends AbstractBlock {
   }
 
   /**
-   * Ensures a parsed block array has every key WP_Block expects. Real parsed
-   * blocks already do; hand-crafted blocks (e.g. in tests) may not.
+   * Fills in any missing keys so the block has the full shape WP_Block expects.
+   * Blocks from parse_blocks() always have them, but ones we build by hand (for
+   * example in tests) might not, and the renderer would choke on the gaps.
    *
-   * We deliberately preserve email_attrs: the email editor's preprocessors
-   * (block gap, padding, ...) attach them to the parsed tree, and the
-   * render_block filter reads them back to apply spacing/styling to each block.
-   * Dropping them would strip the default spacing between the inner blocks.
+   * Keep email_attrs around - the preprocessors store spacing there and the
+   * render_block filter reads it back later. Since we rebuild the array from
+   * scratch here, forgetting to copy it would quietly drop the spacing between
+   * posts.
    *
    * @param array $block
    * @return array{blockName: string|null, attrs: array, innerBlocks: array, innerHTML: string, innerContent: array, email_attrs?: array}
@@ -508,8 +722,86 @@ class LatestPosts extends AbstractBlock {
     return self::DEFAULT_BLOCK_GAP;
   }
 
-  private function getStartSide(?Rendering_Context $renderingContext): string {
-    return $renderingContext !== null ? $renderingContext->get_start_side() : 'left';
+  /**
+   * Width available to this block. The engine stores it in email_attrs after
+   * subtracting every ancestor's padding, so it is the right base for sizing
+   * posts and columns. Falls back to the layout content width when absent.
+   *
+   * @param array<string, mixed> $parsedBlock
+   */
+  private function getAvailableWidth(array $parsedBlock, ?Rendering_Context $renderingContext): int {
+    $emailAttrs = isset($parsedBlock['email_attrs']) && is_array($parsedBlock['email_attrs']) ? $parsedBlock['email_attrs'] : [];
+    if (isset($emailAttrs['width']) && is_string($emailAttrs['width'])) {
+      $width = $this->parsePx($emailAttrs['width']);
+      if ($width > 0) {
+        return $width;
+      }
+    }
+    return $this->getContentWidth($renderingContext);
+  }
+
+  /**
+   * The top margin the engine assigned to our block (block gap from the block
+   * above). Empty when the block is the first in the email.
+   *
+   * @param array<string, mixed> $parsedBlock
+   */
+  private function getBlockMarginTop(array $parsedBlock): string {
+    $emailAttrs = isset($parsedBlock['email_attrs']) && is_array($parsedBlock['email_attrs']) ? $parsedBlock['email_attrs'] : [];
+    if (isset($emailAttrs['margin-top']) && is_string($emailAttrs['margin-top'])) {
+      return $emailAttrs['margin-top'];
+    }
+    return '';
+  }
+
+  /**
+   * Layout content width without padding. Used when preprocessing a row so the
+   * engine sizes columns and nested images.
+   */
+  private function getContentWidth(?Rendering_Context $renderingContext): int {
+    if ($renderingContext !== null) {
+      $width = $this->parsePx($renderingContext->get_layout_width_without_padding());
+      if ($width > 0) {
+        return $width;
+      }
+    }
+    return self::DEFAULT_CONTENT_WIDTH_PX;
+  }
+
+  private function parsePx(string $value): int {
+    $value = trim($value);
+    if ($value === '') {
+      return 0;
+    }
+    return (int)round((float)str_replace('px', '', $value));
+  }
+
+  /**
+   * The engine passes a rendering context during real rendering; when the block
+   * is rendered directly (e.g. tests) we build one from the email theme.
+   */
+  private function resolveRenderingContext(?Rendering_Context $renderingContext): ?Rendering_Context {
+    if ($renderingContext !== null) {
+      return $renderingContext;
+    }
+    $themeController = $this->getEmailEditorService(Theme_Controller::class);
+    if ($themeController instanceof Theme_Controller) {
+      return new Rendering_Context($themeController->get_theme());
+    }
+    return null;
+  }
+
+  /**
+   * @param class-string $class
+   * @return object|null
+   */
+  private function getEmailEditorService(string $class) {
+    try {
+      $service = Email_Editor_Container::container()->get($class);
+    } catch (\Throwable $e) {
+      return null;
+    }
+    return $service instanceof $class ? $service : null;
   }
 
   private function resolveNewsletter(): ?NewsletterEntity {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -348,9 +348,35 @@ class LatestPosts extends AbstractBlock {
     }
     $this->renderedPostsByRequest[$cacheKey] = $renderedIds;
 
-    return array_values(array_filter($posts, static function ($post) {
+    $posts = array_values(array_filter($posts, static function ($post) {
       return $post instanceof \WP_Post;
     }));
+
+    // post__in is queried in date order, not the picked order, so restore the
+    // order the posts were selected in.
+    return $isManual ? $this->orderByIds($posts, $manualPosts) : $posts;
+  }
+
+  /**
+   * Reorders posts to match the given list of IDs, dropping any that are not
+   * in it.
+   *
+   * @param \WP_Post[] $posts
+   * @param int[] $ids
+   * @return \WP_Post[]
+   */
+  private function orderByIds(array $posts, array $ids): array {
+    $postsById = [];
+    foreach ($posts as $post) {
+      $postsById[(int)$post->ID] = $post;
+    }
+    $ordered = [];
+    foreach ($ids as $id) {
+      if (isset($postsById[$id])) {
+        $ordered[] = $postsById[$id];
+      }
+    }
+    return $ordered;
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -320,9 +320,11 @@ class LatestPosts extends AbstractBlock {
   }
 
   /**
-   * Renders the full content of the post provided by the template loop.
-   * Block-based content keeps only blocks the email engine can render;
-   * classic content is reduced to an email-safe subset of HTML.
+   * Renders the post content for the current post in the template loop.
+   * Block posts keep only the blocks the email engine can render, and
+   * classic posts are reduced to email-safe HTML. Password-protected
+   * posts render nothing here, because an email would expose the
+   * protected content to anyone who receives it.
    *
    * @param array<string, mixed>|\WP_Block $attributes
    * @param string $content

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -698,7 +698,23 @@ class LatestPosts extends AbstractBlock {
       $wp_query = $previousQuery; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
     }
 
-    return $content;
+    return $this->withPostId($content, $postId);
+  }
+
+  /**
+   * Adds data-post-id to the post markup. Post notifications read it back from
+   * the sent email (Tasks\Posts) to know which posts already went out.
+   */
+  private function withPostId(string $html, int $postId): string {
+    if (trim($html) === '') {
+      return $html;
+    }
+    $processor = new \WP_HTML_Tag_Processor($html);
+    if (!$processor->next_tag()) {
+      return $html;
+    }
+    $processor->set_attribute('data-post-id', (string)$postId);
+    return $processor->get_updated_html();
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -31,6 +31,7 @@ class LatestPosts extends AbstractBlock {
   protected $blockName = 'latest-posts';
 
   private const TEMPLATE_BLOCK = 'mailpoet/latest-posts-template';
+  private const POST_CONTENT_BLOCK = 'mailpoet/post-content';
   private const DEFAULT_COLUMNS = 1;
   private const MAX_COLUMNS = 2;
   private const DEFAULT_POSTS = 3;
@@ -62,8 +63,52 @@ class LatestPosts extends AbstractBlock {
     'core/avatar',
   ];
 
+  /**
+   * HTML kept when rendering classic (non-block) post content.
+   * Text-level markup email clients handle well.
+   * Everything else (scripts, embeds, forms, ...) is stripped.
+   */
+  private const CLASSIC_CONTENT_ALLOWED_HTML = [
+    'a' => ['href' => true, 'title' => true],
+    'b' => [],
+    'blockquote' => ['cite' => true],
+    'br' => [],
+    'cite' => [],
+    'code' => [],
+    'em' => [],
+    'figcaption' => [],
+    'figure' => [],
+    'h1' => [],
+    'h2' => [],
+    'h3' => [],
+    'h4' => [],
+    'h5' => [],
+    'h6' => [],
+    'hr' => [],
+    'i' => [],
+    'img' => ['src' => true, 'alt' => true, 'width' => true, 'height' => true],
+    'li' => [],
+    'ol' => ['start' => true],
+    'p' => [],
+    'pre' => [],
+    's' => [],
+    'span' => [],
+    'strong' => [],
+    'table' => [],
+    'tbody' => [],
+    'td' => ['colspan' => true, 'rowspan' => true],
+    'tfoot' => [],
+    'th' => ['colspan' => true, 'rowspan' => true],
+    'thead' => [],
+    'tr' => [],
+    'u' => [],
+    'ul' => [],
+  ];
+
   /** @var array<int, int[]> */
   private $renderedPostsByRequest = [];
+
+  private bool $isRenderingPostContent = false;
 
   private AutomatedLatestContent $automatedLatestContent;
   private NewsletterPostsRepository $newsletterPostsRepository;
@@ -85,6 +130,7 @@ class LatestPosts extends AbstractBlock {
   public function initialize() {
     parent::initialize();
     $this->registerTemplateBlock();
+    $this->registerPostContentBlock();
     $this->wp->addFilter('block_categories_all', [$this, 'addBlockCategory']);
     $this->wp->addFilter('allowed_block_types_all', [$this, 'restrictBlocksToEmailEditor'], 10, 2);
     $this->wp->addFilter('block_type_metadata_settings', [$this, 'enableEmailSupportForCoreBlocks']);
@@ -147,7 +193,7 @@ class LatestPosts extends AbstractBlock {
       $allowedBlocks = array_keys(\WP_Block_Type_Registry::get_instance()->get_all_registered());
     }
 
-    $ownBlocks = [$this->getBlockType(), self::TEMPLATE_BLOCK];
+    $ownBlocks = [$this->getBlockType(), self::TEMPLATE_BLOCK, self::POST_CONTENT_BLOCK];
     return array_values(array_filter($allowedBlocks, static function ($blockName) use ($ownBlocks) {
       return !in_array($blockName, $ownBlocks, true);
     }));
@@ -273,6 +319,157 @@ class LatestPosts extends AbstractBlock {
     return $width > 0 ? $width : null;
   }
 
+  /**
+   * Renders the full content of the post provided by the template loop.
+   * Block-based content keeps only blocks the email engine can render;
+   * classic content is reduced to an email-safe subset of HTML.
+   *
+   * @param array<string, mixed>|\WP_Block $attributes
+   * @param string $content
+   * @param \WP_Block|null $block
+   */
+  public function renderPostContent($attributes, $content, $block): string {
+    if ($this->isRenderingPostContent || !$block instanceof \WP_Block) {
+      return '';
+    }
+    $postId = (int)($block->context['postId'] ?? 0);
+    if ($postId <= 0) {
+      return '';
+    }
+    $post = $this->wp->getPost($postId);
+    if (!$post instanceof \WP_Post || $this->wp->postPasswordRequired($post)) {
+      return '';
+    }
+
+    $this->isRenderingPostContent = true;
+    try {
+      if ($this->wp->hasBlocks($post->post_content)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        return $this->renderPostContentBlocks($post, $block);
+      }
+      return $this->renderClassicPostContent($post);
+    } finally {
+      $this->isRenderingPostContent = false;
+    }
+  }
+
+  private function renderPostContentBlocks(\WP_Post $post, \WP_Block $block): string {
+    // The plain core parser, so the engine's email parser does not preprocess
+    // these blocks with the email root padding.
+    $blocks = (new \WP_Block_Parser())->parse($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $blocks = $this->filterEmailRenderableBlocks($blocks);
+    if (!$blocks) {
+      return '';
+    }
+
+    $renderingContext = $this->resolveRenderingContext(null);
+    $availableWidth = $this->getAvailableWidth($block->parsed_block, $renderingContext); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $blocks = $this->preprocessBlocks($this->normalizeInnerBlocks($blocks), $availableWidth, $renderingContext);
+
+    $html = '';
+    foreach ($blocks as $contentBlock) {
+      if (is_array($contentBlock)) {
+        $html .= render_block($this->normalizeBlock($contentBlock));
+      }
+    }
+    return $html;
+  }
+
+  private function renderClassicPostContent(\WP_Post $post): string {
+    $content = $this->wp->stripShortcodes($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $content = $this->wp->wpautop($content);
+    $content = trim($this->wp->wpKses($content, self::CLASSIC_CONTENT_ALLOWED_HTML));
+    if ($content === '') {
+      return '';
+    }
+    return '<div class="mailpoet-post-content">' . $content . '</div>';
+  }
+
+  /**
+   * Keeps only blocks the email engine can render: those opted into email
+   * support or given an email render callback (render-only blocks such as
+   * core/embed). Our own blocks and core/post-content are excluded so post
+   * content cannot render recursively.
+   *
+   * @param array<mixed> $blocks
+   * @return array<int, array<string, mixed>>
+   */
+  private function filterEmailRenderableBlocks(array $blocks): array {
+    $kept = [];
+    foreach ($blocks as $block) {
+      if ($this->isEmailRenderableBlock($block)) {
+        $kept[] = $this->filterInnerEmailRenderableBlocks($block);
+      }
+    }
+    return $kept;
+  }
+
+  /**
+   * @param mixed $block
+   * @phpstan-assert-if-true array<string, mixed> $block
+   */
+  private function isEmailRenderableBlock($block): bool {
+    if (!is_array($block)) {
+      return false;
+    }
+    $name = $block['blockName'] ?? null;
+    if (!is_string($name) || $name === '') {
+      return false;
+    }
+    if (in_array($name, [$this->getBlockType(), self::TEMPLATE_BLOCK, self::POST_CONTENT_BLOCK, 'core/post-content'], true)) {
+      return false;
+    }
+    $blockType = \WP_Block_Type_Registry::get_instance()->get_registered($name);
+    if (!$blockType instanceof \WP_Block_Type) {
+      return false;
+    }
+    $supports = is_array($blockType->supports) ? $blockType->supports : [];
+    if (($supports['email'] ?? false) === true) {
+      return true;
+    }
+    return isset($blockType->render_email_callback) && is_callable($blockType->render_email_callback); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  }
+
+  /**
+   * @param array<string, mixed> $block
+   * @return array<string, mixed>
+   */
+  private function filterInnerEmailRenderableBlocks(array $block): array {
+    $innerBlocks = isset($block['innerBlocks']) && is_array($block['innerBlocks']) ? $block['innerBlocks'] : [];
+    if (!$innerBlocks) {
+      return $block;
+    }
+
+    $keptFlags = [];
+    $kept = [];
+    foreach ($innerBlocks as $innerBlock) {
+      $keep = $this->isEmailRenderableBlock($innerBlock);
+      $keptFlags[] = $keep;
+      if ($keep) {
+        $kept[] = $this->filterInnerEmailRenderableBlocks($innerBlock);
+      }
+    }
+
+    // innerContent holds one null placeholder per inner block; drop the
+    // placeholders of removed blocks so markers and blocks stay aligned.
+    $rawInnerContent = isset($block['innerContent']) && is_array($block['innerContent']) ? $block['innerContent'] : [];
+    $innerContent = [];
+    $innerBlockIndex = 0;
+    foreach ($rawInnerContent as $chunk) {
+      if ($chunk !== null) {
+        $innerContent[] = $chunk;
+        continue;
+      }
+      if ($keptFlags[$innerBlockIndex] ?? false) {
+        $innerContent[] = null;
+      }
+      $innerBlockIndex++;
+    }
+
+    $block['innerBlocks'] = $kept;
+    $block['innerContent'] = $innerContent;
+    return $block;
+  }
+
   private function registerTemplateBlock(): void {
     if (\WP_Block_Type_Registry::get_instance()->is_registered(self::TEMPLATE_BLOCK)) {
       return;
@@ -288,6 +485,29 @@ class LatestPosts extends AbstractBlock {
       'editor_script' => $this->getEditorScript('handle'),
       'editor_style' => $this->getEditorStyle('handle'),
     ]);
+  }
+
+  private function registerPostContentBlock(): void {
+    if (\WP_Block_Type_Registry::get_instance()->is_registered(self::POST_CONTENT_BLOCK)) {
+      return;
+    }
+    $metadataPath = Env::$assetsPath . '/dist/js/email-editor-blocks/latest-posts-post-content/block.json';
+    if (!file_exists($metadataPath)) {
+      return;
+    }
+    $blockType = register_block_type_from_metadata($metadataPath, [
+      'render_callback' => [$this, 'renderPostContent'],
+      'editor_script' => $this->getEditorScript('handle'),
+      'editor_style' => $this->getEditorStyle('handle'),
+    ]);
+    if ($blockType instanceof \WP_Block_Type) {
+      // The render callback already produces email-ready markup; without an
+      // identity callback the engine would wrap it in the fallback text renderer.
+      // @phpstan-ignore-next-line -- WooCommerce email editor reads this dynamic block setting.
+      $blockType->render_email_callback = static function (string $blockContent): string { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        return $blockContent;
+      };
+    }
   }
 
   private function registerEmailRenderCallback(): void {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -43,7 +43,6 @@ class LatestPosts extends AbstractBlock {
     'core/post-featured-image',
     'core/post-title',
     'core/post-excerpt',
-    'core/post-content',
     'core/post-date',
     'core/post-author',
     'core/post-author-name',

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -32,6 +32,8 @@ class LatestPosts extends AbstractBlock {
   private const TEMPLATE_BLOCK = 'mailpoet/latest-posts-template';
   private const DEFAULT_COLUMNS = 1;
   private const MAX_COLUMNS = 2;
+  private const DEFAULT_POSTS = 3;
+  private const MAX_POSTS = 100;
   private const DEFAULT_BLOCK_GAP = '20px';
   private const DEFAULT_CONTENT_WIDTH_PX = 600;
 
@@ -336,11 +338,15 @@ class LatestPosts extends AbstractBlock {
       return $args;
     }
 
-    $args['amount'] = isset($query['perPage']) && is_numeric($query['perPage']) ? (int)$query['perPage'] : 3;
-    $args['offset'] = isset($query['offset']) && is_numeric($query['offset']) ? (int)$query['offset'] : 0;
+    $perPage = isset($query['perPage']) && is_numeric($query['perPage']) ? (int)$query['perPage'] : self::DEFAULT_POSTS;
+    $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int)$query['offset'] : 0;
+    $args['amount'] = max(1, min(self::MAX_POSTS, $perPage));
+    $args['offset'] = max(0, $offset);
     $args['sortBy'] = $this->isOldestFirst($query) ? 'ASC' : 'DESC';
 
-    $terms = $this->getTerms($query);
+    // Categories and tags are post-only taxonomies; applying them to other
+    // content types would wrongly filter out every result.
+    $terms = $args['contentType'] === 'post' ? $this->getTerms($query) : [];
     if ($terms) {
       $args['terms'] = $terms;
       $args['inclusionType'] = $this->isExclude($query) ? 'exclude' : 'include';
@@ -357,7 +363,7 @@ class LatestPosts extends AbstractBlock {
     $posts = isset($query['posts']) && is_array($query['posts']) ? $query['posts'] : [];
     $ids = [];
     foreach ($posts as $post) {
-      if (is_numeric($post)) {
+      if (is_numeric($post) && (int)$post > 0) {
         $ids[] = (int)$post;
       }
     }
@@ -372,7 +378,7 @@ class LatestPosts extends AbstractBlock {
     $terms = isset($query['terms']) && is_array($query['terms']) ? $query['terms'] : [];
     $result = [];
     foreach ($terms as $term) {
-      if (is_array($term) && isset($term['taxonomy'], $term['id']) && is_string($term['taxonomy']) && is_numeric($term['id'])) {
+      if (is_array($term) && isset($term['taxonomy'], $term['id']) && is_string($term['taxonomy']) && is_numeric($term['id']) && (int)$term['id'] > 0) {
         $result[] = ['taxonomy' => $term['taxonomy'], 'id' => (int)$term['id']];
       }
     }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -1,0 +1,558 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use MailPoet\Config\Env;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterPostEntity;
+use MailPoet\Newsletter\AutomatedLatestContent;
+use MailPoet\Newsletter\BlockPostQuery;
+use MailPoet\Newsletter\NewsletterPostsRepository;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\WP\Functions as WPFunctions;
+
+/**
+ * Renders the MailPoet "Latest posts" block for the email editor.
+ *
+ * Modeled on WooCommerce's Product Collection block: a curated container
+ * (mailpoet/latest-posts) holds a template block (mailpoet/latest-posts-template)
+ * whose inner blocks (featured image, title, excerpt, ...) are the composable,
+ * repeating unit. Selection controls (how many posts, post type, order, columns)
+ * live on the container. At render time we select posts dynamically (reusing the
+ * legacy AutomatedLatestContent engine) and render the template's inner blocks
+ * once per post, so the markup stays consistent with the rest of the editor.
+ */
+class LatestPosts extends AbstractBlock {
+  protected $blockName = 'latest-posts';
+
+  private const TEMPLATE_BLOCK = 'mailpoet/latest-posts-template';
+  private const DEFAULT_COLUMNS = 1;
+  private const MAX_COLUMNS = 2;
+  private const COLUMN_GAP_PX = 20;
+  private const DEFAULT_BLOCK_GAP = '28px';
+
+  /**
+   * Core blocks that the template is composed of. They are not email-enabled by
+   * default, so we opt them in to keep them usable inside the email editor.
+   */
+  private const TEMPLATE_CORE_BLOCKS = [
+    'core/post-featured-image',
+    'core/post-title',
+    'core/post-excerpt',
+    'core/post-content',
+    'core/post-date',
+    'core/post-author',
+    'core/post-author-name',
+    'core/post-author-biography',
+    'core/post-terms',
+    'core/avatar',
+    'core/read-more',
+  ];
+
+  /** @var array<int, int[]> */
+  private $renderedPostsByRequest = [];
+
+  private AutomatedLatestContent $automatedLatestContent;
+  private NewsletterPostsRepository $newsletterPostsRepository;
+  private NewslettersRepository $newslettersRepository;
+  private WPFunctions $wp;
+
+  public function __construct(
+    AutomatedLatestContent $automatedLatestContent,
+    NewsletterPostsRepository $newsletterPostsRepository,
+    NewslettersRepository $newslettersRepository,
+    WPFunctions $wp
+  ) {
+    $this->automatedLatestContent = $automatedLatestContent;
+    $this->newsletterPostsRepository = $newsletterPostsRepository;
+    $this->newslettersRepository = $newslettersRepository;
+    $this->wp = $wp;
+  }
+
+  public function initialize() {
+    parent::initialize();
+    $this->registerTemplateBlock();
+    $this->wp->addFilter('block_categories_all', [$this, 'addBlockCategory']);
+    $this->wp->addFilter('block_type_metadata_settings', [$this, 'enableEmailSupportForCoreBlocks']);
+    $this->wp->addFilter('woocommerce_email_content_renderer_styles', [$this, 'makeLinkColorStylesInlineable']);
+    $this->enableEmailSupportForRegisteredCoreBlocks();
+    $this->registerEmailRenderCallback();
+  }
+
+  /**
+   * The block is email-only; it produces no output outside the email rendering
+   * pipeline, where renderEmail (render_email_callback) takes over.
+   *
+   * @param array<string, mixed>|\WP_Block $attributes
+   */
+  public function render($attributes, $content, $block) {
+    return '';
+  }
+
+  /**
+   * @param array<int, array<string, mixed>> $categories
+   * @return array<int, array<string, mixed>>
+   */
+  public function addBlockCategory(array $categories): array {
+    foreach ($categories as $category) {
+      if (($category['slug'] ?? null) === 'mailpoet') {
+        return $categories;
+      }
+    }
+    $categories[] = [
+      'slug' => 'mailpoet',
+      'title' => __('MailPoet', 'mailpoet'),
+    ];
+    return $categories;
+  }
+
+  /**
+   * WordPress styles element link colors (e.g. the "Read more" link in
+   * core/post-excerpt) with a `:where(:not(.wp-element-button))` selector. The
+   * email CSS inliner (Emogrifier) cannot parse `:where()`, so the colour is
+   * dropped from the sent email even though the editor (a real browser) honours
+   * it. Rewriting it to the equivalent `:not()` selector keeps the same meaning
+   * while being inlineable. `:not()` with a single class is supported.
+   */
+  public function makeLinkColorStylesInlineable(string $styles): string {
+    return str_replace(':where(:not(.wp-element-button))', ':not(.wp-element-button)', $styles);
+  }
+
+  /**
+   * @param array<string, mixed> $settings
+   * @return array<string, mixed>
+   */
+  public function enableEmailSupportForCoreBlocks(array $settings): array {
+    $name = isset($settings['name']) && is_string($settings['name']) ? $settings['name'] : '';
+    if (in_array($name, self::TEMPLATE_CORE_BLOCKS, true)) {
+      if (!isset($settings['supports']) || !is_array($settings['supports'])) {
+        $settings['supports'] = [];
+      }
+      $settings['supports']['email'] = true;
+    }
+    return $settings;
+  }
+
+  /**
+   * @param array<string, mixed> $parsedBlock
+   */
+  public function renderEmail(string $blockContent, array $parsedBlock, ?Rendering_Context $renderingContext = null): string {
+    $attrs = isset($parsedBlock['attrs']) && is_array($parsedBlock['attrs']) ? $parsedBlock['attrs'] : [];
+    $query = isset($attrs['query']) && is_array($attrs['query']) ? $attrs['query'] : [];
+
+    $innerBlocks = $this->getTemplateInnerBlocks($parsedBlock);
+
+    $posts = $this->getPosts($query);
+    if (!$posts) {
+      return $this->renderNoPostsMessage();
+    }
+
+    return $this->renderPosts($posts, $innerBlocks, $this->getColumns($attrs), $renderingContext);
+  }
+
+  private function registerTemplateBlock(): void {
+    if (\WP_Block_Type_Registry::get_instance()->is_registered(self::TEMPLATE_BLOCK)) {
+      return;
+    }
+    $metadataPath = Env::$assetsPath . '/dist/js/email-editor-blocks/latest-posts-template/block.json';
+    if (!file_exists($metadataPath)) {
+      return;
+    }
+    register_block_type_from_metadata($metadataPath, [
+      'render_callback' => static function (): string {
+        return '';
+      },
+      'editor_script' => $this->getEditorScript('handle'),
+      'editor_style' => $this->getEditorStyle('handle'),
+    ]);
+  }
+
+  private function registerEmailRenderCallback(): void {
+    $blockType = \WP_Block_Type_Registry::get_instance()->get_registered($this->getBlockType());
+    if (!$blockType instanceof \WP_Block_Type) {
+      return;
+    }
+    $renderEmailCallbackProperty = 'render_email_callback';
+    // @phpstan-ignore-next-line -- WooCommerce email editor reads this dynamic block setting.
+    $blockType->{$renderEmailCallbackProperty} = [$this, 'renderEmail'];
+  }
+
+  private function enableEmailSupportForRegisteredCoreBlocks(): void {
+    foreach (self::TEMPLATE_CORE_BLOCKS as $blockName) {
+      $blockType = \WP_Block_Type_Registry::get_instance()->get_registered($blockName);
+      if (!$blockType instanceof \WP_Block_Type) {
+        continue;
+      }
+      $supports = is_array($blockType->supports) ? $blockType->supports : [];
+      $supports['email'] = true;
+      $blockType->supports = $supports;
+    }
+  }
+
+  /**
+   * @param array<string, mixed> $query
+   * @return \WP_Post[]
+   */
+  private function getPosts(array $query): array {
+    $isManual = ($query['selectionMode'] ?? 'latest') === 'manual';
+    $manualPosts = $this->getManualPostIds($query);
+
+    // Manual mode shows exactly the picked posts; an empty selection shows none.
+    if ($isManual && !$manualPosts) {
+      return [];
+    }
+
+    $newsletter = $this->resolveNewsletter();
+    $newsletterId = $this->getNewsletterIdForQuery($newsletter);
+    $cacheKey = $this->getRenderedPostsCacheKey($newsletter, $newsletterId);
+    $alreadyRendered = $this->renderedPostsByRequest[$cacheKey] ?? [];
+
+    $posts = $this->automatedLatestContent->getPosts(new BlockPostQuery([
+      'args' => $this->buildQueryArgs($query, $isManual, $manualPosts),
+      'dynamic' => true,
+      // Manual picks are explicit, so they bypass deduplication and the
+      // "newer than last sent" filter used by automated latest content.
+      'newsletterId' => $isManual ? false : $newsletterId,
+      'newerThanTimestamp' => $isManual ? false : $this->getNewerThanTimestamp($newsletter),
+      'postsToExclude' => $isManual ? [] : $alreadyRendered,
+    ]));
+
+    $renderedIds = $alreadyRendered;
+    foreach ($posts as $post) {
+      if ($post instanceof \WP_Post) {
+        $renderedIds[] = (int)$post->ID;
+      }
+    }
+    $this->renderedPostsByRequest[$cacheKey] = $renderedIds;
+
+    return array_values(array_filter($posts, static function ($post) {
+      return $post instanceof \WP_Post;
+    }));
+  }
+
+  /**
+   * @param array<string, mixed> $query
+   * @param int[] $manualPosts
+   * @return array{contentType: string, posts?: int[], amount?: int, offset?: int, sortBy?: 'ASC'|'DESC', terms?: array<int, array{taxonomy: string, id: int}>, inclusionType?: 'exclude'|'include'}
+   */
+  private function buildQueryArgs(array $query, bool $isManual, array $manualPosts): array {
+    $args = [
+      'contentType' => isset($query['postType']) && is_string($query['postType']) ? $query['postType'] : 'post',
+    ];
+
+    if ($isManual) {
+      $args['posts'] = $manualPosts;
+      return $args;
+    }
+
+    $args['amount'] = isset($query['perPage']) && is_numeric($query['perPage']) ? (int)$query['perPage'] : 3;
+    $args['offset'] = isset($query['offset']) && is_numeric($query['offset']) ? (int)$query['offset'] : 0;
+    $args['sortBy'] = $this->isOldestFirst($query) ? 'ASC' : 'DESC';
+
+    $terms = $this->getTerms($query);
+    if ($terms) {
+      $args['terms'] = $terms;
+      $args['inclusionType'] = $this->isExclude($query) ? 'exclude' : 'include';
+    }
+
+    return $args;
+  }
+
+  /**
+   * @param array<string, mixed> $query
+   * @return int[]
+   */
+  private function getManualPostIds(array $query): array {
+    $posts = isset($query['posts']) && is_array($query['posts']) ? $query['posts'] : [];
+    $ids = [];
+    foreach ($posts as $post) {
+      if (is_numeric($post)) {
+        $ids[] = (int)$post;
+      }
+    }
+    return $ids;
+  }
+
+  /**
+   * @param array<string, mixed> $query
+   * @return array<int, array{taxonomy: string, id: int}>
+   */
+  private function getTerms(array $query): array {
+    $terms = isset($query['terms']) && is_array($query['terms']) ? $query['terms'] : [];
+    $result = [];
+    foreach ($terms as $term) {
+      if (is_array($term) && isset($term['taxonomy'], $term['id']) && is_string($term['taxonomy']) && is_numeric($term['id'])) {
+        $result[] = ['taxonomy' => $term['taxonomy'], 'id' => (int)$term['id']];
+      }
+    }
+    return $result;
+  }
+
+  /**
+   * @param array<string, mixed> $query
+   */
+  private function isExclude(array $query): bool {
+    return isset($query['inclusionType']) && $query['inclusionType'] === 'exclude';
+  }
+
+  /**
+   * @param array<string, mixed> $query
+   */
+  private function isOldestFirst(array $query): bool {
+    return isset($query['order']) && is_string($query['order']) && strtolower($query['order']) === 'oldest';
+  }
+
+  /**
+   * @param array<string, mixed> $attrs
+   */
+  private function getColumns(array $attrs): int {
+    $displayLayout = isset($attrs['displayLayout']) && is_array($attrs['displayLayout']) ? $attrs['displayLayout'] : [];
+    $columns = isset($displayLayout['columns']) && is_numeric($displayLayout['columns']) ? (int)$displayLayout['columns'] : self::DEFAULT_COLUMNS;
+    return $this->normalizeColumns($columns);
+  }
+
+  /**
+   * Returns the inner blocks rendered once per post. When the block is used
+   * without a composed template (e.g. inserted by a pattern or template as a
+   * self-closing block), we fall back to a sensible default layout.
+   *
+   * @param array<string, mixed> $parentBlock
+   * @return array<int, mixed>
+   */
+  private function getTemplateInnerBlocks(array $parentBlock): array {
+    $innerBlocks = isset($parentBlock['innerBlocks']) && is_array($parentBlock['innerBlocks']) ? $parentBlock['innerBlocks'] : [];
+    foreach ($innerBlocks as $innerBlock) {
+      if (is_array($innerBlock) && ($innerBlock['blockName'] ?? null) === self::TEMPLATE_BLOCK) {
+        $templateInnerBlocks = isset($innerBlock['innerBlocks']) && is_array($innerBlock['innerBlocks']) ? $innerBlock['innerBlocks'] : [];
+        if ($templateInnerBlocks) {
+          return $templateInnerBlocks;
+        }
+      }
+    }
+    return $this->getDefaultTemplateInnerBlocks();
+  }
+
+  /**
+   * @return array<int, array<string, mixed>>
+   */
+  private function getDefaultTemplateInnerBlocks(): array {
+    return [
+      ['blockName' => 'core/post-featured-image', 'attrs' => []],
+      ['blockName' => 'core/post-title', 'attrs' => ['level' => 3, 'isLink' => true]],
+      ['blockName' => 'core/post-excerpt', 'attrs' => []],
+    ];
+  }
+
+  /**
+   * @param \WP_Post[] $posts
+   * @param array<int, mixed> $innerBlocks
+   */
+  private function renderPosts(array $posts, array $innerBlocks, int $columns, ?Rendering_Context $renderingContext): string {
+    if ($columns === 1) {
+      $html = '';
+      $blockGap = $this->getBlockGap($renderingContext);
+      $lastIndex = count($posts) - 1;
+      foreach ($posts as $index => $post) {
+        $marginBottom = $index < $lastIndex ? $blockGap : '0';
+        $html .= sprintf(
+          '<div style="margin:0 0 %s;">%s</div>',
+          $this->wp->escAttr($marginBottom),
+          $this->renderPostItem($post, $innerBlocks)
+        );
+      }
+      return $html;
+    }
+
+    $html = '';
+    foreach (array_chunk($posts, max(1, $columns)) as $row) {
+      $html .= $this->renderPostsRow($row, $innerBlocks, $columns, $renderingContext);
+    }
+    return $html;
+  }
+
+  /**
+   * @param \WP_Post[] $posts
+   * @param array<int, mixed> $innerBlocks
+   */
+  private function renderPostsRow(array $posts, array $innerBlocks, int $columns, ?Rendering_Context $renderingContext): string {
+    $startSide = $this->getStartSide($renderingContext);
+    $endSide = $startSide === 'right' ? 'left' : 'right';
+    $cellWidth = (int)floor(100 / $columns);
+    $gapHalf = (int)floor(self::COLUMN_GAP_PX / 2);
+
+    $html = sprintf(
+      '<table role="presentation" width="100%%" border="0" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 %s;"><tr>',
+      $this->wp->escAttr($this->getBlockGap($renderingContext))
+    );
+
+    foreach ($posts as $columnIndex => $post) {
+      $paddingSide = $columnIndex === 0 ? $endSide : $startSide;
+      $html .= sprintf(
+        '<td valign="top" width="%1$d%%" style="width:%1$d%%;padding-%2$s:%3$dpx;">%4$s</td>',
+        $cellWidth,
+        $this->wp->escAttr($paddingSide),
+        $gapHalf,
+        $this->renderPostItem($post, $innerBlocks)
+      );
+    }
+
+    $missingCells = $columns - count($posts);
+    for ($i = 0; $i < $missingCells; $i++) {
+      $html .= sprintf('<td valign="top" width="%1$d%%" style="width:%1$d%%;"></td>', $cellWidth);
+    }
+
+    $html .= '</tr></table>';
+    return $html;
+  }
+
+  /**
+   * Renders the per-post inner blocks (featured image, title, excerpt, ...)
+   * once for the given post, matching how core/post-template renders its loop.
+   *
+   * We use render_block() (not WP_Block::render directly) on purpose: it applies
+   * the render_block_data filter, which is where WordPress registers block
+   * supports such as element/link colors. Skipping it would render the markup
+   * but drop the matching styles (e.g. the "Read more" link colour). Post context
+   * is provided through the render_block_context filter, exactly like core.
+   *
+   * @param array<int, mixed> $innerBlocks
+   */
+  private function renderPostItem(\WP_Post $templatePost, array $innerBlocks): string {
+    global $post, $wp_query;
+
+    $previousPost = $post;
+    $previousQuery = $wp_query;
+    $post = $templatePost; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+    $wp_query = new \WP_Query(['p' => (int)$templatePost->ID]); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+    $postId = (int)$templatePost->ID;
+    $postType = (string)$templatePost->post_type; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $injectContext = static function (array $context) use ($postId, $postType): array {
+      $context['postId'] = $postId;
+      $context['postType'] = $postType; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      return $context;
+    };
+
+    $content = '';
+    $this->wp->addFilter('render_block_context', $injectContext, 1);
+    try {
+      foreach ($innerBlocks as $innerBlock) {
+        if (!is_array($innerBlock)) {
+          continue;
+        }
+        $content .= render_block($this->normalizeBlock($innerBlock));
+      }
+    } finally {
+      $this->wp->removeFilter('render_block_context', $injectContext, 1);
+      $post = $previousPost; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+      $wp_query = $previousQuery; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+    }
+
+    return $content;
+  }
+
+  /**
+   * Ensures a parsed block array has every key WP_Block expects. Real parsed
+   * blocks already do; hand-crafted blocks (e.g. in tests) may not.
+   *
+   * We deliberately preserve email_attrs: the email editor's preprocessors
+   * (block gap, padding, ...) attach them to the parsed tree, and the
+   * render_block filter reads them back to apply spacing/styling to each block.
+   * Dropping them would strip the default spacing between the inner blocks.
+   *
+   * @param array $block
+   * @return array{blockName: string|null, attrs: array, innerBlocks: array, innerHTML: string, innerContent: array, email_attrs?: array}
+   */
+  private function normalizeBlock(array $block): array {
+    $rawInnerBlocks = isset($block['innerBlocks']) && is_array($block['innerBlocks']) ? $block['innerBlocks'] : [];
+    $innerBlocks = [];
+    foreach ($rawInnerBlocks as $innerBlock) {
+      $innerBlocks[] = is_array($innerBlock) ? $this->normalizeBlock($innerBlock) : $innerBlock;
+    }
+
+    $normalized = [
+      'blockName' => isset($block['blockName']) && is_string($block['blockName']) ? $block['blockName'] : null,
+      'attrs' => isset($block['attrs']) && is_array($block['attrs']) ? $block['attrs'] : [],
+      'innerBlocks' => $innerBlocks,
+      'innerHTML' => isset($block['innerHTML']) && is_string($block['innerHTML']) ? $block['innerHTML'] : '',
+      'innerContent' => isset($block['innerContent']) && is_array($block['innerContent']) ? array_values($block['innerContent']) : [],
+    ];
+
+    if (isset($block['email_attrs']) && is_array($block['email_attrs'])) {
+      $normalized['email_attrs'] = $block['email_attrs'];
+    }
+
+    return $normalized;
+  }
+
+  private function renderNoPostsMessage(): string {
+    return sprintf(
+      '<div style="text-align:center;padding:20px;color:#666666;">%s</div>',
+      $this->wp->escHtml(__('No posts found.', 'mailpoet'))
+    );
+  }
+
+  private function normalizeColumns(int $columns): int {
+    return max(self::DEFAULT_COLUMNS, min(self::MAX_COLUMNS, $columns));
+  }
+
+  private function getBlockGap(?Rendering_Context $renderingContext): string {
+    if ($renderingContext === null) {
+      return self::DEFAULT_BLOCK_GAP;
+    }
+    $styles = $renderingContext->get_theme_styles();
+    if (isset($styles['spacing']['blockGap']) && is_string($styles['spacing']['blockGap']) && $styles['spacing']['blockGap'] !== '') {
+      return $styles['spacing']['blockGap'];
+    }
+    return self::DEFAULT_BLOCK_GAP;
+  }
+
+  private function getStartSide(?Rendering_Context $renderingContext): string {
+    return $renderingContext !== null ? $renderingContext->get_start_side() : 'left';
+  }
+
+  private function resolveNewsletter(): ?NewsletterEntity {
+    $post = $this->wp->getPost();
+    if (!$post instanceof \WP_Post) {
+      return null;
+    }
+    return $this->newslettersRepository->findOneBy(['wpPost' => (int)$post->ID]);
+  }
+
+  /**
+   * @param int|false $newsletterId
+   */
+  private function getRenderedPostsCacheKey(?NewsletterEntity $newsletter, $newsletterId): int {
+    if ($newsletterId !== false) {
+      return (int)$newsletterId;
+    }
+    return $newsletter && $newsletter->getId() ? $newsletter->getId() : 0;
+  }
+
+  /**
+   * @return int|false
+   */
+  private function getNewsletterIdForQuery(?NewsletterEntity $newsletter) {
+    if (!$newsletter || $newsletter->getType() !== NewsletterEntity::TYPE_NOTIFICATION_HISTORY) {
+      return false;
+    }
+    $parent = $newsletter->getParent();
+    return $parent instanceof NewsletterEntity ? ($parent->getId() ?? false) : false;
+  }
+
+  /**
+   * @return \DateTimeInterface|false
+   */
+  private function getNewerThanTimestamp(?NewsletterEntity $newsletter) {
+    if (!$newsletter || $newsletter->getType() !== NewsletterEntity::TYPE_NOTIFICATION_HISTORY) {
+      return false;
+    }
+    $parent = $newsletter->getParent();
+    if (!$parent instanceof NewsletterEntity) {
+      return false;
+    }
+    $lastPost = $this->newsletterPostsRepository->findOneBy(['newsletter' => $parent], ['createdAt' => 'desc']);
+    return $lastPost instanceof NewsletterPostEntity ? ($lastPost->getCreatedAt() ?? false) : false;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Column 
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Columns as ColumnsRenderer;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Image as ImageRenderer;
 use MailPoet\Config\Env;
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterPostEntity;
 use MailPoet\Newsletter\AutomatedLatestContent;
@@ -86,6 +87,7 @@ class LatestPosts extends AbstractBlock {
     parent::initialize();
     $this->registerTemplateBlock();
     $this->wp->addFilter('block_categories_all', [$this, 'addBlockCategory']);
+    $this->wp->addFilter('allowed_block_types_all', [$this, 'restrictBlocksToEmailEditor'], 10, 2);
     $this->wp->addFilter('block_type_metadata_settings', [$this, 'enableEmailSupportForCoreBlocks']);
     $this->wp->addFilter('woocommerce_email_content_renderer_styles', [$this, 'makeLinkColorStylesInlineable']);
     $this->enableEmailSupportForRegisteredCoreBlocks();
@@ -117,6 +119,34 @@ class LatestPosts extends AbstractBlock {
       'title' => __('MailPoet', 'mailpoet'),
     ];
     return $categories;
+  }
+
+  /**
+   * The block is registered globally so it can render when emails are sent, but
+   * it is only meant to be used inside the MailPoet email editor. Hide it (and
+   * its template block) from the inserter of every other editor.
+   *
+   * @param bool|string[] $allowedBlocks
+   * @param \WP_Block_Editor_Context $editorContext
+   * @return bool|string[]
+   */
+  public function restrictBlocksToEmailEditor($allowedBlocks, $editorContext) {
+    $post = $editorContext->post ?? null;
+    $postType = $post instanceof \WP_Post ? $post->post_type : null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    if ($postType === EmailEditor::MAILPOET_EMAIL_POST_TYPE) {
+      return $allowedBlocks;
+    }
+
+    // When every block is allowed the value is `true` rather than a list. Build
+    // the full list of block names first so we have something to remove ours from.
+    if (!is_array($allowedBlocks)) {
+      $allowedBlocks = array_keys(\WP_Block_Type_Registry::get_instance()->get_all_registered());
+    }
+
+    $ownBlocks = [$this->getBlockType(), self::TEMPLATE_BLOCK];
+    return array_values(array_filter($allowedBlocks, static function ($blockName) use ($ownBlocks) {
+      return !in_array($blockName, $ownBlocks, true);
+    }));
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -136,6 +136,11 @@ class LatestPosts extends AbstractBlock {
       return $allowedBlocks;
     }
 
+    // Another integration may have disallowed every block
+    if ($allowedBlocks === false) {
+      return $allowedBlocks;
+    }
+
     // When every block is allowed the value is `true` rather than a list. Build
     // the full list of block names first so we have something to remove ours from.
     if (!is_array($allowedBlocks)) {
@@ -417,12 +422,14 @@ class LatestPosts extends AbstractBlock {
   private function getManualPostIds(array $query): array {
     $posts = isset($query['posts']) && is_array($query['posts']) ? $query['posts'] : [];
     $ids = [];
+
     foreach ($posts as $post) {
       if (is_numeric($post) && (int)$post > 0) {
         $ids[] = (int)$post;
       }
     }
-    return $ids;
+
+    return array_slice($ids, 0, self::MAX_POSTS);
   }
 
   /**
@@ -847,10 +854,14 @@ class LatestPosts extends AbstractBlock {
 
   private function parsePx(string $value): int {
     $value = trim($value);
-    if ($value === '') {
+    if (substr($value, -2) === 'px') {
+      $value = substr($value, 0, -2);
+    }
+    // Other units (rem, em, %, presets) cannot be converted here
+    if (!is_numeric($value)) {
       return 0;
     }
-    return (int)round((float)str_replace('px', '', $value));
+    return (int)round((float)$value);
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypesController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypesController.php
@@ -2,18 +2,23 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Blocks;
 
+use MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes\LatestPosts;
 use MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes\PoweredByMailpoet;
 
 class BlockTypesController {
   private $poweredByMailPoet;
+  private LatestPosts $latestPosts;
 
   public function __construct(
-    PoweredByMailpoet $poweredByMailPoet
+    PoweredByMailpoet $poweredByMailPoet,
+    LatestPosts $latestPosts
   ) {
     $this->poweredByMailPoet = $poweredByMailPoet;
+    $this->latestPosts = $latestPosts;
   }
 
   public function initialize(): void {
     $this->poweredByMailPoet->initialize();
+    $this->latestPosts->initialize();
   }
 }

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -759,6 +759,24 @@ class Functions {
     return wpautop($pee, $br);
   }
 
+  /**
+   * @param int|string|\WP_Post|null $post
+   */
+  public function hasBlocks($post = null): bool {
+    return has_blocks($post);
+  }
+
+  /**
+   * @param int|\WP_Post|null $post
+   */
+  public function postPasswordRequired($post = null): bool {
+    return post_password_required($post);
+  }
+
+  public function stripShortcodes(string $content): string {
+    return strip_shortcodes($content);
+  }
+
   public function inTheLoop(): bool {
     return in_the_loop();
   }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -1,0 +1,324 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\EmailEditor\Integrations\MailPoet\Blocks;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes\LatestPosts;
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterPostEntity;
+use MailPoet\Newsletter\NewsletterPostsRepository;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\WP\Functions as WPFunctions;
+
+class LatestPostsTest extends \MailPoetTest {
+  private LatestPosts $block;
+  private WPFunctions $wp;
+  private NewsletterPostsRepository $newsletterPostsRepository;
+
+  /** @var int[] */
+  private $postIds = [];
+
+  /** @var \WP_Post|null */
+  private $previousGlobalPost;
+
+  public function _before(): void {
+    parent::_before();
+    $this->block = $this->diContainer->get(LatestPosts::class);
+    $this->wp = $this->diContainer->get(WPFunctions::class);
+    $this->newsletterPostsRepository = $this->diContainer->get(NewsletterPostsRepository::class);
+    $globalPost = $GLOBALS['post'] ?? null;
+    $this->previousGlobalPost = $globalPost instanceof \WP_Post ? $globalPost : null;
+
+    foreach ($this->wp->getPosts(['post_type' => ['post', 'page', 'product'], 'post_status' => 'any', 'numberposts' => -1]) as $post) {
+      $this->wp->wpDeletePost((int)$post->ID, true);
+    }
+
+    $this->postIds[] = $this->createPost('Latest posts block A', '2020-01-01 01:01:01');
+    $this->postIds[] = $this->createPost('Latest posts block B', '2020-02-01 01:01:01');
+    $this->postIds[] = $this->createPost('Latest posts block C', '2020-03-01 01:01:01');
+  }
+
+  public function _after(): void {
+    foreach ($this->postIds as $postId) {
+      $this->wp->wpDeletePost($postId, true);
+    }
+    $GLOBALS['post'] = $this->previousGlobalPost;
+    parent::_after();
+  }
+
+  public function testItRendersLatestPosts(): void {
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 2]);
+
+    verify($html)->stringContainsString('Latest posts block C');
+    verify($html)->stringContainsString('Latest posts block B');
+    verify($html)->stringNotContainsString('Latest posts block A');
+  }
+
+  public function testItRendersOnlyTheComposedInnerBlocks(): void {
+    // Each render uses its own newsletter so cross-block deduplication does not
+    // carry the selected post over between the two independent renders.
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+    $titleOnly = $this->render(['perPage' => 1], [], [$this->block('core/post-title')]);
+    verify($titleOnly)->stringContainsString('Latest posts block C');
+    verify($titleOnly)->stringNotContainsString('excerpt content');
+
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+    $withExcerpt = $this->render(['perPage' => 1], [], [
+      $this->block('core/post-title'),
+      $this->block('core/post-excerpt'),
+    ]);
+    verify($withExcerpt)->stringContainsString('Latest posts block C');
+    verify($withExcerpt)->stringContainsString('excerpt content');
+  }
+
+  public function testItRendersDefaultLayoutWhenInsertedWithoutInnerBlocks(): void {
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    // Patterns and templates insert the block as self-closing (no inner blocks).
+    $html = $this->block->renderEmail('', [
+      'blockName' => 'mailpoet/latest-posts',
+      'attrs' => ['query' => ['perPage' => 2]],
+      'innerBlocks' => [],
+    ], null);
+
+    verify($html)->stringContainsString('Latest posts block C');
+    verify($html)->stringContainsString('Latest posts block B');
+    verify($html)->stringContainsString('excerpt content');
+  }
+
+  public function testItDoesNotRepeatPostsAcrossBlocksInTheSameNewsletter(): void {
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $firstBlockHtml = $this->render(['perPage' => 1]);
+    $secondBlockHtml = $this->render(['perPage' => 1]);
+
+    verify($firstBlockHtml)->stringContainsString('Latest posts block C');
+    verify($firstBlockHtml)->stringNotContainsString('Latest posts block B');
+    verify($secondBlockHtml)->stringNotContainsString('Latest posts block C');
+    verify($secondBlockHtml)->stringContainsString('Latest posts block B');
+  }
+
+  public function testItRendersOnlyPostsNewerThanLastSentForNotificationHistory(): void {
+    $notification = $this->createBlockEmailNewsletter(NewsletterEntity::TYPE_NOTIFICATION);
+    $history = $this->createBlockEmailNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, $notification);
+    $this->setCurrentEmailPostForNewsletter($history);
+
+    $newsletterPost = new NewsletterPostEntity($notification, $this->postIds[1]);
+    $this->newsletterPostsRepository->persist($newsletterPost);
+    $this->newsletterPostsRepository->flush();
+    $newsletterPost->setCreatedAt(new \DateTime('2020-02-15 01:01:01'));
+    $this->newsletterPostsRepository->flush();
+
+    $html = $this->render(['perPage' => 3]);
+
+    verify($html)->stringContainsString('Latest posts block C');
+    verify($html)->stringNotContainsString('Latest posts block B');
+    verify($html)->stringNotContainsString('Latest posts block A');
+  }
+
+  public function testItSupportsPages(): void {
+    $this->postIds[] = $this->createPost('Latest pages block A', '2020-04-01 01:01:01', 'page');
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['postType' => 'page']);
+
+    verify($html)->stringContainsString('Latest pages block A');
+    verify($html)->stringNotContainsString('Latest posts block C');
+  }
+
+  public function testItSupportsCustomPostTypes(): void {
+    $this->postIds[] = $this->createPost('Latest products block A', '2020-04-01 01:01:01', 'product');
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['postType' => 'product']);
+
+    verify($html)->stringContainsString('Latest products block A');
+    verify($html)->stringNotContainsString('Latest posts block C');
+  }
+
+  public function testItRespectsOldestOrder(): void {
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1, 'order' => 'oldest']);
+
+    verify($html)->stringContainsString('Latest posts block A');
+    verify($html)->stringNotContainsString('Latest posts block C');
+  }
+
+  public function testItRendersPostsInColumns(): void {
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 2], ['columns' => 2]);
+
+    verify($html)->stringContainsString('width="50%"');
+    verify(substr_count($html, '<td valign="top" width="50%"'))->equals(2);
+  }
+
+  public function testItIncludesPostsFromSelectedCategory(): void {
+    $categoryId = $this->createTerm('Latest posts category', 'category');
+    wp_set_object_terms($this->postIds[0], [$categoryId], 'category');
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render([
+      'perPage' => 10,
+      'terms' => [['taxonomy' => 'category', 'id' => $categoryId]],
+      'inclusionType' => 'include',
+    ]);
+
+    verify($html)->stringContainsString('Latest posts block A');
+    verify($html)->stringNotContainsString('Latest posts block B');
+    verify($html)->stringNotContainsString('Latest posts block C');
+  }
+
+  public function testItExcludesPostsFromSelectedCategory(): void {
+    $categoryId = $this->createTerm('Latest posts category', 'category');
+    wp_set_object_terms($this->postIds[0], [$categoryId], 'category');
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render([
+      'perPage' => 10,
+      'terms' => [['taxonomy' => 'category', 'id' => $categoryId]],
+      'inclusionType' => 'exclude',
+    ]);
+
+    verify($html)->stringNotContainsString('Latest posts block A');
+    verify($html)->stringContainsString('Latest posts block B');
+    verify($html)->stringContainsString('Latest posts block C');
+  }
+
+  public function testItRendersManuallySelectedPosts(): void {
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render([
+      'selectionMode' => 'manual',
+      'posts' => [$this->postIds[0]],
+    ]);
+
+    verify($html)->stringContainsString('Latest posts block A');
+    verify($html)->stringNotContainsString('Latest posts block B');
+    verify($html)->stringNotContainsString('Latest posts block C');
+  }
+
+  public function testItRendersNoPostsMessageForEmptyManualSelection(): void {
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render([
+      'selectionMode' => 'manual',
+      'posts' => [],
+    ]);
+
+    verify($html)->stringContainsString('No posts found.');
+    verify($html)->stringNotContainsString('Latest posts block');
+  }
+
+  public function testItRewritesLinkColorSelectorSoItCanBeInlined(): void {
+    // WordPress styles link colors with a `:where()` selector the email CSS
+    // inliner cannot parse; it must be rewritten to a `:not()` equivalent.
+    $styles = '.wp-elements-abc a:where(:not(.wp-element-button)){color:#ff0000;}';
+
+    $result = $this->block->makeLinkColorStylesInlineable($styles);
+
+    verify($result)->stringContainsString('a:not(.wp-element-button)');
+    verify($result)->stringNotContainsString(':where(');
+  }
+
+  /**
+   * @param array<string, mixed> $query
+   * @param array<string, mixed> $displayLayout
+   * @param array<int, array<string, mixed>> $templateBlocks
+   */
+  private function render(array $query = [], array $displayLayout = [], array $templateBlocks = []): string {
+    if (!$templateBlocks) {
+      $templateBlocks = [$this->block('core/post-title')];
+    }
+
+    $parsedBlock = [
+      'blockName' => 'mailpoet/latest-posts',
+      'attrs' => [
+        'query' => $query,
+        'displayLayout' => $displayLayout,
+      ],
+      'innerHTML' => '',
+      'innerContent' => [],
+      'innerBlocks' => [
+        [
+          'blockName' => 'mailpoet/latest-posts-template',
+          'attrs' => [],
+          'innerHTML' => '',
+          'innerContent' => [],
+          'innerBlocks' => $templateBlocks,
+        ],
+      ],
+    ];
+
+    return $this->block->renderEmail('', $parsedBlock, null);
+  }
+
+  /**
+   * @param array<string, mixed> $attrs
+   * @return array<string, mixed>
+   */
+  private function block(string $blockName, array $attrs = []): array {
+    return [
+      'blockName' => $blockName,
+      'attrs' => $attrs,
+      'innerHTML' => '',
+      'innerContent' => [],
+      'innerBlocks' => [],
+    ];
+  }
+
+  private function createTerm(string $name, string $taxonomy): int {
+    $term = wp_insert_term($name, $taxonomy);
+    if ($term instanceof \WP_Error) {
+      $existingId = $term->get_error_data('term_exists');
+      $this->assertIsNumeric($existingId);
+      return (int)$existingId;
+    }
+    $this->assertIsArray($term);
+    return (int)$term['term_id'];
+  }
+
+  private function createPost(string $title, string $publishDate, string $postType = 'post'): int {
+    return $this->wp->wpInsertPost([
+      'post_title' => $title,
+      'post_content' => $title . ' excerpt content',
+      'post_status' => 'publish',
+      'post_date' => $publishDate,
+      'post_date_gmt' => $this->wp->getGmtFromDate($publishDate),
+      'post_type' => $postType,
+    ]);
+  }
+
+  private function createBlockEmailNewsletter(string $type, ?NewsletterEntity $parent = null): NewsletterEntity {
+    $postId = $this->wp->wpInsertPost([
+      'post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
+      'post_status' => 'publish',
+      'post_title' => 'Latest posts email',
+      'post_content' => '<!-- wp:mailpoet/latest-posts /-->',
+    ]);
+    $this->assertGreaterThan(0, $postId);
+    $this->postIds[] = $postId;
+
+    $factory = (new NewsletterFactory())
+      ->withType($type)
+      ->withStatus(NewsletterEntity::STATUS_ACTIVE)
+      ->withWpPostId($postId);
+
+    if ($parent instanceof NewsletterEntity) {
+      $factory->withParent($parent);
+    }
+
+    return $factory->create();
+  }
+
+  private function setCurrentEmailPostForNewsletter(NewsletterEntity $newsletter): void {
+    $wpPostId = $newsletter->getWpPostId();
+    $this->assertIsInt($wpPostId);
+    $post = $this->wp->getPost($wpPostId);
+    $this->assertInstanceOf(\WP_Post::class, $post);
+    $GLOBALS['post'] = $post;
+  }
+}

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -465,6 +465,38 @@ class LatestPostsTest extends \MailPoetTest {
     verify(in_array('core/paragraph', $allowed, true))->true();
   }
 
+  public function testItTagsEachPostWithADataPostIdForNotificationHistory(): void {
+    // Post notifications detect already-sent posts by scanning the rendered
+    // email for data-post-id attributes, so every post must carry exactly one.
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 2]);
+
+    verify(substr_count($html, 'data-post-id'))->equals(2);
+    verify($html)->stringContainsString('data-post-id="' . $this->postIds[2] . '"');
+    verify($html)->stringContainsString('data-post-id="' . $this->postIds[1] . '"');
+
+    // The IDs must be readable by the sending task's extraction regex.
+    preg_match_all('/data-post-id="(\d+)"/', $html, $matches);
+    verify(array_map('intval', $matches[1]))->equals([$this->postIds[2], $this->postIds[1]]);
+  }
+
+  public function testItKeepsDataPostIdThroughTheFullRenderingPipeline(): void {
+    // The attribute must survive CSS inlining so the sending task can read it
+    // from the final email HTML.
+    $content = '<!-- wp:mailpoet/latest-posts {"query":{"perPage":2},"displayLayout":{"columns":1}} -->'
+      . '<!-- wp:mailpoet/latest-posts-template --><!-- wp:post-title /--><!-- /wp:mailpoet/latest-posts-template -->'
+      . '<!-- /wp:mailpoet/latest-posts -->';
+    $newsletter = $this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD, null, $content);
+
+    $rendered = $this->diContainer->get(Renderer::class)->renderAsPreview($newsletter);
+    $this->assertIsArray($rendered);
+    $html = $rendered['html'] ?? '';
+    $this->assertIsString($html);
+
+    verify(substr_count($html, 'data-post-id'))->equals(2);
+  }
+
   public function testItRewritesLinkColorSelectorSoItCanBeInlined(): void {
     // WordPress styles link colors with a `:where()` selector the email CSS
     // inliner cannot parse; it must be rewritten to a `:not()` equivalent.

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -482,6 +482,7 @@ class LatestPostsTest extends \MailPoetTest {
     $this->assertIsArray($allowed);
     verify(in_array('mailpoet/latest-posts', $allowed, true))->false();
     verify(in_array('mailpoet/latest-posts-template', $allowed, true))->false();
+    verify(in_array('mailpoet/post-content', $allowed, true))->false();
     // Other blocks remain available.
     verify(in_array('core/paragraph', $allowed, true))->true();
   }
@@ -552,6 +553,114 @@ class LatestPostsTest extends \MailPoetTest {
     verify($result)->stringNotContainsString(':where(');
   }
 
+  public function testItRendersFullContentOfBlockPosts(): void {
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts full content',
+      '<!-- wp:paragraph --><p>Full block paragraph</p><!-- /wp:paragraph -->'
+      . '<!-- wp:verse --><pre class="wp-block-verse">Verse text here</pre><!-- /wp:verse -->'
+    );
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1], [], [$this->block('mailpoet/post-content')]);
+
+    verify($html)->stringContainsString('Full block paragraph');
+    // core/verse has no email support, so it is left out.
+    verify($html)->stringNotContainsString('Verse text here');
+  }
+
+  public function testItDropsUnsupportedBlocksNestedInSupportedOnes(): void {
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts nested content',
+      '<!-- wp:group --><div class="wp-block-group">'
+      . '<!-- wp:paragraph --><p>Nested safe paragraph</p><!-- /wp:paragraph -->'
+      . '<!-- wp:verse --><pre class="wp-block-verse">Nested verse</pre><!-- /wp:verse -->'
+      . '</div><!-- /wp:group -->'
+    );
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1], [], [$this->block('mailpoet/post-content')]);
+
+    verify($html)->stringContainsString('Nested safe paragraph');
+    verify($html)->stringNotContainsString('Nested verse');
+  }
+
+  public function testItRendersClassicContentAsEmailSafeHtml(): void {
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts classic content',
+      "Classic intro text\n\n<iframe src=\"https://example.com/embed\"></iframe>More classic text [gallery]"
+    );
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1], [], [$this->block('mailpoet/post-content')]);
+
+    verify($html)->stringContainsString('<p>Classic intro text</p>');
+    verify($html)->stringContainsString('More classic text');
+    verify($html)->stringNotContainsString('<iframe');
+    verify($html)->stringNotContainsString('[gallery]');
+  }
+
+  public function testItSkipsContentOfPasswordProtectedPosts(): void {
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts protected content',
+      '<!-- wp:paragraph --><p>Hidden protected content</p><!-- /wp:paragraph -->',
+      ['post_password' => 'secret']
+    );
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1], [], [$this->block('mailpoet/post-content')]);
+
+    verify($html)->stringNotContainsString('Hidden protected content');
+  }
+
+  public function testItDoesNotRenderItsOwnBlocksInsidePostContent(): void {
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts recursive content',
+      '<!-- wp:paragraph --><p>Recursive safe paragraph</p><!-- /wp:paragraph -->'
+      . '<!-- wp:mailpoet/post-content /-->'
+      . '<!-- wp:mailpoet/latest-posts /-->'
+    );
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1], [], [$this->block('mailpoet/post-content')]);
+
+    verify($html)->stringContainsString('Recursive safe paragraph');
+    // Rendering exactly one post means the nested blocks did not run the loop again.
+    verify(substr_count($html, 'Recursive safe paragraph'))->equals(1);
+  }
+
+  public function testItDoesNotWrapPostContentInnerBlocksWithRootPadding(): void {
+    // The whole block already sits inside the email root padding; inner blocks
+    // with their own wrapper would be indented twice.
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts padding post',
+      '<!-- wp:paragraph --><p>Padding check paragraph</p><!-- /wp:paragraph -->'
+      . '<!-- wp:heading --><h2 class="wp-block-heading">Padding check heading</h2><!-- /wp:heading -->'
+    );
+    $content = '<!-- wp:mailpoet/latest-posts {"query":{"perPage":1},"displayLayout":{"columns":1}} -->'
+      . '<!-- wp:mailpoet/latest-posts-template --><!-- wp:post-title /--><!-- wp:mailpoet/post-content /--><!-- /wp:mailpoet/latest-posts-template -->'
+      . '<!-- /wp:mailpoet/latest-posts -->';
+    $newsletter = $this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD, null, $content);
+
+    $rendered = $this->diContainer->get(Renderer::class)->renderAsPreview($newsletter);
+    $this->assertIsArray($rendered);
+    $html = $rendered['html'] ?? '';
+    $this->assertIsString($html);
+
+    $start = strpos($html, 'data-post-id');
+    $end = strpos($html, 'Padding check heading');
+    $this->assertIsInt($start);
+    $this->assertIsInt($end);
+    $this->assertGreaterThan($start, $end);
+
+    verify(substr($html, $start, $end - $start))->stringNotContainsString('email-root-padding');
+  }
+
   /**
    * @param array<string, mixed> $query
    * @param array<string, mixed> $displayLayout
@@ -607,6 +716,31 @@ class LatestPostsTest extends \MailPoetTest {
     }
     $this->assertIsArray($term);
     return (int)$term['term_id'];
+  }
+
+  private function ensurePostContentBlockRegistered(): void {
+    if (!\WP_Block_Type_Registry::get_instance()->is_registered('mailpoet/post-content')) {
+      $this->block->initialize();
+    }
+    $this->assertTrue(
+      \WP_Block_Type_Registry::get_instance()->is_registered('mailpoet/post-content'),
+      'mailpoet/post-content is not registered; run `pnpm compile:js` to generate its dist block.json first.'
+    );
+  }
+
+  /**
+   * @param array<string, mixed> $extra
+   */
+  private function createPostWithContent(string $title, string $content, array $extra = []): int {
+    $publishDate = '2020-05-01 01:01:01';
+    return $this->wp->wpInsertPost(array_merge([
+      'post_title' => $title,
+      'post_content' => $content,
+      'post_status' => 'publish',
+      'post_date' => $publishDate,
+      'post_date_gmt' => $this->wp->getGmtFromDate($publishDate),
+      'post_type' => 'post',
+    ], $extra));
   }
 
   private function createPost(string $title, string $publishDate, string $postType = 'post'): int {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -7,6 +7,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterPostEntity;
 use MailPoet\Newsletter\NewsletterPostsRepository;
+use MailPoet\Newsletter\Renderer\Renderer;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -152,8 +153,12 @@ class LatestPostsTest extends \MailPoetTest {
 
     $html = $this->render(['perPage' => 2], ['columns' => 2]);
 
-    verify($html)->stringContainsString('width="50%"');
-    verify(substr_count($html, '<td valign="top" width="50%"'))->equals(2);
+    // Columns are rendered with the core email Columns/Column renderers, so the
+    // output matches how the editor renders a real core/columns block.
+    verify($html)->stringContainsString('email-block-columns');
+    verify(substr_count($html, 'email-block-column-content'))->equals(2);
+    verify($html)->stringContainsString('Latest posts block C');
+    verify($html)->stringContainsString('Latest posts block B');
   }
 
   public function testItIncludesPostsFromSelectedCategory(): void {
@@ -211,6 +216,213 @@ class LatestPostsTest extends \MailPoetTest {
 
     verify($html)->stringContainsString('No posts found.');
     verify($html)->stringNotContainsString('Latest posts block');
+  }
+
+  public function testItRendersFeaturedImageAsRegularImageBlock(): void {
+    // core/post-featured-image renders as a bare <figure> with a fixed height
+    // and object-fit:cover. It must be routed through the email image renderer
+    // so it is table-wrapped and scales by width like a regular image block.
+    [$attachmentId, $url] = $this->createAttachment();
+    $figure = sprintf(
+      '<figure class="wp-block-post-featured-image"><img width="600" height="400" src="%s" class="wp-post-image" alt="" style="object-fit:cover;" srcset="%s 600w" sizes="100vw" /></figure>',
+      $url,
+      $url
+    );
+
+    $html = $this->block->renderImageBlockForEmail($figure, [
+      'blockName' => 'core/post-featured-image',
+      'attrs' => ['id' => $attachmentId, 'sizeSlug' => 'full'],
+      'email_attrs' => ['width' => '320px'],
+    ], $this->renderingContext());
+
+    verify($html)->stringContainsString('<table');
+    verify($html)->stringNotContainsString('<figure');
+    verify($html)->stringContainsString($url);
+
+    $image = $this->getImageAttributes($html);
+    // Filling the available width (capped by the 600px intrinsic size).
+    verify($image['width'])->equals(320);
+    // No fixed height + no object-fit means it keeps its natural aspect ratio.
+    verify($image['height'])->null();
+    verify((string)$image['style'])->stringNotContainsString('object-fit');
+
+    wp_delete_post($attachmentId, true);
+  }
+
+  public function testItRendersAvatarAsRegularImageBlockKeepingItsSize(): void {
+    // core/avatar renders as a <div><img> at a fixed pixel size. It must be
+    // table-wrapped like an image while keeping that size (not stretched).
+    $avatar = '<div class="wp-block-avatar">'
+      . '<img src="http://example.com/avatar.jpg" alt="" class="avatar" height="96" width="96" />'
+      . '</div>';
+
+    $html = $this->block->renderImageBlockForEmail($avatar, [
+      'blockName' => 'core/avatar',
+      'attrs' => [],
+      'email_attrs' => ['width' => '600px'],
+    ], $this->renderingContext());
+
+    verify($html)->stringContainsString('<table');
+    verify($html)->stringNotContainsString('<div class="wp-block-avatar"');
+
+    $image = $this->getImageAttributes($html);
+    verify($image['width'])->equals(96);
+    verify($image['height'])->null();
+  }
+
+  public function testItAppliesTheBlocksOwnTopMarginToTheFirstRow(): void {
+    // The block itself is a render_email_callback, so the engine never wraps it
+    // in add_spacer. We carry the block's engine-assigned margin-top onto the
+    // first row: present when a block precedes us, absent when we are first.
+    $template = '<!-- wp:mailpoet/latest-posts {"query":{"perPage":1},"displayLayout":{"columns":1}} -->'
+      . '<!-- wp:mailpoet/latest-posts-template --><!-- wp:post-title /--><!-- /wp:mailpoet/latest-posts-template -->'
+      . '<!-- /wp:mailpoet/latest-posts -->';
+
+    $whenFirst = $this->getRenderedBlockOutput($template);
+    $whenPreceded = $this->getRenderedBlockOutput('<!-- wp:paragraph --><p>Intro</p><!-- /wp:paragraph -->' . $template);
+
+    verify($this->firstLayoutStyle($whenFirst))->stringNotContainsString('margin-top');
+    verify($this->firstLayoutStyle($whenPreceded))->stringContainsString('margin-top');
+  }
+
+  /**
+   * Renders an email and returns the raw HTML our latest-posts block produced
+   * (captured before CSS inlining via the engine's render_block filter).
+   */
+  private function getRenderedBlockOutput(string $content): string {
+    $captured = '';
+    $capture = static function ($blockContent, $parsedBlock) use (&$captured) {
+      if (($parsedBlock['blockName'] ?? '') === 'mailpoet/latest-posts') {
+        $captured = (string)$blockContent;
+      }
+      return $blockContent;
+    };
+    add_filter('render_block', $capture, 11, 2);
+    try {
+      $newsletter = $this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD, null, $content);
+      $this->diContainer->get(Renderer::class)->renderAsPreview($newsletter);
+    } finally {
+      remove_filter('render_block', $capture, 11);
+    }
+    return $captured;
+  }
+
+  private function firstLayoutStyle(string $html): string {
+    $processor = new \WP_HTML_Tag_Processor($html);
+    while ($processor->next_tag('div')) {
+      $class = (string)$processor->get_attribute('class');
+      if (strpos($class, 'email-block-layout') !== false) {
+        return (string)$processor->get_attribute('style');
+      }
+    }
+    return '';
+  }
+
+  public function testItSpacesRowsUsingTheEngineLayoutSpacerNotABespokeMargin(): void {
+    // Posts/rows must be separated with the engine's own add_spacer output
+    // (`email-block-layout` margin-top), like every other block, not a custom
+    // margin wrapper.
+    $content = '<!-- wp:mailpoet/latest-posts {"query":{"perPage":3},"displayLayout":{"columns":1}} -->'
+      . '<!-- wp:mailpoet/latest-posts-template --><!-- wp:post-title /--><!-- /wp:mailpoet/latest-posts-template -->'
+      . '<!-- /wp:mailpoet/latest-posts -->';
+    $newsletter = $this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD, null, $content);
+
+    $rendered = $this->diContainer->get(Renderer::class)->renderAsPreview($newsletter);
+    $this->assertIsArray($rendered);
+    $html = $rendered['html'] ?? '';
+    $this->assertIsString($html);
+
+    verify($html)->stringNotContainsString('margin:0 0');
+    verify($html)->stringContainsString('email-block-layout');
+    verify($html)->stringContainsString('margin-top');
+  }
+
+  public function testItFitsColumnsAndGapWithinTheAvailableWidth(): void {
+    // The engine applies the column gap as padding on top of the column widths,
+    // which would overflow the row. We pre-shrink the split so the columns plus
+    // the gap add up to the available width: the single-column image width.
+    [$attachmentId] = $this->createAttachment();
+    set_post_thumbnail($this->postIds[1], $attachmentId);
+    set_post_thumbnail($this->postIds[2], $attachmentId);
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $singleColumn = $this->render(['perPage' => 1], ['columns' => 1], [$this->block('core/post-featured-image', ['sizeSlug' => 'full'])]);
+    $available = $this->getImageAttributes($singleColumn)['width'];
+    $this->assertIsInt($available);
+
+    $twoColumns = $this->render(['perPage' => 2], ['columns' => 2], [$this->block('core/post-featured-image', ['sizeSlug' => 'full'])]);
+    $layout = $this->getColumnLayout($twoColumns);
+
+    verify(count($layout['widths']))->equals(2);
+    verify($layout['widths'][0])->equals($layout['widths'][1]);
+    verify($layout['gap'])->greaterThan(0);
+    // Columns + the inter-column gap must not exceed the available width.
+    verify($layout['widths'][0] + $layout['widths'][1] + $layout['gap'])->lessThanOrEqual($available);
+
+    wp_delete_post($attachmentId, true);
+  }
+
+  public function testItRendersFeaturedImageAtFullWidthInSingleColumn(): void {
+    // In a single-column layout the featured image fills the whole content
+    // width (capped only by its 600px intrinsic size).
+    [$attachmentId] = $this->createAttachment();
+    set_post_thumbnail($this->postIds[2], $attachmentId);
+
+    $content = '<!-- wp:mailpoet/latest-posts {"query":{"perPage":1},"displayLayout":{"columns":1}} -->'
+      . '<!-- wp:mailpoet/latest-posts-template -->'
+      . '<!-- wp:post-featured-image {"sizeSlug":"full"} /-->'
+      . '<!-- wp:post-title /-->'
+      . '<!-- /wp:mailpoet/latest-posts-template -->'
+      . '<!-- /wp:mailpoet/latest-posts -->';
+    $newsletter = $this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD, null, $content);
+
+    $rendered = $this->diContainer->get(Renderer::class)->renderAsPreview($newsletter);
+    $this->assertIsArray($rendered);
+    $html = $rendered['html'] ?? '';
+    $this->assertIsString($html);
+
+    $src = wp_get_attachment_image_url($attachmentId, 'full');
+    $this->assertIsString($src);
+    $image = $this->getImageAttributesBySrc($html, basename($src));
+    $this->assertNotNull($image);
+    $this->assertNotNull($image['width']);
+    // Single column: image spans the full content width, well above a column.
+    verify($image['width'])->greaterThan(400);
+    verify($image['height'])->null();
+
+    wp_delete_post($attachmentId, true);
+  }
+
+  public function testItConstrainsFeaturedImageToColumnWidthInRenderedEmail(): void {
+    // In a multi-column layout the featured image must be capped to the column
+    // width, not the full email width, or it overflows the email container.
+    [$attachmentId] = $this->createAttachment();
+    set_post_thumbnail($this->postIds[2], $attachmentId);
+
+    $content = '<!-- wp:mailpoet/latest-posts {"query":{"perPage":1},"displayLayout":{"columns":2}} -->'
+      . '<!-- wp:mailpoet/latest-posts-template -->'
+      . '<!-- wp:post-featured-image {"sizeSlug":"full"} /-->'
+      . '<!-- wp:post-title /-->'
+      . '<!-- /wp:mailpoet/latest-posts-template -->'
+      . '<!-- /wp:mailpoet/latest-posts -->';
+    $newsletter = $this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD, null, $content);
+
+    $rendered = $this->diContainer->get(Renderer::class)->renderAsPreview($newsletter);
+    $this->assertIsArray($rendered);
+    $html = $rendered['html'] ?? '';
+    $this->assertIsString($html);
+
+    $src = wp_get_attachment_image_url($attachmentId, 'full');
+    $this->assertIsString($src);
+    $image = $this->getImageAttributesBySrc($html, basename($src));
+    $this->assertNotNull($image);
+    $this->assertNotNull($image['width']);
+    // Content width 600px in two columns leaves ~290px per column.
+    verify($image['width'])->lessThanOrEqual(320);
+    // No fixed height keeps the natural aspect ratio.
+    verify($image['height'])->null();
+
+    wp_delete_post($attachmentId, true);
   }
 
   public function testItRewritesLinkColorSelectorSoItCanBeInlined(): void {
@@ -292,12 +504,12 @@ class LatestPostsTest extends \MailPoetTest {
     ]);
   }
 
-  private function createBlockEmailNewsletter(string $type, ?NewsletterEntity $parent = null): NewsletterEntity {
+  private function createBlockEmailNewsletter(string $type, ?NewsletterEntity $parent = null, string $content = '<!-- wp:mailpoet/latest-posts /-->'): NewsletterEntity {
     $postId = $this->wp->wpInsertPost([
       'post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
       'post_status' => 'publish',
       'post_title' => 'Latest posts email',
-      'post_content' => '<!-- wp:mailpoet/latest-posts /-->',
+      'post_content' => $content,
     ]);
     $this->assertGreaterThan(0, $postId);
     $this->postIds[] = $postId;
@@ -320,5 +532,107 @@ class LatestPostsTest extends \MailPoetTest {
     $post = $this->wp->getPost($wpPostId);
     $this->assertInstanceOf(\WP_Post::class, $post);
     $GLOBALS['post'] = $post;
+  }
+
+  /**
+   * @return array{0: int, 1: string}
+   */
+  private function createAttachment(): array {
+    $filename = dirname(__DIR__, 5) . '/_data/600x400.jpg';
+    $contents = file_get_contents($filename);
+    $this->assertIsString($contents);
+    $upload = wp_upload_bits(basename($filename), null, $contents);
+    $this->assertEmpty($upload['error']);
+
+    $attachmentId = wp_insert_attachment([
+      'post_title' => basename($upload['file']),
+      'post_content' => '',
+      'post_type' => 'attachment',
+      'post_mime_type' => 'image/jpeg',
+      'guid' => $upload['url'],
+    ], $upload['file']);
+    $this->assertIsInt($attachmentId);
+    require_once ABSPATH . 'wp-admin/includes/image.php';
+    $metadata = wp_generate_attachment_metadata($attachmentId, $upload['file']);
+    wp_update_attachment_metadata($attachmentId, $metadata);
+
+    return [$attachmentId, $upload['url']];
+  }
+
+  private function renderingContext(): \Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context {
+    return new \Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context(new \WP_Theme_JSON());
+  }
+
+  /**
+   * Returns the numeric width/height of the first <img> whose src contains the
+   * given needle. A null value means the attribute is absent.
+   *
+   * @return array{width: ?int, height: ?int}|null
+   */
+  private function getImageAttributesBySrc(string $html, string $srcNeedle): ?array {
+    $processor = new \WP_HTML_Tag_Processor($html);
+    while ($processor->next_tag('img')) {
+      $src = $processor->get_attribute('src');
+      if (!is_string($src) || strpos($src, $srcNeedle) === false) {
+        continue;
+      }
+      $width = $processor->get_attribute('width');
+      $height = $processor->get_attribute('height');
+      return [
+        'width' => (is_string($width) && is_numeric($width)) ? (int)$width : null,
+        'height' => (is_string($height) && is_numeric($height)) ? (int)$height : null,
+      ];
+    }
+    return null;
+  }
+
+  /**
+   * Reads the per-column cell widths and the inter-column gap (padding-left of
+   * the non-first columns) from a rendered core/columns row.
+   *
+   * @return array{widths: int[], gap: int}
+   */
+  private function getColumnLayout(string $html): array {
+    $widths = [];
+    $gap = 0;
+    $processor = new \WP_HTML_Tag_Processor($html);
+    while ($processor->next_tag('td')) {
+      $class = (string)$processor->get_attribute('class');
+      if (strpos($class, 'email-block-column') === false || strpos($class, 'content') !== false) {
+        continue;
+      }
+      $width = $processor->get_attribute('width');
+      $widths[] = (is_string($width) && is_numeric($width)) ? (int)$width : 0;
+
+      $style = (string)$processor->get_attribute('style');
+      foreach (explode(';', $style) as $declaration) {
+        [$property, $value] = array_pad(explode(':', $declaration, 2), 2, '');
+        if (trim($property) === 'padding-left') {
+          $gap = max($gap, (int)round((float)str_replace('px', '', trim($value))));
+        }
+      }
+    }
+    return ['widths' => $widths, 'gap' => $gap];
+  }
+
+  /**
+   * Returns the numeric width/height attributes and style of the first <img>.
+   * A null width/height means the attribute is absent.
+   *
+   * @return array{width: ?int, height: ?int, style: ?string}
+   */
+  private function getImageAttributes(string $html): array {
+    $processor = new \WP_HTML_Tag_Processor($html);
+    if (!$processor->next_tag('img')) {
+      return ['width' => null, 'height' => null, 'style' => null];
+    }
+    $width = $processor->get_attribute('width');
+    $height = $processor->get_attribute('height');
+    $style = $processor->get_attribute('style');
+    return [
+      'width' => (is_string($width) && is_numeric($width)) ? (int)$width : null,
+      'height' => (is_string($height) && is_numeric($height)) ? (int)$height : null,
+      'style' => is_string($style) ? $style : null,
+    ];
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -19,6 +19,9 @@ class LatestPostsTest extends \MailPoetTest {
   /** @var int[] */
   private $postIds = [];
 
+  /** @var int[] */
+  private $attachmentIds = [];
+
   /** @var \WP_Post|null */
   private $previousGlobalPost;
 
@@ -40,6 +43,9 @@ class LatestPostsTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    foreach ($this->attachmentIds as $attachmentId) {
+      $this->wp->wpDeletePost($attachmentId, true);
+    }
     foreach ($this->postIds as $postId) {
       $this->wp->wpDeletePost($postId, true);
     }
@@ -281,7 +287,6 @@ class LatestPostsTest extends \MailPoetTest {
     verify($image['height'])->null();
     verify((string)$image['style'])->stringNotContainsString('object-fit');
 
-    wp_delete_post($attachmentId, true);
   }
 
   public function testItRendersAvatarAsRegularImageBlockKeepingItsSize(): void {
@@ -394,7 +399,6 @@ class LatestPostsTest extends \MailPoetTest {
     // Columns + the inter-column gap must not exceed the available width.
     verify($layout['widths'][0] + $layout['widths'][1] + $layout['gap'])->lessThanOrEqual($available);
 
-    wp_delete_post($attachmentId, true);
   }
 
   public function testItRendersFeaturedImageAtFullWidthInSingleColumn(): void {
@@ -425,7 +429,6 @@ class LatestPostsTest extends \MailPoetTest {
     verify($image['width'])->greaterThan(400);
     verify($image['height'])->null();
 
-    wp_delete_post($attachmentId, true);
   }
 
   public function testItConstrainsFeaturedImageToColumnWidthInRenderedEmail(): void {
@@ -457,7 +460,6 @@ class LatestPostsTest extends \MailPoetTest {
     // No fixed height keeps the natural aspect ratio.
     verify($image['height'])->null();
 
-    wp_delete_post($attachmentId, true);
   }
 
   public function testItKeepsTheBlockAvailableInsideTheEmailEditor(): void {
@@ -482,6 +484,29 @@ class LatestPostsTest extends \MailPoetTest {
     verify(in_array('mailpoet/latest-posts-template', $allowed, true))->false();
     // Other blocks remain available.
     verify(in_array('core/paragraph', $allowed, true))->true();
+  }
+
+  public function testItKeepsAnEmptyAllowListFromAnotherIntegration(): void {
+    $regularPost = $this->wp->getPost($this->postIds[0]);
+    $context = new \WP_Block_Editor_Context(['post' => $regularPost]);
+
+    // `false` means another integration disallowed every block; we must not
+    // turn that back into the full block list.
+    verify($this->block->restrictBlocksToEmailEditor(false, $context))->equals(false);
+  }
+
+  public function testItCapsTheNumberOfManuallySelectedPosts(): void {
+    $manual = $this->postIds;
+    for ($i = 0; $i < 100; $i++) {
+      $postId = $this->createPost('Manual cap post ' . $i, '2021-01-01 01:01:01');
+      $this->postIds[] = $postId;
+      $manual[] = $postId;
+    }
+
+    $html = $this->render(['selectionMode' => 'manual', 'posts' => $manual]);
+
+    // The same limit as the latest-posts query keeps huge selections in check.
+    verify(substr_count($html, 'data-post-id'))->equals(100);
   }
 
   public function testItTagsEachPostWithADataPostIdForNotificationHistory(): void {
@@ -643,6 +668,7 @@ class LatestPostsTest extends \MailPoetTest {
       'guid' => $upload['url'],
     ], $upload['file']);
     $this->assertIsInt($attachmentId);
+    $this->attachmentIds[] = $attachmentId;
     require_once ABSPATH . 'wp-admin/includes/image.php';
     $metadata = wp_generate_attachment_metadata($attachmentId, $upload['file']);
     wp_update_attachment_metadata($attachmentId, $metadata);

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -441,6 +441,30 @@ class LatestPostsTest extends \MailPoetTest {
     wp_delete_post($attachmentId, true);
   }
 
+  public function testItKeepsTheBlockAvailableInsideTheEmailEditor(): void {
+    $newsletter = $this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD);
+    $wpPostId = $newsletter->getWpPostId();
+    $this->assertIsInt($wpPostId);
+    $emailPost = $this->wp->getPost($wpPostId);
+    $context = new \WP_Block_Editor_Context(['post' => $emailPost]);
+
+    // The email editor leaves the allow-list untouched (blocks stay available).
+    verify($this->block->restrictBlocksToEmailEditor(true, $context))->equals(true);
+  }
+
+  public function testItHidesTheBlockOutsideTheEmailEditor(): void {
+    $regularPost = $this->wp->getPost($this->postIds[0]);
+    $context = new \WP_Block_Editor_Context(['post' => $regularPost]);
+
+    $allowed = $this->block->restrictBlocksToEmailEditor(true, $context);
+
+    $this->assertIsArray($allowed);
+    verify(in_array('mailpoet/latest-posts', $allowed, true))->false();
+    verify(in_array('mailpoet/latest-posts-template', $allowed, true))->false();
+    // Other blocks remain available.
+    verify(in_array('core/paragraph', $allowed, true))->true();
+  }
+
   public function testItRewritesLinkColorSelectorSoItCanBeInlined(): void {
     // WordPress styles link colors with a `:where()` selector the email CSS
     // inliner cannot parse; it must be rewritten to a `:not()` equivalent.

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -222,6 +222,25 @@ class LatestPostsTest extends \MailPoetTest {
     verify($html)->stringNotContainsString('Latest posts block C');
   }
 
+  public function testItPreservesTheOrderOfManuallySelectedPosts(): void {
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    // Pick in an order that is neither ascending nor descending by date.
+    $html = $this->render([
+      'selectionMode' => 'manual',
+      'posts' => [$this->postIds[1], $this->postIds[0], $this->postIds[2]],
+    ]);
+
+    $positionB = strpos($html, 'Latest posts block B');
+    $positionA = strpos($html, 'Latest posts block A');
+    $positionC = strpos($html, 'Latest posts block C');
+    $this->assertIsInt($positionB);
+    $this->assertIsInt($positionA);
+    $this->assertIsInt($positionC);
+    verify($positionB)->lessThan($positionA);
+    verify($positionA)->lessThan($positionC);
+  }
+
   public function testItRendersNoPostsMessageForEmptyManualSelection(): void {
     $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
 

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -129,6 +129,22 @@ class LatestPostsTest extends \MailPoetTest {
     verify($html)->stringNotContainsString('Latest posts block C');
   }
 
+  public function testItIgnoresCategoryTermsForPages(): void {
+    // Categories/tags are post-only, so stale terms left over from a "post"
+    // selection must not filter out pages (which belong to no such taxonomy).
+    $this->postIds[] = $this->createPost('Latest pages block A', '2020-04-01 01:01:01', 'page');
+    $categoryId = $this->createTerm('Latest posts category', 'category');
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render([
+      'postType' => 'page',
+      'terms' => [['taxonomy' => 'category', 'id' => $categoryId]],
+      'inclusionType' => 'include',
+    ]);
+
+    verify($html)->stringContainsString('Latest pages block A');
+  }
+
   public function testItSupportsCustomPostTypes(): void {
     $this->postIds[] = $this->createPost('Latest products block A', '2020-04-01 01:01:01', 'product');
     $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -631,6 +631,10 @@ const emailEditorBlocks = Object.assign({}, wpScriptConfig, {
           from: 'assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/block.json',
           to: 'latest-posts-template/block.json',
         },
+        {
+          from: 'assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/block.json',
+          to: 'latest-posts-post-content/block.json',
+        },
       ],
     }),
   ],

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -576,6 +576,8 @@ const emailEditorBlocks = Object.assign({}, wpScriptConfig, {
   entry: {
     'powered-by-mailpoet-block':
       '/assets/js/src/mailpoet-custom-email-editor-blocks/powered-by-mailpoet/block.tsx',
+    'latest-posts-block':
+      '/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/index.tsx',
     mailpoet: '/assets/js/src/mailpoet.ts',
   },
   output: {
@@ -620,6 +622,14 @@ const emailEditorBlocks = Object.assign({}, wpScriptConfig, {
         {
           from: 'assets/js/src/mailpoet-custom-email-editor-blocks/powered-by-mailpoet/block.json',
           to: 'powered-by-mailpoet/block.json',
+        },
+        {
+          from: 'assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/block.json',
+          to: 'latest-posts/block.json',
+        },
+        {
+          from: 'assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/block.json',
+          to: 'latest-posts-template/block.json',
         },
       ],
     }),


### PR DESCRIPTION
## Description

Adds a **Latest Posts** block to the block-based email editor. When the email is sent, it automatically pulls in your most recent posts and renders them with a per-post layout you design once and it repeats.

It uses two cooperating blocks - a similar container + repeating-template pattern as core's Query Loop / Post Template:

- **`mailpoet/latest-posts`** (container) - selection control - count, post type, order, offset, category/tag filtering (include or exclude), manual post selection, and 1–2 column layout.
- **`mailpoet/latest-posts-template`** (template) - the inner-block layout for a single post. It has a default layout of featured image, title, excerpt, but it allows full customization - add, remove, and move blocks.

The editor preview mirrors the server-side query so what you see matches what gets sent. At render time, posts are selected dynamically and the template's inner blocks are rendered once per post, with email-safe HTML.

## Code review notes

- `LatestPosts.php` is the render-side entry point. It registers both blocks, opts core inner blocks into email rendering, and wires the `render_email_callback` the email editor expects.
- `post-template/edit.tsx` (`buildRestQuery`) mirrors the server-side `BlockPostQuery` to keep preview and sent output in sync.

## QA notes

1. Add the **Latest Posts** block in the email editor. Confirm the default layout previews recent posts.
2. Adjust selection controls (count, order, offset, columns) and confirm the preview updates.
3. Filter by category and tag, using both include and exclude.
4. Use manual selection - pick/reorder posts; confirm an empty selection shows "No posts found."
5. Customize the per-post template and confirm it repeats for every post.
6. Send a test email and confirm it matches the preview.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8179: Add Posts / Automatic Latest Content email editor block](https://linear.app/a8c/issue/STOMAIL-8179/add-posts-automatic-latest-content-email-editor-block)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Email editor                          | Email preview                          |
| ------------------------------- | ------------------------------ |
| <img width="2870" height="1857" alt="4vI0G83S3pskSdLf@2x" src="https://github.com/user-attachments/assets/f5c5acd1-94de-4656-817b-f1b81ca597c2" /> | <img width="2706" height="1862" alt="KsH8j3O7tOO80A5G@2x" src="https://github.com/user-attachments/assets/f54b8203-131d-4b47-b84c-7e67588aad3f" /> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8179-add-posts-automatic-latest-content-email-editor-block)

_The latest successful build from `stomail-8179-add-posts-automatic-latest-content-email-editor-block` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->