### PR TITLE
Bump oldest WooCommerce CI matrix to 10.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1172,14 +1172,13 @@ workflows:
             - build_release_zip
 
   nightly:
-    # TEMP: triggers disabled to run nightly on push for CI verification — REVERT before merge
-    # triggers:
-    #   - schedule:
-    #       cron: '0 1 * * 1-5'
-    #       filters:
-    #         branches:
-    #           only:
-    #             - trunk
+    triggers:
+      - schedule:
+          cron: '0 1 * * 1-5'
+          filters:
+            branches:
+              only:
+                - trunk
     jobs:
       - build:
           <<: *slack-fail-post-step

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1172,13 +1172,14 @@ workflows:
             - build_release_zip
 
   nightly:
-    triggers:
-      - schedule:
-          cron: '0 1 * * 1-5'
-          filters:
-            branches:
-              only:
-                - trunk
+    # TEMP: triggers disabled to run nightly on push for CI verification — REVERT before merge
+    # triggers:
+    #   - schedule:
+    #       cron: '0 1 * * 1-5'
+    #       filters:
+    #         branches:
+    #           only:
+    #             - trunk
     jobs:
       - build:
           <<: *slack-fail-post-step
@@ -1211,7 +1212,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 10.7.0
+          woo_core_version: 10.8.1
           woo_subscriptions_version: 8.7.1
           automate_woo_version: 6.3.1
           mysql_command: --max_allowed_packet=100M
@@ -1254,7 +1255,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          woo_core_version: 10.7.0
+          woo_core_version: 10.8.1
           woo_subscriptions_version: 8.7.1
           automate_woo_version: 6.3.1
           codeception_image_version: 7.4-cli_20220605.0
@@ -1316,7 +1317,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_with_premium_oldest
-          woo_core_version: 10.7.0
+          woo_core_version: 10.8.1
           woo_subscriptions_version: 8.7.1
           automate_woo_version: 6.3.1
           codeception_image_version: 7.4-cli_20220605.0
@@ -1327,7 +1328,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_with_premium_oldest
-          woo_core_version: 10.7.0
+          woo_core_version: 10.8.1
           woo_subscriptions_version: 8.7.1
           automate_woo_version: 6.3.1
           codeception_image_version: 7.4-cli_20220605.0


### PR DESCRIPTION
## Description

The nightly `*_oldest` jobs were aborting before any test with:

```
In TablePrefixMetadataFactory.php line 30:
  [RuntimeException]
  DB table prefix not initialized
```

Commit bf5c295963 raised `MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION` from 10.7 to 10.8, but the `*_oldest` CI matrix still installed WooCommerce **10.7.0**. With WC below the new minimum, `mailpoet_check_requirements()` returns `false`, so the plugin initializer never loads, `Env::init()` never runs, `Env::$dbPrefix` stays `null`, and the integration/acceptance bootstrap throws at EntityManager creation — taking down the whole suite.

Pins the oldest matrix (4 jobs) to **10.8.1** (latest 10.8.x) to match the minimum.

## Code review notes

Verified on pipeline [24091](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/24091/workflows/afc51210-b81d-439d-a574-a81e960f8df1): with the schedule trigger temporarily disabled, nightly ran on push and all 5 oldest jobs (`integration_oldest`, `integration_with_premium_oldest`, `unit_oldest`, `acceptance_oldest`, `acceptance_with_premium_oldest`) went green. The trigger has been restored in a follow-up commit on this branch.

Unrelated: `acceptance_gutenberg_latest` had a separate flaky WebDriver failure in the original nightly — not addressed here.


## QA notes

CI config only; no plugin code changed.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/circleci-oldest-woocommerce-10-8-1)

_The latest successful build from `fix/circleci-oldest-woocommerce-10-8-1` will be used. If none is available, the link won't work._