### PR TITLE
Add hasPendingScheduledAction to automation ActionScheduler

### DIFF
--- a/mailpoet/lib/Automation/Engine/Control/ActionScheduler.php
+++ b/mailpoet/lib/Automation/Engine/Control/ActionScheduler.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Automation\Engine\Control;
 
 use ActionScheduler_Action;
+use ActionScheduler_Store;
 
 class ActionScheduler {
   private const GROUP_ID = 'mailpoet-automation';
@@ -19,6 +20,24 @@ class ActionScheduler {
 
   public function hasScheduledAction(string $hook, array $args = []): bool {
     return as_has_scheduled_action($hook, $args, self::GROUP_ID);
+  }
+
+  /**
+   * Unlike hasScheduledAction(), this only matches PENDING actions and ignores
+   * RUNNING ones. A recurring hook that reschedules itself from within its own
+   * handler must use this: while the handler runs, its own action has status
+   * RUNNING, so as_has_scheduled_action() would report the action as still
+   * scheduled and the next run would never be queued.
+   */
+  public function hasPendingScheduledAction(string $hook, array $args = []): bool {
+    $actions = as_get_scheduled_actions([
+      'hook' => $hook,
+      'args' => $args,
+      'status' => ActionScheduler_Store::STATUS_PENDING,
+      'group' => self::GROUP_ID,
+      'per_page' => 1,
+    ], 'ids');
+    return is_array($actions) && count($actions) > 0;
   }
 
   /** @return ActionScheduler_Action[] */

--- a/mailpoet/tests/integration/Automation/Engine/Control/ActionSchedulerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/ActionSchedulerTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Engine\Control;
+
+use MailPoet\Automation\Engine\Control\ActionScheduler;
+
+class ActionSchedulerTest extends \MailPoetTest {
+
+  private const TEST_HOOK = 'mailpoet/test/action-scheduler-wrapper';
+
+  /** @var ActionScheduler */
+  private $actionScheduler;
+
+  public function _before(): void {
+    parent::_before();
+    $this->actionScheduler = $this->diContainer->get(ActionScheduler::class);
+    $this->deleteTestActions();
+  }
+
+  public function _after(): void {
+    $this->deleteTestActions();
+    parent::_after();
+  }
+
+  public function testHasPendingScheduledActionReturnsFalseWhenNothingScheduled(): void {
+    $this->assertFalse($this->actionScheduler->hasPendingScheduledAction(self::TEST_HOOK));
+  }
+
+  public function testHasPendingScheduledActionDetectsPendingAction(): void {
+    $this->actionScheduler->schedule(time() + 3600, self::TEST_HOOK);
+    $this->assertTrue($this->actionScheduler->hasPendingScheduledAction(self::TEST_HOOK));
+  }
+
+  /**
+   * Regression for STOMAIL-8208: a hook that reschedules itself from within its
+   * own handler must not see its own action. While the handler runs, that action
+   * has status RUNNING. hasScheduledAction() matches RUNNING (so the next run was
+   * never queued and the chain died after one run); hasPendingScheduledAction()
+   * must ignore RUNNING so the next run can be scheduled.
+   */
+  public function testHasPendingScheduledActionIgnoresRunningAction(): void {
+    $actionId = $this->actionScheduler->schedule(time() + 3600, self::TEST_HOOK);
+    \ActionScheduler::store()->log_execution($actionId);
+
+    $this->assertTrue($this->actionScheduler->hasScheduledAction(self::TEST_HOOK));
+    $this->assertFalse($this->actionScheduler->hasPendingScheduledAction(self::TEST_HOOK));
+  }
+
+  private function deleteTestActions(): void {
+    global $wpdb;
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+    $wpdb->delete($wpdb->prefix . 'actionscheduler_actions', ['hook' => self::TEST_HOOK]);
+  }
+}


### PR DESCRIPTION
## Description

Adds `hasPendingScheduledAction()` to the automation `ActionScheduler` wrapper. `as_has_scheduled_action()` matches both RUNNING and PENDING actions; a hook that reschedules itself from inside its own handler can't use it, because while the handler runs its own action is RUNNING. This PENDING-only check enables the premium fix for STOMAIL-8208.

## Code review notes

`hasScheduledAction()` is intentionally left unchanged — all other callers (DaemonTrigger, StepScheduler, etc.) rely on the RUNNING+PENDING semantics. The new method is purely additive.

## QA notes

`ActionSchedulerTest` includes `testHasPendingScheduledActionIgnoresRunningAction`, which flips a real action to RUNNING via `log_execution()` and proves the wrapper ignores it while `hasScheduledAction()` still matches it.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1113 — premium fix that consumes this method (STOMAIL-8208)

## Linked tickets

STOMAIL-8208

## After-merge notes

_N/A_

## Tasks

- [x] I added sufficient test coverage

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8208-birthday-automation-sometimes-stops-running-after-first)

_The latest successful build from `fix/stomail-8208-birthday-automation-sometimes-stops-running-after-first` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->