### PR TITLE
Add email editor personalization tags for legacy shortcodes

### DIFF
--- a/mailpoet/changelog/2026-06-26-14-03-15-added-personalization-tags-for-subscriber-display-name-s.md
+++ b/mailpoet/changelog/2026-06-26-14-03-15-added-personalization-tags-for-subscriber-display-name-s.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Personalization tags for subscriber display name, subscriber count, custom fields, newsletter subject, and date in the email editor

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -407,8 +407,10 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\OrderProductCollectionProcessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\ProductCollection\ProductCollectionEmailRendererRegistrar::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Date::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Link::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\LinksToShortcodesConvertor::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Newsletter::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUrl::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Site::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Subscriber::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -7,8 +7,11 @@ use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalizatio
 use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Date;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Link;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\LinksToShortcodesConvertor;
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Newsletter;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUrl;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Site;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Subscriber;
@@ -19,33 +22,42 @@ class PersonalizationTagManager {
   private Subscriber $subscriber;
   private Site $site;
   private Link $link;
+  private Newsletter $newsletter;
+  private Date $date;
   private OrderReviewUrl $orderReviewUrl;
   private WPFunctions $wp;
   private LinksToShortcodesConvertor $linksToShortcodesConvertor;
   private AutomationStorage $automationStorage;
   private Registry $registry;
   private NewslettersRepository $newslettersRepository;
+  private CustomFieldsRepository $customFieldsRepository;
 
   public function __construct(
     Subscriber $subscriber,
     Site $site,
     Link $link,
+    Newsletter $newsletter,
+    Date $date,
     OrderReviewUrl $orderReviewUrl,
     WPFunctions $wp,
     LinksToShortcodesConvertor $linksToShortcodesConvertor,
     AutomationStorage $automationStorage,
     Registry $registry,
-    NewslettersRepository $newslettersRepository
+    NewslettersRepository $newslettersRepository,
+    CustomFieldsRepository $customFieldsRepository
   ) {
     $this->subscriber = $subscriber;
     $this->site = $site;
     $this->link = $link;
+    $this->newsletter = $newsletter;
+    $this->date = $date;
     $this->orderReviewUrl = $orderReviewUrl;
     $this->wp = $wp;
     $this->linksToShortcodesConvertor = $linksToShortcodesConvertor;
     $this->automationStorage = $automationStorage;
     $this->registry = $registry;
     $this->newslettersRepository = $newslettersRepository;
+    $this->customFieldsRepository = $customFieldsRepository;
   }
 
   /**
@@ -133,6 +145,92 @@ class PersonalizationTagManager {
         null,
         [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
       ));
+      $registry->register(new Personalization_Tag(
+        __('WordPress User Display Name', 'mailpoet'),
+        'mailpoet/subscriber-displayname',
+        __('Subscriber', 'mailpoet'),
+        [$this->subscriber, 'getDisplayName'],
+        ['default' => __('member', 'mailpoet')],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
+      $registry->register(new Personalization_Tag(
+        __('Total Number of Subscribers', 'mailpoet'),
+        'mailpoet/subscriber-count',
+        __('Subscriber', 'mailpoet'),
+        [$this->subscriber, 'getCount'],
+        [],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
+      $this->registerSubscriberCustomFieldTags($registry);
+
+      // Newsletter Personalization Tags
+      $registry->register(new Personalization_Tag(
+        __('Newsletter Subject', 'mailpoet'),
+        'mailpoet/newsletter-subject',
+        __('Newsletter', 'mailpoet'),
+        [$this->newsletter, 'getSubject'],
+        [],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
+
+      // Date Personalization Tags
+      $registry->register(new Personalization_Tag(
+        __('Current day of the month number', 'mailpoet'),
+        'mailpoet/date-day',
+        __('Date', 'mailpoet'),
+        [$this->date, 'getDay'],
+        [],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
+      $registry->register(new Personalization_Tag(
+        __('Current day of the month in ordinal form, i.e. 2nd, 3rd, 4th, etc.', 'mailpoet'),
+        'mailpoet/date-day-ordinal',
+        __('Date', 'mailpoet'),
+        [$this->date, 'getDayOrdinal'],
+        [],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
+      $registry->register(new Personalization_Tag(
+        __('Full name of current day', 'mailpoet'),
+        'mailpoet/date-day-name',
+        __('Date', 'mailpoet'),
+        [$this->date, 'getDayName'],
+        [],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
+      $registry->register(new Personalization_Tag(
+        __('Current month number', 'mailpoet'),
+        'mailpoet/date-month',
+        __('Date', 'mailpoet'),
+        [$this->date, 'getMonth'],
+        [],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
+      $registry->register(new Personalization_Tag(
+        __('Full name of current month', 'mailpoet'),
+        'mailpoet/date-month-name',
+        __('Date', 'mailpoet'),
+        [$this->date, 'getMonthName'],
+        [],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
+      $registry->register(new Personalization_Tag(
+        __('Year', 'mailpoet'),
+        'mailpoet/date-year',
+        __('Date', 'mailpoet'),
+        [$this->date, 'getYear'],
+        [],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
 
       // Site Personalization Tags
       $registry->register(new Personalization_Tag(
@@ -213,6 +311,24 @@ class PersonalizationTagManager {
       10,
       2
     );
+  }
+
+  private function registerSubscriberCustomFieldTags(Personalization_Tags_Registry $registry): void {
+    $customFields = $this->customFieldsRepository->findAllActive();
+    foreach ($customFields as $customField) {
+      $customFieldId = (int)$customField->getId();
+      $registry->register(new Personalization_Tag(
+        $customField->getName(),
+        'mailpoet/subscriber-cf-' . $customFieldId,
+        __('Subscriber', 'mailpoet'),
+        function (array $context, array $args = []) use ($customFieldId): string {
+          return $this->subscriber->getCustomField($customFieldId, $context, $args);
+        },
+        [],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
+    }
   }
 
   public function convertLinksToShortcodes(array $emailContent): array {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Date.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Date.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\WP\Functions as WPFunctions;
+
+class Date {
+
+  private NewslettersRepository $newslettersRepository;
+  private WPFunctions $wp;
+
+  public function __construct(
+    NewslettersRepository $newslettersRepository,
+    WPFunctions $wp
+  ) {
+    $this->newslettersRepository = $newslettersRepository;
+    $this->wp = $wp;
+  }
+
+  public function getDay(array $context, array $args = []): string {
+    return $this->format('d', $context);
+  }
+
+  public function getDayOrdinal(array $context, array $args = []): string {
+    return $this->format('jS', $context);
+  }
+
+  public function getDayName(array $context, array $args = []): string {
+    return $this->format('l', $context);
+  }
+
+  public function getMonth(array $context, array $args = []): string {
+    return $this->format('m', $context);
+  }
+
+  public function getMonthName(array $context, array $args = []): string {
+    return $this->format('F', $context);
+  }
+
+  public function getYear(array $context, array $args = []): string {
+    return $this->format('Y', $context);
+  }
+
+  private function format(string $phpDateFormat, array $context): string {
+    return (string)$this->wp->dateI18n($phpDateFormat, $this->getTimestamp($context));
+  }
+
+  private function getTimestamp(array $context): int {
+    $newsletter = $this->getNewsletter($context);
+    if (
+      $newsletter
+      && $newsletter->getSentAt() instanceof \DateTimeInterface
+      && $newsletter->getStatus() === NewsletterEntity::STATUS_SENT
+    ) {
+      return $newsletter->getSentAt()->getTimestamp();
+    }
+
+    return (int)$this->wp->currentTime('timestamp');
+  }
+
+  private function getNewsletter(array $context): ?NewsletterEntity {
+    $newsletterId = $context['newsletter_id'] ?? null;
+
+    return $newsletterId ? $this->newslettersRepository->findOneById($newsletterId) : null;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Newsletter.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Newsletter.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewslettersRepository;
+
+class Newsletter {
+
+  private NewslettersRepository $newslettersRepository;
+
+  public function __construct(
+    NewslettersRepository $newslettersRepository
+  ) {
+    $this->newslettersRepository = $newslettersRepository;
+  }
+
+  public function getSubject(array $context, array $args = []): string {
+    $newsletter = $this->getNewsletter($context);
+
+    return $newsletter ? (string)$newsletter->getSubject() : '';
+  }
+
+  private function getNewsletter(array $context): ?NewsletterEntity {
+    $newsletterId = $context['newsletter_id'] ?? null;
+
+    return $newsletterId ? $this->newslettersRepository->findOneById($newsletterId) : null;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Subscriber.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Subscriber.php
@@ -2,31 +2,42 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags;
 
+use MailPoet\Entities\CustomFieldEntity;
+use MailPoet\Entities\SubscriberCustomFieldEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Subscribers\SubscriberCustomFieldRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscription\SubscriptionUrlFactory;
+use MailPoet\WP\Functions as WPFunctions;
 
 class Subscriber {
 
+  private const HTML_ENTITY_FLAGS = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401;
+
   private SubscribersRepository $subscribersRepository;
+  private SubscriberCustomFieldRepository $subscriberCustomFieldRepository;
+  private WPFunctions $wp;
   private SubscriptionUrlFactory $subscriptionUrlFactory;
 
   public function __construct(
-    SubscribersRepository $subscribersRepository
+    SubscribersRepository $subscribersRepository,
+    SubscriberCustomFieldRepository $subscriberCustomFieldRepository,
+    WPFunctions $wp
   ) {
     $this->subscribersRepository = $subscribersRepository;
+    $this->subscriberCustomFieldRepository = $subscriberCustomFieldRepository;
+    $this->wp = $wp;
     $this->subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();
   }
 
   public function getFirstName(array $context, array $args = []): string {
-    $subscriberEmail = $context['recipient_email'] ?? null;
-    $subscriber = $subscriberEmail ? $this->subscribersRepository->findOneBy(['email' => $subscriberEmail]) : null;
+    $subscriber = $this->getSubscriber($context);
 
     return ($subscriber && $subscriber->getFirstName()) ? $subscriber->getFirstName() : $args['default'] ?? '';
   }
 
   public function getLastName(array $context, array $args = []): string {
-    $subscriberEmail = $context['recipient_email'] ?? null;
-    $subscriber = $subscriberEmail ? $this->subscribersRepository->findOneBy(['email' => $subscriberEmail]) : null;
+    $subscriber = $this->getSubscriber($context);
 
     return ($subscriber && $subscriber->getLastName()) ? $subscriber->getLastName() : $args['default'] ?? '';
   }
@@ -36,13 +47,72 @@ class Subscriber {
   }
 
   public function getActivationLink(array $context, array $args = []): string {
-    $subscriberEmail = $context['recipient_email'] ?? null;
-    $subscriber = $subscriberEmail ? $this->subscribersRepository->findOneBy(['email' => $subscriberEmail]) : null;
+    $subscriber = $this->getSubscriber($context);
 
     if (!$subscriber) {
       return '';
     }
 
     return $this->subscriptionUrlFactory->getConfirmationUrl($subscriber);
+  }
+
+  public function getDisplayName(array $context, array $args = []): string {
+    $default = $args['default'] ?? '';
+    $subscriber = $this->getSubscriber($context);
+    if (!$subscriber || !$subscriber->getWpUserId()) {
+      return $default;
+    }
+
+    $wpUser = $this->wp->getUserdata($subscriber->getWpUserId());
+
+    return ($wpUser instanceof \WP_User) ? $wpUser->display_name : $default; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  }
+
+  public function getCount(array $context, array $args = []): string {
+    return (string)$this->subscribersRepository->countBy([
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      'deletedAt' => null,
+    ]);
+  }
+
+  public function getCustomField(int $customFieldId, array $context, array $args = []): string {
+    $default = $args['default'] ?? '';
+    $subscriber = $this->getSubscriber($context);
+    if (!$subscriber || !$subscriber->getId()) {
+      return $default;
+    }
+
+    $subscriberCustomField = $this->subscriberCustomFieldRepository->findOneBy([
+      'subscriber' => $subscriber,
+      'customField' => $customFieldId,
+    ]);
+    if (!($subscriberCustomField instanceof SubscriberCustomFieldEntity) || empty($subscriberCustomField->getValue())) {
+      return $default;
+    }
+
+    $value = (string)$subscriberCustomField->getValue();
+    $definition = $subscriberCustomField->getCustomField();
+    $format = $args['format'] ?? '';
+
+    if ($format !== '' && $definition instanceof CustomFieldEntity && $definition->getType() === CustomFieldEntity::TYPE_DATE) {
+      $timestamp = strtotime($value);
+
+      return $timestamp !== false ? $this->wp->dateI18n($format, $timestamp) : $default;
+    }
+
+    if ($definition instanceof CustomFieldEntity && $definition->getType() === CustomFieldEntity::TYPE_CHECKBOX && $value === '1') {
+      $params = $definition->getParams();
+      $label = (is_array($params) && isset($params['values'][0]['value'])) ? (string)$params['values'][0]['value'] : '';
+
+      return $label !== '' ? htmlspecialchars($label, self::HTML_ENTITY_FLAGS) : $default;
+    }
+
+    return htmlspecialchars($value, self::HTML_ENTITY_FLAGS);
+  }
+
+  private function getSubscriber(array $context): ?SubscriberEntity {
+    $subscriberEmail = $context['recipient_email'] ?? null;
+
+    return $subscriberEmail ? $this->subscribersRepository->findOneBy(['email' => $subscriberEmail]) : null;
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
@@ -15,9 +15,11 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Test\DataFactories\CustomField as CustomFieldFactory;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
+use MailPoet\WP\Functions as WPFunctions;
 
 class PersonalizationTagManagerTest extends \MailPoetTest {
   private NewsletterTask $newsletterTask;
@@ -74,6 +76,33 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
 
     // Tag placed out of href was not replaced
     $this->assertStringContainsString('<!--[mailpoet/subscription-unsubscribe-url]-->', $rendered['html']);
+  }
+
+  public function testItRegistersPersonalizationTagsForLegacyShortcodes(): void {
+    $customField = (new CustomFieldFactory())->create();
+
+    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+    $personalizationManager->initialize();
+
+    $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
+    WPFunctions::get()->applyFilters('woocommerce_email_editor_register_personalization_tags', $registry);
+
+    $expectedTokens = [
+      '[mailpoet/subscriber-displayname]',
+      '[mailpoet/subscriber-count]',
+      '[mailpoet/subscriber-cf-' . $customField->getId() . ']',
+      '[mailpoet/newsletter-subject]',
+      '[mailpoet/date-day]',
+      '[mailpoet/date-day-ordinal]',
+      '[mailpoet/date-day-name]',
+      '[mailpoet/date-month]',
+      '[mailpoet/date-month-name]',
+      '[mailpoet/date-year]',
+    ];
+
+    foreach ($expectedTokens as $token) {
+      $this->assertNotNull($registry->get_by_token($token), "Expected personalization tag {$token} to be registered.");
+    }
   }
 
   public function testItRegistersOrderReviewUrlTagForOrderAutomations(): void {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/DateTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/DateTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\EmailEditor\Integrations\MailPoet\PersonalizationTags;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Date;
+use MailPoet\WP\Functions as WPFunctions;
+
+class DateTest extends \MailPoetTest {
+  private Date $date;
+  private WPFunctions $wp;
+
+  public function _before() {
+    parent::_before();
+    $this->date = $this->diContainer->get(Date::class);
+    $this->wp = $this->diContainer->get(WPFunctions::class);
+  }
+
+  public function testItReturnsCurrentDateParts(): void {
+    $timestamp = $this->wp->currentTime('timestamp');
+
+    $this->assertSame($this->wp->dateI18n('d', $timestamp), $this->date->getDay([]));
+    $this->assertSame($this->wp->dateI18n('jS', $timestamp), $this->date->getDayOrdinal([]));
+    $this->assertSame($this->wp->dateI18n('l', $timestamp), $this->date->getDayName([]));
+    $this->assertSame($this->wp->dateI18n('m', $timestamp), $this->date->getMonth([]));
+    $this->assertSame($this->wp->dateI18n('F', $timestamp), $this->date->getMonthName([]));
+    $this->assertSame($this->wp->dateI18n('Y', $timestamp), $this->date->getYear([]));
+  }
+}

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/DateTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/DateTest.php
@@ -3,6 +3,8 @@
 namespace MailPoet\Test\EmailEditor\Integrations\MailPoet\PersonalizationTags;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Date;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\WP\Functions as WPFunctions;
 
 class DateTest extends \MailPoetTest {
@@ -15,14 +17,30 @@ class DateTest extends \MailPoetTest {
     $this->wp = $this->diContainer->get(WPFunctions::class);
   }
 
-  public function testItReturnsCurrentDateParts(): void {
+  public function testItReturnsDatePartsFromSentNewsletter(): void {
+    $sentAt = new \DateTimeImmutable('2010-04-20 15:30:45');
+    $newsletter = (new NewsletterFactory())
+      ->withStatus(NewsletterEntity::STATUS_SENT)
+      ->create();
+    $newsletter->setSentAt($sentAt);
+    $this->entityManager->flush();
+
+    $context = ['newsletter_id' => $newsletter->getId()];
+    $timestamp = $sentAt->getTimestamp();
+
+    $this->assertSame($this->wp->dateI18n('d', $timestamp), $this->date->getDay($context));
+    $this->assertSame($this->wp->dateI18n('jS', $timestamp), $this->date->getDayOrdinal($context));
+    $this->assertSame($this->wp->dateI18n('l', $timestamp), $this->date->getDayName($context));
+    $this->assertSame($this->wp->dateI18n('m', $timestamp), $this->date->getMonth($context));
+    $this->assertSame($this->wp->dateI18n('F', $timestamp), $this->date->getMonthName($context));
+    $this->assertSame($this->wp->dateI18n('Y', $timestamp), $this->date->getYear($context));
+  }
+
+  public function testItFallsBackToCurrentDateWhenNewsletterIsNotSent(): void {
     $timestamp = $this->wp->currentTime('timestamp');
 
     $this->assertSame($this->wp->dateI18n('d', $timestamp), $this->date->getDay([]));
-    $this->assertSame($this->wp->dateI18n('jS', $timestamp), $this->date->getDayOrdinal([]));
-    $this->assertSame($this->wp->dateI18n('l', $timestamp), $this->date->getDayName([]));
     $this->assertSame($this->wp->dateI18n('m', $timestamp), $this->date->getMonth([]));
-    $this->assertSame($this->wp->dateI18n('F', $timestamp), $this->date->getMonthName([]));
     $this->assertSame($this->wp->dateI18n('Y', $timestamp), $this->date->getYear([]));
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/NewsletterTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/NewsletterTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\EmailEditor\Integrations\MailPoet\PersonalizationTags;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Newsletter;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+
+class NewsletterTest extends \MailPoetTest {
+  private Newsletter $newsletter;
+
+  public function _before() {
+    parent::_before();
+    $this->newsletter = $this->diContainer->get(Newsletter::class);
+  }
+
+  public function testItReturnsNewsletterSubject(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Weekly digest')
+      ->create();
+
+    $result = $this->newsletter->getSubject(['newsletter_id' => $newsletter->getId()]);
+
+    $this->assertSame('Weekly digest', $result);
+  }
+
+  public function testItReturnsEmptyStringWhenNewsletterIsMissing(): void {
+    $result = $this->newsletter->getSubject(['newsletter_id' => 0]);
+
+    $this->assertSame('', $result);
+  }
+}

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/SubscriberTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/SubscriberTest.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\EmailEditor\Integrations\MailPoet\PersonalizationTags;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Subscriber;
+use MailPoet\Entities\CustomFieldEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Test\DataFactories\CustomField as CustomFieldFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+
+class SubscriberTest extends \MailPoetTest {
+  private Subscriber $subscriber;
+
+  public function _before() {
+    parent::_before();
+    $this->subscriber = $this->diContainer->get(Subscriber::class);
+  }
+
+  public function testItReturnsDisplayNameForWordPressUser(): void {
+    wp_create_user('mailpoet_display_name_user', 'pass', 'wp-user@example.com');
+    $wpUser = get_user_by('login', 'mailpoet_display_name_user');
+    $this->assertInstanceOf(\WP_User::class, $wpUser);
+
+    $subscriber = (new SubscriberFactory())
+      ->withEmail('subscriber-with-wp-user@example.com')
+      ->withWpUserId((int)$wpUser->ID)
+      ->create();
+
+    $result = $this->subscriber->getDisplayName(
+      ['recipient_email' => $subscriber->getEmail()],
+      ['default' => 'member']
+    );
+
+    $this->assertSame($wpUser->display_name, $result); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  }
+
+  public function testItReturnsDefaultDisplayNameWhenSubscriberIsNotWordPressUser(): void {
+    $subscriber = (new SubscriberFactory())->create();
+
+    $result = $this->subscriber->getDisplayName(
+      ['recipient_email' => $subscriber->getEmail()],
+      ['default' => 'member']
+    );
+
+    $this->assertSame('member', $result);
+  }
+
+  public function testItReturnsDefaultDisplayNameWhenSubscriberIsMissing(): void {
+    $result = $this->subscriber->getDisplayName(
+      ['recipient_email' => 'missing@example.com'],
+      ['default' => 'member']
+    );
+
+    $this->assertSame('member', $result);
+  }
+
+  public function testItReturnsSubscribersCount(): void {
+    (new SubscriberFactory())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
+    (new SubscriberFactory())->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)->create();
+
+    $expectedCount = $this->diContainer->get(SubscribersRepository::class)->countBy([
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      'deletedAt' => null,
+    ]);
+
+    $result = $this->subscriber->getCount([]);
+
+    $this->assertSame((string)$expectedCount, $result);
+  }
+
+  public function testItReturnsCustomFieldValue(): void {
+    $subscriber = (new SubscriberFactory())->create();
+    $customField = (new CustomFieldFactory())
+      ->withType(CustomFieldEntity::TYPE_TEXT)
+      ->withSubscriber($subscriber->getId(), 'Custom value')
+      ->create();
+
+    $result = $this->subscriber->getCustomField(
+      (int)$customField->getId(),
+      ['recipient_email' => $subscriber->getEmail()]
+    );
+
+    $this->assertSame('Custom value', $result);
+  }
+
+  public function testItReturnsDefaultWhenCustomFieldValueIsEmpty(): void {
+    $subscriber = (new SubscriberFactory())->create();
+    $customField = (new CustomFieldFactory())
+      ->withType(CustomFieldEntity::TYPE_TEXT)
+      ->create();
+
+    $result = $this->subscriber->getCustomField(
+      (int)$customField->getId(),
+      ['recipient_email' => $subscriber->getEmail()],
+      ['default' => 'fallback']
+    );
+
+    $this->assertSame('fallback', $result);
+  }
+
+  public function testItFormatsDateCustomFieldValue(): void {
+    $subscriber = (new SubscriberFactory())->create();
+    $customField = (new CustomFieldFactory())
+      ->withType(CustomFieldEntity::TYPE_DATE)
+      ->withSubscriber($subscriber->getId(), '2010-04-20 00:00:00')
+      ->create();
+
+    $result = $this->subscriber->getCustomField(
+      (int)$customField->getId(),
+      ['recipient_email' => $subscriber->getEmail()],
+      ['format' => 'F j']
+    );
+
+    $this->assertSame('April 20', $result);
+  }
+}

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/SubscriberTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/SubscriberTest.php
@@ -8,13 +8,16 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\CustomField as CustomFieldFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\WP\Functions as WPFunctions;
 
 class SubscriberTest extends \MailPoetTest {
   private Subscriber $subscriber;
+  private WPFunctions $wp;
 
   public function _before() {
     parent::_before();
     $this->subscriber = $this->diContainer->get(Subscriber::class);
+    $this->wp = $this->diContainer->get(WPFunctions::class);
   }
 
   public function testItReturnsDisplayNameForWordPressUser(): void {
@@ -112,6 +115,7 @@ class SubscriberTest extends \MailPoetTest {
       ['format' => 'F j']
     );
 
-    $this->assertSame('April 20', $result);
+    $expected = $this->wp->dateI18n('F j', (int)strtotime('2010-04-20 00:00:00'));
+    $this->assertSame($expected, $result);
   }
 }


### PR DESCRIPTION
## Description

Adds the block email editor personalization tags that were missing compared to the legacy editor shortcodes.

Added:
- **Subscriber** — display name (with default), count, custom fields (`cf_<id>`)
- **Newsletter** — subject
- **Date** — day, day ordinal, day name, month, month name, year

Left out for now:
- `newsletter:total` and `newsletter:post_title` - need latest posts block, which we don't currently have in the email editor. We can look into adding those after https://github.com/mailpoet/mailpoet/pull/6917.
- `newsletter:number` - needs the post-notification email type and we don't currently have email editor support for it.

## Code review notes

_N/A_

## QA notes

In the block editor, insert each tag and verify it resolves in preview and a real send:

- mailpoet/subscriber-displayname
- mailpoet/subscriber-count
- mailpoet/newsletter-subject
- mailpoet/date-day
- mailpoet/date-day-ordinal
- mailpoet/date-day-name
- mailpoet/date-month
- mailpoet/date-month-name
- mailpoet/date-year

Custom fields:

1. Navigate to MailPoet → Subscribers → Custom fields (located on the right above subscribers list).
2. Add some custom fields.
3. Navigate to the email editor and open the Personalization tags modal.
4. Confirm the personalization tags for the custom fields added are available.
5. Send the email and confirm the custom fields personalization tags are resolved with the expected values.

## Linked PRs

[STOMAIL-8179: Add Posts / Automatic Latest Content email editor block](https://linear.app/a8c/issue/STOMAIL-8179/add-posts-automatic-latest-content-email-editor-block)

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Screenshot                          |
| ------------------------------- |
| <img width="2870" height="1860" alt="1b50f2lDUWfvi0A7@2x" src="https://github.com/user-attachments/assets/917769b8-c235-4cd6-8474-fe6043e30570" /> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8196-add-missing-personalization-tags-for-legacy-shortcodes)

_The latest successful build from `stomail-8196-add-missing-personalization-tags-for-legacy-shortcodes` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->