### PR TITLE
Guard malformed bounce.last_report_to setting in bounce report worker [STOMAIL-8218]

### DIFF
--- a/mailpoet/lib/Cron/Workers/Bounce.php
+++ b/mailpoet/lib/Cron/Workers/Bounce.php
@@ -205,9 +205,17 @@ class Bounce extends SimpleWorker {
 
   private function getReportFromDate(Carbon $now): Carbon {
     $lastReportTo = $this->settings->get(self::LAST_REPORT_TO_SETTING_KEY);
-    $from = is_string($lastReportTo) && $lastReportTo !== ''
-      ? Carbon::parse($lastReportTo)
-      : $now->copy()->subDay();
+    // A malformed stored value (corruption, manual edit, older code) would make
+    // Carbon::parse throw and crash the worker on every run, so guard it the
+    // same way the persist path above does and fall back to the default `from`.
+    $from = $now->copy()->subDay();
+    if (is_string($lastReportTo) && $lastReportTo !== '') {
+      try {
+        $from = Carbon::parse($lastReportTo);
+      } catch (\Exception $e) {
+        $from = $now->copy()->subDay();
+      }
+    }
 
     // Keep an hour of margin inside MAX_LOOKBACK_DAYS so clock skew and request
     // latency can't push the `from` past the limit the service enforces.

--- a/mailpoet/tests/integration/Cron/Workers/BounceTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/BounceTest.php
@@ -176,6 +176,20 @@ class BounceTest extends \MailPoetTest {
     verify($from->getTimestamp() - $earliestAllowed->getTimestamp())->lessThan(2 * 3600);
   }
 
+  public function testItFallsBackToDefaultFromDateWhenLastReportToIsMalformed() {
+    // A corrupted/manually-edited setting must not crash the worker: parsing is
+    // guarded and falls back to the default `from` (~ now - 1 day).
+    $this->settings->set(Bounce::LAST_REPORT_TO_SETTING_KEY, 'not-a-date');
+
+    $task = $this->createRunningTask();
+    $completed = $this->worker->processTaskStrategy($task, microtime(true));
+    verify($completed)->true();
+
+    $from = $this->api->getBouncesReportCalls[0]['from'];
+    $expected = Carbon::now()->subDay();
+    verify(abs($from->getTimestamp() - $expected->getTimestamp()))->lessThan(2 * 3600);
+  }
+
   public function testItStoresTheReportRangeOnTheTaskMeta() {
     $task = $this->createRunningTask();
     $this->worker->processTaskStrategy($task, microtime(true));


### PR DESCRIPTION
## What & why

`Bounce::getReportFromDate()` parses the stored `bounce.last_report_to` setting with `Carbon::parse()` and **no try/catch**. If that value is ever malformed (corruption, manual edit, or a value written by older/other code), the parse throws an uncaught exception and the bounce worker fails **on every run**, silently halting bounce processing.

The same setting is already parsed defensively a few lines up — on the persist path — with a `try/catch` that falls back to `null`. This change makes `getReportFromDate()` mirror that guard.

## The fix

Wrap the `Carbon::parse()` in `getReportFromDate()` in a `try/catch` and fall back to the existing default (`now − 1 day`, then clamped to `MAX_LOOKBACK_DAYS`). One method, no behaviour change for valid values.

## Testing

- Added `testItFallsBackToDefaultFromDateWhenLastReportToIsMalformed` to `BounceTest`: stores `'not-a-date'`, asserts the worker completes (no throw) and the report `from` falls back to ~ now − 1 day.
- PHP lint + the repo's lint-staged PHP checks pass locally.
- Integration test suite not run locally (no wp-env here) — relying on CI.

## Linear

STOMAIL-8218

Found by the QAO-510 AI Regression Review pipeline (observe-mode run). Introduced in #6876.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8218-bounce-report-carbon-parse-guard)

_The latest successful build from `fix/stomail-8218-bounce-report-carbon-parse-guard` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

1 issue found:
- Bug: malformed `bounce.last_report_to` values could crash the bounce worker; it now falls back to the default report start date instead.

No Security, Performance, or Suggestion issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->