### PR TITLE
Stream log export in batches to avoid OOM on large installs [STOMAIL-8219]

### DIFF
--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -220,7 +220,7 @@ class LogRepository extends Repository {
 
       foreach ($rows as $row) {
         $lastCreatedAt = $this->castToNullableString($row['created_at']);
-        $lastId = (int)$row['id'];
+        $lastId = (int)$this->castToNullableString($row['id']);
         yield [
           'created_at' => $this->castToNullableString($row['created_at']) ?? '',
           'name' => $this->castToNullableString($row['name']),

--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -167,32 +167,73 @@ class LogRepository extends Repository {
    * Fetch logs matching the listing's filter shape (`from`/`to`/`name`/`level`)
    * and free-text search for export, so a download contains exactly the rows the
    * filtered listing shows. Mirrors deleteLogs()'s WHERE clause and is capped by
-   * $limit to keep memory bounded on large log tables.
+   * $limit.
+   *
+   * Yields rows in batches via keyset pagination on (`created_at`, `id`) rather
+   * than one big result set. MailPoet's WPDB-backed Doctrine driver buffers an
+   * entire result in memory (see Doctrine\WPDB\Result), so a single
+   * `LIMIT 50000` query would load every row at once and can exhaust PHP's
+   * memory on large installs. Paging keeps peak memory at one batch.
    *
    * @param array{from?: string, to?: string, name?: string[], level?: int[]} $filter
-   * @return array<int, array{created_at: string, name: string|null, message: string|null}>
+   * @return iterable<int, array{created_at: string, name: string|null, message: string|null}>
    */
-  public function getLogsForExport(array $filter, ?string $search = null, int $limit = 50000): array {
+  public function getLogsForExport(array $filter, ?string $search = null, int $limit = 50000, int $batchSize = 1000): iterable {
     $logsTable = $this->entityManager->getClassMetadata(LogEntity::class)->getTableName();
-    [$where, $parameters, $types] = $this->buildFilterSql($filter, $search);
-    $parameters['export_limit'] = $limit;
-    $types['export_limit'] = ParameterType::INTEGER;
+    [$where, $baseParameters, $baseTypes] = $this->buildFilterSql($filter, $search);
 
-    $sql = "SELECT `created_at`, `name`, `message` FROM `{$logsTable}`{$where} ORDER BY `created_at` DESC, `id` DESC LIMIT :export_limit";
+    $batchSize = $batchSize > 0 ? $batchSize : 1000;
+    $remaining = $limit;
+    $lastCreatedAt = null;
+    $lastId = null;
 
-    $rows = $this->entityManager->getConnection()
-      ->executeQuery($sql, $parameters, $types)
-      ->fetchAllAssociative();
+    while ($remaining > 0) {
+      $batch = (int)min($batchSize, $remaining);
+      $parameters = $baseParameters;
+      $types = $baseTypes;
+      $conditions = $where;
 
-    $logs = [];
-    foreach ($rows as $row) {
-      $logs[] = [
-        'created_at' => $this->castToNullableString($row['created_at']) ?? '',
-        'name' => $this->castToNullableString($row['name']),
-        'message' => $this->castToNullableString($row['message']),
-      ];
+      if ($lastCreatedAt !== null) {
+        // Keyset cursor: continue strictly after the last row in the same
+        // (`created_at` DESC, `id` DESC) order. Stable even while new rows are
+        // inserted at the top of the table during the export.
+        $keyset = '(`created_at` < :ks_created_at OR (`created_at` = :ks_created_at AND `id` < :ks_id))';
+        $conditions = $conditions === '' ? ' WHERE ' . $keyset : $conditions . ' AND ' . $keyset;
+        $parameters['ks_created_at'] = $lastCreatedAt;
+        $parameters['ks_id'] = $lastId;
+        $types['ks_created_at'] = ParameterType::STRING;
+        $types['ks_id'] = ParameterType::INTEGER;
+      }
+
+      $parameters['batch_limit'] = $batch;
+      $types['batch_limit'] = ParameterType::INTEGER;
+
+      $sql = "SELECT `id`, `created_at`, `name`, `message` FROM `{$logsTable}`{$conditions} ORDER BY `created_at` DESC, `id` DESC LIMIT :batch_limit";
+
+      $rows = $this->entityManager->getConnection()
+        ->executeQuery($sql, $parameters, $types)
+        ->fetchAllAssociative();
+
+      if ($rows === []) {
+        break;
+      }
+
+      foreach ($rows as $row) {
+        $lastCreatedAt = $this->castToNullableString($row['created_at']);
+        $lastId = (int)$row['id'];
+        yield [
+          'created_at' => $this->castToNullableString($row['created_at']) ?? '',
+          'name' => $this->castToNullableString($row['name']),
+          'message' => $this->castToNullableString($row['message']),
+        ];
+        $remaining--;
+      }
+
+      // A short page means the table is exhausted; stop before an empty query.
+      if (count($rows) < $batch) {
+        break;
+      }
     }
-    return $logs;
   }
 
   /**

--- a/mailpoet/lib/Logging/LogsDownload.php
+++ b/mailpoet/lib/Logging/LogsDownload.php
@@ -80,6 +80,7 @@ class LogsDownload {
     header('Pragma: no-cache');
     header('Expires: 0');
 
+    $count = 0;
     foreach ($logs as $log) {
       $createdAt = $log['created_at'] ?? 'N/A';
       $name = $log['name'] ?? '';
@@ -87,6 +88,12 @@ class LogsDownload {
       // Output is a text/plain attachment download, not HTML; HTML-escaping would corrupt the log content.
       // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
       echo '[' . $createdAt . '] [' . $name . '] ' . $message . "\n";
+      // Stream to the client as we go so the output buffer doesn't accumulate
+      // the whole file in memory; the repository already pages the DB rows.
+      $count++;
+      if (($count % 1000) === 0) {
+        flush();
+      }
     }
     exit;
   }

--- a/mailpoet/tests/integration/Logging/LogRepositoryTest.php
+++ b/mailpoet/tests/integration/Logging/LogRepositoryTest.php
@@ -93,4 +93,51 @@ class LogRepositoryTest extends \MailPoetTest {
     verify($remaining)->equals([$other->getId()]);
     verify(in_array($literal->getId(), $remaining, true))->false();
   }
+
+  public function testGetLogsForExportStreamsAllRowsAcrossBatches() {
+    $logFactory = new Log();
+    $sameTime = Carbon::now()->subMinutes(5);
+    $logFactory->withName('a')->withMessage('m1')->withCreatedAt(Carbon::now()->subMinutes(1))->create();
+    $logFactory->withName('b')->withMessage('m2')->withCreatedAt(Carbon::now()->subMinutes(2))->create();
+    // Two rows share a created_at so the (created_at, id) keyset tiebreak is exercised.
+    $logFactory->withName('c')->withMessage('m3')->withCreatedAt($sameTime)->create();
+    $logFactory->withName('d')->withMessage('m4')->withCreatedAt($sameTime)->create();
+    $logFactory->withName('e')->withMessage('m5')->withCreatedAt(Carbon::now()->subMinutes(9))->create();
+
+    // A batch size of 2 forces multiple pages and the keyset cursor.
+    $rows = [];
+    foreach ($this->repository->getLogsForExport([], null, 50000, 2) as $row) {
+      $rows[] = $row;
+    }
+
+    // Every row is returned exactly once (no gaps or duplicates across batches).
+    verify(count($rows))->equals(5);
+    $messages = array_map(function ($row) {
+      return $row['message'];
+    }, $rows);
+    sort($messages);
+    verify($messages)->equals(['m1', 'm2', 'm3', 'm4', 'm5']);
+
+    // Rows stay in newest-first order across batch boundaries.
+    $timestamps = array_map(function ($row) {
+      return $row['created_at'];
+    }, $rows);
+    $sorted = $timestamps;
+    rsort($sorted);
+    verify($timestamps)->equals($sorted);
+  }
+
+  public function testGetLogsForExportRespectsLimit() {
+    $logFactory = new Log();
+    for ($i = 0; $i < 5; $i++) {
+      $logFactory->withMessage('m' . $i)->withCreatedAt(Carbon::now()->subMinutes($i))->create();
+    }
+
+    $rows = [];
+    foreach ($this->repository->getLogsForExport([], null, 3, 2) as $row) {
+      $rows[] = $row;
+    }
+
+    verify(count($rows))->equals(3);
+  }
 }


### PR DESCRIPTION
## What & why

`LogRepository::getLogsForExport()` ran a single `SELECT … LIMIT 50000` and called `->fetchAllAssociative()`, loading up to 50,000 log rows — including potentially large `message` fields — into one PHP array. `LogsDownload::handle()` then iterated and echoed them. On large installs this can exhaust PHP's memory limit during the download.

Note: MailPoet's Doctrine runs on a custom WPDB-backed driver whose `Result` is fully in-memory (`Doctrine\WPDB\Result` — "WPDB fetches all results … so we need to implement the result methods on in-memory data"). So switching to `iterateAssociative()` would **not** help — the WPDB query buffers every row first. The fix has to bound the SQL itself.

## The fix

- `getLogsForExport()` is now a generator that pages the table with **keyset pagination** on `(created_at, id)` (the existing sort order), fetching ~1,000 rows per query, yielding each row, and freeing each batch — capped at `MAX_LOGS` (50,000). Peak memory stays at one batch instead of the whole result set. Keyset (not `OFFSET`) keeps paging stable while new rows are inserted at the top during the export.
- `LogsDownload::handle()` flushes output every 1,000 rows so the response streams to the client.
- Added an optional `$batchSize` arg (default 1,000) so the paging is testable without inserting thousands of rows.

## Testing

- Added `testGetLogsForExportStreamsAllRowsAcrossBatches` (forces batch size 2, includes a `created_at` tie to exercise the `id` tiebreak; asserts every row returned exactly once, newest-first) and `testGetLogsForExportRespectsLimit`.
- PHP lint + the repo's lint-staged phpcs pass locally.
- Integration test suite not run locally (no wp-env here) — relying on CI.

## Linear

STOMAIL-8219

Found by the QAO-510 AI Regression Review pipeline (observe-mode run). Introduced in #6908.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8219-log-export-streaming)

_The latest successful build from `fix/stomail-8219-log-export-streaming` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->