### PR TITLE
Wait for terminal workflow state before CircleCI rerun

### DIFF
--- a/mailpoet/tasks/release/CircleCiController.php
+++ b/mailpoet/tasks/release/CircleCiController.php
@@ -15,6 +15,13 @@ class CircleCiController {
   const FREE_ZIP_FILENAME = 'mailpoet.zip';
   const PREMIUM_ZIP_FILENAME = 'mailpoet-premium.zip';
 
+  const TERMINAL_WORKFLOW_STATUSES = ['success', 'failed', 'error', 'canceled', 'unauthorized'];
+  const RERUNNABLE_WORKFLOW_STATUSES = ['running', 'failed', 'failing', 'canceled'];
+  // The full premium CI workflow runs close to 30 minutes; a 'failing' workflow
+  // stays non-terminal until its remaining jobs finish, so allow ample headroom.
+  const WORKFLOW_RERUN_WAIT_TIMEOUT_SECONDS = 2700;
+  const WORKFLOW_RERUN_POLL_INTERVAL_SECONDS = 30;
+
   /** @var string */
   private $token;
 
@@ -34,13 +41,14 @@ class CircleCiController {
     $username,
     $token,
     $project,
-    GitHubController $githubController
+    GitHubController $githubController,
+    ?Client $httpClient = null
   ) {
     $this->username = $username;
     $this->token = $token;
     $circleCiProject = $this->getCircleCiProject($project);
     $this->zipFilename = $project === self::PROJECT_MAILPOET ? self::FREE_ZIP_FILENAME : self::PREMIUM_ZIP_FILENAME;
-    $this->httpClient = new Client([
+    $this->httpClient = $httpClient ?? new Client([
       'auth' => [$token, null],
       'headers' => [
         'Accept' => 'application/json',
@@ -93,14 +101,18 @@ class CircleCiController {
     }
     $workflowStatus = $workflow['status'] ?? null;
 
-    if (in_array($workflowStatus, ['running', 'failed', 'failing', 'canceled'], true)) {
-      if ($workflowStatus === 'running') {
-        $this->cancelWorkflow($workflow['id']);
-      }
-      $this->rerunWorkflow($workflow['id']);
-      return true;
+    if (!in_array($workflowStatus, self::RERUNNABLE_WORKFLOW_STATUSES, true)) {
+      return false;
     }
-    return false;
+
+    if ($workflowStatus === 'running') {
+      // Cancellation is asynchronous; the workflow stays non-terminal for a while.
+      $this->cancelWorkflow($workflow['id']);
+    }
+
+    $this->waitForWorkflowToReachTerminalState($workflow['id']);
+    $this->rerunWorkflow($workflow['id']);
+    return true;
   }
 
   private function getLatestZipBuildJob(): array {
@@ -190,6 +202,38 @@ class CircleCiController {
     return reset($workflows) ?: null;
   }
 
+  private function getWorkflowById(string $workflowId): ?array {
+    $response = $this->httpClient->get('https://circleci.com/api/v2/workflow/' . urlencode($workflowId));
+    $workflow = json_decode($response->getBody()->getContents(), true);
+    return isset($workflow['id']) ? $workflow : null;
+  }
+
+  /**
+   * Polls the workflow until it reaches a terminal state so it can be rerun.
+   * CircleCI returns 400 ("Workflow must be in a terminal state to be rerun")
+   * when rerunning a 'running'/'failing' workflow, so wait it out first.
+   */
+  private function waitForWorkflowToReachTerminalState(string $workflowId): void {
+    $timeout = $this->getRerunWaitTimeoutSeconds();
+    $deadline = time() + $timeout;
+    while (true) {
+      $workflow = $this->getWorkflowById($workflowId);
+      $lastStatus = $workflow['status'] ?? null;
+      if (in_array($lastStatus, self::TERMINAL_WORKFLOW_STATUSES, true)) {
+        return;
+      }
+      if (time() >= $deadline) {
+        throw new \Exception(sprintf(
+          "Timed out after %ds waiting for CircleCI workflow '%s' to reach a terminal state (last status: '%s').",
+          $timeout,
+          $workflowId,
+          $lastStatus ?? 'unknown'
+        ));
+      }
+      $this->sleep(self::WORKFLOW_RERUN_POLL_INTERVAL_SECONDS);
+    }
+  }
+
   private function rerunWorkflow(string $workflowId, bool $fromFailed = false): void {
     $this->httpClient->post(
       'https://circleci.com/api/v2/workflow/' . urlencode($workflowId) . '/rerun',
@@ -207,5 +251,13 @@ class CircleCiController {
 
   private function getCircleCiProject(string $project): string {
     return $project === self::PROJECT_MAILPOET ? 'mailpoet' : 'mailpoet-premium';
+  }
+
+  protected function sleep(int $seconds): void {
+    sleep($seconds);
+  }
+
+  protected function getRerunWaitTimeoutSeconds(): int {
+    return self::WORKFLOW_RERUN_WAIT_TIMEOUT_SECONDS;
   }
 }

--- a/mailpoet/tests/unit/Tasks/Release/CircleCiControllerTest.php
+++ b/mailpoet/tests/unit/Tasks/Release/CircleCiControllerTest.php
@@ -1,0 +1,171 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Tasks\Release;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use MailPoetTasks\Release\CircleCiController;
+use MailPoetTasks\Release\GitHubController;
+
+class CircleCiControllerTest extends \MailPoetUnitTest {
+  public function testItCancelsPollsAndRerunsRunningWorkflow() {
+    $history = new \ArrayObject();
+    $controller = $this->makeController([
+      $this->jsonResponse(['items' => [['id' => 'p1']]]),
+      $this->jsonResponse(['items' => [['id' => 'w1', 'status' => 'running']]]),
+      $this->jsonResponse(['message' => 'Accepted.']), // cancel
+      $this->jsonResponse(['id' => 'w1', 'status' => 'running']), // still cancelling
+      $this->jsonResponse(['id' => 'w1', 'status' => 'canceled']), // now terminal
+      $this->jsonResponse(['workflow_id' => 'w1']), // rerun
+    ], $history);
+
+    $result = $controller->rerunLatestWorkflow(CircleCiController::PROJECT_PREMIUM);
+
+    verify($result)->true();
+    // The running workflow is cancelled, then polled until it reaches a terminal
+    // state, and only then rerun. The two status fetches before the rerun are the
+    // guard against the original bug (rerunning while still non-terminal).
+    verify($this->requestLines($history))->equals([
+      'GET /api/v2/project/gh/mailpoet/mailpoet-premium/pipeline',
+      'GET /api/v2/pipeline/p1/workflow',
+      'POST /api/v2/workflow/w1/cancel',
+      'GET /api/v2/workflow/w1',
+      'GET /api/v2/workflow/w1',
+      'POST /api/v2/workflow/w1/rerun',
+    ]);
+  }
+
+  public function testItWaitsForFailingWorkflowToFinishThenReruns() {
+    $history = new \ArrayObject();
+    $controller = $this->makeController([
+      $this->jsonResponse(['items' => [['id' => 'p1']]]),
+      $this->jsonResponse(['items' => [['id' => 'w1', 'status' => 'failing']]]),
+      $this->jsonResponse(['id' => 'w1', 'status' => 'failing']), // still running remaining jobs
+      $this->jsonResponse(['id' => 'w1', 'status' => 'failed']), // terminal
+      $this->jsonResponse(['workflow_id' => 'w1']), // rerun
+    ], $history);
+
+    $result = $controller->rerunLatestWorkflow(CircleCiController::PROJECT_PREMIUM);
+
+    verify($result)->true();
+    // A failing workflow is not cancelled, but it is polled until its remaining
+    // jobs finish (terminal 'failed') before the rerun.
+    verify($this->requestLines($history))->equals([
+      'GET /api/v2/project/gh/mailpoet/mailpoet-premium/pipeline',
+      'GET /api/v2/pipeline/p1/workflow',
+      'GET /api/v2/workflow/w1',
+      'GET /api/v2/workflow/w1',
+      'POST /api/v2/workflow/w1/rerun',
+    ]);
+  }
+
+  public function testItRerunsAlreadyTerminalWorkflowWithoutPolling() {
+    $history = new \ArrayObject();
+    $controller = $this->makeController([
+      $this->jsonResponse(['items' => [['id' => 'p1']]]),
+      $this->jsonResponse(['items' => [['id' => 'w1', 'status' => 'failed']]]),
+      $this->jsonResponse(['id' => 'w1', 'status' => 'failed']), // single terminal check
+      $this->jsonResponse(['workflow_id' => 'w1']), // rerun
+    ], $history);
+
+    $result = $controller->rerunLatestWorkflow(CircleCiController::PROJECT_PREMIUM);
+
+    verify($result)->true();
+    // An already-terminal workflow is fetched once (the wait returns immediately),
+    // is not cancelled, and is rerun right after that single status fetch.
+    verify($this->requestLines($history))->equals([
+      'GET /api/v2/project/gh/mailpoet/mailpoet-premium/pipeline',
+      'GET /api/v2/pipeline/p1/workflow',
+      'GET /api/v2/workflow/w1',
+      'POST /api/v2/workflow/w1/rerun',
+    ]);
+  }
+
+  public function testItDoesNotRerunSuccessfulWorkflow() {
+    $history = new \ArrayObject();
+    $controller = $this->makeController([
+      $this->jsonResponse(['items' => [['id' => 'p1']]]),
+      $this->jsonResponse(['items' => [['id' => 'w1', 'status' => 'success']]]),
+    ], $history);
+
+    $result = $controller->rerunLatestWorkflow(CircleCiController::PROJECT_PREMIUM);
+
+    verify($result)->false();
+    // A successful workflow needs no rerun, so nothing happens beyond the two
+    // lookups that read its status: no cancel, no poll, no rerun.
+    verify($this->requestLines($history))->equals([
+      'GET /api/v2/project/gh/mailpoet/mailpoet-premium/pipeline',
+      'GET /api/v2/pipeline/p1/workflow',
+    ]);
+  }
+
+  public function testItThrowsWhenWorkflowNeverReachesTerminalState() {
+    $history = new \ArrayObject();
+    $controller = $this->makeController([
+      $this->jsonResponse(['items' => [['id' => 'p1']]]),
+      $this->jsonResponse(['items' => [['id' => 'w1', 'status' => 'failing']]]),
+      $this->jsonResponse(['id' => 'w1', 'status' => 'failing']),
+    ], $history, 0);
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessageMatches('/terminal state/');
+    $controller->rerunLatestWorkflow(CircleCiController::PROJECT_PREMIUM);
+  }
+
+  private function jsonResponse(array $data): Response {
+    return new Response(200, [], (string)json_encode($data));
+  }
+
+  /**
+   * @param Response[] $responses
+   * @param \ArrayObject $history Guzzle history container, populated as requests are sent.
+   */
+  private function makeController(array $responses, \ArrayObject $history, int $timeout = 600): CircleCiController {
+    $stack = HandlerStack::create(new MockHandler($responses));
+    $stack->push(Middleware::history($history));
+    $client = new Client(['handler' => $stack]);
+    $github = $this->makeEmpty(GitHubController::class);
+
+    return new class('mailpoet', 'token', CircleCiController::PROJECT_PREMIUM, $github, $client, $timeout) extends CircleCiController {
+      /** @var int */
+      private $testTimeout;
+
+      public function __construct(
+        $username,
+        $token,
+        $project,
+        GitHubController $githubController,
+        Client $httpClient,
+        int $timeout
+      ) {
+        parent::__construct($username, $token, $project, $githubController, $httpClient);
+        $this->testTimeout = $timeout;
+      }
+
+      protected function sleep(int $seconds): void {
+      }
+
+      protected function getRerunWaitTimeoutSeconds(): int {
+        return $this->testTimeout;
+      }
+    };
+  }
+
+  /**
+   * @param \ArrayObject $history
+   * @return string[] Each entry is "METHOD path".
+   */
+  private function requestLines(\ArrayObject $history): array {
+    /** @var array<int, array{request: \Psr\Http\Message\RequestInterface}> $transactions */
+    $transactions = $history->getArrayCopy();
+    $lines = [];
+    foreach ($transactions as $transaction) {
+      $request = $transaction['request'];
+      $lines[] = $request->getMethod() . ' ' . $request->getUri()->getPath();
+    }
+    return $lines;
+  }
+}


### PR DESCRIPTION
## Description

During free release preparation, the step that reruns the premium CircleCI workflow fails with a 400:

```
POST https://circleci.com/api/v2/workflow/{id}/rerun
400 Bad Request: {"message":"Workflow must be in a terminal state to be rerun"}
```

CircleCI only allows rerunning a workflow that has reached a terminal state (`success`, `failed`, `error`, `canceled`, `unauthorized`). The original `rerunLatestWorkflow()` may rerun workflows in two non-terminal states:

1. `running` -- `cancelWorkflow()` only requests an asynchronous cancellation, so the very next line called `rerunWorkflow()` while the workflow had not yet reached `canceled`.
2. `failing` -- a `failing` workflow is still running its remaining jobs and is not terminal, so rerunning it directly hits the same 400.

This change polls the workflow until it reaches a terminal state before calling rerun, and raises a clear error if it does not become terminal within a timeout. Already-terminal entry states (`failed`/`canceled`) need only a single status check before the rerun, so they add no polling delay.

## Code review notes

This only touches internal release tooling (`mailpoet/tasks/release/CircleCiController.php`), which is not shipped in the plugin.

Key points:

1. Both status lists are centralized as constants: `TERMINAL_WORKFLOW_STATUSES` (when polling can stop) and `RERUNNABLE_WORKFLOW_STATUSES` (when a rerun is attempted), replacing the ad-hoc inline arrays.
2. `getWorkflowById()` is added because the existing `getWorkflowByPipelineId()` only returns the first workflow of a pipeline and cannot re-poll a specific workflow by ID.
3. The Guzzle client is now an optional 5th constructor argument, so unit tests can drive it with a `MockHandler`. Production callers in `RoboFile.php` pass nothing and are unaffected.
4. The set of statuses that trigger a rerun (`running`, `failed`, `failing`, `canceled`) is kept identical to the previous behavior to avoid scope creep. `error`, `unauthorized`, and `on_hold` are intentionally left out.
5. The poll timeout is 2700 seconds (45 minutes) with a 30-second interval. The full premium CI workflow runs close to 30 minutes, and a `failing` workflow stays non-terminal until its remaining jobs finish, so the timeout leaves headroom above that.
6. For an entry status that is already terminal, the wait helper still issues one status fetch before returning. This is a deliberate trade-off: the helper is self-contained (given a workflow ID, poll until terminal) rather than trusting a possibly stale status from the caller. For the `running`/`failing` paths, this re-fetch is required because the held status is stale, especially after the asynchronous cancel.

## QA notes

This is release tooling that talks to the live CircleCI API, so it cannot be exercised through the plugin UI. Coverage is provided by unit tests in `mailpoet/tests/unit/Tasks/Release/CircleCiControllerTest.php`, which drive the controller with a mocked HTTP client.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8211

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8211-circleci-rerun-terminal-state)

_The latest successful build from `fix/stomail-8211-circleci-rerun-terminal-state` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->