### PR TITLE
Fix flaky WooCommerce dynamic segment count tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1061,25 +1061,6 @@ workflows:
           enable_hpos: 1
           requires:
             - build
-      # TEMP: confirm the dynamic-segment import-race fix on the exact failing
-      # oldest matrix (WC 10.8.1 + AutomateWoo 6.5.0 + WC Subscriptions 8.8.1,
-      # PHP 7.4 / WP 6.9.4). The push workflow otherwise only runs woo
-      # acceptance on the latest versions, where the race did not surface.
-      # Revert this job before merge.
-      - acceptance_tests:
-          name: TEMP_acceptance_oldest_woo
-          group: woo
-          parallelism: 4
-          woo_core_version: 10.8.1
-          woo_subscriptions_version: 8.8.1
-          automate_woo_version: 6.5.0
-          mysql_command: --max_allowed_packet=100M
-          mysql_image: mysql:5.6
-          codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.1.1-php7.4 # PHP 7.4 image, install WordPress version via CLI
-          wordpress_version: 6.9.4
-          requires:
-            - build
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_tests_woo_hpos_sync_on

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1061,6 +1061,25 @@ workflows:
           enable_hpos: 1
           requires:
             - build
+      # TEMP: confirm the dynamic-segment import-race fix on the exact failing
+      # oldest matrix (WC 10.8.1 + AutomateWoo 6.5.0 + WC Subscriptions 8.8.1,
+      # PHP 7.4 / WP 6.9.4). The push workflow otherwise only runs woo
+      # acceptance on the latest versions, where the race did not surface.
+      # Revert this job before merge.
+      - acceptance_tests:
+          name: TEMP_acceptance_oldest_woo
+          group: woo
+          parallelism: 4
+          woo_core_version: 10.8.1
+          woo_subscriptions_version: 8.8.1
+          automate_woo_version: 6.5.0
+          mysql_command: --max_allowed_packet=100M
+          mysql_image: mysql:5.6
+          codeception_image_version: 7.4-cli_20220605.0
+          wordpress_image_version: 6.1.1-php7.4 # PHP 7.4 image, install WordPress version via CLI
+          wordpress_version: 6.9.4
+          requires:
+            - build
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_tests_woo_hpos_sync_on

--- a/mailpoet/tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php
@@ -97,23 +97,13 @@ class WooCommerceDynamicSegmentsCest {
 
     $i->login();
 
-    // run action scheduler to sync customer and order data to lookup tables
-    $i->wait(2);
-    $i->cli(['action-scheduler', 'run', '--hooks=wc-admin_import_orders,wc-admin_import_customers --force']);
-
     $i->wantTo('Check subscriber is in category segment');
-    $i->amOnMailpoetPage('Segments');
-    $i->waitForText(self::CATEGORY_SEGMENT);
-    $categorySegmentSubscribedElement = "[data-automation-id='mailpoet_dynamic_segment_count_all_{$this->categorySegment->getId()}']";
-    $i->see('2', $categorySegmentSubscribedElement);
+    $this->seeSubscribersCountInSegment($i, $this->categorySegment, '2');
     $this->clickAction($i, $this->categorySegment, 'View subscribers');
     $i->waitForText($customerEmail);
 
     $i->wantTo('Check subscriber is in product segment');
-    $i->amOnMailpoetPage('Segments');
-    $i->waitForText(self::PRODUCT_SEGMENT);
-    $productSegmentSubscribedElement = "[data-automation-id='mailpoet_dynamic_segment_count_all_{$this->productSegment->getId()}']";
-    $i->see('2', $productSegmentSubscribedElement);
+    $this->seeSubscribersCountInSegment($i, $this->productSegment, '2');
     $this->clickAction($i, $this->productSegment, 'View subscribers');
     $i->waitForText($customerEmail);
     $i->waitForText($guestEmail);
@@ -129,17 +119,8 @@ class WooCommerceDynamicSegmentsCest {
 
     $i->login();
 
-    // Run action scheduler wc-admin hooks to sync customer and order data to lookup tables
-    // See https://github.com/woocommerce/woocommerce/blob/ba91c94ca9b1c4903964de70c8658cc7bff67d3f/plugins/woocommerce/src/Internal/Admin/Schedulers/ImportScheduler.php#L90
-    $i->wait(2);
-    $i->cli(['action-scheduler', 'run', '--hooks=wc-admin_import_orders,wc-admin_import_customers --force']);
-
     $i->wantTo('Check subscriber is in category segment');
-    $i->amOnMailpoetPage('Segments');
-    $i->waitForText(self::CATEGORY_SEGMENT);
-    $categorySegmentSubscribedElement = "[data-automation-id='mailpoet_dynamic_segment_count_all_{$this->categorySegment->getId()}']";
-
-    $i->see('2', $categorySegmentSubscribedElement);
+    $this->seeSubscribersCountInSegment($i, $this->categorySegment, '2');
     $this->clickAction($i, $this->categorySegment, 'View subscribers');
     $i->waitForText($customerEmail);
     $i->waitForText($guestEmail);
@@ -160,16 +141,8 @@ class WooCommerceDynamicSegmentsCest {
 
     $i->login();
 
-    // run action scheduler to sync customer and order data to lookup tables
-    $i->wait(2);
-    $i->cli(['action-scheduler', 'run', '--hooks=wc-admin_import_orders,wc-admin_import_customers --force']);
-
     $i->wantTo('Check there is one subscriber in the number of orders segments (the segment was configured to match customers that placed one order in the last day)');
-    $i->amOnMailpoetPage('Segments');
-    $i->waitForText(self::NUMBER_OF_ORDERS_SEGMENT);
-    $numberOfOrdersSegmentSubscribedElement = "[data-automation-id='mailpoet_dynamic_segment_count_all_{$this->numberOfOrdersSegment->getId()}']";
-
-    $i->see('1', $numberOfOrdersSegmentSubscribedElement);
+    $this->seeSubscribersCountInSegment($i, $this->numberOfOrdersSegment, '1');
     $this->clickAction($i, $this->numberOfOrdersSegment, 'View subscribers');
     $i->waitForText($customer1Email);
   }
@@ -186,16 +159,8 @@ class WooCommerceDynamicSegmentsCest {
 
     $i->login();
 
-    // run action scheduler to sync customer and order data to lookup tables
-    $i->wait(2);
-    $i->cli(['action-scheduler', 'run', '--hooks=wc-admin_import_orders,wc-admin_import_customers --force']);
-
     $i->wantTo('Check that there is one subscriber in the single order value segment');
-    $i->amOnMailpoetPage('Segments');
-    $i->waitForText(self::SINGLE_ORDER_VALUE_SEGMENT);
-    $singleOrderValueSegmentSubscribedElement = "[data-automation-id='mailpoet_dynamic_segment_count_all_{$this->singleOrderValueSegment->getId()}']";
-
-    $i->see('1', $singleOrderValueSegmentSubscribedElement);
+    $this->seeSubscribersCountInSegment($i, $this->singleOrderValueSegment, '1');
     $this->clickAction($i, $this->singleOrderValueSegment, 'View subscribers');
     $i->waitForText($customerEmail2);
     $i->dontSee($customerEmail1);
@@ -209,16 +174,8 @@ class WooCommerceDynamicSegmentsCest {
 
     $i->login();
 
-    // run action scheduler to sync customer and order data to lookup tables
-    $i->wait(2);
-    $i->cli(['action-scheduler', 'run', '--hooks=wc-admin_import_orders,wc-admin_import_customers --force']);
-
     $i->wantTo('Check that there is one subscriber in the total spent segment');
-    $i->amOnMailpoetPage('Segments');
-    $i->waitForText(self::TOTAL_SPENT_SEGMENT);
-    $totalSpentSegmentSubscribedElement = "[data-automation-id='mailpoet_dynamic_segment_count_all_{$this->totalSpentSegment->getId()}']";
-
-    $i->see('1', $totalSpentSegmentSubscribedElement);
+    $this->seeSubscribersCountInSegment($i, $this->totalSpentSegment, '1');
     $this->clickAction($i, $this->totalSpentSegment, 'View subscribers');
     $i->waitForText($customerEmail);
   }
@@ -233,15 +190,8 @@ class WooCommerceDynamicSegmentsCest {
 
     $i->login();
 
-    // run action scheduler to sync customer and order data to lookup tables
-    $i->wait(2);
-    $i->cli(['action-scheduler', 'run', '--hooks=wc-admin_import_orders,wc-admin_import_customers --force']);
-
     $i->wantTo('Check that there is one subscriber in customer country segment');
-    $i->amOnMailpoetPage('Segments');
-    $i->waitForText(self::CUSTOMER_IN_COUNTRY);
-    $customerInCountryCountElement = "[data-automation-id='mailpoet_dynamic_segment_count_all_{$this->customerCountrySegment->getId()}']";
-    $i->waitForText('2', 30, $customerInCountryCountElement);
+    $this->seeSubscribersCountInSegment($i, $this->customerCountrySegment, '2');
     $this->clickAction($i, $this->customerCountrySegment, 'View subscribers');
     $i->waitForText($customerEmail);
     $i->waitForText($guestEmail);
@@ -275,6 +225,38 @@ class WooCommerceDynamicSegmentsCest {
     $this->seeDisabledEditAction($i, $this->totalSpentSegment);
     $this->seeDisabledEditAction($i, $this->customerCountrySegment);
     $i->seeNoJSErrors();
+  }
+
+  /**
+   * Assert a WooCommerce dynamic segment shows the expected "all" subscriber count.
+   *
+   * These counts come from WooCommerce's analytics lookup tables, which are filled
+   * by an asynchronous Action Scheduler batch import, not by the legacy per-item
+   * wc-admin_import_* actions. The listing reads the count once on load with no
+   * polling, so asserting after a single fixed wait races the import and sees 0
+   * before it finishes; Action Scheduler also claims only one batch per run, so the
+   * chain needs several runs to drain.
+   *
+   * Run the full Action Scheduler queue and reload the listing a few times until
+   * the count settles.
+   */
+  private function seeSubscribersCountInSegment(\AcceptanceTester $i, SegmentEntity $segment, string $expectedCount): void {
+    $countElement = "[data-automation-id='mailpoet_dynamic_segment_count_all_{$segment->getId()}']";
+    $maxAttempts = 5;
+    for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+      $i->cli(['action-scheduler', 'run', '--force']);
+      $i->amOnMailpoetPage('Segments');
+      $i->waitForText($segment->getName());
+      try {
+        $i->waitForText($expectedCount, 5, $countElement);
+        return;
+      } catch (\Exception $e) {
+        if ($attempt === $maxAttempts) {
+          throw $e;
+        }
+        $i->wait(2);
+      }
+    }
   }
 
   private function clickAction(\AcceptanceTester $i, SegmentEntity $segmentEntity, $actionName) {


### PR DESCRIPTION
## Description

The nightly `acceptance_oldest` job started failing consistently on `WooCommerceDynamicSegmentsCest` because the WooCommerce dynamic segment count read `0` instead of the expected value.

<img width="1321" height="913" alt="image" src="https://github.com/user-attachments/assets/a27dc7ea-09da-4e7a-875e-8992575887e3" />

Root cause is a timing race, not a product defect. The WooCommerce dynamic segment counts are read from WooCommerce's analytics lookup tables, which are populated by an asynchronous Action Scheduler batch import. The tests asserted the count right after a single fixed wait, racing that import: until it finished, the lookup tables were empty and every order-based count rendered `0`. A recent AutomateWoo upgrade added Action Scheduler contention that shifted the race so the import usually lost, turning the job consistently red.

The fix routes the count assertions through a `seeSubscribersCountInSegment()` helper that drains the full Action Scheduler queue (`--force`) and reloads the listing a few times until the count settles. The `wc-admin_import_*` hooks the tests previously run are vestigial in modern WooCommerce, so running the full queue is what actually advances the batch import chain. The change also removes six near-identical inline sync blocks in favour of the single helper.

## Code review notes

Verified on CircleCI through a temporary commit 35ec280c4612a03a14903c3ec13a830ae778c820.

https://app.circleci.com/pipelines/github/mailpoet/mailpoet/24126/workflows/19667b0c-09fa-4fe7-8c62-399cebc3a66f/jobs/424737

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/woocommerce-dynamic-segment-count-import-race)

_The latest successful build from `fix/woocommerce-dynamic-segment-count-import-race` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->