### PR TITLE
Skip mismatched CSV rows on CLI subscriber import

### DIFF
--- a/mailpoet/changelog/2026-06-30-11-45-51-fixed-cli-subscriber-import-now-skips-and-warns-about-cs.md
+++ b/mailpoet/changelog/2026-06-30-11-45-51-fixed-cli-subscriber-import-now-skips-and-warns-about-cs.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+CLI subscriber import now skips and warns about CSV rows whose column count does not match the header instead of silently misaligning data

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
@@ -184,20 +184,26 @@ class Cli {
       return;
     }
 
+    $skippedNotice = $totals['skipped'] > 0
+      ? sprintf(' %d row(s) were skipped because their column count did not match the header.', $totals['skipped'])
+      : '';
+
     if ($options['dry_run']) {
       WP_CLI::success(sprintf(
-        'Dry run: %d rows read, %d subscribers with a valid email. Nothing was written.',
+        'Dry run: %d rows read, %d subscribers with a valid email. Nothing was written.%s',
         $totals['rows'],
-        $totals['valid']
+        $totals['valid'],
+        $skippedNotice
       ));
       return;
     }
 
     WP_CLI::success(sprintf(
-      'Import finished: %d created, %d updated (out of %d rows).',
+      'Import finished: %d created, %d updated (out of %d rows).%s',
       $totals['created'],
       $totals['updated'],
-      $totals['rows']
+      $totals['rows'],
+      $skippedNotice
     ));
   }
 
@@ -207,7 +213,7 @@ class Cli {
    *
    * @param array{segments: string[], status: string, existing_status: string, update_existing: bool, tags: string[], batch_size: int, dry_run: bool} $options
    * @param callable(string): void|null $logger
-   * @return array{created: int, updated: int, valid: int, rows: int}
+   * @return array{created: int, updated: int, valid: int, rows: int, skipped: int}
    * @throws \RuntimeException
    */
   public function run(string $file, array $options, ?callable $logger = null): array {
@@ -241,11 +247,23 @@ class Cli {
       }
       $columns = $this->buildColumns($header);
 
-      $totals = ['created' => 0, 'updated' => 0, 'valid' => 0, 'rows' => 0];
+      $headerColumnCount = count($header);
+      $totals = ['created' => 0, 'updated' => 0, 'valid' => 0, 'rows' => 0, 'skipped' => 0];
       $batch = [];
+      $lineNumber = 1; // header is line 1
       while (is_array($row = fgetcsv($handle, 0, ',', '"', '\\'))) {
+        $lineNumber++;
         if ($row === [null]) {
           continue; // skip blank lines
+        }
+        // fgetcsv does not pad short rows or trim long ones. A row whose column
+        // count differs from the header would misalign the per-column arrays built
+        // in Import (a value landing on the wrong subscriber), so skip it and warn
+        // rather than guessing which columns are missing.
+        if (count($row) !== $headerColumnCount) {
+          $totals['skipped']++;
+          $log(sprintf('  Skipped line %d: expected %d column(s) but found %d.', $lineNumber, $headerColumnCount, count($row)));
+          continue;
         }
         $totals['rows']++;
         $batch[] = $row;
@@ -269,7 +287,7 @@ class Cli {
    * @param array<string|int, array{index: int}> $columns
    * @param int[] $segmentIds
    * @param array{segments: string[], status: string, existing_status: string, update_existing: bool, tags: string[], batch_size: int, dry_run: bool} $options
-   * @param array{created: int, updated: int, valid: int, rows: int} $totals
+   * @param array{created: int, updated: int, valid: int, rows: int, skipped: int} $totals
    * @param callable(string): void $log
    */
   private function processBatch(

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
@@ -185,14 +185,13 @@ class Cli {
     }
 
     $rowsRead = $totals['rows'] + $totals['skipped'];
-    $skippedNotice = $totals['skipped'] > 0
-      ? sprintf(
-        ' %d %s skipped because %s column count did not match the header.',
-        $totals['skipped'],
-        $totals['skipped'] === 1 ? 'row was' : 'rows were',
-        $totals['skipped'] === 1 ? 'its' : 'their'
-      )
-      : '';
+    $skippedNotice = '';
+    if ($totals['skipped'] > 0) {
+      $skippedTemplate = $totals['skipped'] === 1
+        ? ' %d row was skipped because its column count did not match the header.'
+        : ' %d rows were skipped because their column count did not match the header.';
+      $skippedNotice = sprintf($skippedTemplate, $totals['skipped']);
+    }
 
     if ($options['dry_run']) {
       WP_CLI::success(sprintf(

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
@@ -184,14 +184,20 @@ class Cli {
       return;
     }
 
+    $rowsRead = $totals['rows'] + $totals['skipped'];
     $skippedNotice = $totals['skipped'] > 0
-      ? sprintf(' %d row(s) were skipped because their column count did not match the header.', $totals['skipped'])
+      ? sprintf(
+        ' %d %s skipped because %s column count did not match the header.',
+        $totals['skipped'],
+        $totals['skipped'] === 1 ? 'row was' : 'rows were',
+        $totals['skipped'] === 1 ? 'its' : 'their'
+      )
       : '';
 
     if ($options['dry_run']) {
       WP_CLI::success(sprintf(
         'Dry run: %d rows read, %d subscribers with a valid email. Nothing was written.%s',
-        $totals['rows'],
+        $rowsRead,
         $totals['valid'],
         $skippedNotice
       ));
@@ -202,7 +208,7 @@ class Cli {
       'Import finished: %d created, %d updated (out of %d rows).%s',
       $totals['created'],
       $totals['updated'],
-      $totals['rows'],
+      $rowsRead,
       $skippedNotice
     ));
   }

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/CliTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/CliTest.php
@@ -195,6 +195,62 @@ class CliTest extends \MailPoetTest {
     $this->cli->run($file, self::DEFAULT_OPTIONS);
   }
 
+  public function testItSkipsRowsWithFewerColumnsThanHeader(): void {
+    $messages = [];
+    $logger = function (string $message) use (&$messages): void {
+      $messages[] = $message;
+    };
+
+    // "email" is deliberately not the last column: a short row, if padded or
+    // passed through, would shift a later subscriber's value onto the wrong
+    // record (Carol's last name landing on Bob's email).
+    $file = $this->writeCsv([
+      ['first_name', 'email', 'last_name'],
+      ['Adam', 'adam@example.com', 'Smith'],
+      ['Bob', 'bob@example.com'], // short row: last_name missing
+      ['Carol', 'carol@example.com', 'Jones'],
+    ]);
+
+    $totals = $this->cli->run($file, self::DEFAULT_OPTIONS, $logger);
+
+    $this->assertSame(2, $totals['rows']);
+    $this->assertSame(2, $totals['created']);
+    $this->assertSame(1, $totals['skipped']);
+
+    $this->subscribersRepository->refreshAll();
+    $adam = $this->subscribersRepository->findOneBy(['email' => 'adam@example.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $adam);
+    $this->assertSame('Smith', $adam->getLastName());
+
+    $carol = $this->subscribersRepository->findOneBy(['email' => 'carol@example.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $carol);
+    $this->assertSame('Jones', $carol->getLastName());
+
+    // The malformed row must not be imported under a guessed alignment.
+    $this->assertNull($this->subscribersRepository->findOneBy(['email' => 'bob@example.com']));
+
+    $skippedWarnings = array_filter($messages, function (string $message): bool {
+      return strpos($message, 'Skipped line 3') !== false;
+    });
+    $this->assertCount(1, $skippedWarnings);
+  }
+
+  public function testItSkipsRowsWithMoreColumnsThanHeader(): void {
+    $file = $this->writeCsv([
+      ['email', 'first_name'],
+      ['valid@example.com', 'Valid'],
+      ['extra@example.com', 'Extra', 'unexpected-column'], // too many columns
+    ]);
+
+    $totals = $this->cli->run($file, self::DEFAULT_OPTIONS);
+
+    $this->assertSame(1, $totals['rows']);
+    $this->assertSame(1, $totals['created']);
+    $this->assertSame(1, $totals['skipped']);
+    $this->assertInstanceOf(SubscriberEntity::class, $this->subscribersRepository->findOneBy(['email' => 'valid@example.com']));
+    $this->assertNull($this->subscribersRepository->findOneBy(['email' => 'extra@example.com']));
+  }
+
   public function testItThrowsForMissingFile(): void {
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('does not exist or is not readable');


### PR DESCRIPTION
## Description

The CLI subscriber import (`wp mailpoet import`, in `mailpoet/lib/Subscribers/ImportExport/Import/Cli.php`) read each CSV row with `fgetcsv` and appended it to the batch unchanged. `fgetcsv` does not pad short rows, so a row with fewer columns than the header (which happens when an export drops trailing empty fields) made `Import::transformSubscribersData` build per-column arrays of different lengths via `array_column`. `splitSubscribersData` then pairs columns by position, so a value lands on the wrong subscriber — and the import still reports success.

This fix skips any row whose column count does not match the header and logs a warning with the line number, rather than guessing which columns are missing. The email column is not necessarily the last one, so padding short rows could shove a name into the email slot — skipping is the safe choice and mirrors the web UI, which already drops mismatched rows (`sanitize-csv-data.jsx`). The run now also reports a count of skipped rows in the WP-CLI success message.

## Code review notes

Padding (`array_pad`) was the fix suggested on the ticket, but it assumes the missing columns are always trailing. Since the header can map `email` to any position, a corrupt short row could pad a later field's value into `email`. Skip-and-warn avoids importing data under a guessed alignment.

## QA notes

Covered by integration tests in `CliTest.php` (`testItSkipsRowsWithFewerColumnsThanHeader`, `testItSkipsRowsWithMoreColumnsThanHeader`). To verify manually:

1. Create a CSV with `first_name,email,last_name` header and a row missing the trailing `last_name` value (e.g. `Bob,bob@example.com`), plus well-formed rows before and after it.
2. Run `wp mailpoet import <file>.csv`.
3. Expected: the short row is skipped with a `Skipped line N: expected 3 column(s) but found 2.` warning, the success message reports the skipped count, and the other subscribers import with their data correctly aligned (no name landing on the wrong email).

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8215

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8215-cli-csv-import-misaligns-data-on-short-rows)

_The latest successful build from `fix/stomail-8215-cli-csv-import-misaligns-data-on-short-rows` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->