### PR TITLE
Clean up related rows in removeByWpUserIds

### DIFF
--- a/mailpoet/assets/js/src/help/data-inconsistencies.tsx
+++ b/mailpoet/assets/js/src/help/data-inconsistencies.tsx
@@ -42,6 +42,11 @@ export function DataInconsistencies() {
         'mailpoet',
       ),
       orphaned_subscriptions: __('Orphaned Subscriptions', 'mailpoet'),
+      orphaned_subscriber_custom_fields: __(
+        'Orphaned Subscriber Custom Fields',
+        'mailpoet',
+      ),
+      orphaned_subscriber_tags: __('Orphaned Subscriber Tags', 'mailpoet'),
       orphaned_links: __('Orphaned Links', 'mailpoet'),
       orphaned_newsletter_posts: __('Orphaned Newsletter Posts', 'mailpoet'),
     }),

--- a/mailpoet/changelog/2026-07-01-08-14-21-fixed-remove-orphaned-subscribersegment-subscribercustom.md
+++ b/mailpoet/changelog/2026-07-01-08-14-21-fixed-remove-orphaned-subscribersegment-subscribercustom.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Remove orphaned subscriber_segment, subscriber_custom_field and subscriber_tag rows when deleting subscribers linked to invalid WordPress users

--- a/mailpoet/changelog/2026-07-01-08-33-49-added-data-inconsistencies-tool-can-now-clean-up-orphane.md
+++ b/mailpoet/changelog/2026-07-01-08-33-49-added-data-inconsistencies-tool-can-now-clean-up-orphane.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Data inconsistencies tool can now clean up orphaned subscriber custom field and subscriber tag rows

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -1135,14 +1135,76 @@ class SubscribersRepository extends Repository {
   }
 
   public function removeByWpUserIds(array $wpUserIds) {
-    $queryBuilder = $this->entityManager->createQueryBuilder();
+    if (empty($wpUserIds)) {
+      return 0;
+    }
 
-    $queryBuilder
-      ->delete(SubscriberEntity::class, 's')
-      ->where('s.wpUserId IN (:wpUserIds)')
-      ->setParameter('wpUserIds', $wpUserIds);
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $subscriberIds = array_map(
+      function($id): int {
+        return $this->toInt($id);
+      },
+      $this->entityManager->getConnection()->executeQuery(
+        "SELECT `id` FROM $subscriberTable WHERE `wp_user_id` IN (:wpUserIds)",
+        ['wpUserIds' => $wpUserIds],
+        ['wpUserIds' => ArrayParameterType::INTEGER]
+      )->fetchFirstColumn()
+    );
 
-    return $queryBuilder->getQuery()->execute();
+    if (empty($subscriberIds)) {
+      return 0;
+    }
+
+    $count = 0;
+    $this->entityManager->transactional(function (EntityManager $entityManager) use ($subscriberIds, &$count) {
+      $this->removeSubscribersRelatedRows($subscriberIds);
+
+      $count = $entityManager->createQueryBuilder()
+        ->delete(SubscriberEntity::class, 's')
+        ->where('s.id IN (:ids)')
+        ->setParameter('ids', $subscriberIds)
+        ->getQuery()->execute();
+    });
+
+    $this->changesNotifier->subscribersDeleted($subscriberIds);
+    $this->invalidateTotalSubscribersCache();
+
+    return $count;
+  }
+
+  /**
+   * Removes rows in tables related to the given subscribers so no orphans are
+   * left behind after the subscribers themselves are deleted. Unlike
+   * removeSubscribersFromAllSegments() this removes every segment membership
+   * regardless of segment type, since the subscribers are being fully removed.
+   */
+  private function removeSubscribersRelatedRows(array $subscriberIds): void {
+    if (empty($subscriberIds)) {
+      return;
+    }
+
+    $connection = $this->entityManager->getConnection();
+    $subscriberSegmentsTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
+    $subscriberCustomFieldTable = $this->entityManager->getClassMetadata(SubscriberCustomFieldEntity::class)->getTableName();
+    $subscriberTagTable = $this->entityManager->getClassMetadata(SubscriberTagEntity::class)->getTableName();
+
+    $connection->executeStatement(
+      "DELETE FROM $subscriberSegmentsTable WHERE `subscriber_id` IN (:ids)",
+      ['ids' => $subscriberIds],
+      ['ids' => ArrayParameterType::INTEGER]
+    );
+
+    $connection->executeStatement(
+      "DELETE FROM $subscriberCustomFieldTable WHERE `subscriber_id` IN (:ids)",
+      ['ids' => $subscriberIds],
+      ['ids' => ArrayParameterType::INTEGER]
+    );
+
+    $connection->executeStatement(
+      "DELETE FROM $subscriberTagTable WHERE `subscriber_id` IN (:ids)",
+      ['ids' => $subscriberIds],
+      ['ids' => ArrayParameterType::INTEGER]
+    );
   }
 
   /**

--- a/mailpoet/lib/Util/DataInconsistency/DataInconsistencyController.php
+++ b/mailpoet/lib/Util/DataInconsistency/DataInconsistencyController.php
@@ -9,6 +9,8 @@ class DataInconsistencyController {
   const ORPHANED_SENDING_TASK_SUBSCRIBERS = 'orphaned_sending_task_subscribers';
   const SENDING_QUEUE_WITHOUT_NEWSLETTER = 'sending_queue_without_newsletter';
   const ORPHANED_SUBSCRIPTIONS = 'orphaned_subscriptions';
+  const ORPHANED_SUBSCRIBER_CUSTOM_FIELDS = 'orphaned_subscriber_custom_fields';
+  const ORPHANED_SUBSCRIBER_TAGS = 'orphaned_subscriber_tags';
   const ORPHANED_LINKS = 'orphaned_links';
   const ORPHANED_NEWSLETTER_POSTS = 'orphaned_newsletter_posts';
 
@@ -17,6 +19,8 @@ class DataInconsistencyController {
     self::ORPHANED_SENDING_TASK_SUBSCRIBERS,
     self::SENDING_QUEUE_WITHOUT_NEWSLETTER,
     self::ORPHANED_SUBSCRIPTIONS,
+    self::ORPHANED_SUBSCRIBER_CUSTOM_FIELDS,
+    self::ORPHANED_SUBSCRIBER_TAGS,
     self::ORPHANED_LINKS,
     self::ORPHANED_NEWSLETTER_POSTS,
   ];
@@ -35,6 +39,8 @@ class DataInconsistencyController {
       self::ORPHANED_SENDING_TASK_SUBSCRIBERS => $this->repository->getOrphanedScheduledTasksSubscribersCount(),
       self::SENDING_QUEUE_WITHOUT_NEWSLETTER => $this->repository->getSendingQueuesWithoutNewsletterCount(),
       self::ORPHANED_SUBSCRIPTIONS => $this->repository->getOrphanedSubscriptionsCount(),
+      self::ORPHANED_SUBSCRIBER_CUSTOM_FIELDS => $this->repository->getOrphanedSubscriberCustomFieldsCount(),
+      self::ORPHANED_SUBSCRIBER_TAGS => $this->repository->getOrphanedSubscriberTagsCount(),
       self::ORPHANED_LINKS => $this->repository->getOrphanedNewsletterLinksCount(),
       self::ORPHANED_NEWSLETTER_POSTS => $this->repository->getOrphanedNewsletterPostsCount(),
     ];
@@ -54,6 +60,10 @@ class DataInconsistencyController {
       $this->repository->cleanupSendingQueuesWithoutNewsletter();
     } elseif ($inconsistency === self::ORPHANED_SUBSCRIPTIONS) {
       $this->repository->cleanupOrphanedSubscriptions();
+    } elseif ($inconsistency === self::ORPHANED_SUBSCRIBER_CUSTOM_FIELDS) {
+      $this->repository->cleanupOrphanedSubscriberCustomFields();
+    } elseif ($inconsistency === self::ORPHANED_SUBSCRIBER_TAGS) {
+      $this->repository->cleanupOrphanedSubscriberTags();
     } elseif ($inconsistency === self::ORPHANED_LINKS) {
       $this->repository->cleanupOrphanedNewsletterLinks();
     } elseif ($inconsistency === self::ORPHANED_NEWSLETTER_POSTS) {

--- a/mailpoet/lib/Util/DataInconsistency/DataInconsistencyRepository.php
+++ b/mailpoet/lib/Util/DataInconsistency/DataInconsistencyRepository.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Util\DataInconsistency;
 
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
+use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\NewsletterPostEntity;
@@ -10,8 +11,11 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Entities\SubscriberTagEntity;
+use MailPoet\Entities\TagEntity;
 use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\DBAL\ParameterType;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -74,6 +78,34 @@ class DataInconsistencyRepository {
       LEFT JOIN $segmentTable seg ON seg.`id` = ss.`segment_id`
       LEFT JOIN $subscriberTable sub ON sub.`id` = ss.`subscriber_id`
       WHERE seg.`id` IS NULL OR sub.`id` IS NULL
+    ")->fetchOne();
+    return intval($count);
+  }
+
+  public function getOrphanedSubscriberCustomFieldsCount(): int {
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $customFieldTable = $this->entityManager->getClassMetadata(CustomFieldEntity::class)->getTableName();
+    $subscriberCustomFieldTable = $this->entityManager->getClassMetadata(SubscriberCustomFieldEntity::class)->getTableName();
+    /** @var string $count */
+    $count = $this->entityManager->getConnection()->executeQuery("
+      SELECT count(distinct scf.`id`) FROM $subscriberCustomFieldTable scf
+      LEFT JOIN $customFieldTable cf ON cf.`id` = scf.`custom_field_id`
+      LEFT JOIN $subscriberTable sub ON sub.`id` = scf.`subscriber_id`
+      WHERE cf.`id` IS NULL OR sub.`id` IS NULL
+    ")->fetchOne();
+    return intval($count);
+  }
+
+  public function getOrphanedSubscriberTagsCount(): int {
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $tagTable = $this->entityManager->getClassMetadata(TagEntity::class)->getTableName();
+    $subscriberTagTable = $this->entityManager->getClassMetadata(SubscriberTagEntity::class)->getTableName();
+    /** @var string $count */
+    $count = $this->entityManager->getConnection()->executeQuery("
+      SELECT count(distinct st.`id`) FROM $subscriberTagTable st
+      LEFT JOIN $tagTable t ON t.`id` = st.`tag_id`
+      LEFT JOIN $subscriberTable sub ON sub.`id` = st.`subscriber_id`
+      WHERE t.`id` IS NULL OR sub.`id` IS NULL
     ")->fetchOne();
     return intval($count);
   }
@@ -193,6 +225,30 @@ class DataInconsistencyRepository {
       LEFT JOIN $segmentTable seg ON seg.`id` = ss.`segment_id`
       LEFT JOIN $subscriberTable sub ON sub.`id` = ss.`subscriber_id`
       WHERE seg.`id` IS NULL OR sub.`id` IS NULL
+    ");
+  }
+
+  public function cleanupOrphanedSubscriberCustomFields(): int {
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $customFieldTable = $this->entityManager->getClassMetadata(CustomFieldEntity::class)->getTableName();
+    $subscriberCustomFieldTable = $this->entityManager->getClassMetadata(SubscriberCustomFieldEntity::class)->getTableName();
+    return (int)$this->entityManager->getConnection()->executeStatement("
+      DELETE scf FROM $subscriberCustomFieldTable scf
+      LEFT JOIN $customFieldTable cf ON cf.`id` = scf.`custom_field_id`
+      LEFT JOIN $subscriberTable sub ON sub.`id` = scf.`subscriber_id`
+      WHERE cf.`id` IS NULL OR sub.`id` IS NULL
+    ");
+  }
+
+  public function cleanupOrphanedSubscriberTags(): int {
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $tagTable = $this->entityManager->getClassMetadata(TagEntity::class)->getTableName();
+    $subscriberTagTable = $this->entityManager->getClassMetadata(SubscriberTagEntity::class)->getTableName();
+    return (int)$this->entityManager->getConnection()->executeStatement("
+      DELETE st FROM $subscriberTagTable st
+      LEFT JOIN $tagTable t ON t.`id` = st.`tag_id`
+      LEFT JOIN $subscriberTable sub ON sub.`id` = st.`subscriber_id`
+      WHERE t.`id` IS NULL OR sub.`id` IS NULL
     ");
   }
 

--- a/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
@@ -453,14 +453,50 @@ class SubscribersRepositoryTest extends \MailPoetTest {
     $wpUserId1 = $this->tester->createWordPressUser('subscriber1@email.com', 'author');
     $wpUserId2 = $this->tester->createWordPressUser('subscriber2@email.com', 'author');
     $wpUserId3 = $this->tester->createWordPressUser('subscriber3@email.com', 'author');
+
+    $subscriber1 = $this->repository->findOneBy(['wpUserId' => $wpUserId1]);
+    $subscriber2 = $this->repository->findOneBy(['wpUserId' => $wpUserId2]);
     $subscriber3 = $this->repository->findOneBy(['wpUserId' => $wpUserId3]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber3);
+
+    $subscriber1Id = (int)$subscriber1->getId();
+    $subscriber2Id = (int)$subscriber2->getId();
+    $subscriber3Id = (int)$subscriber3->getId();
+
+    // Attach related rows to each subscriber so we can assert they get cleaned up.
+    $segment = $this->segmentRepository->createOrUpdate('Removed WP users segment');
+    $customField = $this->createCustomField('WP users CF');
+    $tag = $this->createTag('WP users tag');
+    foreach ([$subscriber1, $subscriber2, $subscriber3] as $subscriber) {
+      $this->createSubscriberSegment($segment, $subscriber);
+      $this->createSubscriberCustomField($subscriber, $customField);
+      $this->createSubscriberTag($subscriber, $tag);
+    }
+
+    $subscriberTagRepository = $this->entityManager->getRepository(SubscriberTagEntity::class);
 
     $deletedRows = $this->repository->removeByWpUserIds([$wpUserId1, $wpUserId2]);
+    $this->entityManager->clear();
 
     $this->assertSame(2, $deletedRows);
     $subscribers = $this->repository->findAll();
     $this->assertCount(1, $subscribers);
-    $this->assertSame($subscribers[0], $subscriber3);
+    $this->assertSame($subscriber3Id, $subscribers[0]->getId());
+
+    // Related rows of the removed subscribers are gone, including the WP-Users
+    // segment memberships created during synchronization.
+    foreach ([$subscriber1Id, $subscriber2Id] as $removedId) {
+      verify($this->subscriberSegmentRepository->findBy(['subscriber' => $removedId]))->empty();
+      verify($this->subscriberCustomFieldRepository->findOneBy(['subscriber' => $removedId]))->null();
+      verify($subscriberTagRepository->findOneBy(['subscriber' => $removedId]))->null();
+    }
+
+    // Related rows of the surviving subscriber are untouched.
+    verify($this->subscriberSegmentRepository->findOneBy(['subscriber' => $subscriber3Id]))->notNull();
+    verify($this->subscriberCustomFieldRepository->findOneBy(['subscriber' => $subscriber3Id]))->notNull();
+    verify($subscriberTagRepository->findOneBy(['subscriber' => $subscriber3Id]))->notNull();
   }
 
   public function testItDeletesOnlyEligibleUnconfirmedSubscribersForCleanup(): void {

--- a/mailpoet/tests/integration/Util/DataInconsistency/DataInconsistencyRepositoryTest.php
+++ b/mailpoet/tests/integration/Util/DataInconsistency/DataInconsistencyRepositoryTest.php
@@ -3,10 +3,15 @@
 namespace MailPoet\Util\DataInconsistency;
 
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
+use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberTagEntity;
+use MailPoet\Entities\TagEntity;
+use MailPoet\Test\DataFactories\CustomField;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterLink;
 use MailPoet\Test\DataFactories\NewsletterPost;
@@ -15,6 +20,7 @@ use MailPoet\Test\DataFactories\ScheduledTaskSubscriber;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\SendingQueue;
 use MailPoet\Test\DataFactories\Subscriber;
+use MailPoet\Test\DataFactories\Tag;
 
 class DataInconsistencyRepositoryTest extends \MailPoetTest {
   private DataInconsistencyRepository $repository;
@@ -142,6 +148,58 @@ class DataInconsistencyRepositoryTest extends \MailPoetTest {
     $this->assertInstanceOf(SegmentEntity::class, $segmentToKeep);
   }
 
+  public function testItHandlesOrphanedSubscriberCustomFields(): void {
+    $customFieldToDelete = (new CustomField())->create();
+    $customFieldToKeep = (new CustomField())->create();
+    $subscriberToDelete = (new Subscriber())->create();
+    $subscriberToKeep = (new Subscriber())->create();
+
+    // Orphaned via subscriber, orphaned via custom field, and a healthy row.
+    $this->createSubscriberCustomField($subscriberToDelete, $customFieldToKeep);
+    $this->createSubscriberCustomField($subscriberToKeep, $customFieldToDelete);
+    $this->createSubscriberCustomField($subscriberToKeep, $customFieldToKeep);
+
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $this->entityManager->getConnection()
+      ->executeStatement("DELETE FROM $subscriberTable WHERE id = :id", ['id' => $subscriberToDelete->getId()]);
+    $customFieldTable = $this->entityManager->getClassMetadata(CustomFieldEntity::class)->getTableName();
+    $this->entityManager->getConnection()
+      ->executeStatement("DELETE FROM $customFieldTable WHERE id = :id", ['id' => $customFieldToDelete->getId()]);
+
+    verify($this->repository->getOrphanedSubscriberCustomFieldsCount())->equals(2);
+    $this->repository->cleanupOrphanedSubscriberCustomFields();
+    verify($this->repository->getOrphanedSubscriberCustomFieldsCount())->equals(0);
+
+    // The healthy row is untouched.
+    verify($this->entityManager->getRepository(SubscriberCustomFieldEntity::class)->count([]))->equals(1);
+  }
+
+  public function testItHandlesOrphanedSubscriberTags(): void {
+    $tagToDelete = (new Tag())->create();
+    $tagToKeep = (new Tag())->create();
+    $subscriberToDelete = (new Subscriber())->create();
+    $subscriberToKeep = (new Subscriber())->create();
+
+    // Orphaned via subscriber, orphaned via tag, and a healthy row.
+    $this->createSubscriberTag($subscriberToDelete, $tagToKeep);
+    $this->createSubscriberTag($subscriberToKeep, $tagToDelete);
+    $this->createSubscriberTag($subscriberToKeep, $tagToKeep);
+
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $this->entityManager->getConnection()
+      ->executeStatement("DELETE FROM $subscriberTable WHERE id = :id", ['id' => $subscriberToDelete->getId()]);
+    $tagTable = $this->entityManager->getClassMetadata(TagEntity::class)->getTableName();
+    $this->entityManager->getConnection()
+      ->executeStatement("DELETE FROM $tagTable WHERE id = :id", ['id' => $tagToDelete->getId()]);
+
+    verify($this->repository->getOrphanedSubscriberTagsCount())->equals(2);
+    $this->repository->cleanupOrphanedSubscriberTags();
+    verify($this->repository->getOrphanedSubscriberTagsCount())->equals(0);
+
+    // The healthy row is untouched.
+    verify($this->entityManager->getRepository(SubscriberTagEntity::class)->count([]))->equals(1);
+  }
+
   public function testItHandlesOrphanedLinks(): void {
     $newsletterToDelete = (new Newsletter())->create();
     $task1 = (new ScheduledTask())->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
@@ -183,5 +241,17 @@ class DataInconsistencyRepositoryTest extends \MailPoetTest {
     verify($this->repository->getOrphanedNewsletterPostsCount())->equals(1);
     $this->repository->cleanupOrphanedNewsletterPosts();
     verify($this->repository->getOrphanedNewsletterPostsCount())->equals(0);
+  }
+
+  private function createSubscriberCustomField(SubscriberEntity $subscriber, CustomFieldEntity $customField): void {
+    $subscriberCustomField = new SubscriberCustomFieldEntity($subscriber, $customField, 'some value');
+    $this->entityManager->persist($subscriberCustomField);
+    $this->entityManager->flush();
+  }
+
+  private function createSubscriberTag(SubscriberEntity $subscriber, TagEntity $tag): void {
+    $subscriberTag = new SubscriberTagEntity($tag, $subscriber);
+    $this->entityManager->persist($subscriberTag);
+    $this->entityManager->flush();
   }
 }


### PR DESCRIPTION
## Description

This addresses RSM-4511 in two parts.

**1. Stop creating new orphans.** `SubscribersRepository::removeByWpUserIds()` deleted subscribers with a DQL `DELETE`, which bypasses Doctrine's `orphanRemoval`. As a result the related rows were left behind in `subscriber_segment`, `subscriber_custom_field` and `subscriber_tag`. For WordPress users (the actual callers, via `Segments\WP::removeUpdatedSubscribersWithInvalidEmail()`) this notably orphaned their WP-Users segment memberships. The method now resolves the affected subscriber ids up front and, inside a transaction, removes every related row — all segment memberships regardless of type (not just the default type that `removeSubscribersFromAllSegments()` handles), custom fields and tags — before deleting the subscribers by id, then notifies the change tracker and invalidates the subscriber-count cache.

**2. Clean up the historical backlog.** The existing "Data inconsistencies" tool (Help page) already cleaned orphaned `subscriber_segment` rows (`orphaned_subscriptions`) but had no equivalent for `subscriber_custom_field` / `subscriber_tag`, which the old behaviour also orphaned. Added two matching checks — `orphaned_subscriber_custom_fields` and `orphaned_subscriber_tags` — that flag and clean rows whose subscriber, or whose custom field / tag, no longer exists.

## Code review notes

- `removeSubscribersRelatedRows()` deliberately deletes **all** `subscriber_segment` rows for the affected subscribers rather than reusing `removeSubscribersFromAllSegments()`, which only clears `default`-type segments. These subscribers are WP users, so leaving the WP-Users membership behind is exactly the orphan we're fixing. Statistics tables are intentionally left untouched, consistent with the existing `bulkDelete()` / cleanup paths.
- The two new DataInconsistency checks mirror `getOrphanedSubscriptionsCount()` / `cleanupOrphanedSubscriptions()` exactly (LEFT JOIN both parents, `WHERE parent IS NULL`). `SystemReportCollector` and the Help UI iterate the status map dynamically, so the new keys flow through without further wiring beyond the label map.

## QA notes

- `SubscribersRepositoryTest::testRemoveByWpUserIds` now attaches a segment, custom field and tag to each WP-user subscriber and asserts the removed subscribers' related rows are gone (incl. the WP-Users membership) while the surviving subscriber's rows remain.
- `DataInconsistencyRepositoryTest` gains `testItHandlesOrphanedSubscriberCustomFields` and `testItHandlesOrphanedSubscriberTags`, covering orphaning via either parent plus a healthy row left intact.
- Manual: Help → Data inconsistencies should now list "Orphaned Subscriber Custom Fields" / "Orphaned Subscriber Tags" when present, each with a working Fix button.
- PHPStan, PHPCS, ESLint, tsc and Prettier all pass. The local integration container currently can't boot MailPoet (`Env::$dbPrefix` not initialized) independent of this change, so the integration suite was not run here.

## Linked PRs

_N/A_

## Linked tickets

[RSM-4511](https://linear.app/a8c/issue/RSM-4511/clean-up-related-rows-in-removebywpuserids)

## After-merge notes

On sites with an existing backlog (e.g. the large test instance), the orphaned rows can be cleared from Help → Data inconsistencies after this ships.

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->