### PR TITLE
Raise integration test memory limit to 2048M

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1023,39 +1023,9 @@ workflows:
           <<: *slack-fail-post-step
       - build_premium:
           <<: *slack-fail-post-step
-          # TEMP (revert before merge): dropped *only_release so build_premium runs on this branch
+          <<: *only_release
           requires:
             - build
-      # TEMP (revert before merge): run the nightly-only PHP 7.4 integration jobs on push to
-      # verify the mailpoet/codeception.yml memory_limit bump. Both jobs run the free suite
-      # under the free config (the with_premium job just also activates the premium plugin),
-      # so this branch's bump covers both. Copied verbatim from the nightly workflow.
-      - integration_tests:
-          <<: *slack-fail-post-step
-          name: integration_oldest
-          woo_core_version: 10.8.1
-          woo_subscriptions_version: 8.8.1
-          automate_woo_version: 6.5.0
-          codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.1.1-php7.4
-          wordpress_version: 6.9.4
-          mysql_command: --max_allowed_packet=100M
-          mysql_image: mysql:5.6
-          requires:
-            - build
-      - integration_tests:
-          <<: *slack-fail-post-step
-          name: integration_with_premium_oldest
-          woo_core_version: 10.8.1
-          woo_subscriptions_version: 8.8.1
-          automate_woo_version: 6.5.0
-          codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.1.1-php7.4
-          wordpress_version: 6.9.4
-          mysql_command: --max_allowed_packet=100M
-          mysql_image: mysql:5.6
-          requires:
-            - build_premium
       - unit_tests:
           <<: *slack-fail-post-step
           name: unit_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1023,9 +1023,39 @@ workflows:
           <<: *slack-fail-post-step
       - build_premium:
           <<: *slack-fail-post-step
-          <<: *only_release
+          # TEMP (revert before merge): dropped *only_release so build_premium runs on this branch
           requires:
             - build
+      # TEMP (revert before merge): run the nightly-only PHP 7.4 integration jobs on push to
+      # verify the mailpoet/codeception.yml memory_limit bump. Both jobs run the free suite
+      # under the free config (the with_premium job just also activates the premium plugin),
+      # so this branch's bump covers both. Copied verbatim from the nightly workflow.
+      - integration_tests:
+          <<: *slack-fail-post-step
+          name: integration_oldest
+          woo_core_version: 10.8.1
+          woo_subscriptions_version: 8.8.1
+          automate_woo_version: 6.5.0
+          codeception_image_version: 7.4-cli_20220605.0
+          wordpress_image_version: 6.1.1-php7.4
+          wordpress_version: 6.9.4
+          mysql_command: --max_allowed_packet=100M
+          mysql_image: mysql:5.6
+          requires:
+            - build
+      - integration_tests:
+          <<: *slack-fail-post-step
+          name: integration_with_premium_oldest
+          woo_core_version: 10.8.1
+          woo_subscriptions_version: 8.8.1
+          automate_woo_version: 6.5.0
+          codeception_image_version: 7.4-cli_20220605.0
+          wordpress_image_version: 6.1.1-php7.4
+          wordpress_version: 6.9.4
+          mysql_command: --max_allowed_packet=100M
+          mysql_image: mysql:5.6
+          requires:
+            - build_premium
       - unit_tests:
           <<: *slack-fail-post-step
           name: unit_tests

--- a/mailpoet/codeception.yml
+++ b/mailpoet/codeception.yml
@@ -7,7 +7,7 @@ paths:
   envs: tests/_envs
 settings:
   colors: true
-  memory_limit: 1024M
+  memory_limit: 2048M
   log: true
   strict_xml: true
 extensions:


### PR DESCRIPTION
## Description

The nightly `integration_oldest` and `integration_with_premium_oldest` jobs (PHP 7.4) started failing with a PHP fatal error rather than a test assertion:

<img width="1338" height="839" alt="image" src="https://github.com/user-attachments/assets/f9c6d5c0-fada-4280-9e10-39315d18137f" />

<img width="1333" height="853" alt="image" src="https://github.com/user-attachments/assets/95f10230-ff9a-46f4-acf7-19d197bc25ee" />

The whole integration suite runs in a single PHP process, so peak memory is cumulative. The suite's high-water mark crept past the former `1024M` cap, and the run died while rendering the end-of-run report. PHP 8 stays under the cap because it represents memory more compactly, so only the PHP 7.4 ("oldest") jobs tripped, and they did so consistently (3 of 3 attempts on the same commit).

This PR raises `memory_limit` in `mailpoet/codeception.yml` from `1024M` to `2048M`.

## Code review notes

Verified on CircleCI through a temporary commit 38c0f1fd002384bfb829e0384cbaf876bee1f00a.
- integration_oldest: https://app.circleci.com/pipelines/github/mailpoet/mailpoet/24171/workflows/924befd4-6797-4c07-a1c9-f0211c3ca8f1/jobs/425628
- integration_with_premium_oldest: https://app.circleci.com/pipelines/github/mailpoet/mailpoet/24171/workflows/924befd4-6797-4c07-a1c9-f0211c3ca8f1/jobs/425615

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/integration-oldest-php74-memory-limit)

_The latest successful build from `fix/integration-oldest-php74-memory-limit` will be used. If none is available, the link won't work._