### PR TITLE
Fix post notification status toggles

### DIFF
--- a/mailpoet/changelog/2026-07-02-08-57-52-fixed-post-notification-activation-and-deactivation-on-h.md
+++ b/mailpoet/changelog/2026-07-02-08-57-52-fixed-post-notification-activation-and-deactivation-on-h.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Post notification activation and deactivation on hosts that strip method override headers

--- a/mailpoet/lib/Newsletter/RestApi/Api.php
+++ b/mailpoet/lib/Newsletter/RestApi/Api.php
@@ -32,6 +32,9 @@ class Api {
       $this->api->registerPostRoute('newsletters/bulk-action', NewslettersBulkActionEndpoint::class);
       $this->api->registerPostRoute('newsletters/(?P<id>\d+)/duplicate', NewsletterDuplicateEndpoint::class);
       $this->api->registerPutRoute('newsletters/(?P<id>\d+)/status', NewsletterStatusEndpoint::class);
+      // @wordpress/api-fetch sends PUT requests as POST with X-HTTP-Method-Override.
+      // Accept POST too so hosts that strip the override header can still update the status.
+      $this->api->registerPostRoute('newsletters/(?P<id>\d+)/status', NewsletterStatusEndpoint::class);
       $this->api->registerGetRoute('newsletters/(?P<id>\d+)/sending-status', SendingStatusListingEndpoint::class);
       $this->api->registerPostRoute('newsletters/(?P<id>\d+)/sending-status/resend', SendingStatusResendEndpoint::class);
     });

--- a/mailpoet/tests/integration/REST/Newsletters/NewslettersEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Newsletters/NewslettersEndpointsTest.php
@@ -292,6 +292,26 @@ class NewslettersEndpointsTest extends Test {
     $this->assertSame(NewsletterEntity::STATUS_DRAFT, $newsletter->getStatus());
   }
 
+  public function testStatusEndpointUpdatesNewsletterStatusWithPostRequest(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Status_' . uniqid())
+      ->withType(NewsletterEntity::TYPE_STANDARD)
+      ->withSentStatus()
+      ->create();
+
+    $response = $this->post('/mailpoet/v1/newsletters/' . $newsletter->getId() . '/status', [
+      'json' => ['status' => NewsletterEntity::STATUS_DRAFT],
+    ]);
+
+    $this->assertIsArray($response);
+    $payload = $response['data'];
+    $this->assertIsArray($payload);
+    $this->assertSame(NewsletterEntity::STATUS_DRAFT, $payload['status']);
+
+    $this->newslettersRepository->refresh($newsletter);
+    $this->assertSame(NewsletterEntity::STATUS_DRAFT, $newsletter->getStatus());
+  }
+
   public function testStatusEndpointReturnsNotFoundForUnknownId(): void {
     $response = $this->put('/mailpoet/v1/newsletters/9999999/status', [
       'json' => ['status' => NewsletterEntity::STATUS_DRAFT],


### PR DESCRIPTION
## Description

Fixes post notification status toggles on hosts that strip `X-HTTP-Method-Override`. `@wordpress/api-fetch` sends PUT requests as POST with that override header, so the newsletter status endpoint now accepts POST in addition to PUT.

## Code review notes

The endpoint handler is unchanged; this only registers the same status endpoint for the POST fallback path.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8224](https://linear.app/a8c/issue/STOMAIL-8224/fix-post-notification-status-toggle-when-method-override-is)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8224-post-notification-status-toggle-method-override)

_The latest successful build from `fix/stomail-8224-post-notification-status-toggle-method-override` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->