### PR TITLE
Group WP-CLI commands under the mailpoet namespace

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -619,11 +619,11 @@ class RoboFile extends \Robo\Tasks {
   }
 
   public function migrationsStatus() {
-    return $this->taskExec('vendor/bin/wp mailpoet:migrations:status');
+    return $this->taskExec('vendor/bin/wp mailpoet migrations status');
   }
 
   public function migrationsRun() {
-    return $this->taskExec('vendor/bin/wp mailpoet:migrations:run');
+    return $this->taskExec('vendor/bin/wp mailpoet migrations run');
   }
 
   public function qa() {
@@ -1545,7 +1545,7 @@ class RoboFile extends \Robo\Tasks {
   }
 
   public function emailCreateTemplates() {
-    return $this->taskExec('vendor/bin/wp mailpoet:email-editor:create-templates');
+    return $this->taskExec('vendor/bin/wp mailpoet email-editor create-templates');
   }
 
   protected function rsearch($folder, $extensions = []) {

--- a/mailpoet/changelog/2026-07-02-12-07-59-changed-mailpoet-wp-cli-commands-to-space-separated-subcom.md
+++ b/mailpoet/changelog/2026-07-02-12-07-59-changed-mailpoet-wp-cli-commands-to-space-separated-subcom.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+MailPoet WP-CLI commands to space-separated subcommands (e.g. `wp mailpoet migrations run`); the old colon-separated names still work but are deprecated

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Cli.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Cli.php
@@ -33,8 +33,20 @@ class Cli {
       return;
     }
 
-    WP_CLI::add_command('mailpoet:email-editor:create-templates', [$this, 'createTemplates'], [
+    WP_CLI::add_command('mailpoet email-editor create-templates', [$this, 'createTemplates'], [
       'shortdesc' => 'Create MailPoet email editor templates',
+    ]);
+
+    // Deprecated colon-named alias kept for backwards compatibility. Remove in a future release (STOMAIL-8177).
+    $this->registerDeprecatedAlias('mailpoet:email-editor:create-templates', 'mailpoet email-editor create-templates', [$this, 'createTemplates']);
+  }
+
+  private function registerDeprecatedAlias(string $oldName, string $newName, callable $handler): void {
+    WP_CLI::add_command($oldName, function () use ($oldName, $newName, $handler): void {
+      WP_CLI::warning(sprintf('`wp %s` is deprecated and will be removed in a future release. Use `wp %s` instead.', $oldName, $newName));
+      $handler();
+    }, [
+      'shortdesc' => sprintf('Deprecated. Use `wp %s` instead', $newName),
     ]);
   }
 

--- a/mailpoet/lib/Migrator/Cli.php
+++ b/mailpoet/lib/Migrator/Cli.php
@@ -29,12 +29,25 @@ class Cli {
       return;
     }
 
-    WP_CLI::add_command('mailpoet:migrations:run', [$this, 'run'], [
+    WP_CLI::add_command('mailpoet migrations run', [$this, 'run'], [
       'shortdesc' => 'Runs MailPoet database migrations',
     ]);
 
-    WP_CLI::add_command('mailpoet:migrations:status', [$this, 'status'], [
+    WP_CLI::add_command('mailpoet migrations status', [$this, 'status'], [
       'shortdesc' => 'Shows status of MailPoet database migrations',
+    ]);
+
+    // Deprecated colon-named aliases kept for backwards compatibility. Remove in a future release (STOMAIL-8177).
+    $this->registerDeprecatedAlias('mailpoet:migrations:run', 'mailpoet migrations run', [$this, 'run']);
+    $this->registerDeprecatedAlias('mailpoet:migrations:status', 'mailpoet migrations status', [$this, 'status']);
+  }
+
+  private function registerDeprecatedAlias(string $oldName, string $newName, callable $handler): void {
+    WP_CLI::add_command($oldName, function () use ($oldName, $newName, $handler): void {
+      WP_CLI::warning(sprintf('`wp %s` is deprecated and will be removed in a future release. Use `wp %s` instead.', $oldName, $newName));
+      $handler();
+    }, [
+      'shortdesc' => sprintf('Deprecated. Use `wp %s` instead', $newName),
     ]);
   }
 


### PR DESCRIPTION
## Description

MailPoet's WP-CLI commands use a Symfony/Laravel-style colon convention (`mailpoet:migrations:run`). WP-CLI doesn't treat the colon as a separator, so each command registers as a **separate top-level command** and shows up in the global `wp help` list next to core commands. As we add more CLI commands (starting with background-job management), every new one would add another top-level entry.

This switches the migrations and email-editor commands to WP-CLI's native space-separated subcommands under a single `mailpoet` namespace, so the global list stays clean and the commands are browsable:

| Before | After |
| --- | --- |
| `wp mailpoet:migrations:run` | `wp mailpoet migrations run` |
| `wp mailpoet:migrations:status` | `wp mailpoet migrations status` |
| `wp mailpoet:email-editor:create-templates` | `wp mailpoet email-editor create-templates` |

The old colon-named commands keep working as **deprecated aliases** that print a warning and delegate to the same handlers, so existing scripts/CI don't break. `RoboFile` is updated to the new names.

This aligns with the two commands that already use this convention (`wp mailpoet import`, `wp mailpoet cron`), so it's really a consistency change.

## Code review notes

- WP-CLI has no way to hide a command from `wp help`, so the deprecated colon aliases will still appear there (clearly labeled "Deprecated") until we drop them.

## QA notes

Check that both variants `wp mailpoet migrations run` and `wp mailpoet:migrations:run` work as expected. Also for `wp mailpoet:migrations:status` and `wp mailpoet:email-editor:create-templates`

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8177](https://linear.app/a8c/issue/STOMAIL-8177/switch-wp-cli-commands-from-mailpoetxy-to-wp-mailpoet-x-y)

## After-merge notes

The deprecated colon-named aliases should be removed in a later release (tracked via a follow-up to STOMAIL-8177). No pinned version yet.

## Screenshots or screencast

_N/A (CLI change)_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/cli-commands-names)

_The latest successful build from `fix/cli-commands-names` will be used. If none is available, the link won't work._