### PR TITLE
Fix flaky rand-based emails in integration tests

### DIFF
--- a/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
@@ -283,8 +283,7 @@ class SegmentSubscribersRepositoryTest extends \MailPoetTest {
 
   private function createSubscriberEntity(): SubscriberEntity {
     $subscriber = new SubscriberEntity();
-    $rand = rand(0, 100000);
-    $subscriber->setEmail("john{$rand}@mailpoet.com");
+    $subscriber->setEmail('john' . bin2hex(random_bytes(7)) . '@mailpoet.com');
     $subscriber->setFirstName('John');
     $subscriber->setLastName('Doe');
     $subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);

--- a/mailpoet/tests/integration/Segments/SegmentsSimpleListRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentsSimpleListRepositoryTest.php
@@ -123,8 +123,7 @@ class SegmentsSimpleListRepositoryTest extends \MailPoetTest {
 
   private function createSubscriberEntity(): SubscriberEntity {
     $subscriber = new SubscriberEntity();
-    $rand = rand(0, 100000);
-    $subscriber->setEmail("john{$rand}@mailpoet.com");
+    $subscriber->setEmail('john' . bin2hex(random_bytes(7)) . '@mailpoet.com');
     $subscriber->setFirstName('John');
     $subscriber->setLastName('Doe');
     $subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);

--- a/mailpoet/tests/integration/Statistics/StatisticsFormsRepositoryTest.php
+++ b/mailpoet/tests/integration/Statistics/StatisticsFormsRepositoryTest.php
@@ -68,7 +68,7 @@ class StatisticsFormsRepositoryTest extends \MailPoetTest {
   private function createSubscriber(): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
-    $subscriber->setEmail('subscriber' . rand(0, 10000) . '@example.com');
+    $subscriber->setEmail('subscriber' . bin2hex(random_bytes(7)) . '@example.com');
     $this->entityManager->persist($subscriber);
     $this->entityManager->flush();
     return $subscriber;

--- a/mailpoet/tests/integration/Statistics/StatisticsOpensRepositoryTest.php
+++ b/mailpoet/tests/integration/Statistics/StatisticsOpensRepositoryTest.php
@@ -223,7 +223,7 @@ class StatisticsOpensRepositoryTest extends \MailPoetTest {
   private function createSubscriber(): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
-    $subscriber->setEmail('subscriber' . rand(0, 10000) . '@example.com');
+    $subscriber->setEmail('subscriber' . bin2hex(random_bytes(7)) . '@example.com');
     $this->entityManager->persist($subscriber);
     return $subscriber;
   }


### PR DESCRIPTION
## Description

A flaky integration-test failure was turning trunk red:

```
UniqueConstraintViolationException: Duplicate entry 'john37538@mailpoet.com' for key 'email'
```

followed by a cascade of `EntityManager is closed` errors across the rest of the suite.

**Root cause:** several integration test helpers built subscriber emails with `rand(0, 100000)` / `rand(0, 10000)`. With only tens of thousands of possible values and multiple subscribers created per test, the birthday paradox made a duplicate email likely enough to hit in CI. When it does, the duplicate-key violation on `flush()` closes Doctrine's `EntityManager`, so every subsequent test in the process fails with `EntityManager is closed`.

This swaps those helpers to `bin2hex(random_bytes(7))` (56 bits of entropy, effectively collision-free) — the same scheme the shared `Subscriber` data factory already uses.

Affected helpers:

- `SegmentSubscribersRepositoryTest` (the one that failed)
- `SegmentsSimpleListRepositoryTest` (byte-identical copy of the same helper)
- `StatisticsFormsRepositoryTest`
- `StatisticsOpensRepositoryTest`

## Code review notes

- `rand()` used elsewhere for form names / newsletter subjects / segment names was left as-is on purpose — those aren't `UNIQUE` columns, so a collision there can't produce the fatal violation.
- `SubscriberListingRepositoryTest` already generates emails from a static incrementing sequence, so it needed no change.

## QA notes

Run the affected integration tests (they should be green and stable):

```
pnpm test:integration --file=tests/integration/Segments/SegmentSubscribersRepositoryTest.php
pnpm test:integration --file=tests/integration/Segments/SegmentsSimpleListRepositoryTest.php
pnpm test:integration --file=tests/integration/Statistics/StatisticsFormsRepositoryTest.php
pnpm test:integration --file=tests/integration/Statistics/StatisticsOpensRepositoryTest.php
```

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-trunk)

_The latest successful build from `fix-trunk` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->