### PR TITLE
Stop DelayAction test flaking on second boundary

### DIFF
--- a/mailpoet/tests/integration/Automation/Integrations/Core/Actions/DelayActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/Core/Actions/DelayActionTest.php
@@ -30,11 +30,24 @@ class DelayActionTest extends \MailPoetTest {
     $automation = $this->createMock(Automation::class);
     $automationRun = $this->createMock(AutomationRun::class);
     $controller = $this->createMock(StepRunController::class);
-    $controller->expects($this->once())->method('scheduleProgress')->with(time() + $expectation);
+    $scheduledTimestamp = null;
+    $controller->expects($this->once())
+      ->method('scheduleProgress')
+      ->willReturnCallback(function (?int $timestamp) use (&$scheduledTimestamp): int {
+        $scheduledTimestamp = $timestamp;
+        return (int)$timestamp;
+      });
 
     $args = new StepRunArgs($automation, $automationRun, $step, [], 1);
     $testee = new DelayAction();
+    // DelayAction::run() samples time() internally, so bracket the call and assert the
+    // scheduled timestamp lands in that window rather than matching a single time() snapshot
+    // captured here (which flakes when the clock ticks over a second boundary in between).
+    $before = time();
     $testee->run($args, $controller);
+    $after = time();
+    $this->assertGreaterThanOrEqual($before + $expectation, $scheduledTimestamp);
+    $this->assertLessThanOrEqual($after + $expectation, $scheduledTimestamp);
   }
 
   public function dataForTestItCalculatesDelayTypesCorrectly(): array {


### PR DESCRIPTION
## Description

Fixes an intermittently-failing test. `DelayActionTest::testItCalculatesDelayTypesCorrectly` occasionally failed in CI with `scheduleProgress(N)` being exactly one second higher than expected (e.g. [job 426015](https://circleci.com/gh/mailpoet/mailpoet/426015), which was an unrelated branch — the flake trips any branch).

**Why it flaked:** the test snapshotted `time()` while configuring the mock expectation and required exact equality against the timestamp `DelayAction::run()` derives from its _own_, slightly later `time()` call. Whenever the wall clock crossed a second boundary between those two calls, the scheduled timestamp was one second higher and the equality assertion failed. The production code is correct — only the test's exact-match assertion was fragile.

**Fix:** capture the actual scheduled timestamp and assert it lands in the `[before, after]` window bracketing `run()`, so a clock tick can no longer break it.

## Code review notes

Verified deterministically both directions: injecting a temporary `sleep(1)` between the old test's `time()` snapshot and `run()` reproduces the CI failure exactly (8 failures, off by one); the new range assertion passes under that same forced tick. The temporary `sleep` was removed before committing.

Side note (not addressed here): the test has to bracket the call because `DelayAction::run()` calls the global `time()` directly rather than an injected clock. Making it injectable would let the test assert an exact value, but that's a production-code change out of scope for a flaky-test fix.

## QA notes

Test-only change, no user-facing impact. `DelayActionTest` runs green (13 tests, 43 assertions); phpcs and phpstan clean.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:flaky-delay-activation)

_The latest successful build from `flaky-delay-activation` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->