### PR TITLE
Wait for Action Scheduler to finish before restoring the DB in acceptance tests

### DIFF
--- a/mailpoet/tests/_support/CleanupExtension.php
+++ b/mailpoet/tests/_support/CleanupExtension.php
@@ -16,6 +16,9 @@ class CleanupExtension extends Extension {
   const DB_PASSWORD = 'wordpress';
   const DB_NAME = 'wordpress';
   const MAILHOG_DATA_PATH = '/mailhog-data';
+  const ACTION_SCHEDULER_ACTIONS_TABLE = 'mp_actionscheduler_actions';
+  const ACTION_SCHEDULER_DRAIN_TIMEOUT_SECONDS = 10;
+  const ACTION_SCHEDULER_DRAIN_POLL_MICROSECONDS = 50000; // 50ms
 
   public static $events = [
     Events::SUITE_BEFORE => 'backupDatabase',
@@ -85,6 +88,8 @@ class CleanupExtension extends Extension {
   }
 
   public function cleanupEnvironment(TestEvent $event) {
+    $this->waitForActionSchedulerToFinish();
+
     $backupSql = file_get_contents(self::DB_BACKUP_PATH);
     if (!is_string($backupSql)) {
       throw new \RuntimeException('Missing or empty DB backup file: ' . self::DB_BACKUP_PATH);
@@ -110,6 +115,48 @@ class CleanupExtension extends Extension {
     if ($wp_object_cache) {
       $wp_object_cache->flush();
     }
+  }
+
+  /**
+   * A background Action Scheduler runner (fire-and-forget async request) can outlive the test
+   * that triggered it. If we restore the DB below while such a runner is mid-batch, the
+   * actionscheduler rows it is processing get wiped, and its mark_failure()/mark_complete()
+   * calls then throw "Unidentified action X: ... deleted by another process." That uncaught
+   * exception is logged and fails an unrelated test via ErrorsExtension. Wait for any active
+   * runner to finish before restoring so the row is still there when it writes its result.
+   *
+   * A short timeout keeps a genuinely stuck runner from ever hanging the suite; the next
+   * restore wipes its rows anyway, so the worst case is a single test paying the timeout.
+   */
+  private function waitForActionSchedulerToFinish(): void {
+    $deadline = microtime(true) + self::ACTION_SCHEDULER_DRAIN_TIMEOUT_SECONDS;
+    while ($this->hasActiveActionSchedulerClaim()) {
+      if (microtime(true) >= $deadline) {
+        return;
+      }
+      usleep(self::ACTION_SCHEDULER_DRAIN_POLL_MICROSECONDS);
+    }
+  }
+
+  /**
+   * Mirrors Action Scheduler's own ActionScheduler_DBStore::get_claim_count(): a claim is
+   * active while it still holds actions that haven't reached a terminal status. This brackets
+   * the whole vulnerable window, from staking the claim through writing the final result.
+   */
+  private function hasActiveActionSchedulerClaim(): bool {
+    $sql = "SELECT COUNT(*) FROM " . self::ACTION_SCHEDULER_ACTIONS_TABLE
+      . " WHERE claim_id != 0 AND status IN ('pending', 'in-progress')";
+    try {
+      $result = $this->rootConnection->query($sql);
+    } catch (\mysqli_sql_exception $e) {
+      return false; // Action Scheduler tables absent — nothing to wait for.
+    }
+    if (!$result instanceof \mysqli_result) {
+      return false;
+    }
+    $row = $result->fetch_row();
+    $result->free();
+    return $row !== null && (int)$row[0] > 0;
   }
 
   private function createMysqlDumpCommand() {

--- a/mailpoet/tests/_support/CleanupExtension.php
+++ b/mailpoet/tests/_support/CleanupExtension.php
@@ -149,7 +149,13 @@ class CleanupExtension extends Extension {
     try {
       $result = $this->rootConnection->query($sql);
     } catch (\mysqli_sql_exception $e) {
-      return false; // Action Scheduler tables absent — nothing to wait for.
+      // 1146 = "table doesn't exist": Action Scheduler isn't installed in this suite, so there
+      // is nothing to wait for. Let any other error (lost connection, permissions, ...) surface
+      // rather than silently skipping the drain and masking a real DB problem.
+      if ($e->getCode() === 1146) {
+        return false;
+      }
+      throw $e;
     }
     if (!$result instanceof \mysqli_result) {
       return false;


### PR DESCRIPTION
## Description

Acceptance test shards fail intermittently with an `InvalidArgumentException` from Action Scheduler that has nothing to do with any assertion:

```
InvalidArgumentException: Unidentified action 48: we were unable to mark this
action as having failed. It may may have been deleted by another process.
  ActionScheduler_DBStore::mark_failure()
  ← process_action(48, 'Async Request') ← ActionScheduler's own async queue runner
```

**Root cause — a teardown race:**

1. A test triggers MailPoet cron, so Action Scheduler dispatches a **non-blocking, fire-and-forget** async request that runs the queue in a separate PHP process.
2. That request can outlive the test. The next test's `CleanupExtension::cleanupEnvironment` (`TEST_BEFORE`) restores the whole DB from a `mysqldump` backup, dropping and recreating every table — including `mp_actionscheduler_actions`.
3. The still-running runner from the previous test calls `$action->execute()`; its data has vanished, so the callback throws. Action Scheduler then tries to `mark_failure()`/`mark_complete()`, the `UPDATE ... WHERE action_id = X` touches zero rows, and it throws a secondary `InvalidArgumentException`.

Tracy (production mode in tests) logs the exception, and `ErrorsExtension` turns any new line in `exception.log` into a synthetic suite failure — so the shard goes red because of a stray background process, attributed to whatever unrelated test happened to be running. That's why these failures look flaky, have an empty `failed` file, and show all-green JUnit rows.

**Fix:** wait for any active Action Scheduler runner to finish before restoring the DB, so the action row is still present when the runner writes its result. `waitForActionSchedulerToFinish()` polls Action Scheduler's own active-claim signal (`claim_id != 0 AND status IN ('pending', 'in-progress')`, exactly what `ActionScheduler_DBStore::get_claim_count()` counts), which brackets the whole vulnerable window from staking the claim through writing the final result. A 10s safety-net timeout guarantees a genuinely stuck runner can never hang the suite.

## Code review notes

_N/A_

## QA notes

Not reproducible as a deterministic red→green run: it's a non-deterministic timing race across PHP processes during a DB restore. Verified instead:

- `php -l`, MailPoet PHPCS (free ruleset), and PHPStan all clean on the changed file.
- Drain loop control flow checked: no wait / zero polls when no runner is active (common case), clean exit when a runner finishes, and a hard bail at the timeout so a stuck runner never hangs the suite.
- The claim query is matched to Action Scheduler's own `get_claim_count()` definition.

Residual risk (acceptable, matches the "almost eliminate" goal): a runner still executing past the 10s timeout, or the sub-millisecond window between staking a claim and the row becoming visible, could still slip through.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:flaky-test-action-scheduler-error)

_The latest successful build from `flaky-test-action-scheduler-error` will be used. If none is available, the link won't work._