### PR TITLE
Reactivate inactive subscribers immediately on engagement

### DIFF
--- a/mailpoet/changelog/2026-07-03-07-22-02-improved-reactivate-inactive-subscribers-immediately-when-t.md
+++ b/mailpoet/changelog/2026-07-03-07-22-02-improved-reactivate-inactive-subscribers-immediately-when-t.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Reactivate inactive subscribers immediately when they open, click, or otherwise engage instead of waiting for the maintenance cron

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -682,8 +682,24 @@ class SubscriberEntity {
     return $this->lastEngagementAt;
   }
 
+  /**
+   * Sets the raw engagement timestamp without touching status. Prefer markEngaged() when
+   * recording a real engagement event (open, click, purchase, page view) so inactive
+   * subscribers are reactivated immediately instead of waiting for the maintenance cron.
+   */
   public function setLastEngagementAt(DateTimeInterface $lastEngagementAt): void {
     $this->lastEngagementAt = $lastEngagementAt;
+  }
+
+  /**
+   * Records engagement and immediately reactivates the subscriber if they were inactive,
+   * so they don't wait for the InactiveSubscribersMaintenance cron to be reactivated.
+   */
+  public function markEngaged(DateTimeInterface $engagedAt): void {
+    $this->setLastEngagementAt($engagedAt);
+    if ($this->getStatus() === self::STATUS_INACTIVE) {
+      $this->setStatus(self::STATUS_SUBSCRIBED);
+    }
   }
 
   public function getLastSendingAt(): ?DateTimeInterface {

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -932,7 +932,7 @@ class SubscribersRepository extends Repository {
       return;
     }
     // Update last engagement
-    $subscriberEntity->setLastEngagementAt($now);
+    $subscriberEntity->markEngaged($now);
     $this->flush();
   }
 
@@ -943,7 +943,7 @@ class SubscribersRepository extends Repository {
       return;
     }
     $subscriberEntity->setLastOpenAt($now);
-    $subscriberEntity->setLastEngagementAt($now);
+    $subscriberEntity->markEngaged($now);
     $this->flush();
   }
 
@@ -954,7 +954,7 @@ class SubscribersRepository extends Repository {
       return;
     }
     $subscriberEntity->setLastClickAt($now);
-    $subscriberEntity->setLastEngagementAt($now);
+    $subscriberEntity->markEngaged($now);
     $this->flush();
   }
 
@@ -965,7 +965,7 @@ class SubscribersRepository extends Repository {
       return;
     }
     $subscriberEntity->setLastPurchaseAt($now);
-    $subscriberEntity->setLastEngagementAt($now);
+    $subscriberEntity->markEngaged($now);
     $this->flush();
   }
 
@@ -976,7 +976,7 @@ class SubscribersRepository extends Repository {
       return;
     }
     $subscriberEntity->setLastPageViewAt($now);
-    $subscriberEntity->setLastEngagementAt($now);
+    $subscriberEntity->markEngaged($now);
     $this->flush();
   }
 

--- a/mailpoet/tests/integration/Statistics/Track/OpensTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/OpensTest.php
@@ -354,6 +354,22 @@ class OpensTest extends \MailPoetTest {
     verify($openEntity->getUserAgentType())->equals(UserAgentEntity::USER_AGENT_TYPE_HUMAN);
   }
 
+  public function testItReactivatesInactiveSubscriberOnOpen() {
+    $this->subscriber->setStatus(SubscriberEntity::STATUS_INACTIVE);
+    $this->entityManager->flush();
+    $opens = Stub::construct($this->opens, [
+      $this->diContainer->get(StatisticsOpensRepository::class),
+      $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
+    ], [
+      'returnResponse' => null,
+    ], $this);
+
+    $opens->track($this->trackData);
+
+    verify($this->subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+  }
+
   public function testItUpdatesSubscriberEngagementForHumanAgent() {
     $now = Carbon::now();
     Carbon::setTestNow($now);

--- a/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
@@ -639,6 +639,37 @@ class SubscribersRepositoryTest extends \MailPoetTest {
     verify($subscriber->getConfirmationsCount())->equals(3);
   }
   
+  public function testEngagementUpdatesReactivateInactiveSubscribers(): void {
+    $engagementUpdates = [
+      fn(SubscriberEntity $s) => $this->repository->maybeUpdateLastEngagement($s),
+      fn(SubscriberEntity $s) => $this->repository->maybeUpdateLastOpenAt($s),
+      fn(SubscriberEntity $s) => $this->repository->maybeUpdateLastClickAt($s),
+      fn(SubscriberEntity $s) => $this->repository->maybeUpdateLastPurchaseAt($s),
+      fn(SubscriberEntity $s) => $this->repository->maybeUpdateLastPageViewAt($s),
+    ];
+
+    foreach ($engagementUpdates as $index => $update) {
+      $subscriber = $this->createSubscriber("inactive-{$index}@reactivate.com");
+      $subscriber->setStatus(SubscriberEntity::STATUS_INACTIVE);
+      $this->entityManager->flush();
+
+      $update($subscriber);
+
+      verify($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+      verify($subscriber->getLastEngagementAt())->notNull();
+    }
+  }
+
+  public function testEngagementUpdatesDoNotChangeStatusOfActiveSubscriber(): void {
+    $subscriber = $this->createSubscriber('active@reactivate.com');
+    verify($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+
+    $this->repository->maybeUpdateLastOpenAt($subscriber);
+
+    verify($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+    verify($subscriber->getLastEngagementAt())->notNull();
+  }
+
   private function createSubscriber(string $email, ?DateTimeImmutable $deletedAt = null): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($email);

--- a/mailpoet/tests/unit/Entities/SubscriberEntityTest.php
+++ b/mailpoet/tests/unit/Entities/SubscriberEntityTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Entities;
+
+use MailPoetVendor\Carbon\Carbon;
+
+class SubscriberEntityTest extends \MailPoetUnitTest {
+  public function testMarkEngagedReactivatesInactiveSubscriber(): void {
+    $now = new Carbon();
+    $subscriber = new SubscriberEntity();
+    $subscriber->setStatus(SubscriberEntity::STATUS_INACTIVE);
+
+    $subscriber->markEngaged($now);
+
+    verify($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+    verify($subscriber->getLastEngagementAt())->equals($now);
+  }
+
+  /** @dataProvider dataProviderNonInactiveStatuses */
+  public function testMarkEngagedKeepsNonInactiveStatus(string $status): void {
+    $now = new Carbon();
+    $subscriber = new SubscriberEntity();
+    $subscriber->setStatus($status);
+
+    $subscriber->markEngaged($now);
+
+    verify($subscriber->getStatus())->equals($status);
+    verify($subscriber->getLastEngagementAt())->equals($now);
+  }
+
+  public function dataProviderNonInactiveStatuses(): array {
+    return [
+      [SubscriberEntity::STATUS_SUBSCRIBED],
+      [SubscriberEntity::STATUS_UNCONFIRMED],
+      [SubscriberEntity::STATUS_UNSUBSCRIBED],
+      [SubscriberEntity::STATUS_BOUNCED],
+    ];
+  }
+}


### PR DESCRIPTION
## Description

Inactive subscribers are now reactivated the moment they engage (open, click, purchase, page view) instead of waiting for the `InactiveSubscribersMaintenance` cron. Previously a re-engaged subscriber could stay `inactive` until the next worker run and be skipped by newsletters sent in the meantime.

Follow-up to #6904 ([discussion](https://github.com/mailpoet/mailpoet/pull/6904#discussion_r3510750474)). The batch worker stays in place as the backstop.

## Code review notes

Reactivation now flows through the entity, so it fires `HOOK_SUBSCRIBER_STATUS_CHANGED` (the worker's raw SQL doesn't). Verified the consumers are safe: `SomeoneUnsubscribesTrigger` no-ops for any non-unsubscribed status, and the AutomateWoo sync is desirable.

## QA notes

Set a subscriber to `inactive`, trigger an open/click, and confirm the status flips to `subscribed` immediately.

## Linked PRs

#6904

## Linked tickets

STOMAIL-8164

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:improve/immediate-subscriber-reactivation)

_The latest successful build from `improve/immediate-subscriber-reactivation` will be used. If none is available, the link won't work._