### PR TITLE
Fix SMTP sending when secure connection is disabled

### DIFF
--- a/mailpoet/changelog/2026-07-02-10-12-15-fixed-fix-smtp-sending-when-secure-connection-is-disable.md
+++ b/mailpoet/changelog/2026-07-02-10-12-15-fixed-fix-smtp-sending-when-secure-connection-is-disable.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix SMTP sending when secure connection is disabled

--- a/mailpoet/lib/Mailer/Methods/SMTP.php
+++ b/mailpoet/lib/Mailer/Methods/SMTP.php
@@ -60,6 +60,9 @@ class SMTP extends PHPMailerMethod {
     $mailer->Port = $this->wp->applyFilters('mailpoet_mailer_smtp_port', $this->port); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     /** @phpstan-ignore-next-line - we cannot annotate the return type from a filter */
     $mailer->SMTPSecure = $this->wp->applyFilters('mailpoet_mailer_smtp_encryption', $this->encryption);
+    if (empty($mailer->SMTPSecure)) {
+      $mailer->SMTPAutoTLS = false; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    }
     /** @phpstan-ignore-next-line - we cannot annotate the return type from a filter */
     $mailer->SMTPOptions = $this->wp->applyFilters('mailpoet_mailer_smtp_options', []);
     /** @phpstan-ignore-next-line - we cannot annotate the return type from a filter */

--- a/mailpoet/tests/integration/Mailer/Methods/SMTPTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/SMTPTest.php
@@ -91,6 +91,13 @@ class SMTPTest extends \MailPoetTest {
       ->equals($this->settings['encryption']);
   }
 
+  public function testItDisablesAutoTLSWhenEncryptionIsDisabled() {
+    $this->mailer->encryption = '';
+    $mailer = $this->mailer->buildMailer();
+    verify($mailer->SMTPSecure)->equals('');
+    verify($mailer->SMTPAutoTLS)->false();
+  }
+
   public function testItCanCreateMessage() {
     $mailer = $this->mailer
       ->configureMailerWithMessage($this->newsletter, $this->subscriber, $this->extraParams);


### PR DESCRIPTION
## Description

Emails could fail to send over SMTP when the "secure connection" option was set to none. PHPMailer's `SMTPAutoTLS` is enabled by default and opportunistically attempts STARTTLS whenever the server advertises it — against servers with broken or misconfigured TLS this makes sending fail even though the user explicitly disabled encryption.

This disables `SMTPAutoTLS` when no encryption is selected, so an unencrypted connection stays unencrypted.

## Code review notes

Only forced off when the encryption filter resolves to empty; SSL/TLS paths are unchanged.

## QA notes

Integration `SMTPTest` passes (10 tests); added a test asserting `SMTPAutoTLS` is `false` when encryption is empty.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7279, closes #4810

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I added sufficient test coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->