### PR TITLE
Show when the sender domain is authenticated in settings

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_common.scss
+++ b/mailpoet/assets/css/src/components-plugin/_common.scss
@@ -53,6 +53,19 @@ p.sender_email_address_warning:first-child {
   margin-top: 0; // unify spacing with parsley errors
 }
 
+.mailpoet_sender_domain_authenticated {
+  align-items: center;
+  color: #005c12;
+  display: flex;
+  gap: 4px;
+  margin: 4px 0 0;
+
+  svg {
+    height: 20px;
+    width: 20px;
+  }
+}
+
 .button.mailpoet-button-bigger {
   font-size: 1.5em;
   height: 46px;

--- a/mailpoet/assets/js/src/settings/pages/basics/default-sender.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/default-sender.tsx
@@ -145,6 +145,17 @@ export function DefaultSender({ showModal }) {
                 });
               }
               if (data.type === 'domain') {
+                // keep the global verified list in sync so a later blur or
+                // email change still recognises the domain as verified
+                const verifiedDomain = data.data ? String(data.data) : '';
+                if (
+                  verifiedDomain &&
+                  !window.mailpoet_verified_sender_domains.includes(
+                    verifiedDomain,
+                  )
+                ) {
+                  window.mailpoet_verified_sender_domains.push(verifiedDomain);
+                }
                 setShowSenderDomainWarning(false);
                 setIsPartiallyVerifiedDomain(false);
                 setIsSenderDomainVerified(true);

--- a/mailpoet/assets/js/src/settings/pages/basics/default-sender.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/default-sender.tsx
@@ -11,6 +11,7 @@ import {
 import { Input } from 'common/form/input/input';
 import { useSetting, useSelector, useAction } from 'settings/store/hooks';
 import { SenderEmailAddressWarning } from 'common/sender-email-address-warning';
+import { SenderDomainAuthenticatedStatus } from './sender-domain-authenticated-status';
 
 export function DefaultSender({ showModal }) {
   const isMssActive = useSelector('isMssActive');
@@ -20,6 +21,9 @@ export function DefaultSender({ showModal }) {
   const senderDomain = extractEmailDomain(senderEmail);
   const [showSenderDomainWarning, setShowSenderDomainWarning] = useState(
     !window.mailpoet_verified_sender_domains.includes(senderDomain),
+  );
+  const [isSenderDomainVerified, setIsSenderDomainVerified] = useState(
+    window.mailpoet_verified_sender_domains.includes(senderDomain),
   );
   const [isPartiallyVerifiedDomain, setIsPartiallyVerifiedDomain] = useState(
     window.mailpoet_partially_verified_sender_domains.includes(senderDomain),
@@ -43,11 +47,15 @@ export function DefaultSender({ showModal }) {
 
     if (window.mailpoet_verified_sender_domains.includes(emailDomain)) {
       // allow user send with any email address from verified domains
+      setShowSenderDomainWarning(false);
+      setIsPartiallyVerifiedDomain(false);
+      setIsSenderDomainVerified(true);
       return;
     }
 
     isAuthorizedEmail(email);
 
+    setIsSenderDomainVerified(false);
     setShowSenderDomainWarning(true);
     setIsPartiallyVerifiedDomain(
       window.mailpoet_partially_verified_sender_domains.includes(emailDomain),
@@ -59,6 +67,11 @@ export function DefaultSender({ showModal }) {
     setIsAuthorized(true);
     setShowSenderDomainWarning(false);
     setIsPartiallyVerifiedDomain(false);
+    setIsSenderDomainVerified(
+      window.mailpoet_verified_sender_domains.includes(
+        extractEmailDomain(email),
+      ),
+    );
     setSenderEmail(email);
   };
 
@@ -134,6 +147,7 @@ export function DefaultSender({ showModal }) {
               if (data.type === 'domain') {
                 setShowSenderDomainWarning(false);
                 setIsPartiallyVerifiedDomain(false);
+                setIsSenderDomainVerified(true);
                 MailPoet.trackEvent('MSS in plugin verify sender domain', {
                   'verify sender domain source': 'settings',
                   wasSuccessful: 'yes',
@@ -141,6 +155,9 @@ export function DefaultSender({ showModal }) {
               }
             }}
           />
+          {isMssActive && !invalidSenderEmail && isSenderDomainVerified && (
+            <SenderDomainAuthenticatedStatus senderDomain={senderDomain} />
+          )}
         </div>
         <label className="mailpoet-settings-inputs-row" htmlFor="reply_to-name">
           Reply-to

--- a/mailpoet/assets/js/src/settings/pages/basics/sender-domain-authenticated-status.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/sender-domain-authenticated-status.tsx
@@ -1,0 +1,26 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { OkIcon } from 'common/manage-sender-domain/icons';
+
+type Props = {
+  senderDomain: string;
+};
+
+export function SenderDomainAuthenticatedStatus({
+  senderDomain,
+}: Props): JSX.Element {
+  return (
+    <p
+      className="mailpoet_sender_domain_authenticated"
+      data-automation-id="sender-domain-authenticated-status"
+    >
+      <OkIcon />
+      {createInterpolateElement(
+        __('Sender domain <domain/> is authenticated.', 'mailpoet'),
+        {
+          domain: <strong>{senderDomain}</strong>,
+        },
+      )}
+    </p>
+  );
+}

--- a/mailpoet/changelog/2026-07-02-10-37-05-improved-show-when-the-sender-domain-is-authenticated-in-se.md
+++ b/mailpoet/changelog/2026-07-02-10-37-05-improved-show-when-the-sender-domain-is-authenticated-in-se.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Show when the sender domain is authenticated in settings

--- a/mailpoet/tests/javascript/settings/default-sender.spec.ts
+++ b/mailpoet/tests/javascript/settings/default-sender.spec.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { SenderDomainAuthenticatedStatus } from '../../../assets/js/src/settings/pages/basics/sender-domain-authenticated-status';
+
+describe('SenderDomainAuthenticatedStatus', () => {
+  it('renders the authenticated sender domain', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SenderDomainAuthenticatedStatus, {
+        senderDomain: 'example.com',
+      }),
+    );
+
+    expect(html).to.contain(
+      'data-automation-id="sender-domain-authenticated-status"',
+    );
+    expect(html).to.contain('Sender domain');
+    expect(html).to.contain('<strong>example.com</strong>');
+    expect(html).to.contain('is authenticated.');
+  });
+});


### PR DESCRIPTION
## Description

Adds a positive "Sender domain <domain> is authenticated." confirmation in Settings when the sender domain is verified, complementing the existing warning shown for unverified domains.

## Code review notes

New `isSenderDomainVerified` state follows the same update points as the existing `showSenderDomainWarning`/`isPartiallyVerifiedDomain` state.

## QA notes

JS spec added for the new component; `tsc` and Stylelint pass.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8226, closes #5388

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I followed best practices for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript