### PR TITLE
Clarify SMTP secure connection labels

### DIFF
--- a/mailpoet/assets/js/src/settings/pages/send-with/other/smtp-fields.tsx
+++ b/mailpoet/assets/js/src/settings/pages/send-with/other/smtp-fields.tsx
@@ -76,8 +76,8 @@ export function SmtpFields() {
           dimension="small"
         >
           <option value="">{t('no')}</option>
-          <option value="ssl">SSL</option>
-          <option value="tls">TLS</option>
+          <option value="ssl">SSL/TLS</option>
+          <option value="tls">STARTTLS</option>
         </Select>
       </Inputs>
       <Label

--- a/mailpoet/changelog/2026-07-02-10-13-34-improved-clarify-smtp-secure-connection-labels.md
+++ b/mailpoet/changelog/2026-07-02-10-13-34-improved-clarify-smtp-secure-connection-labels.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Clarify SMTP secure connection labels


### PR DESCRIPTION
## Description

Clarifies the SMTP "secure connection" dropdown labels: `SSL` → `SSL/TLS` and `TLS` → `STARTTLS`, matching what the underlying PHPMailer values (`ssl` = implicit TLS, `tls` = STARTTLS) actually do.

## Code review notes

Display labels only — the stored option values (`ssl`/`tls`) are unchanged, so there is no effect on existing configurations.

## QA notes

ESLint, `tsc`, and Prettier pass. Label-only change, no test added.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8227, closes #5155

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I embraced TypeScript