### PR TITLE
Add DB timezone test for invalid WordPress offset

### DIFF
--- a/mailpoet/tests/integration/Doctrine/Middlewares/PostConnectMiddlewareTest.php
+++ b/mailpoet/tests/integration/Doctrine/Middlewares/PostConnectMiddlewareTest.php
@@ -15,4 +15,18 @@ class PostConnectMiddlewareTest extends \MailPoetTest {
     $bigSelects = $this->entityManager->getConnection()->fetchOne('SELECT @@SESSION.sql_big_selects');
     verify($bigSelects)->equals('1');
   }
+
+  public function testItUsesUtcDatabaseTimezoneWithInvalidWordPressOffset() {
+    $originalOffset = get_option('gmt_offset');
+    update_option('gmt_offset', -15);
+
+    try {
+      $connection = (new ConnectionFactory())->createConnection();
+      $databaseTimezone = $connection->fetchOne('SELECT @@SESSION.time_zone');
+    } finally {
+      update_option('gmt_offset', $originalOffset);
+    }
+
+    verify($databaseTimezone)->equals('+00:00');
+  }
 }


### PR DESCRIPTION
## Description

Adds an integration test asserting that the Doctrine connection forces the database session timezone to `+00:00` even when WordPress reports an out-of-range `gmt_offset`.

## Code review notes

Test-only change — no production code is modified. Note the branch name references showing an admin error for an invalid timezone DB, but this branch only adds the regression test; please confirm whether the production-side change is expected in a separate PR.

## QA notes

Integration `PostConnectMiddlewareTest` passes (3 tests).

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8228, closes #4762

## After-merge notes

_N/A_

## Tasks

- [x] I added sufficient test coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->