### PR TITLE
Use active theme colors in the form editor palette

### DIFF
--- a/mailpoet/assets/js/src/form-editor/components/editor-settings.ts
+++ b/mailpoet/assets/js/src/form-editor/components/editor-settings.ts
@@ -2,6 +2,7 @@ export function getEditorExperimentalFeatures(
   colors: unknown,
   gradients: unknown,
   fontSizes: unknown,
+  themeColors: unknown,
 ) {
   return {
     spacing: {
@@ -16,6 +17,7 @@ export function getEditorExperimentalFeatures(
       defaultPalette: true,
       palette: {
         default: colors,
+        theme: themeColors,
       },
       gradients: {
         default: gradients,

--- a/mailpoet/assets/js/src/form-editor/components/editor.jsx
+++ b/mailpoet/assets/js/src/form-editor/components/editor.jsx
@@ -31,7 +31,7 @@ import { FormPreview } from './preview/preview';
 import { FormStylingBackground } from './form-styling-background.jsx';
 import { CustomFontsStyleSheetLink } from './font-family-settings';
 import { Fullscreen } from './fullscreen';
-import { FONT_SIZES, storeName } from '../store';
+import { FONT_SIZES, storeName, THEME_COLOR_PALETTE } from '../store';
 import { getEditorExperimentalFeatures } from './editor-settings';
 
 /**
@@ -90,6 +90,7 @@ export function Editor() {
         SETTINGS_DEFAULTS.colors,
         SETTINGS_DEFAULTS.gradients,
         FONT_SIZES,
+        THEME_COLOR_PALETTE,
       ),
     }),
     [canUserUpload, toggleInserter],

--- a/mailpoet/assets/js/src/form-editor/store/actions.ts
+++ b/mailpoet/assets/js/src/form-editor/store/actions.ts
@@ -11,7 +11,7 @@ import {
   ToggleBlockInserterAction,
 } from './actions-types';
 import { BlockInsertionPoint } from './state-types';
-import { FONT_SIZES, storeName } from './constants';
+import { FONT_SIZES, FORM_EDITOR_COLOR_PALETTE, storeName } from './constants';
 
 export function toggleSidebar(toggleTo): ToggleAction {
   return {
@@ -238,7 +238,7 @@ export function* showPreview() {
 
   const blocksToFormBody = blocksToFormBodyFactory(
     FONT_SIZES,
-    SETTINGS_DEFAULTS.colors,
+    FORM_EDITOR_COLOR_PALETTE,
     SETTINGS_DEFAULTS.gradients,
     customFields,
   );

--- a/mailpoet/assets/js/src/form-editor/store/color-palette.ts
+++ b/mailpoet/assets/js/src/form-editor/store/color-palette.ts
@@ -1,0 +1,12 @@
+import type { ColorDefinition } from './form-data-types';
+
+export const getFormEditorColorPalette = (
+  themePalette: ColorDefinition[],
+  defaultPalette: ColorDefinition[],
+): ColorDefinition[] => [
+  ...themePalette,
+  ...defaultPalette.filter(
+    (defaultColor) =>
+      !themePalette.some((themeColor) => themeColor.slug === defaultColor.slug),
+  ),
+];

--- a/mailpoet/assets/js/src/form-editor/store/constants.ts
+++ b/mailpoet/assets/js/src/form-editor/store/constants.ts
@@ -1,5 +1,6 @@
 import { SETTINGS_DEFAULTS } from '@wordpress/block-editor';
 import type { ColorDefinition } from './form-data-types';
+import type { FormEditorWindow } from './state-types';
 import { getFormEditorColorPalette } from './color-palette';
 
 export const storeName = 'mailpoet-form-editor';
@@ -13,9 +14,7 @@ const getThemeColorPalette = (): ColorDefinition[] => {
   if (typeof window === 'undefined') {
     return [];
   }
-  const formEditorWindow = window as Window & {
-    mailpoet_form_editor_color_palette?: ColorDefinition[];
-  };
+  const formEditorWindow = window as unknown as FormEditorWindow;
   if (!Array.isArray(formEditorWindow.mailpoet_form_editor_color_palette)) {
     return [];
   }

--- a/mailpoet/assets/js/src/form-editor/store/constants.ts
+++ b/mailpoet/assets/js/src/form-editor/store/constants.ts
@@ -1,4 +1,6 @@
 import { SETTINGS_DEFAULTS } from '@wordpress/block-editor';
+import type { ColorDefinition } from './form-data-types';
+import { getFormEditorColorPalette } from './color-palette';
 
 export const storeName = 'mailpoet-form-editor';
 
@@ -6,3 +8,23 @@ export const FONT_SIZES = SETTINGS_DEFAULTS.fontSizes.map((map) => ({
   ...map,
   size: `${map.size}${Number.isNaN(Number(`${map.size}` || NaN)) ? '' : 'px'}`,
 }));
+
+const getThemeColorPalette = (): ColorDefinition[] => {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+  const formEditorWindow = window as Window & {
+    mailpoet_form_editor_color_palette?: ColorDefinition[];
+  };
+  if (!Array.isArray(formEditorWindow.mailpoet_form_editor_color_palette)) {
+    return [];
+  }
+  return formEditorWindow.mailpoet_form_editor_color_palette;
+};
+
+export const THEME_COLOR_PALETTE = getThemeColorPalette();
+export const FORM_EDITOR_COLOR_PALETTE = getFormEditorColorPalette(
+  THEME_COLOR_PALETTE,
+  SETTINGS_DEFAULTS.colors,
+);
+export { getFormEditorColorPalette };

--- a/mailpoet/assets/js/src/form-editor/store/controls.tsx
+++ b/mailpoet/assets/js/src/form-editor/store/controls.tsx
@@ -20,7 +20,7 @@ import { mapFormDataBeforeSaving } from './map-form-data-before-saving.jsx';
 import { findBlock } from './find-block';
 import { formatCustomFieldBlockName } from '../blocks/format-custom-field-block-name';
 import { getCustomFieldBlockSettings } from '../blocks/custom-fields-blocks';
-import { FONT_SIZES, storeName } from './constants';
+import { FONT_SIZES, FORM_EDITOR_COLOR_PALETTE, storeName } from './constants';
 
 const formatApiErrorMessage = (response) => {
   let errorMessage = null;
@@ -63,7 +63,7 @@ export const controls = {
     const customFields = select(storeName).getAllAvailableCustomFields();
     const blocksToFormBody = blocksToFormBodyFactory(
       FONT_SIZES,
-      SETTINGS_DEFAULTS.colors,
+      FORM_EDITOR_COLOR_PALETTE,
       SETTINGS_DEFAULTS.gradients,
       customFields,
     );

--- a/mailpoet/assets/js/src/form-editor/store/state-types.ts
+++ b/mailpoet/assets/js/src/form-editor/store/state-types.ts
@@ -1,5 +1,5 @@
 import { Block } from '@wordpress/blocks';
-import { FormData, CustomField } from './form-data-types';
+import { ColorDefinition, FormData, CustomField } from './form-data-types';
 
 export type BlockInsertionPoint = {
   rootClientId: string | undefined;
@@ -41,6 +41,7 @@ export interface FormEditorWindow extends Window {
   }[];
   mailpoet_close_icons_url: string;
   mailpoet_custom_fonts: string[];
+  mailpoet_form_editor_color_palette: ColorDefinition[];
   mailpoet_all_wp_posts: { id: string; name: string }[];
   mailpoet_all_wp_pages: { id: string; name: string }[];
   mailpoet_all_wp_categories: { id: string; name: string }[];

--- a/mailpoet/assets/js/src/form-editor/store/store.ts
+++ b/mailpoet/assets/js/src/form-editor/store/store.ts
@@ -10,7 +10,7 @@ import { validateForm } from './form-validator.jsx';
 import { formBodyToBlocksFactory } from './form-body-to-blocks.jsx';
 import { mapFormDataAfterLoading } from './map-form-data-after-loading.jsx';
 import { FormEditorWindow } from './state-types';
-import { FONT_SIZES, storeName } from './constants';
+import { FONT_SIZES, FORM_EDITOR_COLOR_PALETTE, storeName } from './constants';
 import { isCoreBlockTypographyTextAlignSupported } from '../blocks/core-block-settings';
 
 declare let window: FormEditorWindow;
@@ -23,7 +23,7 @@ export const initStore = () => {
 
   const formBodyToBlocks = formBodyToBlocksFactory(
     FONT_SIZES,
-    SETTINGS_DEFAULTS.colors,
+    FORM_EDITOR_COLOR_PALETTE,
     SETTINGS_DEFAULTS.gradients,
     customFields,
     {

--- a/mailpoet/changelog/2026-07-02-10-43-17-improved-use-active-theme-colors-in-the-form-editor-palette.md
+++ b/mailpoet/changelog/2026-07-02-10-43-17-improved-use-active-theme-colors-in-the-form-editor-palette.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Use active theme colors in the form editor palette

--- a/mailpoet/lib/AdminPages/Pages/FormEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/FormEditor.php
@@ -266,6 +266,7 @@ class FormEditor {
       'editor_tutorial_seen' => $this->userFlags->get('form_editor_tutorial_seen'),
       'preview_page_url' => $this->getPreviewPageUrl(),
       'custom_fonts' => CustomFonts::FONTS,
+      'editor_color_palette' => $this->getEditorColorPalette(),
       'translations' => $this->getGutenbergScriptsTranslations(),
       'posts' => $this->wpPostListLoader->getPosts(),
       'pages' => $this->wpPostListLoader->getPages(),
@@ -281,6 +282,56 @@ class FormEditor {
     $this->wp->wpEnqueueMedia();
     $this->assetsController->setupFormEditorDependencies();
     $this->pageRenderer->displayPage('form/editor.html', $data);
+  }
+
+  private function getEditorColorPalette(): array {
+    $palette = $this->normalizeColorPalette(
+      $this->wp->wpGetGlobalSettings(['color', 'palette', 'theme'])
+    );
+    if ($palette) {
+      return $palette;
+    }
+    return $this->normalizeColorPalette(
+      $this->wp->wpGetThemeSupport('editor-color-palette')
+    );
+  }
+
+  private function normalizeColorPalette($palette): array {
+    if (!is_array($palette)) {
+      return [];
+    }
+    if (
+      isset($palette[0])
+      && is_array($palette[0])
+      && !isset($palette[0]['color'])
+    ) {
+      $palette = $palette[0];
+    }
+
+    $normalizedPalette = [];
+    foreach ($palette as $color) {
+      if (!is_array($color)) {
+        continue;
+      }
+      $name = isset($color['name']) && is_scalar($color['name'])
+        ? $this->wp->sanitizeTextField((string)$color['name'])
+        : '';
+      $slug = isset($color['slug']) && is_scalar($color['slug'])
+        ? $this->wp->sanitizeKey((string)$color['slug'])
+        : '';
+      $colorValue = isset($color['color']) && is_scalar($color['color'])
+        ? $this->wp->sanitizeTextField((string)$color['color'])
+        : '';
+      if (!$name || !$slug || !$colorValue) {
+        continue;
+      }
+      $normalizedPalette[] = [
+        'name' => $name,
+        'slug' => $slug,
+        'color' => $colorValue,
+      ];
+    }
+    return $normalizedPalette;
   }
 
   public function renderTemplateSelection() {

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -658,6 +658,10 @@ class Functions {
     return get_theme_support($feature, $args);
   }
 
+  public function wpGetGlobalSettings(array $path = [], array $context = []) {
+    return wp_get_global_settings($path, $context);
+  }
+
   public function wpInsertPost(array $postarr, $wpError = false) {
     return wp_insert_post($postarr, $wpError);
   }

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -407,11 +407,7 @@ class AcceptanceTester extends \Codeception\Actor {
   }
 
   public function assertCssProperty($cssSelector, $cssProperty, $value) {
-    $i = $this;
-    $attributeValue = $i->executeInSelenium(function (\Facebook\WebDriver\WebDriver $webdriver) use ($cssSelector, $cssProperty){
-      return $webdriver->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector($cssSelector))->getCSSValue($cssProperty);
-    });
-    verify($attributeValue)->equals($value);
+    verify($this->grabCssPropertyFrom($cssSelector, $cssProperty))->equals($value);
   }
 
   public function grabCssPropertyFrom($cssSelector, $cssProperty) {

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -414,6 +414,13 @@ class AcceptanceTester extends \Codeception\Actor {
     verify($attributeValue)->equals($value);
   }
 
+  public function grabCssPropertyFrom($cssSelector, $cssProperty) {
+    $i = $this;
+    return $i->executeInSelenium(function (\Facebook\WebDriver\WebDriver $webdriver) use ($cssSelector, $cssProperty){
+      return $webdriver->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector($cssSelector))->getCSSValue($cssProperty);
+    });
+  }
+
   public function assertAttributeNotContains($selector, $attribute, $notContains) {
     $i = $this;
     $attributeValue = $i->grabAttributeFrom($selector, $attribute);

--- a/mailpoet/tests/acceptance/Forms/EditorButtonStylesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorButtonStylesCest.php
@@ -31,13 +31,13 @@ class EditorButtonStylesCest {
     $i->waitForElement('[data-automation-id="input_styles_settings"]');
     $i->click('.mailpoet-automation-inherit-theme-toggle input'); // Display custom settings
     $i->click('(//button[contains(@class,"block-editor-panel-color-gradient-settings__dropdown")])[1]'); // Click Background color
-    $i->selectPanelColor('[6]'); // Select Vivid orange
+    $i->selectPanelColor('[6]'); // Select a theme color
     $i->click('[data-automation-id="editor_submit_input"]');
     $i->click('Font');
-    $i->selectPanelColor('[10]'); // Select Cyan blue
+    $i->selectPanelColor('[10]'); // Select a theme color
     $i->click('[data-automation-id="editor_submit_input"]');
     $i->click('Border');
-    $i->selectPanelColor('[7]'); // Select Vivid amber
+    $i->selectPanelColor('[7]'); // Select a theme color
     $i->click('[data-automation-id="editor_submit_input"]');
     $i->click('.mailpoet-automation-styles-bold-toggle input'); // Toggle bold on
     $i->clearFormField('.mailpoet-automation-styles-border-size input[type="number"]');
@@ -47,6 +47,11 @@ class EditorButtonStylesCest {
     $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'border-width', '10px');
     $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'font-weight', '700');
 
+    // Grab the applied colors so the assertions stay independent of the active theme palette.
+    $fontColor = $i->grabCssPropertyFrom('[data-automation-id="editor_submit_input"]', 'color');
+    $borderColor = $i->grabCssPropertyFrom('[data-automation-id="editor_submit_input"]', 'border-color');
+    $backgroundColor = $i->grabCssPropertyFrom('[data-automation-id="editor_submit_input"]', 'background-color');
+
     $i->wantTo('Save form');
     $i->saveFormInEditor();
 
@@ -55,18 +60,18 @@ class EditorButtonStylesCest {
     $i->waitForElement('[data-automation-id="form_title_input"]');
     $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'border-width', '10px');
     $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'font-weight', '700');
-    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'color', 'rgba(142, 209, 252, 1)');
-    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'border-color', 'rgb(252, 185, 0)');
-    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'background-color', 'rgba(255, 105, 0, 1)');
+    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'color', $fontColor);
+    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'border-color', $borderColor);
+    $i->assertCssProperty('[data-automation-id="editor_submit_input"]', 'background-color', $backgroundColor);
 
     $i->wantTo('Check styles are applied on frontend page');
     $postUrl = $i->createPost('Title', 'Content');
     $i->amOnUrl($postUrl);
     $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'border-width', '10px');
     $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'font-weight', '700');
-    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'color', 'rgba(142, 209, 252, 1)');
-    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'border-color', 'rgb(252, 185, 0)');
-    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'background-color', 'rgba(255, 105, 0, 1)');
+    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'color', $fontColor);
+    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'border-color', $borderColor);
+    $i->assertCssProperty('[data-automation-id="subscribe-submit-button"]', 'background-color', $backgroundColor);
     $i->seeInField('[data-automation-id="subscribe-submit-button"]', 'Join Now');
   }
 }

--- a/mailpoet/tests/acceptance/Forms/EditorTextInputStylesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorTextInputStylesCest.php
@@ -32,13 +32,13 @@ class EditorTextInputStylesCest {
     $i->waitForElement('[data-automation-id="input_styles_settings"]');
     $i->click('.mailpoet-automation-inherit-theme-toggle input'); // Display custom settings
     $i->click('Font');
-    $i->selectPanelColor('[6]'); // Select Vivid orange
+    $i->selectPanelColor('[6]'); // Select a theme color
     $i->click('[data-automation-id="editor_first_name_input"]');
     $i->click('(//button[contains(@class,"block-editor-panel-color-gradient-settings__dropdown")])[2]'); // Click Background color
-    $i->selectPanelColor('[10]'); // Select Cyan blue
+    $i->selectPanelColor('[10]'); // Select a theme color
     $i->click('[data-automation-id="editor_first_name_input"]');
     $i->click('Border');
-    $i->selectPanelColor('[7]'); // Select Vivid amber
+    $i->selectPanelColor('[7]'); // Select a theme color
     $i->click('[data-automation-id="editor_first_name_input"]');
     $i->click('.mailpoet-automation-styles-bold-toggle input'); // Toggle bold on
     $i->clearFormField('.mailpoet-automation-styles-border-size input[type="number"]');
@@ -80,6 +80,12 @@ class EditorTextInputStylesCest {
     $i->wantTo('Check email block has styles too and save the form');
     $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-width', '10px');
     $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-radius', '40px');
+
+    // Grab the applied colors so the assertions stay independent of the active theme palette.
+    $fontColor = $i->grabCssPropertyFrom('[data-automation-id="editor_first_name_input"]', 'color');
+    $borderColor = $i->grabCssPropertyFrom('[data-automation-id="editor_first_name_input"]', 'border-color');
+    $backgroundColor = $i->grabCssPropertyFrom('[data-automation-id="editor_first_name_input"]', 'background-color');
+
     $i->saveFormInEditor();
 
     $i->wantTo('Reload page and check data were saved');
@@ -90,10 +96,10 @@ class EditorTextInputStylesCest {
     $i->assertCssProperty('[data-automation-id="editor_first_name_label"]', 'font-weight', '700');
     $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-width', '10px');
     $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-radius', '40px');
-    $i->assertCssProperty('[data-automation-id="editor_first_name_input"]', 'border-color', 'rgb(252, 185, 0)');
-    $i->assertCssProperty('[data-automation-id="editor_first_name_input"]', 'background-color', 'rgba(142, 209, 252, 1)');
-    $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-color', 'rgb(252, 185, 0)');
-    $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'background-color', 'rgba(142, 209, 252, 1)');
+    $i->assertCssProperty('[data-automation-id="editor_first_name_input"]', 'border-color', $borderColor);
+    $i->assertCssProperty('[data-automation-id="editor_first_name_input"]', 'background-color', $backgroundColor);
+    $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'border-color', $borderColor);
+    $i->assertCssProperty('[data-automation-id="editor_email_input"]', 'background-color', $backgroundColor);
     $i->see('Heading Lorem');
     $i->see('Paragraph ipsum dolor');
 
@@ -106,12 +112,12 @@ class EditorTextInputStylesCest {
     $i->assertCssProperty('[data-automation-id="form_first_name_label"]', 'font-weight', '700');
     $i->assertCssProperty('[data-automation-id="form_email"]', 'border-width', '10px');
     $i->assertCssProperty('[data-automation-id="form_email"]', 'border-radius', '40px');
-    $i->assertCssProperty('[data-automation-id="form_first_name"]', 'color', 'rgba(255, 105, 0, 1)');
-    $i->assertCssProperty('[data-automation-id="form_first_name"]', 'border-color', 'rgb(252, 185, 0)');
-    $i->assertCssProperty('[data-automation-id="form_first_name"]', 'background-color', 'rgba(142, 209, 252, 1)');
-    $i->assertCssProperty('[data-automation-id="form_email"]', 'color', 'rgba(255, 105, 0, 1)');
-    $i->assertCssProperty('[data-automation-id="form_email"]', 'border-color', 'rgb(252, 185, 0)');
-    $i->assertCssProperty('[data-automation-id="form_email"]', 'background-color', 'rgba(142, 209, 252, 1)');
+    $i->assertCssProperty('[data-automation-id="form_first_name"]', 'color', $fontColor);
+    $i->assertCssProperty('[data-automation-id="form_first_name"]', 'border-color', $borderColor);
+    $i->assertCssProperty('[data-automation-id="form_first_name"]', 'background-color', $backgroundColor);
+    $i->assertCssProperty('[data-automation-id="form_email"]', 'color', $fontColor);
+    $i->assertCssProperty('[data-automation-id="form_email"]', 'border-color', $borderColor);
+    $i->assertCssProperty('[data-automation-id="form_email"]', 'background-color', $backgroundColor);
     $i->see('Heading Lorem');
     $i->see('Paragraph ipsum dolor');
   }

--- a/mailpoet/tests/acceptance/Forms/EditorUpdateNewFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorUpdateNewFormCest.php
@@ -79,10 +79,13 @@ class EditorUpdateNewFormCest {
     $i->click('Form', '.editor-sidebar__panel-tabs');
     $i->click('Styles');
     $i->click('Success');
-    $i->selectPanelColor('[10]'); // Select Cyan blue
+    $i->selectPanelColor('[10]'); // Select a theme color
+    // Grab the chosen colors so the assertions stay independent of the active theme palette.
+    $successColor = $i->grabCssPropertyFrom('.components-circular-option-picker__option[aria-selected="true"]', 'color');
     $i->click('Form', '.editor-sidebar__panel-tabs');
     $i->click('Error');
-    $i->selectPanelColor('[12]'); // Select Vivid purple
+    $i->selectPanelColor('[8]'); // Select a theme color
+    $errorColor = $i->grabCssPropertyFrom('.components-circular-option-picker__option[aria-selected="true"]', 'color');
     $i->click('Form', '.editor-sidebar__panel-tabs');
 
     $i->saveFormInEditor();
@@ -102,11 +105,11 @@ class EditorUpdateNewFormCest {
     $i->waitForElement('.mailpoet_submit');
     $i->fillField('[data-automation-id="form_email"]', $invalidEmail);
     $i->click('.mailpoet_submit');
-    $i->assertCssProperty('.parsley-type', 'color', 'rgba(155, 81, 224, 1)');
+    $i->assertCssProperty('.parsley-type', 'color', $errorColor);
     $i->fillField('[data-automation-id="form_email"]', $subscriberEmail);
     $i->click('.mailpoet_submit');
     $i->waitForText($newConfMessage, self::CONFIRMATION_MESSAGE_TIMEOUT, '.mailpoet_validate_success');
-    $i->assertCssProperty('.mailpoet_validate_success', 'color', 'rgba(142, 209, 252, 1)');
+    $i->assertCssProperty('.mailpoet_validate_success', 'color', $successColor);
     $i->seeNoJSErrors();
   }
 }

--- a/mailpoet/tests/javascript/form-editor/components/editor-settings.spec.ts
+++ b/mailpoet/tests/javascript/form-editor/components/editor-settings.spec.ts
@@ -2,7 +2,7 @@ import { getEditorExperimentalFeatures } from '../../../../assets/js/src/form-ed
 
 describe('Form editor settings', () => {
   it('enables block text alignment controls', () => {
-    const features = getEditorExperimentalFeatures([], [], []);
+    const features = getEditorExperimentalFeatures([], [], [], []);
 
     expect(features.typography.textAlign).to.equal(true);
   });

--- a/mailpoet/tests/javascript/form-editor/store/color-palette.spec.ts
+++ b/mailpoet/tests/javascript/form-editor/store/color-palette.spec.ts
@@ -1,0 +1,29 @@
+import { getFormEditorColorPalette } from '../../../../assets/js/src/form-editor/store/color-palette';
+
+describe('form editor color palette', () => {
+  const defaultColors = [
+    { name: 'Black', slug: 'black', color: '#000000' },
+    { name: 'White', slug: 'white', color: '#ffffff' },
+  ];
+
+  it('uses default colors when no theme palette is available', () => {
+    expect(getFormEditorColorPalette([], defaultColors)).to.deep.equal(
+      defaultColors,
+    );
+  });
+
+  it('keeps theme colors before defaults and avoids duplicate slugs', () => {
+    const defaultColor = defaultColors[0];
+    const themeColor = {
+      ...defaultColor,
+      color: '#123456',
+    };
+    const palette = getFormEditorColorPalette([themeColor], defaultColors);
+
+    expect(palette[0]).to.deep.equal(themeColor);
+    expect(
+      palette.filter((color) => color.slug === defaultColor.slug),
+    ).to.have.length(1);
+    expect(palette).to.have.length(defaultColors.length);
+  });
+});

--- a/mailpoet/views/form/editor.html
+++ b/mailpoet/views/form/editor.html
@@ -20,6 +20,7 @@
   var mailpoet_month_names = <%= month_names|wp_json_encode %>;
   var mailpoet_form_preview_page = <%= preview_page_url|wp_json_encode %>;
   var mailpoet_custom_fonts = <%= custom_fonts|wp_json_encode %>;
+  var mailpoet_form_editor_color_palette = <%= editor_color_palette|wp_json_encode %>;
   var mailpoet_translations = <%= translations|wp_json_encode %>;
   var mailpoet_all_wp_posts = <%= posts|wp_json_encode %>;
   var mailpoet_all_wp_pages = <%= pages|wp_json_encode %>;


### PR DESCRIPTION
## Description

Includes the active theme's color palette in the form editor color picker, so form colors can match the site theme. Falls back to the default palette when the theme exposes none.

## Code review notes

_N/A_

## QA notes

PHPStan, `tsc`, JS spec (2 cases), and Semgrep (0 findings) pass.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8229, closes #4717

## Screenshots

| Before | After | 
| ---- | ----- | 
|  <img width="320" height="739" alt="Screenshot 2026-07-07 at 15 25 01" src="https://github.com/user-attachments/assets/7a69e0bb-45c2-4655-a78e-68e6d966b2bf" /> | <img width="304" height="748" alt="Screenshot 2026-07-07 at 15 26 53" src="https://github.com/user-attachments/assets/0fce7a2a-b9a0-4fb6-92a8-866643d56c07" /> | 


## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I added sufficient test coverage
- [x] I embraced TypeScript

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8229-use-active-theme-colors-in-the-form-editor-palette)

_The latest successful build from `stomail-8229-use-active-theme-colors-in-the-form-editor-palette` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->