### PR TITLE
Fix subscriber import column auto-mapping for CSV headers

### DIFF
--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/match-columns.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/match-columns.jsx
@@ -1,5 +1,11 @@
 const FIRST_NAME_HEADERS = ['first', 'first name', 'firstname', 'given name'];
-const LAST_NAME_HEADERS = ['last', 'last name', 'lastname'];
+const LAST_NAME_HEADERS = [
+  'last',
+  'last name',
+  'lastname',
+  'surname',
+  'family name',
+];
 
 const getMatchedNameColumnId = (headerName) => {
   const normalizedHeaderName = String(headerName).trim().toLowerCase();

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/match-columns.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/match-columns.jsx
@@ -1,5 +1,5 @@
-const FIRST_NAME_HEADERS = ['first', 'first name', 'given name'];
-const LAST_NAME_HEADERS = ['last', 'last name'];
+const FIRST_NAME_HEADERS = ['first', 'first name', 'firstname', 'given name'];
+const LAST_NAME_HEADERS = ['last', 'last name', 'lastname'];
 
 const getMatchedNameColumnId = (headerName) => {
   const normalizedHeaderName = String(headerName).trim().toLowerCase();

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/match-columns.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/match-columns.jsx
@@ -1,3 +1,17 @@
+const FIRST_NAME_HEADERS = ['first', 'first name', 'given name'];
+const LAST_NAME_HEADERS = ['last', 'last name'];
+
+const getMatchedNameColumnId = (headerName) => {
+  const normalizedHeaderName = String(headerName).trim().toLowerCase();
+  if (FIRST_NAME_HEADERS.includes(normalizedHeaderName)) {
+    return 'first_name';
+  }
+  if (LAST_NAME_HEADERS.includes(normalizedHeaderName)) {
+    return 'last_name';
+  }
+  return 'ignore';
+};
+
 export const matchColumns = (subscribers, header) => {
   const displayedColumns = [];
   const displayedColumnsIds = [];
@@ -21,12 +35,7 @@ export const matchColumns = (subscribers, header) => {
       if (headerNameMatch !== -1) {
         columnId = window.mailpoetColumns[headerNameMatch].id;
       } else if (headerName) {
-        // set column type using header name
-        if (/first|first name|given name/i.test(headerName)) {
-          columnId = 'first_name';
-        } else if (/last|last name/i.test(headerName)) {
-          columnId = 'last_name';
-        }
+        columnId = getMatchedNameColumnId(headerName);
       }
     }
     // make sure the column id has not been previously selected

--- a/mailpoet/changelog/2026-07-02-10-23-22-fixed-fix-subscriber-import-column-auto-mapping-for-csv-.md
+++ b/mailpoet/changelog/2026-07-02-10-23-22-fixed-fix-subscriber-import-column-auto-mapping-for-csv-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix subscriber import column auto-mapping for CSV headers

--- a/mailpoet/tests/javascript/subscribers/import-match-columns.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/import-match-columns.spec.ts
@@ -48,6 +48,26 @@ describe('Subscriber import column matching', () => {
     ]);
   });
 
+  it('matches single-word name headers without a space', () => {
+    const columns = matchColumns(
+      [
+        {
+          0: 'John',
+          1: 'Doe',
+        },
+      ],
+      {
+        0: 'FirstName',
+        1: 'lastname',
+      },
+    );
+
+    expect(columns).to.deep.equal([
+      { column_id: 'first_name' },
+      { column_id: 'last_name' },
+    ]);
+  });
+
   it('does not match unrelated headers containing name words', () => {
     const columns = matchColumns(
       [

--- a/mailpoet/tests/javascript/subscribers/import-match-columns.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/import-match-columns.spec.ts
@@ -1,0 +1,73 @@
+import { matchColumns } from '../../../assets/js/src/subscribers/import-export/import/step-data-manipulation/match-columns.jsx';
+
+type WindowGlobals = typeof globalThis & {
+  window?: Window &
+    typeof globalThis & {
+      mailpoetColumns: Array<{ id: string; name: string }>;
+      mailpoet_email_regex: RegExp;
+    };
+};
+
+describe('Subscriber import column matching', () => {
+  beforeEach(() => {
+    const globals = global as WindowGlobals;
+    globals.window = {
+      mailpoetColumns: [
+        { id: 'email', name: 'Email' },
+        { id: 'first_name', name: 'First name' },
+        { id: 'last_name', name: 'Last name' },
+      ],
+      mailpoet_email_regex: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+    } as unknown as WindowGlobals['window'];
+  });
+
+  afterEach(() => {
+    delete (global as WindowGlobals).window;
+  });
+
+  it('matches common name headers exactly', () => {
+    const columns = matchColumns(
+      [
+        {
+          0: 'first',
+          1: 'last',
+          2: 'customer@example.com',
+        },
+      ],
+      {
+        0: ' Given Name ',
+        1: 'LAST',
+        2: 'Email',
+      },
+    );
+
+    expect(columns).to.deep.equal([
+      { column_id: 'first_name' },
+      { column_id: 'last_name' },
+      { column_id: 'email' },
+    ]);
+  });
+
+  it('does not match unrelated headers containing name words', () => {
+    const columns = matchColumns(
+      [
+        {
+          0: 'customer@example.com',
+          1: '2026-07-02',
+          2: '2026-07-02',
+        },
+      ],
+      {
+        0: 'Email',
+        1: 'FIRSTUPDATED',
+        2: 'LASTUPDATED',
+      },
+    );
+
+    expect(columns).to.deep.equal([
+      { column_id: 'email' },
+      { column_id: 'ignore' },
+      { column_id: 'ignore' },
+    ]);
+  });
+});

--- a/mailpoet/tests/javascript/subscribers/import-match-columns.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/import-match-columns.spec.ts
@@ -48,6 +48,39 @@ describe('Subscriber import column matching', () => {
     ]);
   });
 
+  it('matches surname variants for the last name column', () => {
+    const columns = matchColumns(
+      [
+        {
+          0: 'John',
+          1: 'Doe',
+        },
+      ],
+      {
+        0: 'Given name',
+        1: 'Surname',
+      },
+    );
+
+    expect(columns).to.deep.equal([
+      { column_id: 'first_name' },
+      { column_id: 'last_name' },
+    ]);
+
+    const familyName = matchColumns(
+      [
+        {
+          0: 'Doe',
+        },
+      ],
+      {
+        0: 'Family name',
+      },
+    );
+
+    expect(familyName).to.deep.equal([{ column_id: 'last_name' }]);
+  });
+
   it('matches single-word name headers without a space', () => {
     const columns = matchColumns(
       [


### PR DESCRIPTION
## Description

Fixes subscriber-import column auto-mapping so headers like `LASTUPDATED`/`FIRSTUPDATED` are no longer mapped to Last/First name. Replaces the greedy substring regex with an exact match against a small list of known name headers.

## Code review notes

The exact-match lists intentionally keep the single-word `firstname`/`lastname` variants (added on top of the original change) so common exports still auto-map, while `lastupdated`/`firstupdated` are excluded. Header matching normalizes case and trims whitespace.

## QA notes

JS spec passes (3 cases): exact matches, single-word no-space variants, and the excluded `*UPDATED` headers.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8230, closes #4444

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I added sufficient test coverage
- [x] I embraced TypeScript

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8230-avoid-mapping-lastupdated-csv-header-to-last-name)

_The latest successful build from `stomail-8230-avoid-mapping-lastupdated-csv-header-to-last-name` will be used. If none is available, the link won't work._