### PR TITLE
Prevent manage subscription saves conflicting with dashboard-blocking plugins

### DIFF
--- a/mailpoet/changelog/2026-07-02-11-02-55-fixed-prevent-manage-subscription-form-saves-from-confli.md
+++ b/mailpoet/changelog/2026-07-02-11-02-55-fixed-prevent-manage-subscription-form-saves-from-confli.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Prevent manage subscription form saves from conflicting with plugins that block subscriber dashboard access

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -286,6 +286,10 @@ class Hooks {
 
     // Manage subscription
     $this->wp->addAction(
+      'wp_loaded',
+      [$this->subscriptionManage, 'onFrontendSave']
+    );
+    $this->wp->addAction(
       'admin_post_mailpoet_subscription_update',
       [$this->subscriptionManage, 'onSave']
     );

--- a/mailpoet/lib/Subscription/Manage.php
+++ b/mailpoet/lib/Subscription/Manage.php
@@ -81,8 +81,8 @@ class Manage {
   }
 
   public function onSave() {
-    $action = (isset($_POST['action']) && is_string($_POST['action']) ? sanitize_text_field(wp_unslash($_POST['action'])) : '');
-    $token = (isset($_POST['token']) && is_string($_POST['token']) ? sanitize_text_field(wp_unslash($_POST['token'])) : '');
+    $action = $this->getPostString('action');
+    $token = $this->getPostString('token');
 
     if ($action !== 'mailpoet_subscription_update' || empty($_POST['data'])) {
       $this->urlHelper->redirectBack();
@@ -132,6 +132,14 @@ class Manage {
     }
 
     $this->urlHelper->redirectBack($result);
+  }
+
+  public function onFrontendSave() {
+    if ($this->getPostString('action') !== 'mailpoet_subscription_update') {
+      return;
+    }
+
+    $this->onSave();
   }
 
   private function updateSubscriptions(
@@ -486,5 +494,11 @@ class Manage {
       }
     }
     return $mandatory;
+  }
+
+  private function getPostString(string $key): string {
+    return isset($_POST[$key]) && is_string($_POST[$key])
+      ? sanitize_text_field(wp_unslash($_POST[$key]))
+      : '';
   }
 }

--- a/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
+++ b/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
@@ -98,9 +98,10 @@ class ManageSubscriptionFormRenderer {
       $form = $filteredForm;
     }
 
+    $currentUrl = $this->urlHelper->getCurrentUrl();
     $templateData = [
-      'actionUrl' => admin_url('admin-post.php'),
-      'redirectUrl' => $this->urlHelper->getCurrentUrl(),
+      'actionUrl' => $currentUrl,
+      'redirectUrl' => $currentUrl,
       'email' => $subscriber->getEmail(),
       'token' => $this->linkTokens->getToken($subscriber),
       'editEmailInfo' => __('Need to change your email address? Unsubscribe using the form below, then simply sign up again.', 'mailpoet'),

--- a/mailpoet/tests/integration/Config/HooksTest.php
+++ b/mailpoet/tests/integration/Config/HooksTest.php
@@ -6,6 +6,7 @@ use Helper\WordPressHooks as WPHooksHelper;
 use MailPoet\Config\Hooks;
 use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Subscription\Manage;
 use MailPoet\WP\Functions as WPFunctions;
 
 class HooksTest extends \MailPoetTest {
@@ -16,6 +17,7 @@ class HooksTest extends \MailPoetTest {
   }
 
   public function testItHooksSubscriberChangesNotifier() {
+    WPHooksHelper::releaseAllHooks();
     $wp = $this->make(new WPFunctions(), [
       'addAction' => asCallable([WPHooksHelper::class, 'addAction']),
       'doAction' => asCallable([WPHooksHelper::class, 'doAction']),
@@ -35,5 +37,29 @@ class HooksTest extends \MailPoetTest {
     // manual hook execution and check with mocked return value
     $shutdownHook = WPHooksHelper::getActionAdded('shutdown');
     $this->assertEquals('success', call_user_func($shutdownHook[0]));
+    WPHooksHelper::releaseAllHooks();
+  }
+
+  public function testItHooksManageSubscriptionSaveOnFrontend() {
+    WPHooksHelper::releaseAllHooks();
+    $wp = $this->make(new WPFunctions(), [
+      'addAction' => asCallable([WPHooksHelper::class, 'addAction']),
+      'addFilter' => asCallable([WPHooksHelper::class, 'addFilter']),
+    ]);
+    $subscriptionManage = $this->make(Manage::class, [
+      'onFrontendSave' => 'frontend-save',
+      'onSave' => 'admin-post-save',
+    ]);
+    $hooks = $this->getServiceWithOverrides(Hooks::class, [
+      'wp' => $wp,
+      'subscriptionManage' => $subscriptionManage,
+    ]);
+
+    $hooks->setupSubscriptionEvents();
+
+    $this->assertSame([$subscriptionManage, 'onFrontendSave'], WPHooksHelper::getActionAdded('wp_loaded')[0]);
+    $this->assertSame([$subscriptionManage, 'onSave'], WPHooksHelper::getActionAdded('admin_post_mailpoet_subscription_update')[0]);
+    $this->assertSame([$subscriptionManage, 'onSave'], WPHooksHelper::getActionAdded('admin_post_nopriv_mailpoet_subscription_update')[0]);
+    WPHooksHelper::releaseAllHooks();
   }
 }

--- a/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
@@ -32,7 +32,8 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
 
   public function testItGeneratesForm() {
     $form = $this->formRenderer->renderForm($this->subscriber);
-    verify($form)->stringMatchesRegExp('/<form class="mailpoet-manage-subscription mailpoet-manage-subscription--modern" method="post" action="[a-z0-9:\/\._]+wp-admin\/admin-post.php" novalidate>/');
+    verify($form)->stringMatchesRegExp('/<form class="mailpoet-manage-subscription mailpoet-manage-subscription--modern" method="post" action="[^"]+" novalidate>/');
+    verify($form)->stringNotContainsString('wp-admin/admin-post.php');
     verify($form)->stringContainsString('<input type="hidden" name="data[email]" value="subscriber@test.com" />');
     verify($form)->stringMatchesRegExp('/<input type="text" autocomplete="given-name" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="First name" value="Fname" data-automation-id="form_first_name" data-parsley-errors-container=".mailpoet_error_[a-zA-Z0-9]{5}" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
     verify($form)->stringMatchesRegExp('/<input type="text" autocomplete="family-name" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Last name" value="Lname" data-automation-id="form_last_name" data-parsley-errors-container=".mailpoet_error_[a-zA-Z0-9]{5}" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
@@ -59,7 +60,8 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
 
     $form = $this->formRenderer->renderForm($this->subscriber, ManageSubscriptionFormRenderer::FORM_STATE_SUCCESS);
 
-    verify($form)->stringMatchesRegExp('/<form class="mailpoet-manage-subscription" method="post" action="[a-z0-9:\/\._]+wp-admin\/admin-post.php" novalidate>/');
+    verify($form)->stringMatchesRegExp('/<form class="mailpoet-manage-subscription" method="post" action="[^"]+" novalidate>/');
+    verify($form)->stringNotContainsString('wp-admin/admin-post.php');
     verify($form)->stringNotContainsString('mailpoet-manage-subscription--modern');
     verify($form)->stringMatchesRegExp('/<input type="checkbox" class="mailpoet_checkbox" id="mailpoet_segment_[a-zA-Z0-9]+" name="data\[[a-zA-Z0-9=_]+\]\[\]" value="' . $this->segment->getId() . '" checked="checked" data-parsley-errors-container=".mailpoet_error_[a-zA-Z0-9]{5}" \/> Test segment/');
     verify($form)->stringContainsString('mailpoet-manage-subscription-list-fields');
@@ -88,7 +90,8 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
 
     $form = $this->formRenderer->renderForm($this->subscriber);
 
-    verify($form)->stringMatchesRegExp('/<form class="mailpoet-manage-subscription" method="post" action="[a-z0-9:\/\._]+wp-admin\/admin-post.php" novalidate>/');
+    verify($form)->stringMatchesRegExp('/<form class="mailpoet-manage-subscription" method="post" action="[^"]+" novalidate>/');
+    verify($form)->stringNotContainsString('wp-admin/admin-post.php');
     verify($form)->stringNotContainsString('mailpoet-manage-subscription--global-unsubscribed');
     verify($form)->stringContainsString('mailpoet-manage-subscription-list-fields');
   }

--- a/mailpoet/tests/integration/Subscription/ManageTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageTest.php
@@ -101,6 +101,49 @@ class ManageTest extends \MailPoetTest {
     ]);
   }
 
+  public function testFrontendSaveProcessesManageSubscriptionUpdate() {
+    $manage = $this->getManageService();
+    $_POST['action'] = 'mailpoet_subscription_update';
+    $_POST['token'] = 'token';
+    $_POST['data'] = [
+      'first_name' => 'John',
+      'last_name' => 'John',
+      'email' => 'john.doe@example.com',
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      'segment_choices' => [
+        (string)$this->segmentA->getId() => 'unsubscribed',
+      ],
+    ];
+
+    $manage->onFrontendSave();
+
+    $subscriber = $this->subscribersRepository->findOneById($this->subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    verify($this->createSegmentsMap($subscriber))->equals([
+      ['segment_id' => $this->segmentA->getId(), 'status' => SubscriberEntity::STATUS_UNSUBSCRIBED],
+      ['segment_id' => $this->hiddenSegment->getId(), 'status' => SubscriberEntity::STATUS_SUBSCRIBED],
+    ]);
+  }
+
+  public function testFrontendSaveIgnoresOtherPostActions() {
+    $manage = $this->getManageService();
+    $_POST['action'] = 'other_action';
+    $_POST['token'] = 'token';
+    $_POST['data'] = [
+      'first_name' => 'Changed',
+      'last_name' => 'Changed',
+      'email' => 'john.doe@example.com',
+      'status' => SubscriberEntity::STATUS_UNSUBSCRIBED,
+    ];
+
+    $manage->onFrontendSave();
+
+    $subscriber = $this->subscribersRepository->findOneById($this->subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    verify($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+    verify($subscriber->getFirstName())->equals('John');
+  }
+
   public function testItUsesSegmentChoicesAndIgnoresLegacySegmentsWhenPresent() {
     $manage = $this->getManageService();
     $_POST['action'] = 'mailpoet_subscription_update';


### PR DESCRIPTION
## Description

Prevents manage-subscription form saves from failing when a plugin blocks subscriber access to `wp-admin/admin-post.php`. The form now posts to the current front-end URL, and the save is processed on `wp_loaded`.

## Code review notes

`Manage::onSave()` always ends in `UrlHelper::redirectBack()`, which redirects and `exit()`s — so the new `wp_loaded` handler processes the submission and exits before the legacy `admin_post_*` hooks would run, avoiding any double save. The `admin_post` / `admin_post_nopriv` hooks are kept for backwards compatibility with already-rendered forms. Token authentication in `onSave()` is unchanged.

## QA notes

Integration passes: `HooksTest` (3), `ManageSubscriptionFormRendererTest` (8), `ManageTest` (18). Semgrep: 0 findings.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8231, closes #3645

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I added sufficient test coverage