### PR TITLE
Allow smaller spacer heights in the email editor

### DIFF
--- a/mailpoet/assets/js/src/newsletter-editor/blocks/spacer.js
+++ b/mailpoet/assets/js/src/newsletter-editor/blocks/spacer.js
@@ -35,7 +35,7 @@ Module.SpacerBlockView = base.BlockView.extend({
       ResizableBehavior: {
         elementSelector: '.mailpoet_spacer',
         resizeHandleSelector: '.mailpoet_resize_handle',
-        minLength: 20, // TODO: Move this number to editor configuration
+        minLength: 2, // TODO: Move this number to editor configuration
         modelField: 'styles.block.height',
       },
       ShowSettingsBehavior: {

--- a/mailpoet/changelog/2026-07-02-10-25-34-improved-allow-smaller-spacer-heights-in-the-email-editor.md
+++ b/mailpoet/changelog/2026-07-02-10-25-34-improved-allow-smaller-spacer-heights-in-the-email-editor.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Allow smaller spacer heights in the email editor

--- a/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/blocks/spacer.spec.js
+++ b/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/blocks/spacer.spec.js
@@ -118,6 +118,10 @@ describe('Spacer', function () {
       expect(view.$('.mailpoet_spacer').css('height')).to.equal('71px');
     });
 
+    it('allows spacer height to be resized down to 2px', function () {
+      expect(view.behaviors.ResizableBehavior.minLength).to.equal(2);
+    });
+
     it('opens settings if clicked', function () {
       var mock = sinon.mock().once();
       model.on('startEditing', mock);


### PR DESCRIPTION
## Description

Allows the email editor spacer block to be resized down to 2px (previously 20px).

## Code review notes

Single `minLength` constant change in the legacy Backbone editor — a tweak to existing behavior, not new functionality.

## QA notes

Newsletter-editor JS tests pass (472), including a new assertion that `minLength` is 2.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8232, closes #3481

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I added sufficient test coverage