### PR TITLE
Render manage subscription pages in the current frontend language

### DIFF
--- a/mailpoet/changelog/2026-07-02-11-07-11-fixed-render-manage-subscription-pages-in-the-current-fr.md
+++ b/mailpoet/changelog/2026-07-02-11-07-11-fixed-render-manage-subscription-pages-in-the-current-fr.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Render manage subscription pages in the current frontend language

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Subscription;
 
+use MailPoet\Config\Localizer;
 use MailPoet\Config\Renderer as TemplateRenderer;
 use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
 use MailPoet\Entities\NewsletterLinkEntity;
@@ -104,6 +105,12 @@ class Pages {
   /*** @var Request */
   private $request;
 
+  /** @var Localizer */
+  private $localizer;
+
+  /** @var string|null */
+  private $subscriptionPageLocale;
+
   public function __construct(
     NewSubscriberNotificationMailer $newSubscriberNotificationSender,
     WPFunctions $wp,
@@ -125,7 +132,8 @@ class Pages {
     SendingQueuesRepository $sendingQueuesRepository,
     SettingsController $settings,
     UnsubscribeReasonTracker $unsubscribeReasonTracker,
-    Request $request
+    Request $request,
+    ?Localizer $localizer = null
   ) {
     $this->wp = $wp;
     $this->newSubscriberNotificationSender = $newSubscriberNotificationSender;
@@ -148,6 +156,7 @@ class Pages {
     $this->settings = $settings;
     $this->unsubscribeReasonTracker = $unsubscribeReasonTracker;
     $this->request = $request;
+    $this->localizer = $localizer ?? new Localizer();
   }
 
   public function init($action = false, $data = [], $initShortcodes = false, $initPageFilters = false) {
@@ -307,6 +316,8 @@ class Pages {
   }
 
   public function setPageTitle($pageTitle = '') {
+    $this->ensureFrontendLocaleText();
+
     global $post;
 
     if (
@@ -342,6 +353,8 @@ class Pages {
   }
 
   public function setPageContent($pageContent = '[mailpoet_page]') {
+    $this->ensureFrontendLocaleText();
+
     if ($this->isPreview() === false && $this->subscriber === null) {
       return __("Your email address doesn't appear in our lists anymore. Sign up again or contact us if this appears to be a mistake.", 'mailpoet');
     }
@@ -446,6 +459,8 @@ class Pages {
   }
 
   public function getManageContent() {
+    $this->ensureFrontendLocaleText();
+
     if ($this->isPreview()) {
       $subscriber = new SubscriberEntity();
       $previewEmail = $this->wp->applyFilters('mailpoet_manage_subscription_preview_subscriber_email', self::DEMO_EMAIL);
@@ -589,6 +604,8 @@ class Pages {
   }
 
   public function getManageLink($params) {
+    $this->ensureFrontendLocaleText();
+
     $subscriber = $this->subscriber;
     if (!$subscriber && $this->subscribersRepository->findOneBy(['wpUserId' => $this->wp->getCurrentUserId()])) {
       $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $this->wp->getCurrentUserId()]);
@@ -632,5 +649,19 @@ class Pages {
     }
     // using the same value as mailpoet/views/subscription/confirm_unsubscribe.html#4
     return $this->wp->addQueryArg('type', 'confirmation', $unsubscribeUrl);
+  }
+
+  private function ensureFrontendLocaleText(): void {
+    if ($this->wp->isAdmin()) {
+      return;
+    }
+
+    $locale = $this->wp->getLocale();
+    if ($this->subscriptionPageLocale === $locale) {
+      return;
+    }
+
+    $this->localizer->forceLoadWebsiteLocaleText();
+    $this->subscriptionPageLocale = $locale;
   }
 }

--- a/mailpoet/tests/integration/Subscription/PagesTest.php
+++ b/mailpoet/tests/integration/Subscription/PagesTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Subscription;
 
 use Codeception\Stub;
+use MailPoet\Config\Localizer;
 use MailPoet\Config\Renderer;
 use MailPoet\Cron\Workers\SendingQueue\Tasks\Links;
 use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
@@ -380,6 +381,36 @@ class PagesTest extends \MailPoetTest {
     verify($content)->stringNotContainsString('Your subscription settings have been saved.');
   }
 
+  public function testItLoadsWebsiteLocaleTextBeforeRenderingManageSubscriptionContent(): void {
+    $localeReloads = 0;
+    $localizer = $this->make(Localizer::class, [
+      'forceLoadWebsiteLocaleText' => function() use (&$localeReloads) {
+        $localeReloads++;
+      },
+    ]);
+    $wp = $this->make(WPFunctions::class, [
+      'applyFilters' => function($tag, $value) {
+        return $value;
+      },
+      'getLocale' => 'en_US',
+      'isAdmin' => false,
+    ]);
+    $manageSubscriptionFormRenderer = $this->make(ManageSubscriptionFormRenderer::class, [
+      'renderForm' => 'manage form',
+    ]);
+
+    $content = $this->getPages(
+      null,
+      null,
+      $wp,
+      $manageSubscriptionFormRenderer,
+      $localizer
+    )->init(Pages::ACTION_MANAGE, $this->testData)->getManageContent();
+
+    verify($content)->equals('manage form');
+    verify($localeReloads)->equals(1);
+  }
+
   public function testItDoesNotSaveUnsubscribeReasonForPreview() {
     SettingsController::getInstance()->set('subscription.unsubscribe_survey.enabled', '1');
     $this->testData['preview'] = 1;
@@ -414,19 +445,22 @@ class PagesTest extends \MailPoetTest {
 
   private function getPages(
     ?NewSubscriberNotificationMailer $newSubscriberNotificationsMock = null,
-    ?Unsubscribes $unsubscribesMock = null
+    ?Unsubscribes $unsubscribesMock = null,
+    ?WPFunctions $wp = null,
+    ?ManageSubscriptionFormRenderer $manageSubscriptionFormRenderer = null,
+    ?Localizer $localizer = null
   ): Pages {
     $container = ContainerWrapper::getInstance();
     return new Pages(
       $newSubscriberNotificationsMock ?? $container->get(NewSubscriberNotificationMailer::class),
-      $container->get(WPFunctions::class),
+      $wp ?? $container->get(WPFunctions::class),
       $container->get(WelcomeScheduler::class),
       $container->get(LinkTokens::class),
       $container->get(SubscriptionUrlFactory::class),
       $container->get(AssetsController::class),
       $container->get(Renderer::class),
       $unsubscribesMock ?? $container->get(Unsubscribes::class),
-      $container->get(ManageSubscriptionFormRenderer::class),
+      $manageSubscriptionFormRenderer ?? $container->get(ManageSubscriptionFormRenderer::class),
       $container->get(SubscriberHandler::class),
       $this->subscribersRepository,
       $container->get(TrackingConfig::class),
@@ -438,7 +472,8 @@ class PagesTest extends \MailPoetTest {
       $container->get(SendingQueuesRepository::class),
       $container->get(SettingsController::class),
       $container->get(UnsubscribeReasonTracker::class),
-      $container->get(Request::class)
+      $container->get(Request::class),
+      $localizer ?? new Localizer()
     );
   }
 


### PR DESCRIPTION
## Description

Renders manage-subscription pages in the site's front-end language instead of the admin user's language, fixing a mismatch on multilingual sites.

## Code review notes

`ensureFrontendLocaleText()` calls `Localizer::forceLoadWebsiteLocaleText()`, which reloads only the MailPoet text domain using the website locale. It is guarded by `isAdmin()` and cached per locale so it runs at most once per request. `Localizer` is injected as an optional nullable constructor argument to preserve backwards compatibility for any direct instantiation.

## QA notes

Integration `PagesTest` passes (20 tests). PHPStan passes.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8233, closes #3472

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I followed best practices for translations
- [x] I added sufficient test coverage