### PR TITLE
Document how to create a release build

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 3. [Commands](#commands)
    1. [Environment lifecycle](#environment-lifecycle)
    2. [Build and watch](#build-and-watch)
-   3. [Quality assurance](#quality-assurance)
-   4. [Tests](#tests)
-   5. [Migrations, templates, wp-cli](#migrations-templates-wp-cli)
+   3. [Release build](#release-build)
+   4. [Quality assurance](#quality-assurance)
+   5. [Tests](#tests)
+   6. [Migrations, templates, wp-cli](#migrations-templates-wp-cli)
 4. [Xdebug](#xdebug)
    1. [PhpStorm setup](#phpstorm-setup)
    2. [VS Code setup](#vs-code-setup)
@@ -73,6 +74,27 @@ pnpm compile:css    # Compile SCSS only
 pnpm watch:js       # Rebuild JS on change
 pnpm watch:css      # Rebuild SCSS on change
 ```
+
+### Release build
+
+Run the release build from the free plugin directory:
+
+```shell
+cd mailpoet
+./build.sh
+```
+
+The script creates `mailpoet/mailpoet.zip`. It installs production dependencies,
+compiles production CSS and JS, builds translation files and generated caches,
+copies the distributable plugin files, removes development-only sources and
+tools such as Tracy, removes vendor tests/demo files, adds direct-access guards,
+and strips vendor PHP comments/whitespace before zipping the `mailpoet/`
+directory.
+
+Start from a clean working tree when possible. The script removes and reinstalls
+`mailpoet/node_modules`, temporarily moves `vendor/` and `vendor-prefixed/`
+while installing production Composer dependencies, and restores the development
+dependencies at the end.
 
 ### Quality assurance
 


### PR DESCRIPTION
## Description

Adds a README section documenting how to create a release build with `mailpoet/build.sh`, including what the script produces and the caveats around `node_modules` and `vendor` handling.

## Code review notes

Documentation only. Verified the described steps against `mailpoet/build.sh`.

## QA notes

Prettier passes.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8234, closes #3429

## After-merge notes

_N/A_

## Tasks

_N/A_