### PR TITLE
Standardize required validation messages for date fields

### DIFF
--- a/mailpoet/changelog/2026-07-02-10-28-07-fixed-standardize-required-validation-messages-for-date-.md
+++ b/mailpoet/changelog/2026-07-02-10-28-07-fixed-standardize-required-validation-messages-for-date-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Standardize required validation messages for date fields

--- a/mailpoet/lib/Form/Block/Date.php
+++ b/mailpoet/lib/Form/Block/Date.php
@@ -66,7 +66,7 @@ class Date {
         $html .= '<select class="mailpoet_date_day" ';
         $html .= ' style="' . $this->wp->escAttr($this->blockStylesRenderer->renderForSelect([], $formSettings)) . '"';
         $html .= $this->rendererHelper->getInputValidation($block, [
-          'required-message' => $this->wp->escAttr(__('Please select a day', 'mailpoet')),
+          'required-message' => $this->wp->escAttr(__('This field is required.', 'mailpoet')),
         ], $formId);
         $html .= 'name="' . $fieldName . '[day]" placeholder="' . $this->wp->escAttr(__('Day', 'mailpoet')) . '">';
         $html .= $this->getDays($block);
@@ -75,7 +75,7 @@ class Date {
         $html .= '<select class="mailpoet_select mailpoet_date_month" data-automation-id="form_date_month" ';
         $html .= ' style="' . $this->wp->escAttr($this->blockStylesRenderer->renderForSelect([], $formSettings)) . '"';
         $html .= $this->rendererHelper->getInputValidation($block, [
-          'required-message' => $this->wp->escAttr(__('Please select a month', 'mailpoet')),
+          'required-message' => $this->wp->escAttr(__('This field is required.', 'mailpoet')),
         ], $formId);
         $html .= 'name="' . $fieldName . '[month]" placeholder="' . $this->wp->escAttr(__('Month', 'mailpoet')) . '">';
         $html .= $this->getMonths($block);
@@ -84,7 +84,7 @@ class Date {
         $html .= '<select class="mailpoet_date_year" data-automation-id="form_date_year" ';
         $html .= ' style="' . $this->wp->escAttr($this->blockStylesRenderer->renderForSelect([], $formSettings)) . '"';
         $html .= $this->rendererHelper->getInputValidation($block, [
-          'required-message' => $this->wp->escAttr(__('Please select a year', 'mailpoet')),
+          'required-message' => $this->wp->escAttr(__('This field is required.', 'mailpoet')),
         ], $formId);
         $html .= 'name="' . $fieldName . '[year]" placeholder="' . $this->wp->escAttr(__('Year', 'mailpoet')) . '">';
         $html .= $this->getYears($block);

--- a/mailpoet/tests/acceptance/Forms/EditorCreateCustomFieldCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorCreateCustomFieldCest.php
@@ -314,8 +314,7 @@ class EditorCreateCustomFieldCest {
     $i->assertAttributeContains('[data-automation-id="form_date_year"]', 'placeholder', 'Year');
     $i->assertAttributeContains('[data-automation-id="form_date_month"]', 'placeholder', 'Month');
     $i->click('.mailpoet_submit');
-    $i->waitForText('Please select a year');
-    $i->waitForText('Please select a month');
+    $i->waitForText('This field is required.');
     $i->selectOption('[data-automation-id="form_date_year"]', '2000');
     $i->selectOption('[data-automation-id="form_date_month"]', 'January');
     $i->click('.mailpoet_submit');

--- a/mailpoet/tests/unit/Form/Block/DateTest.php
+++ b/mailpoet/tests/unit/Form/Block/DateTest.php
@@ -110,6 +110,20 @@ class DateTest extends \MailPoetUnitTest {
     verify($selectedYear->textContent)->equals($currentYear);
   }
 
+  public function testItShouldUseGenericRequiredMessageForDateSelects() {
+    $this->baseMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
+    $this->baseMock->expects($this->once())->method('getFieldName')->willReturn('Field name');
+    $this->baseMock->expects($this->exactly(2))
+      ->method('getInputValidation')
+      ->withConsecutive(
+        [$this->block, ['required-message' => 'This field is required.'], null],
+        [$this->block, ['required-message' => 'This field is required.'], null]
+      )
+      ->willReturn(' validation="1" ');
+
+    $this->date->render($this->block, []);
+  }
+
   public function testItShouldAddValue() {
     $this->baseMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
     $this->baseMock->expects($this->once())->method('getFieldName')->willReturn('Field name');


### PR DESCRIPTION
## Description

Standardizes the "required" validation message for date form fields (day/month/year) to a single "This field is required." string, instead of three distinct messages.

## Code review notes

The acceptance `EditorCreateCustomFieldCest` was updated to wait for the new message. Acceptance (Selenium) was not run locally; the assertion matches the new `Date.php` output.

## QA notes

Unit `DateTest` passes (5 tests, 34 assertions), including a case asserting the shared message on the date selects.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8235, closes #3338

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I followed best practices for translations
- [x] I added sufficient test coverage