### PR TITLE
Add action hook after signup confirmation

### DIFF
--- a/mailpoet/changelog/2026-07-02-10-48-21-added-add-action-hook-after-signup-confirmation.md
+++ b/mailpoet/changelog/2026-07-02-10-48-21-added-add-action-hook-after-signup-confirmation.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Add action hook after signup confirmation

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -216,6 +216,7 @@ class Pages {
 
     $subscriberData = json_decode((string)$this->subscriber->getUnconfirmedData(), true);
     $originalStatus = $this->subscriber->getStatus();
+    $confirmationCompleted = $originalStatus !== SubscriberEntity::STATUS_SUBSCRIBED || $subscriberData !== null;
 
     $this->subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
     $this->subscriber->setConfirmedIp(Helpers::getIP());
@@ -255,7 +256,7 @@ class Pages {
     }
 
     // Send new subscriber notification only when status changes to subscribed or there are unconfirmed data to avoid spamming
-    if ($originalStatus !== SubscriberEntity::STATUS_SUBSCRIBED || $subscriberData !== null) {
+    if ($confirmationCompleted) {
       $this->newSubscriberNotificationSender->send($this->subscriber, $subscriberSegments);
     }
 
@@ -263,6 +264,10 @@ class Pages {
     if (!empty($subscriberData)) {
       $this->subscriberSaveController->createOrUpdate((array)$subscriberData, $this->subscriber);
       $this->subscriberSaveController->updateCustomFields((array)$subscriberData, $this->subscriber);
+    }
+
+    if ($confirmationCompleted) {
+      $this->wp->doAction('mailpoet_subscription_confirmed', $this->subscriber);
     }
   }
 

--- a/mailpoet/tests/integration/Subscription/PagesTest.php
+++ b/mailpoet/tests/integration/Subscription/PagesTest.php
@@ -162,7 +162,7 @@ class PagesTest extends \MailPoetTest {
       $wp->removeAllActions('mailpoet_subscription_confirmed');
     }
 
-    $this->assertSame(1, $hookCalls); // @phpstan-ignore-line -- PHPStan doesn't get the $hookCalls side effect
+    $this->assertSame(1, $hookCalls);
     $this->assertSame($this->subscriber->getId(), $hookSubscriberId);
     $this->assertSame($firstName, $hookFirstName);
   }
@@ -191,7 +191,7 @@ class PagesTest extends \MailPoetTest {
       $wp->removeAllActions('mailpoet_subscription_confirmed');
     }
 
-    $this->assertSame(0, $hookCalls); // @phpstan-ignore-line -- PHPStan doesn't get the $hookCalls side effect
+    $this->assertSame(0, $hookCalls);
     $this->entityManager->clear();
     $confirmedSubscriber = $this->subscribersRepository->findOneById($subscriber->getId());
     $this->assertInstanceOf(SubscriberEntity::class, $confirmedSubscriber);

--- a/mailpoet/tests/integration/Subscription/PagesTest.php
+++ b/mailpoet/tests/integration/Subscription/PagesTest.php
@@ -132,6 +132,41 @@ class PagesTest extends \MailPoetTest {
     $this->assertSame('Nickname', $subscriberCustomField->getValue());
   }
 
+  public function testItTriggersSubscriptionConfirmedHookAfterStoredDataIsApplied() {
+    $firstName = 'Jane';
+    $this->subscriber->setUnconfirmedData((string)json_encode([
+      'first_name' => $firstName,
+      'email' => 'jane.doe@example.com',
+    ]));
+    $this->entityManager->persist($this->subscriber);
+    $this->entityManager->flush();
+
+    $hookCalls = 0;
+    $hookSubscriberId = null;
+    $hookFirstName = null;
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->removeAllActions('mailpoet_subscription_confirmed');
+    $wp->addAction('mailpoet_subscription_confirmed', function (SubscriberEntity $subscriber) use (&$hookCalls, &$hookSubscriberId, &$hookFirstName) {
+      $hookCalls++;
+      $hookSubscriberId = $subscriber->getId();
+      $hookFirstName = $subscriber->getFirstName();
+    }, 10, 1);
+
+    $newSubscriberNotificationSender = $this->makeEmpty(NewSubscriberNotificationMailer::class, ['sendWithSubscriberAndSegmentEntities' => Stub\Expected::once()]);
+    $pages = $this->getPages($newSubscriberNotificationSender);
+    $subscription = $pages->init(false, $this->testData, false, false);
+
+    try {
+      $subscription->confirm();
+    } finally {
+      $wp->removeAllActions('mailpoet_subscription_confirmed');
+    }
+
+    $this->assertSame(1, $hookCalls); // @phpstan-ignore-line -- PHPStan doesn't get the $hookCalls side effect
+    $this->assertSame($this->subscriber->getId(), $hookSubscriberId);
+    $this->assertSame($firstName, $hookFirstName);
+  }
+
   public function testItUpdatesSubscriptionOnDuplicateAttemptButDoesntSendNotification() {
     $newSubscriberNotificationSender = $this->makeEmpty(NewSubscriberNotificationMailer::class, ['send' => Stub\Expected::never()]);
     $pages = $this->getPages($newSubscriberNotificationSender);
@@ -143,7 +178,20 @@ class PagesTest extends \MailPoetTest {
     $subscriber->setConfirmedIp('111.111.111.111');
     $this->entityManager->flush();
     $subscription = $pages->init(false, $this->testData, false, false);
-    $subscription->confirm();
+
+    $hookCalls = 0;
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->removeAllActions('mailpoet_subscription_confirmed');
+    $wp->addAction('mailpoet_subscription_confirmed', function () use (&$hookCalls) {
+      $hookCalls++;
+    });
+    try {
+      $subscription->confirm();
+    } finally {
+      $wp->removeAllActions('mailpoet_subscription_confirmed');
+    }
+
+    $this->assertSame(0, $hookCalls); // @phpstan-ignore-line -- PHPStan doesn't get the $hookCalls side effect
     $this->entityManager->clear();
     $confirmedSubscriber = $this->subscribersRepository->findOneById($subscriber->getId());
     $this->assertInstanceOf(SubscriberEntity::class, $confirmedSubscriber);


### PR DESCRIPTION
## Description

Adds a `mailpoet_subscription_confirmed` action hook that fires after a subscriber completes signup confirmation, for integrations to react to.

## Code review notes

The hook reuses the existing "confirmation completed" condition (original status not subscribed, or unconfirmed data present), so it fires only on a genuine confirmation and not on a duplicate re-confirmation. It is dispatched after the stored unconfirmed data has been applied to the subscriber.

## QA notes

Integration `PagesTest` passes (20 tests), covering both the fires-once and does-not-fire cases. PHPStan passes.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8236, closes #3290

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I added sufficient test coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->