### PR TITLE
Add public action hooks for MailPoet integrations

### DIFF
--- a/mailpoet/changelog/2026-07-02-10-57-49-added-add-public-action-hooks-for-mailpoet-integrations.md
+++ b/mailpoet/changelog/2026-07-02-10-57-49-added-add-public-action-hooks-for-mailpoet-integrations.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Public action hooks `mailpoet_segment_unsubscribed` and `mailpoet_subscription_after_subscribe` for third-party integrations

--- a/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
@@ -78,6 +78,15 @@ class SubscriberSegmentRepository extends Repository {
       }
       $this->entityManager->flush();
     } else {
+      $subscriberSegmentsToUnsubscribe = array_values(array_filter(
+        $subscriber->getSubscriberSegments()->toArray(),
+        function (SubscriberSegmentEntity $subscriberSegment): bool {
+          $segment = $subscriberSegment->getSegment();
+          return $subscriberSegment->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED
+            && $segment instanceof SegmentEntity
+            && $segment->getType() !== SegmentEntity::TYPE_WP_USERS;
+        }
+      ));
       $subscriberSegmentTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
       $segmentTable = $this->entityManager->getClassMetadata(SegmentEntity::class)->getTableName();
       $this->entityManager->getConnection()->executeStatement("
@@ -93,6 +102,9 @@ class SubscriberSegmentRepository extends Repository {
       // Refresh SubscriberSegments status
       foreach ($subscriber->getSubscriberSegments() as $subscriberSegment) {
         $this->entityManager->refresh($subscriberSegment);
+      }
+      foreach ($subscriberSegmentsToUnsubscribe as $subscriberSegment) {
+        $this->wp->doAction('mailpoet_segment_unsubscribed', $subscriberSegment);
       }
     }
     $this->segmentsCountRecalculator->recalculateForSubscribers([(int)$subscriber->getId()]);
@@ -193,6 +205,13 @@ class SubscriberSegmentRepository extends Repository {
       && $oldStatus !== SubscriberEntity::STATUS_SUBSCRIBED
     ) {
       $this->wp->doAction('mailpoet_segment_subscribed', $subscriberSegment);
+    }
+    if (
+      !$skipHooks
+      && $oldStatus === SubscriberEntity::STATUS_SUBSCRIBED
+      && $subscriberSegment->getStatus() === SubscriberEntity::STATUS_UNSUBSCRIBED
+    ) {
+      $this->wp->doAction('mailpoet_segment_unsubscribed', $subscriberSegment);
     }
 
     // segments_count only counts 'subscribed' memberships, so it can only change

--- a/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
@@ -200,6 +200,8 @@ class SubscriberSubscribeController {
       return $meta;
     }
 
+    $this->wp->doAction('mailpoet_subscription_after_subscribe', $subscriber, $data, $segmentIds, $form);
+
     if (!empty($formSettings['on_success'])) {
       if ($formSettings['on_success'] === 'page') {
         // redirect to a page on a success, pass the page url in the meta

--- a/mailpoet/tests/integration/Subscribers/SubscriberSegmentRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSegmentRepositoryTest.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Subscriber;
+use MailPoet\WP\Functions as WPFunctions;
 
 class SubscriberSegmentRepositoryTest extends \MailPoetTest {
 
@@ -64,6 +65,58 @@ class SubscriberSegmentRepositoryTest extends \MailPoetTest {
     $unsubscribedSegments = $subscriber->getSubscriberSegments(SubscriberEntity::STATUS_UNSUBSCRIBED);
     $this->assertEquals(4, $unsubscribedSegments->count());
     $this->assertEquals(0, $subscribedSegments->count());
+  }
+
+  public function testItTriggersSegmentUnsubscribedHookOnStatusChange() {
+    $subscriber = (new Subscriber())->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
+    $segment = (new Segment())->create();
+    $subscriberSegment = $this->testee->createOrUpdate($subscriber, $segment, SubscriberEntity::STATUS_SUBSCRIBED);
+
+    $hookCalls = 0;
+    $receivedSubscriberSegmentId = null;
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->removeAllActions('mailpoet_segment_unsubscribed');
+    $wp->addAction('mailpoet_segment_unsubscribed', function (SubscriberSegmentEntity $receivedSubscriberSegment) use (&$hookCalls, &$receivedSubscriberSegmentId) {
+      $hookCalls++;
+      $receivedSubscriberSegmentId = $receivedSubscriberSegment->getId();
+    }, 10, 1);
+
+    try {
+      $this->testee->createOrUpdate($subscriber, $segment, SubscriberEntity::STATUS_UNSUBSCRIBED);
+      $this->testee->createOrUpdate($subscriber, $segment, SubscriberEntity::STATUS_UNSUBSCRIBED);
+    } finally {
+      $wp->removeAllActions('mailpoet_segment_unsubscribed');
+    }
+
+    $this->assertSame(1, $hookCalls);
+    $this->assertSame($subscriberSegment->getId(), $receivedSubscriberSegmentId);
+  }
+
+  public function testItTriggersSegmentUnsubscribedHookWhenUnsubscribingFromAllSegments() {
+    $segment1 = (new Segment())->create();
+    $segment2 = (new Segment())->create();
+    $subscriber = (new Subscriber())
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->withSegments([$segment1, $segment2])
+      ->create();
+
+    $receivedSegmentIds = [];
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->removeAllActions('mailpoet_segment_unsubscribed');
+    $wp->addAction('mailpoet_segment_unsubscribed', function (SubscriberSegmentEntity $subscriberSegment) use (&$receivedSegmentIds) {
+      $segment = $subscriberSegment->getSegment();
+      $receivedSegmentIds[] = $segment ? $segment->getId() : null;
+    }, 10, 1);
+
+    try {
+      $this->testee->unsubscribeFromSegments($subscriber);
+      $this->testee->unsubscribeFromSegments($subscriber);
+    } finally {
+      $wp->removeAllActions('mailpoet_segment_unsubscribed');
+    }
+
+    sort($receivedSegmentIds);
+    $this->assertSame([$segment1->getId(), $segment2->getId()], $receivedSegmentIds);
   }
 
   /**

--- a/mailpoet/tests/unit/Subscribers/SubscriberSubscribeControllerUnitTest.php
+++ b/mailpoet/tests/unit/Subscribers/SubscriberSubscribeControllerUnitTest.php
@@ -735,14 +735,17 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
       ]
     );
     $statisticsFormsRepository = Stub::makeEmpty(StatisticsFormsRepository::class);
+    $receivedHooks = [];
     $wp = Stub::make(
       WPFunctions::class,
       [
-      'doAction' => function($receivedHook, $receivedData, $receivedSegmentIds, $receivedForm) use ($formFields, $segmentIds, $form) {
-        verify($receivedHook)->equals('mailpoet_subscription_before_subscribe');
-        verify($receivedData)->equals($formFields);
-        verify($receivedSegmentIds)->equals($segmentIds);
-        verify($receivedForm)->equals($form);
+      'doAction' => function($receivedHook, ...$args) use (&$receivedHooks, $formFields, $segmentIds, $form, $subscriber) {
+        $receivedHooks[] = $receivedHook;
+        if ($receivedHook === 'mailpoet_subscription_before_subscribe') {
+          verify($args)->equals([$formFields, $segmentIds, $form]);
+        } elseif ($receivedHook === 'mailpoet_subscription_after_subscribe') {
+          verify($args)->equals([$subscriber, $formFields, $segmentIds, $form]);
+        }
       },
       ]
     );
@@ -783,6 +786,10 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
 
     $result = $testee->subscribe(array_merge(['form_id' => 1], $submitData));
     verify($result)->equals([]);
+    verify($receivedHooks)->equals([
+      'mailpoet_subscription_before_subscribe',
+      'mailpoet_subscription_after_subscribe',
+    ]);
   }
 
   public function testBehavioralBaselineEscalatesWhenSignalsAreMissing() {


### PR DESCRIPTION
## Description

Adds public action hooks for integrations: `mailpoet_segment_unsubscribed`, and `mailpoet_subscription_after_subscribe`.

## Code review notes

In the bulk `unsubscribeFromSegments()` path — which updates rows via raw SQL rather than per entity — the list of affected memberships is pre-collected (subscribed-only, excluding WP Users) so the hook fires only on real subscribed→unsubscribed transitions and stays idempotent on repeated calls, matching the SQL's `type != wp_users` filter. `Mailer` gains an optional `WPFunctions` constructor argument for backwards compatibility.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8237, closes #3175

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I added sufficient test coverage

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8237-add-public-action-hooks-for-mailpoet-integration-workflows)

_The latest successful build from `stomail-8237-add-public-action-hooks-for-mailpoet-integration-workflows` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->