### PR TITLE
Fix dead tracked links for site-level personalization tags

### DIFF
--- a/mailpoet/changelog/2026-06-24-08-03-12-fixed-homepage-links-in-email-editor-emails-becoming-dea.md
+++ b/mailpoet/changelog/2026-06-24-08-03-12-fixed-homepage-links-in-email-editor-emails-becoming-dea.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Homepage links in email editor emails becoming dead tracked links

--- a/mailpoet/changelog/2026-06-24-08-03-12-fixed-homepage-links-in-email-editor-emails-becoming-dea.md
+++ b/mailpoet/changelog/2026-06-24-08-03-12-fixed-homepage-links-in-email-editor-emails-becoming-dea.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Homepage links in email editor emails becoming dead tracked links
+Homepage, store, and account links in email editor emails becoming dead tracked links

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -398,7 +398,12 @@ class PersonalizationTagManager {
       if (!$tag) {
         continue;
       }
-      $tokens[$token] = $tag->execute_callback([]);
+      try {
+        $tokens[$token] = $tag->execute_callback([]);
+      } catch (\Throwable $e) {
+        // A broken tag callback must not block newsletter pre-processing
+        continue;
+      }
     }
     return $tokens;
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -344,7 +344,10 @@ class PersonalizationTagManager {
     if (!isset($emailContent['html'])) {
       return $emailContent;
     }
-    $emailContent['html'] = $this->linksToShortcodesConvertor->convertLinkTagsToShortcodes($emailContent['html']);
+    $emailContent['html'] = $this->linksToShortcodesConvertor->convertLinkTagsToShortcodes(
+      $emailContent['html'],
+      $this->getPreTrackingUrlTokens()
+    );
     return $emailContent;
   }
 
@@ -369,6 +372,15 @@ class PersonalizationTagManager {
   private function getPersonalizedUrlTokens(array $context): array {
     return [
       '[woocommerce/order-review-url]' => $this->orderReviewUrl->getUrl($context),
+    ];
+  }
+
+  /**
+   * @return array<string, string>
+   */
+  private function getPreTrackingUrlTokens(): array {
+    return [
+      '[mailpoet/site-homepage-url]' => $this->site->getHomepageURL([]),
     ];
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -21,6 +21,18 @@ use MailPoetVendor\Doctrine\DBAL\Exception\InvalidFieldNameException;
 use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 
 class PersonalizationTagManager {
+  /**
+   * URL tokens that don't depend on subscriber or order context and can be
+   * resolved before link tracking hashes hrefs. Context-dependent URL tokens
+   * (activation link, order URLs) must not be added here.
+   */
+  private const PRE_TRACKING_URL_TOKENS = [
+    '[mailpoet/site-homepage-url]',
+    '[woocommerce/site-homepage-url]',
+    '[woocommerce/store-url]',
+    '[woocommerce/my-account-url]',
+  ];
+
   private Subscriber $subscriber;
   private Site $site;
   private Link $link;
@@ -379,9 +391,16 @@ class PersonalizationTagManager {
    * @return array<string, string>
    */
   private function getPreTrackingUrlTokens(): array {
-    return [
-      '[mailpoet/site-homepage-url]' => $this->site->getHomepageURL([]),
-    ];
+    $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
+    $tokens = [];
+    foreach (self::PRE_TRACKING_URL_TOKENS as $token) {
+      $tag = $registry->get_by_token($token);
+      if (!$tag) {
+        continue;
+      }
+      $tokens[$token] = $tag->execute_callback([]);
+    }
+    return $tokens;
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
@@ -22,9 +22,6 @@ class LinksToShortcodesConvertor {
     '[woocommerce/order-review-url]' => true,
   ];
 
-  /**
-   * @param array<string, string> $resolvedUrlTokens
-   */
   public function convertLinkTagsToShortcodes(string $content, array $resolvedUrlTokens = []): string {
     $contentProcessor = new HTML_Tag_Processor($content);
     while ($contentProcessor->next_token()) {
@@ -110,9 +107,6 @@ class LinksToShortcodesConvertor {
     return $content;
   }
 
-  /**
-   * @param array<string, string> $resolvedUrlTokens
-   */
   private function convertLinkToken(HTML_Tag_Processor $contentProcessor, string $href, array $resolvedUrlTokens): void {
     $shortcode = $this->getShortcodeForUrlToken($href);
     if ($shortcode !== null) {
@@ -149,9 +143,6 @@ class LinksToShortcodesConvertor {
     return self::TOKEN_MAP[$token];
   }
 
-  /**
-   * @param array<string, string> $resolvedUrlTokens
-   */
   private function getResolvedUrlToken(string $url, array $resolvedUrlTokens): ?string {
     $token = $this->normalizeUrlToken($url, array_keys($resolvedUrlTokens));
     if ($token === null) {
@@ -162,9 +153,6 @@ class LinksToShortcodesConvertor {
     return $resolvedUrl === '' ? null : $resolvedUrl;
   }
 
-  /**
-   * @param string[] $tokens
-   */
   private function normalizeUrlToken(string $url, array $tokens): ?string {
     $decodedUrl = trim($this->decodeUrl($url));
     foreach ($tokens as $token) {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
@@ -22,7 +22,10 @@ class LinksToShortcodesConvertor {
     '[woocommerce/order-review-url]' => true,
   ];
 
-  public function convertLinkTagsToShortcodes(string $content): string {
+  /**
+   * @param array<string, string> $resolvedUrlTokens
+   */
+  public function convertLinkTagsToShortcodes(string $content, array $resolvedUrlTokens = []): string {
     $contentProcessor = new HTML_Tag_Processor($content);
     while ($contentProcessor->next_token()) {
       if ($contentProcessor->get_token_type() !== '#tag' || $contentProcessor->get_tag() !== 'A') {
@@ -31,8 +34,9 @@ class LinksToShortcodesConvertor {
 
       $href = $contentProcessor->get_attribute('data-link-href');
       if (is_string($href)) {
-        if (isset(self::TOKEN_MAP[$href])) {
-          $contentProcessor->set_attribute('href', 'http://' . self::TOKEN_MAP[$href]);
+        $shortcode = $this->getShortcodeForUrlToken($href);
+        if ($shortcode !== null) {
+          $contentProcessor->set_attribute('href', 'http://' . $shortcode);
           $contentProcessor->remove_attribute('data-link-href');
           $contentProcessor->remove_attribute('contenteditable');
           continue;
@@ -42,6 +46,14 @@ class LinksToShortcodesConvertor {
         if ($personalizedUrlToken !== null) {
           $contentProcessor->set_attribute('data-link-href', $personalizedUrlToken);
           $contentProcessor->remove_attribute('href');
+          continue;
+        }
+
+        $resolvedUrl = $this->getResolvedUrlToken($href, $resolvedUrlTokens);
+        if ($resolvedUrl !== null) {
+          $contentProcessor->set_attribute('href', $resolvedUrl);
+          $contentProcessor->remove_attribute('data-link-href');
+          $contentProcessor->remove_attribute('contenteditable');
         }
         continue;
       }
@@ -51,10 +63,22 @@ class LinksToShortcodesConvertor {
         continue;
       }
 
+      $shortcode = $this->getShortcodeForUrlToken($href);
+      if ($shortcode !== null) {
+        $contentProcessor->set_attribute('href', 'http://' . $shortcode);
+        continue;
+      }
+
       $personalizedUrlToken = $this->normalizePersonalizedUrlToken($href);
       if ($personalizedUrlToken !== null) {
         $contentProcessor->set_attribute('data-link-href', $personalizedUrlToken);
         $contentProcessor->remove_attribute('href');
+        continue;
+      }
+
+      $resolvedUrl = $this->getResolvedUrlToken($href, $resolvedUrlTokens);
+      if ($resolvedUrl !== null) {
+        $contentProcessor->set_attribute('href', $resolvedUrl);
       }
     }
     $contentProcessor->flush_updates();
@@ -126,13 +150,46 @@ class LinksToShortcodesConvertor {
   }
 
   private function normalizePersonalizedUrlToken(string $url): ?string {
-    $decodedUrl = rawurldecode($url);
-    foreach (array_keys(self::PERSONALIZED_URL_TOKENS) as $token) {
+    return $this->normalizeUrlToken($url, array_keys(self::PERSONALIZED_URL_TOKENS));
+  }
+
+  private function getShortcodeForUrlToken(string $url): ?string {
+    $token = $this->normalizeUrlToken($url, array_keys(self::TOKEN_MAP));
+    if ($token === null) {
+      return null;
+    }
+    return self::TOKEN_MAP[$token];
+  }
+
+  /**
+   * @param array<string, string> $resolvedUrlTokens
+   */
+  private function getResolvedUrlToken(string $url, array $resolvedUrlTokens): ?string {
+    $token = $this->normalizeUrlToken($url, array_keys($resolvedUrlTokens));
+    if ($token === null) {
+      return null;
+    }
+
+    $resolvedUrl = $resolvedUrlTokens[$token];
+    return $resolvedUrl === '' ? null : $resolvedUrl;
+  }
+
+  /**
+   * @param string[] $tokens
+   */
+  private function normalizeUrlToken(string $url, array $tokens): ?string {
+    $decodedUrl = trim($this->decodeUrl($url));
+    foreach ($tokens as $token) {
       if ($decodedUrl === $token || $decodedUrl === 'http://' . $token || $decodedUrl === 'https://' . $token) {
         return $token;
       }
     }
+
     return null;
+  }
+
+  private function decodeUrl(string $url): string {
+    return html_entity_decode(rawurldecode($url), ENT_QUOTES, 'UTF-8');
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
@@ -33,53 +33,14 @@ class LinksToShortcodesConvertor {
       }
 
       $href = $contentProcessor->get_attribute('data-link-href');
-      if (is_string($href)) {
-        $shortcode = $this->getShortcodeForUrlToken($href);
-        if ($shortcode !== null) {
-          $contentProcessor->set_attribute('href', 'http://' . $shortcode);
-          $contentProcessor->remove_attribute('data-link-href');
-          $contentProcessor->remove_attribute('contenteditable');
-          continue;
-        }
-
-        $personalizedUrlToken = $this->normalizePersonalizedUrlToken($href);
-        if ($personalizedUrlToken !== null) {
-          $contentProcessor->set_attribute('data-link-href', $personalizedUrlToken);
-          $contentProcessor->remove_attribute('href');
-          continue;
-        }
-
-        $resolvedUrl = $this->getResolvedUrlToken($href, $resolvedUrlTokens);
-        if ($resolvedUrl !== null) {
-          $contentProcessor->set_attribute('href', $resolvedUrl);
-          $contentProcessor->remove_attribute('data-link-href');
-          $contentProcessor->remove_attribute('contenteditable');
-        }
-        continue;
+      if (!is_string($href)) {
+        $href = $contentProcessor->get_attribute('href');
       }
-
-      $href = $contentProcessor->get_attribute('href');
       if (!is_string($href)) {
         continue;
       }
 
-      $shortcode = $this->getShortcodeForUrlToken($href);
-      if ($shortcode !== null) {
-        $contentProcessor->set_attribute('href', 'http://' . $shortcode);
-        continue;
-      }
-
-      $personalizedUrlToken = $this->normalizePersonalizedUrlToken($href);
-      if ($personalizedUrlToken !== null) {
-        $contentProcessor->set_attribute('data-link-href', $personalizedUrlToken);
-        $contentProcessor->remove_attribute('href');
-        continue;
-      }
-
-      $resolvedUrl = $this->getResolvedUrlToken($href, $resolvedUrlTokens);
-      if ($resolvedUrl !== null) {
-        $contentProcessor->set_attribute('href', $resolvedUrl);
-      }
+      $this->convertLinkToken($contentProcessor, $href, $resolvedUrlTokens);
     }
     $contentProcessor->flush_updates();
     $updated = $contentProcessor->get_updated_html();
@@ -147,6 +108,33 @@ class LinksToShortcodesConvertor {
       $content = str_replace($variants, $resolvedUrl, $content);
     }
     return $content;
+  }
+
+  /**
+   * @param array<string, string> $resolvedUrlTokens
+   */
+  private function convertLinkToken(HTML_Tag_Processor $contentProcessor, string $href, array $resolvedUrlTokens): void {
+    $shortcode = $this->getShortcodeForUrlToken($href);
+    if ($shortcode !== null) {
+      $contentProcessor->set_attribute('href', 'http://' . $shortcode);
+      $contentProcessor->remove_attribute('data-link-href');
+      $contentProcessor->remove_attribute('contenteditable');
+      return;
+    }
+
+    $personalizedUrlToken = $this->normalizePersonalizedUrlToken($href);
+    if ($personalizedUrlToken !== null) {
+      $contentProcessor->set_attribute('data-link-href', $personalizedUrlToken);
+      $contentProcessor->remove_attribute('href');
+      return;
+    }
+
+    $resolvedUrl = $this->getResolvedUrlToken($href, $resolvedUrlTokens);
+    if ($resolvedUrl !== null) {
+      $contentProcessor->set_attribute('href', $resolvedUrl);
+      $contentProcessor->remove_attribute('data-link-href');
+      $contentProcessor->remove_attribute('contenteditable');
+    }
   }
 
   private function normalizePersonalizedUrlToken(string $url): ?string {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
 use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tag;
 use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry;
 use Codeception\Util\Fixtures;
 use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
@@ -173,6 +174,79 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
     $this->assertStringContainsString('href="' . $homepageUrl . '"', $emailContent['html']);
     $this->assertStringNotContainsString('%5Bmailpoet/site-homepage-url%5D', $emailContent['html']);
     $this->assertStringNotContainsString('[mailpoet/site-homepage-url]', $emailContent['html']);
+  }
+
+  public function testItResolvesUnencodedHomepageUrlHrefBeforeLinkTracking(): void {
+    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+
+    $emailContent = $personalizationManager->convertLinksToShortcodes([
+      'html' => '<a href="[mailpoet/site-homepage-url]">Homepage</a>',
+    ]);
+
+    $homepageUrl = (string)WPFunctions::get()->getBloginfo('url');
+    $this->assertStringContainsString('href="' . $homepageUrl . '"', $emailContent['html']);
+    $this->assertStringNotContainsString('[mailpoet/site-homepage-url]', $emailContent['html']);
+  }
+
+  public function testItResolvesHomepageUrlDataLinkHrefBeforeLinkTracking(): void {
+    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+
+    $emailContent = $personalizationManager->convertLinksToShortcodes([
+      'html' => '<a data-link-href="[mailpoet/site-homepage-url]" contenteditable="false">Homepage</a>',
+    ]);
+
+    $homepageUrl = (string)WPFunctions::get()->getBloginfo('url');
+    $this->assertStringContainsString('href="' . $homepageUrl . '"', $emailContent['html']);
+    $this->assertStringNotContainsString('data-link-href=', $emailContent['html']);
+    $this->assertStringNotContainsString('contenteditable=', $emailContent['html']);
+  }
+
+  public function testItResolvesRegisteredWooCommerceUrlTokensBeforeLinkTracking(): void {
+    $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
+    $originalTag = $registry->unregister('[woocommerce/store-url]');
+    $registry->register(new Personalization_Tag(
+      'Store URL',
+      'woocommerce/store-url',
+      'Store',
+      function (): string {
+        return 'https://example.com/shop';
+      }
+    ));
+
+    try {
+      $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+
+      $emailContent = $personalizationManager->convertLinksToShortcodes([
+        'html' => '<a href="http://%5Bwoocommerce/store-url%5D">Shop now</a>',
+      ]);
+
+      $this->assertStringContainsString('href="https://example.com/shop"', $emailContent['html']);
+      $this->assertStringNotContainsString('%5Bwoocommerce/store-url%5D', $emailContent['html']);
+    } finally {
+      $registry->unregister('[woocommerce/store-url]');
+      if ($originalTag) {
+        $registry->register($originalTag);
+      }
+    }
+  }
+
+  public function testItLeavesUnregisteredPreTrackingUrlTokensUntouched(): void {
+    $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
+    $originalTag = $registry->unregister('[woocommerce/my-account-url]');
+
+    try {
+      $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+
+      $emailContent = $personalizationManager->convertLinksToShortcodes([
+        'html' => '<a href="http://%5Bwoocommerce/my-account-url%5D">My account</a>',
+      ]);
+
+      $this->assertStringContainsString('href="http://%5Bwoocommerce/my-account-url%5D"', $emailContent['html']);
+    } finally {
+      if ($originalTag) {
+        $registry->register($originalTag);
+      }
+    }
   }
 
   public function testItOnlyRemovesTemporaryHttpPrefixForKnownLinkTokens(): void {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
@@ -230,6 +230,37 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
     }
   }
 
+  public function testItSkipsPreTrackingTokensWhoseCallbackFails(): void {
+    $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
+    $originalTag = $registry->unregister('[woocommerce/store-url]');
+    $registry->register(new Personalization_Tag(
+      'Store URL',
+      'woocommerce/store-url',
+      'Store',
+      function (): string {
+        throw new \RuntimeException('Broken tag callback');
+      }
+    ));
+
+    try {
+      $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+
+      $emailContent = $personalizationManager->convertLinksToShortcodes([
+        'html' => '<a href="http://%5Bwoocommerce/store-url%5D">Shop now</a><a href="[mailpoet/site-homepage-url]">Homepage</a>',
+      ]);
+
+      // The failing tag is skipped, other tokens still resolve
+      $this->assertStringContainsString('href="http://%5Bwoocommerce/store-url%5D"', $emailContent['html']);
+      $homepageUrl = (string)WPFunctions::get()->getBloginfo('url');
+      $this->assertStringContainsString('href="' . $homepageUrl . '"', $emailContent['html']);
+    } finally {
+      $registry->unregister('[woocommerce/store-url]');
+      if ($originalTag) {
+        $registry->register($originalTag);
+      }
+    }
+  }
+
   public function testItLeavesUnregisteredPreTrackingUrlTokensUntouched(): void {
     $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
     $originalTag = $registry->unregister('[woocommerce/my-account-url]');

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
@@ -48,6 +48,7 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
         <a data-link-href="[mailpoet/subscription-unsubscribe-url]">Unsubscribe</a>
         <a data-link-href="[mailpoet/subscription-manage-url]">Manage</a>
         <a data-link-href="[mailpoet/newsletter-view-in-browser-url]">View in browser</a>
+        <a href="http://%5Bmailpoet/site-homepage-url%5D">Homepage</a>
         <!--[mailpoet/subscription-unsubscribe-url]-->
       ';
     $this->newsletter->setBody((array)$body);
@@ -74,6 +75,12 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
     $viewInBrowserLink = $newsletterLinkRepository->findOneBy(['newsletter' => $this->newsletter, 'queue' => $this->sendingQueueEntity, 'url' => '[link:newsletter_view_in_browser_url]']);
     $this->assertInstanceOf(NewsletterLinkEntity::class, $viewInBrowserLink);
     $this->assertStringContainsString('<a href="[mailpoet_click_data]-' . $viewInBrowserLink->getHash() . '">View in browser</a>', $rendered['html']);
+
+    $homepageUrl = (string)WPFunctions::get()->getBloginfo('url');
+    $homepageLink = $this->findNewsletterLinkStartingWithUrl($homepageUrl);
+    $this->assertInstanceOf(NewsletterLinkEntity::class, $homepageLink);
+    $this->assertStringContainsString('<a href="[mailpoet_click_data]-' . $homepageLink->getHash() . '">Homepage</a>', $rendered['html']);
+    $this->assertNull($newsletterLinkRepository->findOneBy(['newsletter' => $this->newsletter, 'queue' => $this->sendingQueueEntity, 'url' => 'http://%5Bmailpoet/site-homepage-url%5D']));
 
     // Tag placed out of href was not replaced
     $this->assertStringContainsString('<!--[mailpoet/subscription-unsubscribe-url]-->', $rendered['html']);
@@ -155,6 +162,19 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
     $this->assertStringNotContainsString('%5Bwoocommerce/order-review-url%5D', $emailContent['html']);
   }
 
+  public function testItResolvesEncodedHomepageUrlHrefBeforeLinkTracking(): void {
+    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+
+    $emailContent = $personalizationManager->convertLinksToShortcodes([
+      'html' => '<a href="http://%5Bmailpoet/site-homepage-url%5D">Homepage</a>',
+    ]);
+
+    $homepageUrl = (string)WPFunctions::get()->getBloginfo('url');
+    $this->assertStringContainsString('href="' . $homepageUrl . '"', $emailContent['html']);
+    $this->assertStringNotContainsString('%5Bmailpoet/site-homepage-url%5D', $emailContent['html']);
+    $this->assertStringNotContainsString('[mailpoet/site-homepage-url]', $emailContent['html']);
+  }
+
   public function testItOnlyRemovesTemporaryHttpPrefixForKnownLinkTokens(): void {
     $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
 
@@ -228,5 +248,17 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
         $connection->executeStatement("ALTER TABLE `{$table}` ADD COLUMN `deleted_at` TIMESTAMP NULL DEFAULT NULL");
       }
     }
+  }
+
+  private function findNewsletterLinkStartingWithUrl(string $url): ?NewsletterLinkEntity {
+    $newsletterLinkRepository = $this->diContainer->get(NewsletterLinkRepository::class);
+    /** @var NewsletterLinkEntity[] $newsletterLinks */
+    $newsletterLinks = $newsletterLinkRepository->findBy(['newsletter' => $this->newsletter, 'queue' => $this->sendingQueueEntity]);
+    foreach ($newsletterLinks as $newsletterLink) {
+      if (strpos($newsletterLink->getUrl(), $url) === 0) {
+        return $newsletterLink;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Description

Email patterns ship buttons like "Visit our store" that link to the site homepage via a personalization tag. When click tracking is enabled, the tracked link stored the unresolved tag instead of the real URL, so the button in the sent email led nowhere — a dead link. The same happens for the other site-level links (store page, my-account page) when used as a link in the email editor.

This PR fixes it by resolving these site-level URLs to their real values right before link tracking runs. Since these URLs don't depend on the recipient, resolving them early is the intended permanent behavior — tracked links point to the correct destination, engagement stats show real URLs, and Google Analytics parameters are applied as expected.

**Scope note:** links whose destination depends on the recipient (e.g. activation link, order links) can't be resolved early and are intentionally not covered here. They are addressed by a separate change to how link tracking works with personalization tags, described in [STOMAIL-8241](https://linear.app/a8c/issue/STOMAIL-8241/track-personalization-tag-urls-symbolically-and-resolve-them-at-click).

## Code review notes

- Resolution goes through the personalization tags registry rather than duplicating the tag callbacks, so the pre-tracking value is by construction identical to what the personalizer would produce, and WooCommerce-only tags are skipped automatically when not registered.
- The token list in `PRE_TRACKING_URL_TOKENS` must stay limited to context-free URLs — recipient/order-dependent tags would resolve wrongly there (noted in a doc comment).

## QA notes

1. Enable click tracking (Settings → Advanced).
2. Create a newsletter in the new email editor from a pattern with a homepage button (e.g. Welcome Email — "Visit our store"), or insert a link and use the "Homepage URL" personalization tag as its target.
3. Send the newsletter to a subscriber.
4. In the received email, click the button — it should redirect to the site homepage instead of a dead link containing the raw URL-encoded personalization tag.
5. With WooCommerce active, repeat with "Store URL" / "My Account URL" tags used as a link.

## Linked PRs

_N/A_

## Linked tickets

- [STOMAIL-8205](https://linear.app/a8c/issue/STOMAIL-8205/homepage-personalization-tag-becomes-a-dead-tracked-link)
- [STOMAIL-8241](https://linear.app/a8c/issue/STOMAIL-8241/track-personalization-tag-urls-symbolically-and-resolve-them-at-click) — follow-up covering recipient-dependent links

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes:** 2  
  - Fixed dead/invalid tracked homepage, store, and account links by resolving site-level personalization URL tokens before click tracking.
  - Prevented newsletter preprocessing from aborting when a pre-tracking personalization tag callback throws (skips failing tokens).

- **Security:** 0  
- **Performance:** 0  
- **Suggestion:** 0  

- **Tests:** Expanded integration coverage for pre-tracking homepage/WooCommerce URL token resolution, encoded vs. unencoded/data-link-href variants, and callback-failure skipping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/homepage-link)

_The latest successful build from `fix/homepage-link` will be used. If none is available, the link won't work._