### PR TITLE
Upgrade GitHub Actions to Node.js v24 runtimes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -38,4 +38,4 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/create-trunk-snapshot-build.yml
+++ b/.github/workflows/create-trunk-snapshot-build.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: 'Update trunk-snapshot tag'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -62,7 +62,7 @@ jobs:
             }
 
       - name: 'Checkout ref'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.TARGET_REF }}
 
@@ -74,10 +74,10 @@ jobs:
           tools: wp-cli
 
       - name: 'Setup pnpm'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: 'Setup Node.js'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
@@ -120,7 +120,7 @@ jobs:
           echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: 'Upload trunk snapshot build'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -142,7 +142,7 @@ jobs:
       # Create a pull request if there are changes
       - name: Create Pull Request
         if: env.CHANGES_DETECTED == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_TOKEN }}
           branch: update-plugins-and-wordpress

--- a/.github/workflows/wordpress-playground-preview.yml
+++ b/.github/workflows/wordpress-playground-preview.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Check and append description
         shell: bash


### PR DESCRIPTION
## Description

GitHub has started deprecating the Node 20 action runtimes. This bumps every third-party GitHub Actions `uses:` in the repository that still runs on a Node.js runtime below v24 to its latest major, each verified to run on `node24`.

| Action | Current | Runtime now | Target | Runtime target |
| --- | --- | --- | --- | --- |
| `actions/checkout` | v3 / v4 | node16 / node20 | v7 | node24 |
| `github/codeql-action/init` + `analyze` | v3 | node20 | v4 | node24 |
| `actions/github-script` | v7 | node20 | v9 | node24 |
| `pnpm/action-setup` | v4 | node20 | v6 | node24 |
| `actions/setup-node` | v4 | node20 | v6 | node24 |
| `peter-evans/create-pull-request` | v6 | node20 | v8 | node24 |

`shivammathur/setup-php@v2` already resolves to node24 and is left unchanged.

## Code review notes

Per-action compatibility was checked against actual usage:

- `checkout` v3/v4 -> v7: standard checkout / `ref:` input, unchanged. v7 only blocks fork checkouts for `pull_request_target` / `workflow_run`; `wordpress-playground-preview` uses the `pull_request` trigger, so that block does not apply.
- `codeql-action` v3 -> v4: v4 is GA (latest v4.36.3), raises the minimum CodeQL bundle to 2.19.4 which GitHub-hosted runners already exceed. `languages: javascript-typescript` naming unchanged.
- `github-script` v7 -> v9: the v9 breaking changes (`require('@actions/github')` removed, `getOctokit` now injected) do not apply. The two inline scripts only use `github.rest.*`, `core.*`, `context.*`, and `require('fs')`.
- `pnpm/action-setup` v4 -> v6: used without a `version:` input, so it keeps reading the pnpm version from the root `packageManager: pnpm@10.33.0` field.
- `setup-node` v4 -> v6: `cache: 'pnpm'` is set explicitly, and `pnpm/action-setup` already runs before it. Node version comes from `.nvmrc` (v24.14.1).
- `create-pull-request` v6 -> v8: uses `token/branch/base/labels/body`, all of which still exist in v8. The v7 input rename (`git-token` -> `branch-token`) does not apply because this workflow uses the separate `token` input, and the removed `PULL_REQUEST_NUMBER` output is not used.

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:chore/ci-node24-actions)

_The latest successful build from `chore/ci-node24-actions` will be used. If none is available, the link won't work._