### PR TITLE
Restore auto-mapping of name CSV headers with separators and abbreviations

### DIFF
--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/match-columns.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/match-columns.jsx
@@ -1,14 +1,36 @@
-const FIRST_NAME_HEADERS = ['first', 'first name', 'firstname', 'given name'];
+const FIRST_NAME_HEADERS = [
+  'first',
+  'first name',
+  'firstname',
+  'given name',
+  'fname',
+];
 const LAST_NAME_HEADERS = [
   'last',
   'last name',
   'lastname',
   'surname',
   'family name',
+  'lname',
 ];
 
+// Collapse common word separators (underscore, hyphen, dot) to a single space
+// so that first_name, first-name, first.name and "first name" all normalize to
+// the same value. Whole-string matching is preserved, so unrelated headers such
+// as first_updated or last_login still fall through to "ignore".
+const normalizeHeaderName = (headerName) =>
+  String(headerName)
+    .trim()
+    .toLowerCase()
+    .replaceAll('_', ' ')
+    .replaceAll('-', ' ')
+    .replaceAll('.', ' ')
+    .split(' ')
+    .filter(Boolean)
+    .join(' ');
+
 const getMatchedNameColumnId = (headerName) => {
-  const normalizedHeaderName = String(headerName).trim().toLowerCase();
+  const normalizedHeaderName = normalizeHeaderName(headerName);
   if (FIRST_NAME_HEADERS.includes(normalizedHeaderName)) {
     return 'first_name';
   }

--- a/mailpoet/changelog/2026-07-07-09-16-05-fixed-restored-auto-mapping-of-snakecase-firstname-and-l.md
+++ b/mailpoet/changelog/2026-07-07-09-16-05-fixed-restored-auto-mapping-of-snakecase-firstname-and-l.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Restored auto-mapping of snake_case first_name and last_name CSV headers during subscriber import
+Restored auto-mapping of first and last name CSV headers that use underscores, hyphens, dots or common abbreviations during subscriber import

--- a/mailpoet/changelog/2026-07-07-09-16-05-fixed-restored-auto-mapping-of-snakecase-firstname-and-l.md
+++ b/mailpoet/changelog/2026-07-07-09-16-05-fixed-restored-auto-mapping-of-snakecase-firstname-and-l.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Restored auto-mapping of snake_case first_name and last_name CSV headers during subscriber import

--- a/mailpoet/tests/javascript/subscribers/import-match-columns.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/import-match-columns.spec.ts
@@ -101,6 +101,55 @@ describe('Subscriber import column matching', () => {
     ]);
   });
 
+  it('matches name headers regardless of the word separator', () => {
+    const separatorVariants = [
+      ['first_name', 'last_name'],
+      ['first-name', 'last-name'],
+      ['first.name', 'last.name'],
+      ['First Name', 'Last Name'],
+    ];
+
+    separatorVariants.forEach(([firstHeader, lastHeader]) => {
+      const columns = matchColumns(
+        [
+          {
+            0: 'John',
+            1: 'Doe',
+          },
+        ],
+        {
+          0: firstHeader,
+          1: lastHeader,
+        },
+      );
+
+      expect(columns).to.deep.equal([
+        { column_id: 'first_name' },
+        { column_id: 'last_name' },
+      ]);
+    });
+  });
+
+  it('matches abbreviated fname and lname headers', () => {
+    const columns = matchColumns(
+      [
+        {
+          0: 'John',
+          1: 'Doe',
+        },
+      ],
+      {
+        0: 'fname',
+        1: 'lname',
+      },
+    );
+
+    expect(columns).to.deep.equal([
+      { column_id: 'first_name' },
+      { column_id: 'last_name' },
+    ]);
+  });
+
   it('does not match unrelated headers containing name words', () => {
     const columns = matchColumns(
       [
@@ -108,17 +157,23 @@ describe('Subscriber import column matching', () => {
           0: 'customer@example.com',
           1: '2026-07-02',
           2: '2026-07-02',
+          3: '2026-07-02',
+          4: '5',
         },
       ],
       {
         0: 'Email',
         1: 'FIRSTUPDATED',
         2: 'LASTUPDATED',
+        3: 'first_seen',
+        4: 'last_order',
       },
     );
 
     expect(columns).to.deep.equal([
       { column_id: 'email' },
+      { column_id: 'ignore' },
+      { column_id: 'ignore' },
       { column_id: 'ignore' },
       { column_id: 'ignore' },
     ]);


### PR DESCRIPTION
## Description

The subscriber import auto-mapper was switched from substring regex matching to exact-match header arrays (PR #6949). That tightening dropped support for name headers that use a separator other than a space — `first_name`, `first-name`, `first.name` — as well as common abbreviations (`fname`, `lname`). Those columns were silently mapped to `ignore`, so exports from databases and CRM tools (Salesforce, HubSpot) required manual re-mapping with no error shown.

Rather than enumerate every separator × synonym combination, the header is now normalized before matching: underscore, hyphen and dot are collapsed to a single space, so `first_name` / `first-name` / `first.name` / `First Name` all resolve to the same value. The `fname` / `lname` abbreviations are added explicitly.

Matching stays whole-string, so the original tightening is preserved — unrelated headers like `first_updated`, `last_login`, `FIRSTUPDATED` still fall through to `ignore`.

## Code review notes

The exact-match arrays were introduced in #6949 specifically to stop the old `/first/i` and `/last/i` substring regexes from grabbing headers like `last_login`. Normalization keeps that guarantee because it compares the whole normalized header, not a substring — see the `does not match unrelated headers` test covering `first_updated` / `last_order`.

## QA notes

Import a CSV whose header row uses any of `first_name` / `first-name` / `first.name` / `fname` (and the last-name equivalents). Those columns should auto-map to First name / Last name instead of Ignore.

## Linked PRs

Regression from #6949

## Linked tickets

STOMAIL-8243

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->