### PR TITLE
Fix heading selector in EditorTextInputStyles acceptance test (WP 6.9)

### DIFF
--- a/mailpoet/tests/acceptance/Forms/EditorTextInputStylesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorTextInputStylesCest.php
@@ -69,7 +69,7 @@ class EditorTextInputStylesCest {
 
     $i->wantTo('Add heading block and write some title');
     $i->addFromBlockInEditor('Heading');
-    $i->fillField('[data-title="Heading 2"]', 'Heading Lorem'); // Default inserted heading is with level 2
+    $i->fillField('[data-title^="Heading"]', 'Heading Lorem'); // Matches 'Heading' (WP 6.9) and 'Heading 2' (latest WP)
     $i->see('Heading Lorem');
 
     $i->wantTo('Add paragraph block and write some text');


### PR DESCRIPTION
## Description

The nightly `acceptance_oldest` and `acceptance_with_premium_oldest` jobs (WordPress 6.9.4) fail on `EditorTextInputStylesCest::changeTextInputStyles`. The latest-WordPress acceptance jobs pass.

The form editor is Gutenberg-based and uses WordPress core's block editor, so the heading block's editor-wrapper `data-title` attribute is rendered by whatever Gutenberg ships with the installed WordPress:

- Latest WP: `data-title="Heading 2"` (includes the level)
- WP 6.9.4: `data-title="Heading"` (no level)

Commit `b13536ff62` ("Update @wordpress/* packages to latest versions") pinned the selector to `[data-title="Heading 2"]`, which matches the latest Gutenberg but not the one bundled with WP 6.9.4. Since MailPoet still supports WP 6.9 (`Requires at least: 6.9`), the oldest job must stay green.

This changes the selector to `[data-title^="Heading"]`, which matches both variants. Test-only change, no product code affected.

## Code review notes

Verified from the CI failure DOM artifact that WP 6.9.4 renders `data-title="Heading"` (no level). The test only ever inserts one heading block, so the starts-with selector has no ambiguity.

## QA notes

Version-specific — reproduce with the acceptance suite against **WP 6.9.4** (the latest-WP env will not reproduce it). Confirm `changeTextInputStyles` fails on trunk and passes with this change.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8249

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8249-editor-text-input-styles-heading-selector-oldest-wp)

_The latest successful build from `fix/stomail-8249-editor-text-input-styles-heading-selector-oldest-wp` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->