### PR TITLE
Fire tag hooks from subscriber bulk actions

### DIFF
--- a/mailpoet/changelog/2026-07-08-13-59-55-fixed-tag-added-and-tag-removed-automation-triggers-now-.md
+++ b/mailpoet/changelog/2026-07-08-13-59-55-fixed-tag-added-and-tag-removed-automation-triggers-now-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Tag added and Tag removed automation triggers now fire when tags are changed from the Subscribers list page

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -1117,12 +1117,29 @@ class SubscribersRepository extends Repository {
       return 0;
     }
 
+    /** @var SubscriberTagEntity[] $subscriberTags */
+    $subscriberTags = $this->entityManager
+      ->createQueryBuilder()
+      ->select('st')
+      ->from(SubscriberTagEntity::class, 'st')
+      ->where('st.subscriber IN (:ids)')
+      ->andWhere('st.tag = :tag')
+      ->setParameter('ids', $ids)
+      ->setParameter('tag', $tag)
+      ->getQuery()->execute();
+
     $subscriberTagsTable = $this->entityManager->getClassMetadata(SubscriberTagEntity::class)->getTableName();
     $count = (int)$this->entityManager->getConnection()->executeStatement("
        DELETE st FROM $subscriberTagsTable st
        WHERE st.`subscriber_id` IN (:ids)
        AND st.`tag_id` = :tag_id
     ", ['ids' => $ids, 'tag_id' => $tag->getId()], ['ids' => ArrayParameterType::INTEGER]);
+
+    // Fires the hook that triggers "Tag removed" automations (see SubscriberSaveController::updateTags()).
+    foreach ($subscriberTags as $subscriberTag) {
+      $this->entityManager->detach($subscriberTag);
+      $this->wp->doAction('mailpoet_subscriber_tag_removed', $subscriberTag);
+    }
 
     $this->changesNotifier->subscribersUpdated($ids);
     return $count;
@@ -1423,13 +1440,20 @@ class SubscribersRepository extends Repository {
       ->setParameter('tag', $tag)
       ->getQuery()->execute();
 
-    $this->entityManager->wrapInTransaction(function (EntityManager $entityManager) use ($subscribers, $tag) {
+    $subscriberTags = [];
+    $this->entityManager->wrapInTransaction(function (EntityManager $entityManager) use ($subscribers, $tag, &$subscriberTags) {
       foreach ($subscribers as $subscriber) {
         $subscriberTag = new SubscriberTagEntity($tag, $subscriber);
         $entityManager->persist($subscriberTag);
+        $subscriberTags[] = $subscriberTag;
       }
       $entityManager->flush();
     });
+
+    // Fires the hook that triggers "Tag added" automations (see SubscriberSaveController::updateTags()).
+    foreach ($subscriberTags as $subscriberTag) {
+      $this->wp->doAction('mailpoet_subscriber_tag_added', $subscriberTag);
+    }
 
     return count($subscribers);
   }

--- a/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
@@ -13,6 +13,7 @@ use MailPoet\Entities\SubscriberTagEntity;
 use MailPoet\Entities\TagEntity;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
 class SubscribersRepositoryTest extends \MailPoetTest {
@@ -668,6 +669,55 @@ class SubscribersRepositoryTest extends \MailPoetTest {
 
     verify($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
     verify($subscriber->getLastEngagementAt())->notNull();
+  }
+
+  public function testItBulkAddTagFiresTagAddedHookOnlyForNewlyTaggedSubscribers(): void {
+    $tag = $this->createTag('Bulk added tag');
+    $subscriberOne = $this->createSubscriber('one@bulk-add-tag.com');
+    $subscriberTwo = $this->createSubscriber('two@bulk-add-tag.com');
+    $this->createSubscriberTag($subscriberTwo, $tag);
+
+    $wp = new WPFunctions();
+    $wp->removeAllActions('mailpoet_subscriber_tag_added');
+    $firedFor = [];
+    $wp->addAction('mailpoet_subscriber_tag_added', function (SubscriberTagEntity $subscriberTag) use (&$firedFor) {
+      $subscriber = $subscriberTag->getSubscriber();
+      $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+      $firedFor[] = $subscriber->getEmail();
+    });
+
+    $count = $this->repository->bulkAddTag($tag, [$subscriberOne->getId(), $subscriberTwo->getId()]);
+
+    verify($count)->equals(1);
+    verify($firedFor)->equals(['one@bulk-add-tag.com']);
+    $subscriberTags = $this->entityManager->getRepository(SubscriberTagEntity::class)->findBy(['tag' => $tag]);
+    verify($subscriberTags)->arrayCount(2);
+    $wp->removeAllActions('mailpoet_subscriber_tag_added');
+  }
+
+  public function testItBulkRemoveTagFiresTagRemovedHookOnlyForSubscribersThatHadTag(): void {
+    $tag = $this->createTag('Bulk removed tag');
+    $subscriberOne = $this->createSubscriber('one@bulk-remove-tag.com');
+    $subscriberTwo = $this->createSubscriber('two@bulk-remove-tag.com');
+    $this->createSubscriberTag($subscriberOne, $tag);
+
+    $wp = new WPFunctions();
+    $wp->removeAllActions('mailpoet_subscriber_tag_removed');
+    $firedFor = [];
+    $wp->addAction('mailpoet_subscriber_tag_removed', function (SubscriberTagEntity $subscriberTag) use (&$firedFor) {
+      $subscriber = $subscriberTag->getSubscriber();
+      $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+      $firedFor[] = $subscriber->getEmail();
+    });
+
+    $count = $this->repository->bulkRemoveTag($tag, [$subscriberOne->getId(), $subscriberTwo->getId()]);
+
+    verify($count)->equals(1);
+    verify($firedFor)->equals(['one@bulk-remove-tag.com']);
+    $this->entityManager->clear();
+    $subscriberTags = $this->entityManager->getRepository(SubscriberTagEntity::class)->findBy(['tag' => $tag]);
+    verify($subscriberTags)->arrayCount(0);
+    $wp->removeAllActions('mailpoet_subscriber_tag_removed');
   }
 
   private function createSubscriber(string $email, ?DateTimeImmutable $deletedAt = null): SubscriberEntity {


### PR DESCRIPTION
## Description

Bulk tagging subscribers didn't trigger "Tag added/removed" automation triggers. Same gap exists for segment bulk actions and CSV import - created STOMAIL-8252 as follow-up.

## Code review notes

_N/A_

## QA notes

1. Active automation with premium "Tag added" trigger; add that tag via the list-page three-dot menu → automation should now run (didn't before).
2. Repeat the same bulk action → must not trigger again (only actual tag changes fire).
3. Same for "Remove tag…" with a "Tag removed" trigger.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8245

## After-merge notes

Update the [Automation Triggers KB article](https://kb.mailpoet.com/article/421-automation-triggers) — it documents bulk actions as not firing automations.

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
1 issue found: **Bug** (bulk subscriber tag actions now correctly fire “tag added/removed” automation hooks only when tags actually change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->