### PR TITLE
Add timezone scheduling mode selector to newsletter send UI

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_forms.scss
+++ b/mailpoet/assets/css/src/components-plugin/_forms.scss
@@ -182,7 +182,6 @@ progress::-moz-progress-bar {
   }
 }
 
-.mailpoet-form-schedule-time,
 .mailpoet-form-toggle-text {
   color: $color-text;
   margin-left: $grid-gap;

--- a/mailpoet/assets/js/src/common/newsletter-schedule-mode.ts
+++ b/mailpoet/assets/js/src/common/newsletter-schedule-mode.ts
@@ -1,0 +1,82 @@
+export const SCHEDULE_MODE_WEBSITE_TIME = 'website_time';
+export const SCHEDULE_MODE_SUBSCRIBER_TIMEZONE = 'subscriber_timezone';
+
+export type ScheduleMode =
+  | typeof SCHEDULE_MODE_WEBSITE_TIME
+  | typeof SCHEDULE_MODE_SUBSCRIBER_TIMEZONE;
+
+export const DEFAULT_SCHEDULED_LOCAL_TIME = '08:00:00';
+export const SUBSCRIBER_TIMEZONE_LEAD_TIME_HOURS = 24;
+
+export function getScheduleMode(scheduleMode?: string | null): ScheduleMode {
+  return scheduleMode === SCHEDULE_MODE_SUBSCRIBER_TIMEZONE
+    ? SCHEDULE_MODE_SUBSCRIBER_TIMEZONE
+    : SCHEDULE_MODE_WEBSITE_TIME;
+}
+
+export type ScheduleModeOptionChanges = {
+  scheduleMode: ScheduleMode;
+  scheduledLocalDate: string;
+  scheduledLocalTime: string;
+};
+
+export function getScheduleModeOptionChanges(
+  mode: ScheduleMode,
+  current: { scheduledLocalDate?: string; scheduledLocalTime?: string },
+  defaultLocalDate: string,
+): ScheduleModeOptionChanges {
+  if (mode === SCHEDULE_MODE_SUBSCRIBER_TIMEZONE) {
+    return {
+      scheduleMode: SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+      scheduledLocalDate: current.scheduledLocalDate || defaultLocalDate,
+      scheduledLocalTime:
+        current.scheduledLocalTime || DEFAULT_SCHEDULED_LOCAL_TIME,
+    };
+  }
+  return {
+    scheduleMode: SCHEDULE_MODE_WEBSITE_TIME,
+    scheduledLocalDate: '',
+    scheduledLocalTime: '',
+  };
+}
+
+export function normalizeLocalTime(localTime: string): string {
+  return localTime.length === 5 ? `${localTime}:00` : localTime;
+}
+
+export function isLocalDateTimeInFuture(
+  localDate?: string | null,
+  localTime?: string | null,
+  now: Date = new Date(),
+): boolean {
+  if (!localDate || !localTime) {
+    return false;
+  }
+  const parsed = new Date(`${localDate}T${normalizeLocalTime(localTime)}`);
+  if (Number.isNaN(parsed.getTime())) {
+    return false;
+  }
+  return parsed.getTime() > now.getTime();
+}
+
+export function getTomorrowLocalDate(now: Date = new Date()): string {
+  const tomorrow = new Date(now.getTime());
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const month = String(tomorrow.getMonth() + 1).padStart(2, '0');
+  const day = String(tomorrow.getDate()).padStart(2, '0');
+  return `${tomorrow.getFullYear()}-${month}-${day}`;
+}
+
+export function getLocalTimeOfDayItems(): Record<string, string> {
+  const items: Record<string, string> = {};
+  for (let hour = 0; hour < 24; hour += 1) {
+    for (let minute = 0; minute < 60; minute += 15) {
+      const label = `${String(hour).padStart(2, '0')}:${String(minute).padStart(
+        2,
+        '0',
+      )}`;
+      items[`${label}:00`] = label;
+    }
+  }
+  return items;
+}

--- a/mailpoet/assets/js/src/common/newsletter-schedule-mode.ts
+++ b/mailpoet/assets/js/src/common/newsletter-schedule-mode.ts
@@ -40,35 +40,10 @@ export function getScheduleModeOptionChanges(
   };
 }
 
-export function normalizeLocalTime(localTime: string): string {
-  return localTime.length === 5 ? `${localTime}:00` : localTime;
-}
-
-export function isLocalDateTimeInFuture(
-  localDate?: string | null,
-  localTime?: string | null,
-  now: Date = new Date(),
-): boolean {
-  if (!localDate || !localTime) {
-    return false;
-  }
-  const parsed = new Date(`${localDate}T${normalizeLocalTime(localTime)}`);
-  if (Number.isNaN(parsed.getTime())) {
-    return false;
-  }
-  return parsed.getTime() > now.getTime();
-}
-
 function formatLocalDate(date: Date): string {
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
   return `${date.getFullYear()}-${month}-${day}`;
-}
-
-export function getTomorrowLocalDate(now: Date = new Date()): string {
-  const tomorrow = new Date(now.getTime());
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  return formatLocalDate(tomorrow);
 }
 
 export type LocalDateTime = {

--- a/mailpoet/assets/js/src/common/newsletter-schedule-mode.ts
+++ b/mailpoet/assets/js/src/common/newsletter-schedule-mode.ts
@@ -59,24 +59,38 @@ export function isLocalDateTimeInFuture(
   return parsed.getTime() > now.getTime();
 }
 
+function formatLocalDate(date: Date): string {
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
 export function getTomorrowLocalDate(now: Date = new Date()): string {
   const tomorrow = new Date(now.getTime());
   tomorrow.setDate(tomorrow.getDate() + 1);
-  const month = String(tomorrow.getMonth() + 1).padStart(2, '0');
-  const day = String(tomorrow.getDate()).padStart(2, '0');
-  return `${tomorrow.getFullYear()}-${month}-${day}`;
+  return formatLocalDate(tomorrow);
 }
 
-export function getLocalTimeOfDayItems(): Record<string, string> {
-  const items: Record<string, string> = {};
-  for (let hour = 0; hour < 24; hour += 1) {
-    for (let minute = 0; minute < 60; minute += 15) {
-      const label = `${String(hour).padStart(2, '0')}:${String(minute).padStart(
-        2,
-        '0',
-      )}`;
-      items[`${label}:00`] = label;
-    }
+export type LocalDateTime = {
+  localDate: string;
+  localTime: string;
+};
+
+export function snapLocalDateTimeToQuarterHour(
+  value: string,
+): LocalDateTime | null {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
   }
-  return items;
+  const quarterHourMs = 15 * 60 * 1000;
+  const snapped = new Date(
+    Math.round(parsed.getTime() / quarterHourMs) * quarterHourMs,
+  );
+  const hours = String(snapped.getHours()).padStart(2, '0');
+  const minutes = String(snapped.getMinutes()).padStart(2, '0');
+  return {
+    localDate: formatLocalDate(snapped),
+    localTime: `${hours}:${minutes}:00`,
+  };
 }

--- a/mailpoet/assets/js/src/common/newsletter.ts
+++ b/mailpoet/assets/js/src/common/newsletter.ts
@@ -47,6 +47,9 @@ export type NewsLetter = {
   options: {
     isScheduled: string;
     scheduledAt: string;
+    scheduleMode?: string;
+    scheduledLocalDate?: string;
+    scheduledLocalTime?: string;
     shareVisibility?: 'default' | 'public' | 'private';
     disabled?: string;
     group: NewsletterOptionGroup;

--- a/mailpoet/assets/js/src/common/premium-modal/upgrade-info.ts
+++ b/mailpoet/assets/js/src/common/premium-modal/upgrade-info.ts
@@ -161,6 +161,12 @@ export const getUpgradeInfo = (
           'mailpoet',
         );
         break;
+      case 'sendByTimezone':
+        info = __(
+          'Sending emails in each subscriber’s time zone is not available in your current plan. Upgrade your MailPoet plan to deliver campaigns at the right local time for every subscriber.',
+          'mailpoet',
+        );
+        break;
       case 'segmentFilters':
         info = __(
           'Advanced contact segmentation is not available in your current plan. Upgrade your MailPoet plan to create highly targeted subscriber segments using multiple subscriber properties and AND/OR logic, ensuring you send the right message to the right people.',

--- a/mailpoet/assets/js/src/features-controller.js
+++ b/mailpoet/assets/js/src/features-controller.js
@@ -1,5 +1,6 @@
 export const FeaturesController = (config) => ({
   FEATURE_BRAND_TEMPLATES: 'brand_templates',
+  FEATURE_SEND_BY_TIMEZONE: 'send_by_timezone',
 
   isSupported: (feature) => {
     return config[feature] || false;

--- a/mailpoet/assets/js/src/features-controller.js
+++ b/mailpoet/assets/js/src/features-controller.js
@@ -3,6 +3,6 @@ export const FeaturesController = (config) => ({
   FEATURE_SEND_BY_TIMEZONE: 'send_by_timezone',
 
   isSupported: (feature) => {
-    return config[feature] || false;
+    return (config && config[feature]) || false;
   },
 });

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
@@ -256,12 +256,6 @@
   gap: $grid-unit-05;
 }
 
-.mailpoet-schedule-mode-controls__local-inputs {
-  display: flex;
-  flex-direction: column;
-  gap: $grid-unit-10;
-}
-
 .mailpoet-schedule-mode-controls__hint {
   color: $gray-700;
   font-size: $font-size-small;

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
@@ -238,6 +238,36 @@
   padding: 0 $grid-unit-20;
 }
 
+.mailpoet-schedule-mode-controls {
+  display: flex;
+  flex-direction: column;
+  gap: $grid-unit-10;
+}
+
+.mailpoet-schedule-mode-controls__selector {
+  display: flex;
+  flex-direction: column;
+  gap: $grid-unit-05;
+}
+
+.mailpoet-schedule-mode-controls__option {
+  align-items: center;
+  display: flex;
+  gap: $grid-unit-05;
+}
+
+.mailpoet-schedule-mode-controls__local-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: $grid-unit-10;
+}
+
+.mailpoet-schedule-mode-controls__hint {
+  color: $gray-700;
+  font-size: $font-size-small;
+  margin: 0;
+}
+
 .mailpoet-send-panel__notice {
   margin: 0 16px 16px;
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/send-panel/send-panel.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/send-panel/send-panel.tsx
@@ -147,7 +147,7 @@ export function SendPanel() {
                 )}
               </Stack>
               <ScheduleModeControls />
-              {!isSubscriberTimezoneMode && <ScheduledDatePicker />}
+              <ScheduledDatePicker />
             </Stack>
           </PanelBody>
 

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/send-panel/send-panel.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/send-panel/send-panel.tsx
@@ -5,10 +5,12 @@ import { useCallback } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { storeName as emailEditorStore } from '@woocommerce/email-editor';
+import { SCHEDULE_MODE_SUBSCRIBER_TIMEZONE } from 'common/newsletter-schedule-mode';
 import { InboxPreviewCard } from '../shared/inbox-preview-card';
 import { useScheduledDate } from '../shared/use-scheduled-date';
 import { useRecipients } from '../shared/use-recipients';
 import { ScheduledDatePicker } from '../shared/scheduled-date-picker';
+import { ScheduleModeControls } from '../shared/schedule-mode-controls';
 import { RecipientsSelector } from '../shared/recipients-selector';
 import { store as emailEditorIntegrationStore } from '../store';
 import { useSendEmail } from './use-send-email';
@@ -28,7 +30,10 @@ export function SendPanel() {
   const { closeSendPanel } = useDispatch(emailEditorIntegrationStore);
   const { setEmailPost, togglePreviewModal } = useDispatch(emailEditorStore);
 
-  const { isScheduled, formattedDate, setScheduledDate } = useScheduledDate();
+  const { isScheduled, formattedDate, setScheduledDate, scheduleMode } =
+    useScheduledDate();
+  const isSubscriberTimezoneMode =
+    scheduleMode === SCHEDULE_MODE_SUBSCRIBER_TIMEZONE;
   const recipients = useRecipients();
   const {
     recipientLabel,
@@ -131,15 +136,18 @@ export function SendPanel() {
                 >
                   {__('Send', 'mailpoet')}
                 </Text>
-                <Button
-                  size="small"
-                  variant="tertiary"
-                  onClick={() => setScheduledDate(null)}
-                >
-                  {__('Now', 'mailpoet')}
-                </Button>
+                {!isSubscriberTimezoneMode && (
+                  <Button
+                    size="small"
+                    variant="tertiary"
+                    onClick={() => setScheduledDate(null)}
+                  >
+                    {__('Now', 'mailpoet')}
+                  </Button>
+                )}
               </Stack>
-              <ScheduledDatePicker />
+              <ScheduleModeControls />
+              {!isSubscriberTimezoneMode && <ScheduledDatePicker />}
             </Stack>
           </PanelBody>
 

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/schedule-mode-controls.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/schedule-mode-controls.tsx
@@ -37,7 +37,7 @@ export function ScheduleModeControls(): JSX.Element | null {
   }
 
   const isRestricted =
-    !MailPoet.capabilities.sendByTimezone ||
+    !MailPoet.capabilities?.sendByTimezone ||
     MailPoet.capabilities.sendByTimezone.isRestricted;
   const isSubscriberTimezoneMode =
     scheduleMode === SCHEDULE_MODE_SUBSCRIBER_TIMEZONE;

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/schedule-mode-controls.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/schedule-mode-controls.tsx
@@ -1,0 +1,137 @@
+import { DatePicker, SelectControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { MailPoet } from 'mailpoet';
+import { PremiumModal } from 'common/premium-modal';
+import { LockedBadge } from 'common/premium-modal/locked-badge';
+import {
+  DEFAULT_SCHEDULED_LOCAL_TIME,
+  SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+  SCHEDULE_MODE_WEBSITE_TIME,
+  SUBSCRIBER_TIMEZONE_LEAD_TIME_HOURS,
+  ScheduleMode,
+  getLocalTimeOfDayItems,
+} from 'common/newsletter-schedule-mode';
+import { useScheduledDate } from './use-scheduled-date';
+
+/**
+ * Scheduling mode selector (website time vs subscriber's time zone) with the
+ * local date & time inputs for the subscriber timezone mode. Shared between
+ * the scheduled sidebar row and the review & send panel. Renders nothing when
+ * the send_by_timezone feature flag is off.
+ */
+export function ScheduleModeControls(): JSX.Element | null {
+  const {
+    isTimezoneSchedulingAvailable,
+    scheduleMode,
+    setScheduleMode,
+    scheduledLocalDate,
+    scheduledLocalTime,
+    setScheduledLocalDate,
+    setScheduledLocalTime,
+  } = useScheduledDate();
+  const [showPremiumModal, setShowPremiumModal] = useState(false);
+
+  if (!isTimezoneSchedulingAvailable) {
+    return null;
+  }
+
+  const isRestricted =
+    !MailPoet.capabilities.sendByTimezone ||
+    MailPoet.capabilities.sendByTimezone.isRestricted;
+  const isSubscriberTimezoneMode =
+    scheduleMode === SCHEDULE_MODE_SUBSCRIBER_TIMEZONE;
+
+  const handleModeChange = (mode: ScheduleMode) => {
+    if (mode === SCHEDULE_MODE_SUBSCRIBER_TIMEZONE && isRestricted) {
+      setShowPremiumModal(true);
+      return;
+    }
+    setScheduleMode(mode);
+  };
+
+  // Used for comparing today with DatePicker dates to determine validity.
+  const today = new Date().setHours(0, 0, 0, 0);
+
+  return (
+    <div className="mailpoet-schedule-mode-controls">
+      <div
+        className="mailpoet-schedule-mode-controls__selector"
+        role="radiogroup"
+        aria-label={__('Scheduling mode', 'mailpoet')}
+      >
+        <label className="mailpoet-schedule-mode-controls__option">
+          <input
+            type="radio"
+            name="mailpoet-schedule-mode"
+            value={SCHEDULE_MODE_WEBSITE_TIME}
+            checked={!isSubscriberTimezoneMode}
+            onChange={() => handleModeChange(SCHEDULE_MODE_WEBSITE_TIME)}
+          />
+          {__('Website time', 'mailpoet')}
+        </label>
+        <label className="mailpoet-schedule-mode-controls__option">
+          <input
+            type="radio"
+            name="mailpoet-schedule-mode"
+            value={SCHEDULE_MODE_SUBSCRIBER_TIMEZONE}
+            checked={isSubscriberTimezoneMode}
+            onChange={() => handleModeChange(SCHEDULE_MODE_SUBSCRIBER_TIMEZONE)}
+            data-automation-id="email-schedule-mode-subscriber-timezone"
+          />
+          {__('Subscriber’s time zone', 'mailpoet')}
+          {isRestricted && <LockedBadge text={__('Premium', 'mailpoet')} />}
+        </label>
+      </div>
+
+      {isSubscriberTimezoneMode && (
+        <div className="mailpoet-schedule-mode-controls__local-inputs">
+          <DatePicker
+            currentDate={scheduledLocalDate}
+            onChange={(newDate) => setScheduledLocalDate(newDate.slice(0, 10))}
+            isInvalidDate={(date) => date.getTime() < today}
+          />
+          <SelectControl
+            __nextHasNoMarginBottom
+            label={__('Time', 'mailpoet')}
+            value={scheduledLocalTime || DEFAULT_SCHEDULED_LOCAL_TIME}
+            options={Object.entries(getLocalTimeOfDayItems()).map(
+              ([value, label]) => ({ value, label }),
+            )}
+            onChange={setScheduledLocalTime}
+          />
+          <p className="mailpoet-schedule-mode-controls__hint">
+            {__(
+              'Emails will arrive at the selected time in each subscriber’s time zone.',
+              'mailpoet',
+            )}{' '}
+            {sprintf(
+              // translators: %d is the minimum number of hours required before the first timezone batch can send.
+              __(
+                'Scheduling requires at least %d hours of lead time before the earliest time zone.',
+                'mailpoet',
+              ),
+              SUBSCRIBER_TIMEZONE_LEAD_TIME_HOURS,
+            )}
+          </p>
+        </div>
+      )}
+
+      {showPremiumModal && (
+        <PremiumModal
+          onRequestClose={() => setShowPremiumModal(false)}
+          data={{ capabilities: { sendByTimezone: true } }}
+          tracking={{
+            utm_medium: 'upsell_modal',
+            utm_campaign: 'send_by_timezone',
+          }}
+        >
+          {__(
+            'Sending emails in each subscriber’s time zone is a premium feature.',
+            'mailpoet',
+          )}
+        </PremiumModal>
+      )}
+    </div>
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/schedule-mode-controls.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/schedule-mode-controls.tsx
@@ -1,35 +1,24 @@
-import { DatePicker, SelectControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import { PremiumModal } from 'common/premium-modal';
 import { LockedBadge } from 'common/premium-modal/locked-badge';
 import {
-  DEFAULT_SCHEDULED_LOCAL_TIME,
   SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
   SCHEDULE_MODE_WEBSITE_TIME,
   SUBSCRIBER_TIMEZONE_LEAD_TIME_HOURS,
   ScheduleMode,
-  getLocalTimeOfDayItems,
 } from 'common/newsletter-schedule-mode';
 import { useScheduledDate } from './use-scheduled-date';
 
 /**
- * Scheduling mode selector (website time vs subscriber's time zone) with the
- * local date & time inputs for the subscriber timezone mode. Shared between
- * the scheduled sidebar row and the review & send panel. Renders nothing when
- * the send_by_timezone feature flag is off.
+ * Scheduling mode selector (website time vs subscriber's time zone). Shared
+ * between the scheduled sidebar row and the review & send panel. Renders
+ * nothing when the send_by_timezone feature flag is off.
  */
 export function ScheduleModeControls(): JSX.Element | null {
-  const {
-    isTimezoneSchedulingAvailable,
-    scheduleMode,
-    setScheduleMode,
-    scheduledLocalDate,
-    scheduledLocalTime,
-    setScheduledLocalDate,
-    setScheduledLocalTime,
-  } = useScheduledDate();
+  const { isTimezoneSchedulingAvailable, scheduleMode, setScheduleMode } =
+    useScheduledDate();
   const [showPremiumModal, setShowPremiumModal] = useState(false);
 
   if (!isTimezoneSchedulingAvailable) {
@@ -49,9 +38,6 @@ export function ScheduleModeControls(): JSX.Element | null {
     }
     setScheduleMode(mode);
   };
-
-  // Used for comparing today with DatePicker dates to determine validity.
-  const today = new Date().setHours(0, 0, 0, 0);
 
   return (
     <div className="mailpoet-schedule-mode-controls">
@@ -85,32 +71,16 @@ export function ScheduleModeControls(): JSX.Element | null {
       </div>
 
       {isSubscriberTimezoneMode && (
-        <div className="mailpoet-schedule-mode-controls__local-inputs">
-          <DatePicker
-            currentDate={scheduledLocalDate}
-            onChange={(newDate) => setScheduledLocalDate(newDate.slice(0, 10))}
-            isInvalidDate={(date) => date.getTime() < today}
-          />
-          <SelectControl
-            __nextHasNoMarginBottom
-            label={__('Time', 'mailpoet')}
-            value={scheduledLocalTime || DEFAULT_SCHEDULED_LOCAL_TIME}
-            options={Object.entries(getLocalTimeOfDayItems()).map(
-              ([value, label]) => ({ value, label }),
-            )}
-            onChange={setScheduledLocalTime}
-          />
-          <p className="mailpoet-schedule-mode-controls__hint">
-            {sprintf(
-              // translators: %d is the minimum number of hours required before the first timezone batch can send.
-              __(
-                'Emails will arrive at the selected time in each subscriber’s time zone — or your website’s time zone if unknown. Schedule at least %d hours ahead.',
-                'mailpoet',
-              ),
-              SUBSCRIBER_TIMEZONE_LEAD_TIME_HOURS,
-            )}
-          </p>
-        </div>
+        <p className="mailpoet-schedule-mode-controls__hint">
+          {sprintf(
+            // translators: %d is the minimum number of hours required before the first timezone batch can send.
+            __(
+              'Emails will arrive at the selected time in each subscriber’s time zone — or your website’s time zone if unknown. Schedule at least %d hours ahead.',
+              'mailpoet',
+            ),
+            SUBSCRIBER_TIMEZONE_LEAD_TIME_HOURS,
+          )}
+        </p>
       )}
 
       {showPremiumModal && (

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/schedule-mode-controls.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/schedule-mode-controls.tsx
@@ -101,14 +101,10 @@ export function ScheduleModeControls(): JSX.Element | null {
             onChange={setScheduledLocalTime}
           />
           <p className="mailpoet-schedule-mode-controls__hint">
-            {__(
-              'Emails will arrive at the selected time in each subscriber’s time zone.',
-              'mailpoet',
-            )}{' '}
             {sprintf(
               // translators: %d is the minimum number of hours required before the first timezone batch can send.
               __(
-                'Scheduling requires at least %d hours of lead time before the earliest time zone.',
+                'Emails will arrive at the selected time in each subscriber’s time zone — or your website’s time zone if unknown. Schedule at least %d hours ahead.',
                 'mailpoet',
               ),
               SUBSCRIBER_TIMEZONE_LEAD_TIME_HOURS,

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/scheduled-date-picker.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/scheduled-date-picker.tsx
@@ -1,15 +1,33 @@
 import { DateTimePicker } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 import { getSettings } from '@wordpress/date';
+import {
+  DEFAULT_SCHEDULED_LOCAL_TIME,
+  SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+  getTomorrowLocalDate,
+  snapLocalDateTimeToQuarterHour,
+} from 'common/newsletter-schedule-mode';
 import { useScheduledDate } from './use-scheduled-date';
 
 /**
  * The date & time picker used to choose when an email is sent. Shared between
- * the scheduled sidebar row and the review & send panel.
+ * the scheduled sidebar row and the review & send panel. In subscriber
+ * timezone mode it edits the local wall-clock date and time instead of the
+ * website datetime, snapping the time to the 15-minute steps the server
+ * validates.
  */
 export function ScheduledDatePicker() {
-  const { scheduledDate, setScheduledDate } = useScheduledDate();
+  const {
+    scheduledDate,
+    setScheduledDate,
+    scheduleMode,
+    scheduledLocalDate,
+    scheduledLocalTime,
+    setScheduledLocalDateTime,
+  } = useScheduledDate();
   const settings = getSettings();
+  const isSubscriberTimezoneMode =
+    scheduleMode === SCHEDULE_MODE_SUBSCRIBER_TIMEZONE;
 
   const is12HourTime = /a(?!\\)/i.test(
     settings.formats.time
@@ -23,10 +41,27 @@ export function ScheduledDatePicker() {
   // We set the hours to 0:00:00 to match the time format of DateTimePicker dates.
   const today = new Date().setHours(0, 0, 0, 0);
 
+  const currentDate = isSubscriberTimezoneMode
+    ? `${scheduledLocalDate || getTomorrowLocalDate()}T${
+        scheduledLocalTime || DEFAULT_SCHEDULED_LOCAL_TIME
+      }`
+    : scheduledDate;
+
+  const handleChange = (newDate: string | null) => {
+    if (!isSubscriberTimezoneMode) {
+      setScheduledDate(newDate);
+      return;
+    }
+    const snapped = newDate ? snapLocalDateTimeToQuarterHour(newDate) : null;
+    if (snapped) {
+      setScheduledLocalDateTime(snapped.localDate, snapped.localTime);
+    }
+  };
+
   return (
     <DateTimePicker
-      currentDate={scheduledDate}
-      onChange={(newDate) => setScheduledDate(newDate)}
+      currentDate={currentDate}
+      onChange={handleChange}
       dateOrder={
         /* translators: Order of day, month, and year. Available formats are 'dmy', 'mdy', and 'ymd'. */
         _x('dmy', 'date order', 'mailpoet') as 'dmy' | 'mdy' | 'ymd'

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/scheduled-date-picker.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/scheduled-date-picker.tsx
@@ -2,11 +2,10 @@ import { DateTimePicker } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 import { getSettings } from '@wordpress/date';
 import {
-  DEFAULT_SCHEDULED_LOCAL_TIME,
   SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
   snapLocalDateTimeToQuarterHour,
 } from 'common/newsletter-schedule-mode';
-import { getSiteTomorrowDate, useScheduledDate } from './use-scheduled-date';
+import { useScheduledDate } from './use-scheduled-date';
 
 /**
  * The date & time picker used to choose when an email is sent. Shared between
@@ -20,8 +19,8 @@ export function ScheduledDatePicker() {
     scheduledDate,
     setScheduledDate,
     scheduleMode,
-    scheduledLocalDate,
-    scheduledLocalTime,
+    effectiveLocalDate,
+    effectiveLocalTime,
     setScheduledLocalDateTime,
   } = useScheduledDate();
   const settings = getSettings();
@@ -41,9 +40,7 @@ export function ScheduledDatePicker() {
   const today = new Date().setHours(0, 0, 0, 0);
 
   const currentDate = isSubscriberTimezoneMode
-    ? `${scheduledLocalDate || getSiteTomorrowDate()}T${
-        scheduledLocalTime || DEFAULT_SCHEDULED_LOCAL_TIME
-      }`
+    ? `${effectiveLocalDate}T${effectiveLocalTime}`
     : scheduledDate;
 
   const handleChange = (newDate: string | null) => {

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/scheduled-date-picker.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/scheduled-date-picker.tsx
@@ -4,10 +4,9 @@ import { getSettings } from '@wordpress/date';
 import {
   DEFAULT_SCHEDULED_LOCAL_TIME,
   SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
-  getTomorrowLocalDate,
   snapLocalDateTimeToQuarterHour,
 } from 'common/newsletter-schedule-mode';
-import { useScheduledDate } from './use-scheduled-date';
+import { getSiteTomorrowDate, useScheduledDate } from './use-scheduled-date';
 
 /**
  * The date & time picker used to choose when an email is sent. Shared between
@@ -42,7 +41,7 @@ export function ScheduledDatePicker() {
   const today = new Date().setHours(0, 0, 0, 0);
 
   const currentDate = isSubscriberTimezoneMode
-    ? `${scheduledLocalDate || getTomorrowLocalDate()}T${
+    ? `${scheduledLocalDate || getSiteTomorrowDate()}T${
         scheduledLocalTime || DEFAULT_SCHEDULED_LOCAL_TIME
       }`
     : scheduledDate;

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/use-scheduled-date.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/use-scheduled-date.ts
@@ -1,5 +1,5 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { dateI18n, getSettings } from '@wordpress/date';
+import { date as formatWpDate, dateI18n, getSettings } from '@wordpress/date';
 import { select, dispatch } from '@wordpress/data';
 import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
@@ -10,7 +10,6 @@ import {
   ScheduleMode,
   getScheduleMode,
   getScheduleModeOptionChanges,
-  getTomorrowLocalDate,
 } from 'common/newsletter-schedule-mode';
 import { MAILPOET_EMAIL_POST_TYPE } from '../constants';
 
@@ -26,6 +25,15 @@ type UseScheduledDate = {
   setScheduleMode: (mode: ScheduleMode) => void;
   setScheduledLocalDateTime: (date: string, time: string) => void;
 };
+
+/**
+ * Tomorrow's date in the site timezone (wp date() falls back to it when no
+ * timezone is passed), matching the default the legacy send page gets from
+ * the server via mailpoet_tomorrow_date.
+ */
+export function getSiteTomorrowDate(): string {
+  return formatWpDate('Y-m-d', new Date(Date.now() + 24 * 60 * 60 * 1000));
+}
 
 function editMailpoetData(changes: Record<string, string | null>): void {
   const postId = select(editorStore).getCurrentPostId();
@@ -89,7 +97,7 @@ export function useScheduledDate(): UseScheduledDate {
         scheduledLocalDate: scheduledLocalDate || undefined,
         scheduledLocalTime: scheduledLocalTime || undefined,
       },
-      getTomorrowLocalDate(),
+      getSiteTomorrowDate(),
     );
     editMailpoetData({
       schedule_mode: changes.scheduleMode,

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/use-scheduled-date.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/use-scheduled-date.ts
@@ -1,8 +1,17 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings } from '@wordpress/date';
 import { select, dispatch } from '@wordpress/data';
 import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
+import { MailPoet } from 'mailpoet';
+import {
+  SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+  SCHEDULE_MODE_WEBSITE_TIME,
+  ScheduleMode,
+  getScheduleMode,
+  getScheduleModeOptionChanges,
+  getTomorrowLocalDate,
+} from 'common/newsletter-schedule-mode';
 import { MAILPOET_EMAIL_POST_TYPE } from '../constants';
 
 type UseScheduledDate = {
@@ -10,7 +19,39 @@ type UseScheduledDate = {
   isScheduled: boolean;
   formattedDate: string;
   setScheduledDate: (date: string | null) => void;
+  scheduleMode: ScheduleMode;
+  scheduledLocalDate: string | null;
+  scheduledLocalTime: string | null;
+  isTimezoneSchedulingAvailable: boolean;
+  setScheduleMode: (mode: ScheduleMode) => void;
+  setScheduledLocalDate: (date: string) => void;
+  setScheduledLocalTime: (time: string) => void;
 };
+
+function editMailpoetData(changes: Record<string, string | null>): void {
+  const postId = select(editorStore).getCurrentPostId();
+  const currentPostType = MAILPOET_EMAIL_POST_TYPE;
+
+  const editedPost = select(coreDataStore).getEditedEntityRecord(
+    'postType',
+    currentPostType,
+    postId,
+  );
+
+  // @ts-expect-error Property 'mailpoet_data' does not exist on type 'Updatable<Attachment<any>>'.
+  const mailpoetData = editedPost?.mailpoet_data || {};
+  void dispatch(coreDataStore).editEntityRecord(
+    'postType',
+    currentPostType,
+    postId,
+    {
+      mailpoet_data: {
+        ...mailpoetData,
+        ...changes,
+      },
+    },
+  );
+}
 
 /**
  * Reads and writes the email's scheduled send time from `mailpoet_data`.
@@ -24,45 +65,79 @@ export function useScheduledDate(): UseScheduledDate {
   );
 
   const scheduledDate = (mailpoetEmailData?.scheduled_at as string) || null;
+  const isTimezoneSchedulingAvailable = MailPoet.FeaturesController.isSupported(
+    MailPoet.FeaturesController.FEATURE_SEND_BY_TIMEZONE,
+  );
+  const scheduleMode = isTimezoneSchedulingAvailable
+    ? getScheduleMode(mailpoetEmailData?.schedule_mode as string)
+    : SCHEDULE_MODE_WEBSITE_TIME;
+  const isSubscriberTimezoneMode =
+    scheduleMode === SCHEDULE_MODE_SUBSCRIBER_TIMEZONE;
+  const scheduledLocalDate =
+    (mailpoetEmailData?.scheduled_local_date as string) || null;
+  const scheduledLocalTime =
+    (mailpoetEmailData?.scheduled_local_time as string) || null;
   const settings = getSettings();
 
   const setScheduledDate = (date: string | null) => {
-    const postId = select(editorStore).getCurrentPostId();
-    const currentPostType = MAILPOET_EMAIL_POST_TYPE;
-
-    const editedPost = select(coreDataStore).getEditedEntityRecord(
-      'postType',
-      currentPostType,
-      postId,
-    );
-
-    // @ts-expect-error Property 'mailpoet_data' does not exist on type 'Updatable<Attachment<any>>'.
-    const mailpoetData = editedPost?.mailpoet_data || {};
-    void dispatch(coreDataStore).editEntityRecord(
-      'postType',
-      currentPostType,
-      postId,
-      {
-        mailpoet_data: {
-          ...mailpoetData,
-          scheduled_at: date,
-        },
-      },
-    );
+    editMailpoetData({ scheduled_at: date });
   };
 
-  const formattedDate = scheduledDate
-    ? dateI18n(
-        settings.formats.datetime,
-        scheduledDate,
-        settings.timezone.string,
-      )
-    : __('Immediately', 'mailpoet');
+  const setScheduleMode = (mode: ScheduleMode) => {
+    const changes = getScheduleModeOptionChanges(
+      mode,
+      {
+        scheduledLocalDate: scheduledLocalDate || undefined,
+        scheduledLocalTime: scheduledLocalTime || undefined,
+      },
+      getTomorrowLocalDate(),
+    );
+    editMailpoetData({
+      schedule_mode: changes.scheduleMode,
+      scheduled_local_date: changes.scheduledLocalDate,
+      scheduled_local_time: changes.scheduledLocalTime,
+    });
+  };
+
+  const setScheduledLocalDate = (date: string) => {
+    editMailpoetData({ scheduled_local_date: date });
+  };
+
+  const setScheduledLocalTime = (time: string) => {
+    editMailpoetData({ scheduled_local_time: time });
+  };
+
+  let formattedDate;
+  if (isSubscriberTimezoneMode) {
+    formattedDate = sprintf(
+      // translators: %1$s is a date, %2$s is a time. Example: "2026-07-10 at 08:00 in subscriber’s time zone".
+      __('%1$s at %2$s in subscriber’s time zone', 'mailpoet'),
+      scheduledLocalDate || '',
+      (scheduledLocalTime || '').slice(0, 5),
+    );
+  } else {
+    formattedDate = scheduledDate
+      ? dateI18n(
+          settings.formats.datetime,
+          scheduledDate,
+          settings.timezone.string,
+        )
+      : __('Immediately', 'mailpoet');
+  }
 
   return {
     scheduledDate,
-    isScheduled: Boolean(scheduledDate),
+    isScheduled: isSubscriberTimezoneMode
+      ? Boolean(scheduledLocalDate)
+      : Boolean(scheduledDate),
     formattedDate,
     setScheduledDate,
+    scheduleMode,
+    scheduledLocalDate,
+    scheduledLocalTime,
+    isTimezoneSchedulingAvailable,
+    setScheduleMode,
+    setScheduledLocalDate,
+    setScheduledLocalTime,
   };
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/use-scheduled-date.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/use-scheduled-date.ts
@@ -5,6 +5,7 @@ import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { MailPoet } from 'mailpoet';
 import {
+  DEFAULT_SCHEDULED_LOCAL_TIME,
   SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
   SCHEDULE_MODE_WEBSITE_TIME,
   ScheduleMode,
@@ -21,6 +22,8 @@ type UseScheduledDate = {
   scheduleMode: ScheduleMode;
   scheduledLocalDate: string | null;
   scheduledLocalTime: string | null;
+  effectiveLocalDate: string;
+  effectiveLocalTime: string;
   isTimezoneSchedulingAvailable: boolean;
   setScheduleMode: (mode: ScheduleMode) => void;
   setScheduledLocalDateTime: (date: string, time: string) => void;
@@ -84,6 +87,11 @@ export function useScheduledDate(): UseScheduledDate {
     (mailpoetEmailData?.scheduled_local_date as string) || null;
   const scheduledLocalTime =
     (mailpoetEmailData?.scheduled_local_time as string) || null;
+  // Defaults shown by the picker when the local options are not stored yet;
+  // used everywhere the local schedule is displayed so the panel stays
+  // consistent with what the picker shows.
+  const effectiveLocalDate = scheduledLocalDate || getSiteTomorrowDate();
+  const effectiveLocalTime = scheduledLocalTime || DEFAULT_SCHEDULED_LOCAL_TIME;
   const settings = getSettings();
 
   const setScheduledDate = (date: string | null) => {
@@ -118,8 +126,8 @@ export function useScheduledDate(): UseScheduledDate {
     formattedDate = sprintf(
       // translators: %1$s is a date, %2$s is a time. Example: "2026-07-10 at 08:00 in subscriber’s time zone".
       __('%1$s at %2$s in subscriber’s time zone', 'mailpoet'),
-      scheduledLocalDate || '',
-      (scheduledLocalTime || '').slice(0, 5),
+      effectiveLocalDate,
+      effectiveLocalTime.slice(0, 5),
     );
   } else {
     formattedDate = scheduledDate
@@ -133,14 +141,16 @@ export function useScheduledDate(): UseScheduledDate {
 
   return {
     scheduledDate,
-    isScheduled: isSubscriberTimezoneMode
-      ? Boolean(scheduledLocalDate)
-      : Boolean(scheduledDate),
+    // Subscriber timezone mode is always a scheduled send — the picker shows
+    // the effective local date even before the options are stored.
+    isScheduled: isSubscriberTimezoneMode || Boolean(scheduledDate),
     formattedDate,
     setScheduledDate,
     scheduleMode,
     scheduledLocalDate,
     scheduledLocalTime,
+    effectiveLocalDate,
+    effectiveLocalTime,
     isTimezoneSchedulingAvailable,
     setScheduleMode,
     setScheduledLocalDateTime,

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/use-scheduled-date.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/use-scheduled-date.ts
@@ -24,8 +24,7 @@ type UseScheduledDate = {
   scheduledLocalTime: string | null;
   isTimezoneSchedulingAvailable: boolean;
   setScheduleMode: (mode: ScheduleMode) => void;
-  setScheduledLocalDate: (date: string) => void;
-  setScheduledLocalTime: (time: string) => void;
+  setScheduledLocalDateTime: (date: string, time: string) => void;
 };
 
 function editMailpoetData(changes: Record<string, string | null>): void {
@@ -99,12 +98,11 @@ export function useScheduledDate(): UseScheduledDate {
     });
   };
 
-  const setScheduledLocalDate = (date: string) => {
-    editMailpoetData({ scheduled_local_date: date });
-  };
-
-  const setScheduledLocalTime = (time: string) => {
-    editMailpoetData({ scheduled_local_time: time });
+  const setScheduledLocalDateTime = (date: string, time: string) => {
+    editMailpoetData({
+      scheduled_local_date: date,
+      scheduled_local_time: time,
+    });
   };
 
   let formattedDate;
@@ -137,7 +135,6 @@ export function useScheduledDate(): UseScheduledDate {
     scheduledLocalTime,
     isTimezoneSchedulingAvailable,
     setScheduleMode,
-    setScheduledLocalDate,
-    setScheduledLocalTime,
+    setScheduledLocalDateTime,
   };
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/scheduled-row.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/scheduled-row.tsx
@@ -82,7 +82,7 @@ export function ScheduledRow() {
                   </HStack>
                 </VStack>
                 <ScheduleModeControls />
-                {!isSubscriberTimezoneMode && <ScheduledDatePicker />}
+                <ScheduledDatePicker />
               </div>
             )}
           />

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/scheduled-row.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/scheduled-row.tsx
@@ -12,11 +12,15 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
+import { SCHEDULE_MODE_SUBSCRIBER_TIMEZONE } from 'common/newsletter-schedule-mode';
 import { useScheduledDate } from '../../shared/use-scheduled-date';
 import { ScheduledDatePicker } from '../../shared/scheduled-date-picker';
+import { ScheduleModeControls } from '../../shared/schedule-mode-controls';
 
 export function ScheduledRow() {
-  const { formattedDate, setScheduledDate } = useScheduledDate();
+  const { formattedDate, setScheduledDate, scheduleMode } = useScheduledDate();
+  const isSubscriberTimezoneMode =
+    scheduleMode === SCHEDULE_MODE_SUBSCRIBER_TIMEZONE;
   const sendPopoverAnchor = useRef(null);
 
   return (
@@ -57,15 +61,17 @@ export function ScheduledRow() {
                       {__('Send', 'mailpoet')}
                     </Heading>
                     <Spacer />
-                    <Button
-                      size="small"
-                      className="block-editor-inspector-popover-header__action"
-                      label={__('Now', 'mailpoet')}
-                      variant="tertiary"
-                      onClick={() => setScheduledDate(null)}
-                    >
-                      {__('Now', 'mailpoet')}
-                    </Button>
+                    {!isSubscriberTimezoneMode && (
+                      <Button
+                        size="small"
+                        className="block-editor-inspector-popover-header__action"
+                        label={__('Now', 'mailpoet')}
+                        variant="tertiary"
+                        onClick={() => setScheduledDate(null)}
+                      >
+                        {__('Now', 'mailpoet')}
+                      </Button>
+                    )}
                     <Button
                       size="small"
                       className="block-editor-inspector-popover-header__action"
@@ -75,7 +81,8 @@ export function ScheduledRow() {
                     />
                   </HStack>
                 </VStack>
-                <ScheduledDatePicker />
+                <ScheduleModeControls />
+                {!isSubscriberTimezoneMode && <ScheduledDatePicker />}
               </div>
             )}
           />

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -25,7 +25,6 @@ import {
   ScheduleMode,
   getScheduleMode,
   getScheduleModeOptionChanges,
-  isLocalDateTimeInFuture,
 } from 'common/newsletter-schedule-mode';
 import { PremiumModal } from 'common/premium-modal';
 import { LockedBadge } from 'common/premium-modal/locked-badge';
@@ -559,18 +558,14 @@ export const StandardNewsletterFields = {
       ) &&
       getScheduleMode(newsletter.options?.scheduleMode) ===
         SCHEDULE_MODE_SUBSCRIBER_TIMEZONE;
+    // Subscriber timezone campaigns are always scheduled sends; whether the
+    // selected local date is still valid is decided by the server, which sees
+    // it relative to every subscriber's timezone.
     const isScheduled =
       typeof newsletter.options === 'object' &&
       newsletter.options?.isScheduled === '1' &&
-      (isSubscriberTimezoneMode
-        ? isLocalDateTimeInFuture(
-            newsletter.options?.scheduledLocalDate,
-            newsletter.options?.scheduledLocalTime,
-          )
-        : MailPoet.Date.isInFuture(
-            newsletter.options?.scheduledAt,
-            new Date(),
-          ));
+      (isSubscriberTimezoneMode ||
+        MailPoet.Date.isInFuture(newsletter.options?.scheduledAt, new Date()));
 
     const options: SendButtonOptions = {
       value: isScheduled ? __('Schedule', 'mailpoet') : __('Send', 'mailpoet'),

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -191,12 +191,16 @@ class StandardScheduling extends Component<
 
     return (
       <>
-        <span className="mailpoet-form-schedule-time">
-          {__(
-            'Emails will arrive at the selected time in each subscriber’s time zone.',
-            'mailpoet',
+        <div>
+          {sprintf(
+            // translators: %d is the minimum number of hours required before the first timezone batch can send.
+            __(
+              'Emails will arrive at the selected time in each subscriber’s time zone — or your website’s time zone if unknown. Schedule at least %d hours ahead.',
+              'mailpoet',
+            ),
+            SUBSCRIBER_TIMEZONE_LEAD_TIME_HOURS,
           )}
-        </span>
+        </div>
         <div className="mailpoet-gap" />
         <div id="mailpoet_scheduling">
           <Grid.Column className="mailpoet-datetime-container">
@@ -224,16 +228,6 @@ class StandardScheduling extends Component<
             />
           </Grid.Column>
         </div>
-        <p className="mailpoet-form-field-description">
-          {sprintf(
-            // translators: %d is the minimum number of hours required before the first timezone batch can send.
-            __(
-              'Scheduling requires at least %d hours of lead time before the earliest time zone.',
-              'mailpoet',
-            ),
-            SUBSCRIBER_TIMEZONE_LEAD_TIME_HOURS,
-          )}
-        </p>
       </>
     );
   };
@@ -244,10 +238,10 @@ class StandardScheduling extends Component<
 
     return (
       <>
-        <span className="mailpoet-form-schedule-time">
+        <div>
           {__('Your website’s time is', 'mailpoet')}{' '}
           {MailPoet.Date.time(new Date())}
-        </span>
+        </div>
         <div className="mailpoet-gap" />
         <div id="mailpoet_scheduling">
           <DateTime

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -97,7 +97,7 @@ class StandardScheduling extends Component<
     );
 
   isSubscriberTimezoneRestricted = () =>
-    !MailPoet.capabilities.sendByTimezone ||
+    !MailPoet.capabilities?.sendByTimezone ||
     MailPoet.capabilities.sendByTimezone.isRestricted;
 
   handleScheduleModeChange = (mode: ScheduleMode) => {

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -1,11 +1,14 @@
 import { ChangeEvent, Component, useEffect } from 'react';
 import { MailPoet } from 'mailpoet';
 import { Hooks } from 'wp-js-hooks';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 import { DateTime } from 'newsletters/send/date-time';
+import { DateText } from 'newsletters/send/date-text';
+import { TimeSelect } from 'newsletters/send/time-select.jsx';
 import { SenderField } from 'newsletters/send/sender-address-field.jsx';
 import { GATrackingField } from 'newsletters/send/ga-tracking';
+import { Grid } from 'common/grid';
 import { Toggle } from 'common/form/toggle/toggle';
 import { Radio } from 'common/form/radio/radio';
 import { withBoundary } from 'common';
@@ -14,6 +17,18 @@ import {
   getExcludeFromArchiveOptionValue,
   isNewsletterShownInArchive,
 } from 'common/newsletter-archive-visibility';
+import {
+  DEFAULT_SCHEDULED_LOCAL_TIME,
+  SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+  SCHEDULE_MODE_WEBSITE_TIME,
+  SUBSCRIBER_TIMEZONE_LEAD_TIME_HOURS,
+  ScheduleMode,
+  getScheduleMode,
+  getScheduleModeOptionChanges,
+  isLocalDateTimeInFuture,
+} from 'common/newsletter-schedule-mode';
+import { PremiumModal } from 'common/premium-modal';
+import { LockedBadge } from 'common/premium-modal/locked-badge';
 import { Field } from 'form/types';
 import { SendToFieldWithCount } from './send-to-field';
 
@@ -38,8 +53,20 @@ type StandardSchedulingProps = {
   field: Field;
 };
 
-class StandardScheduling extends Component<StandardSchedulingProps> {
-  getCurrentValue = () => {
+type StandardSchedulingState = {
+  showPremiumModal: boolean;
+};
+
+class StandardScheduling extends Component<
+  StandardSchedulingProps,
+  StandardSchedulingState
+> {
+  constructor(props: StandardSchedulingProps) {
+    super(props);
+    this.state = { showPremiumModal: false };
+  }
+
+  getCurrentValue = (): Partial<NewsLetter['options']> => {
     const schedulingOptions = {
       isScheduled: '0',
       scheduledAt: tomorrowDateTime,
@@ -47,7 +74,9 @@ class StandardScheduling extends Component<StandardSchedulingProps> {
 
     return {
       ...schedulingOptions,
-      ...(this.props.item?.[this.props.field.name] ?? {}),
+      ...((this.props.item?.[this.props.field.name] as Partial<
+        NewsLetter['options']
+      >) ?? {}),
     };
   };
 
@@ -61,6 +90,39 @@ class StandardScheduling extends Component<StandardSchedulingProps> {
   });
 
   isScheduled = () => this.getCurrentValue().isScheduled === '1';
+
+  isTimezoneSchedulingAvailable = () =>
+    MailPoet.FeaturesController.isSupported(
+      MailPoet.FeaturesController.FEATURE_SEND_BY_TIMEZONE,
+    );
+
+  isSubscriberTimezoneRestricted = () =>
+    !MailPoet.capabilities.sendByTimezone ||
+    MailPoet.capabilities.sendByTimezone.isRestricted;
+
+  handleScheduleModeChange = (mode: ScheduleMode) => {
+    if (
+      mode === SCHEDULE_MODE_SUBSCRIBER_TIMEZONE &&
+      this.isSubscriberTimezoneRestricted()
+    ) {
+      this.setState({ showPremiumModal: true });
+      return;
+    }
+    const oldValue = this.getCurrentValue();
+    this.props.onValueChange({
+      target: {
+        name: this.props.field.name,
+        value: {
+          ...oldValue,
+          ...getScheduleModeOptionChanges(
+            mode,
+            oldValue,
+            window.mailpoet_tomorrow_date,
+          ),
+        },
+      },
+    });
+  };
 
   handleCheckboxChange = (_, event: ChangeEvent<HTMLInputElement>): void => {
     const changeEvent = { ...event };
@@ -81,34 +143,146 @@ class StandardScheduling extends Component<StandardSchedulingProps> {
     });
   };
 
-  render() {
-    let schedulingOptions;
+  renderScheduleModeSelector = (isSubscriberTimezoneMode: boolean) => (
+    <>
+      <div className="mailpoet-settings-inputs-row">
+        <Radio
+          id="mailpoet-schedule-mode-website-time"
+          value={SCHEDULE_MODE_WEBSITE_TIME}
+          checked={!isSubscriberTimezoneMode}
+          onCheck={() =>
+            this.handleScheduleModeChange(SCHEDULE_MODE_WEBSITE_TIME)
+          }
+          disabled={this.props.field.disabled}
+          name="scheduleMode"
+          automationId="email-schedule-mode-website-time"
+        />
+        <label htmlFor="mailpoet-schedule-mode-website-time">
+          {__('Website time', 'mailpoet')}
+        </label>
+      </div>
+      <div className="mailpoet-settings-inputs-row">
+        <Radio
+          id="mailpoet-schedule-mode-subscriber-timezone"
+          value={SCHEDULE_MODE_SUBSCRIBER_TIMEZONE}
+          checked={isSubscriberTimezoneMode}
+          onCheck={() =>
+            this.handleScheduleModeChange(SCHEDULE_MODE_SUBSCRIBER_TIMEZONE)
+          }
+          disabled={this.props.field.disabled}
+          name="scheduleMode"
+          automationId="email-schedule-mode-subscriber-timezone"
+        />
+        <label htmlFor="mailpoet-schedule-mode-subscriber-timezone">
+          {__('Subscriber’s time zone', 'mailpoet')}{' '}
+          {this.isSubscriberTimezoneRestricted() && (
+            <LockedBadge text={__('Premium', 'mailpoet')} />
+          )}
+        </label>
+      </div>
+      <div className="mailpoet-gap" />
+    </>
+  );
 
+  renderSubscriberTimezoneScheduling = () => {
+    const currentValue = this.getCurrentValue();
     const maxDate = new Date();
     maxDate.setFullYear(maxDate.getFullYear() + 5);
 
-    if (this.isScheduled()) {
-      schedulingOptions = (
-        <>
-          <span className="mailpoet-form-schedule-time">
-            {__('Your website’s time is', 'mailpoet')}{' '}
-            {MailPoet.Date.time(new Date())}
-          </span>
-          <div className="mailpoet-gap" />
-          <div id="mailpoet_scheduling">
-            <DateTime
-              name="scheduledAt"
-              value={this.getCurrentValue().scheduledAt}
+    return (
+      <>
+        <span className="mailpoet-form-schedule-time">
+          {__(
+            'Emails will arrive at the selected time in each subscriber’s time zone.',
+            'mailpoet',
+          )}
+        </span>
+        <div className="mailpoet-gap" />
+        <div id="mailpoet_scheduling">
+          <Grid.Column className="mailpoet-datetime-container">
+            <DateText
+              name="scheduledLocalDate"
+              value={
+                currentValue.scheduledLocalDate || window.mailpoet_tomorrow_date
+              }
               onChange={this.handleValueChange}
+              displayFormat={dateDisplayFormat}
+              storageFormat={dateStorageFormat}
               disabled={this.props.field.disabled}
-              dateValidation={this.getDateValidation()}
-              defaultDateTime={tomorrowDateTime}
-              timeOfDayItems={timeOfDayItems}
-              dateDisplayFormat={dateDisplayFormat}
-              dateStorageFormat={dateStorageFormat}
+              validation={this.getDateValidation()}
               maxDate={maxDate}
             />
-          </div>
+            <div className="mailpoet-gap" />
+            <TimeSelect
+              name="scheduledLocalTime"
+              value={
+                currentValue.scheduledLocalTime || DEFAULT_SCHEDULED_LOCAL_TIME
+              }
+              onChange={this.handleValueChange}
+              disabled={this.props.field.disabled}
+              timeOfDayItems={timeOfDayItems}
+            />
+          </Grid.Column>
+        </div>
+        <p className="mailpoet-form-field-description">
+          {sprintf(
+            // translators: %d is the minimum number of hours required before the first timezone batch can send.
+            __(
+              'Scheduling requires at least %d hours of lead time before the earliest time zone.',
+              'mailpoet',
+            ),
+            SUBSCRIBER_TIMEZONE_LEAD_TIME_HOURS,
+          )}
+        </p>
+      </>
+    );
+  };
+
+  renderWebsiteTimeScheduling = () => {
+    const maxDate = new Date();
+    maxDate.setFullYear(maxDate.getFullYear() + 5);
+
+    return (
+      <>
+        <span className="mailpoet-form-schedule-time">
+          {__('Your website’s time is', 'mailpoet')}{' '}
+          {MailPoet.Date.time(new Date())}
+        </span>
+        <div className="mailpoet-gap" />
+        <div id="mailpoet_scheduling">
+          <DateTime
+            name="scheduledAt"
+            value={this.getCurrentValue().scheduledAt}
+            onChange={this.handleValueChange}
+            disabled={this.props.field.disabled}
+            dateValidation={this.getDateValidation()}
+            defaultDateTime={tomorrowDateTime}
+            timeOfDayItems={timeOfDayItems}
+            dateDisplayFormat={dateDisplayFormat}
+            dateStorageFormat={dateStorageFormat}
+            maxDate={maxDate}
+          />
+        </div>
+      </>
+    );
+  };
+
+  render() {
+    let schedulingOptions;
+
+    if (this.isScheduled()) {
+      const isSubscriberTimezoneMode =
+        this.isTimezoneSchedulingAvailable() &&
+        getScheduleMode(this.getCurrentValue().scheduleMode) ===
+          SCHEDULE_MODE_SUBSCRIBER_TIMEZONE;
+
+      schedulingOptions = (
+        <>
+          {this.isTimezoneSchedulingAvailable() &&
+            this.renderScheduleModeSelector(isSubscriberTimezoneMode)}
+          {isSubscriberTimezoneMode
+            ? this.renderSubscriberTimezoneScheduling()
+            : this.renderWebsiteTimeScheduling()}
         </>
       );
     }
@@ -123,6 +297,21 @@ class StandardScheduling extends Component<StandardSchedulingProps> {
         />
 
         {schedulingOptions}
+        {this.state.showPremiumModal && (
+          <PremiumModal
+            onRequestClose={() => this.setState({ showPremiumModal: false })}
+            data={{ capabilities: { sendByTimezone: true } }}
+            tracking={{
+              utm_medium: 'upsell_modal',
+              utm_campaign: 'send_by_timezone',
+            }}
+          >
+            {__(
+              'Sending emails in each subscriber’s time zone is a premium feature.',
+              'mailpoet',
+            )}
+          </PremiumModal>
+        )}
       </div>
     );
   }
@@ -370,10 +559,24 @@ export const StandardNewsletterFields = {
   getSendButtonOptions: (
     newsletter: Partial<NewsLetter> = {},
   ): SendButtonOptions => {
+    const isSubscriberTimezoneMode =
+      MailPoet.FeaturesController.isSupported(
+        MailPoet.FeaturesController.FEATURE_SEND_BY_TIMEZONE,
+      ) &&
+      getScheduleMode(newsletter.options?.scheduleMode) ===
+        SCHEDULE_MODE_SUBSCRIBER_TIMEZONE;
     const isScheduled =
       typeof newsletter.options === 'object' &&
       newsletter.options?.isScheduled === '1' &&
-      MailPoet.Date.isInFuture(newsletter.options?.scheduledAt, new Date());
+      (isSubscriberTimezoneMode
+        ? isLocalDateTimeInFuture(
+            newsletter.options?.scheduledLocalDate,
+            newsletter.options?.scheduledLocalTime,
+          )
+        : MailPoet.Date.isInFuture(
+            newsletter.options?.scheduledAt,
+            new Date(),
+          ));
 
     const options: SendButtonOptions = {
       value: isScheduled ? __('Schedule', 'mailpoet') : __('Send', 'mailpoet'),

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -12,6 +12,7 @@ use MailPoet\Config\Installer;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor as EditorInitController;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Features\FeaturesController;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\AuthorizedSenderDomainController;
@@ -20,6 +21,7 @@ use MailPoet\Settings\SettingsController as MailPoetSettings;
 use MailPoet\Settings\UserFlagsController;
 use MailPoet\Util\CdnAssetUrl;
 use MailPoet\Util\FreeDomains;
+use MailPoet\Util\License\Features\CapabilitiesManager;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -54,6 +56,10 @@ class EditorPageRenderer {
 
   private AuthorizedSenderDomainController $senderDomainController;
 
+  private FeaturesController $featuresController;
+
+  private CapabilitiesManager $capabilitiesManager;
+
   public function __construct(
     WPFunctions $wp,
     CdnAssetUrl $cdnAssetUrl,
@@ -66,7 +72,9 @@ class EditorPageRenderer {
     Analytics $analytics,
     Bridge $bridge,
     AuthorizedEmailsController $authorizedEmailsController,
-    AuthorizedSenderDomainController $senderDomainController
+    AuthorizedSenderDomainController $senderDomainController,
+    FeaturesController $featuresController,
+    CapabilitiesManager $capabilitiesManager
   ) {
     $this->wp = $wp;
     $this->settingsController = Email_Editor_Container::container()->get(Settings_Controller::class);
@@ -83,6 +91,8 @@ class EditorPageRenderer {
     $this->bridge = $bridge;
     $this->authorizedEmailsController = $authorizedEmailsController;
     $this->senderDomainController = $senderDomainController;
+    $this->featuresController = $featuresController;
+    $this->capabilitiesManager = $capabilitiesManager;
   }
 
   public function render() {
@@ -225,6 +235,8 @@ class EditorPageRenderer {
       ],
       'mailpoet_is_automation_newsletter' => $isAutomationNewsletter,
       'mailpoet_automation_id' => $automationId,
+      'mailpoet_feature_flags' => $this->featuresController->getAllFlags(),
+      'mailpoet_capabilities' => $this->capabilitiesManager->getCapabilities(),
       'mailpoet_ai_text_generation_available' => function_exists('wp_ai_client_prompt')
         && wp_ai_client_prompt('test')->is_supported_for_text_generation(),
     ];

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -249,6 +249,19 @@ class EmailApiController {
     // immediate path instead of TimeZoneCampaignScheduler.
     if ($scheduleModeValue === TimeZoneCampaignScheduler::SCHEDULE_MODE_SUBSCRIBER_TIMEZONE) {
       $this->updateOption($newsletter, NewsletterOptionFieldEntity::NAME_IS_SCHEDULED, '1');
+      return;
+    }
+
+    // Switching back to website time must re-derive isScheduled from scheduledAt,
+    // otherwise a payload without the scheduled_at key would leave isScheduled
+    // stuck at '1' with no datetime and sending would take the scheduled path.
+    if ($scheduleModeValue === TimeZoneCampaignScheduler::SCHEDULE_MODE_WEBSITE_TIME) {
+      $scheduledAt = $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SCHEDULED_AT);
+      $this->updateOption(
+        $newsletter,
+        NewsletterOptionFieldEntity::NAME_IS_SCHEDULED,
+        $scheduledAt !== null && $scheduledAt !== '' ? '1' : '0'
+      );
     }
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -11,6 +11,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Newsletter\Sharing\ShareVisibility;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\NotFoundException;
@@ -80,6 +81,9 @@ class EmailApiController {
       'preview_url' => $this->newsletterUrl->getViewInBrowserUrl($newsletter),
       'deleted_at' => $newsletter && $newsletter->getDeletedAt() !== null ? $newsletter->getDeletedAt()->format('c') : null,
       'scheduled_at' => $newsletter ? $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SCHEDULED_AT) : null,
+      'schedule_mode' => $newsletter ? $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SCHEDULE_MODE) : null,
+      'scheduled_local_date' => $newsletter ? $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_DATE) : null,
+      'scheduled_local_time' => $newsletter ? $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_TIME) : null,
       'utm_campaign' => $newsletter ? $newsletter->getGaCampaign() : '',
       'segment_ids' => $newsletter ? $newsletter->getSegmentIds() : [],
       'is_automation_newsletter' => $isAutomationNewsletter,
@@ -145,6 +149,30 @@ class EmailApiController {
       $this->updateScheduledAtOption($newsletter, $data['scheduled_at']);
     }
 
+    if (array_key_exists('schedule_mode', $data)) {
+      $this->updateScheduleModeOption($newsletter, $data['schedule_mode']);
+    }
+
+    if (array_key_exists('scheduled_local_date', $data)) {
+      $this->updateScheduledLocalOption(
+        $newsletter,
+        NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_DATE,
+        $data['scheduled_local_date'],
+        'Y-m-d',
+        'Invalid scheduled_local_date format. Expected a Y-m-d date string.'
+      );
+    }
+
+    if (array_key_exists('scheduled_local_time', $data)) {
+      $this->updateScheduledLocalOption(
+        $newsletter,
+        NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_TIME,
+        $data['scheduled_local_time'],
+        'H:i:s',
+        'Invalid scheduled_local_time format. Expected a H:i:s time string.'
+      );
+    }
+
     if (array_key_exists('share_visibility', $data)) {
       $this->updateOption(
         $newsletter,
@@ -203,6 +231,36 @@ class EmailApiController {
     }
 
     $option->setValue($optionValue);
+  }
+
+  private function updateScheduleModeOption(NewsletterEntity $newsletter, $scheduleModeValue): void {
+    $allowedModes = [
+      TimeZoneCampaignScheduler::SCHEDULE_MODE_WEBSITE_TIME,
+      TimeZoneCampaignScheduler::SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+    ];
+    if ($scheduleModeValue !== null && $scheduleModeValue !== '' && !in_array($scheduleModeValue, $allowedModes, true)) {
+      throw new UnexpectedValueException('Invalid schedule_mode value.');
+    }
+
+    $this->updateOption($newsletter, NewsletterOptionFieldEntity::NAME_SCHEDULE_MODE, $scheduleModeValue);
+
+    // Subscriber timezone scheduling has no scheduled_at datetime, so the isScheduled
+    // option derived from scheduled_at would stay '0' and sending would dispatch to the
+    // immediate path instead of TimeZoneCampaignScheduler.
+    if ($scheduleModeValue === TimeZoneCampaignScheduler::SCHEDULE_MODE_SUBSCRIBER_TIMEZONE) {
+      $this->updateOption($newsletter, NewsletterOptionFieldEntity::NAME_IS_SCHEDULED, '1');
+    }
+  }
+
+  private function updateScheduledLocalOption(NewsletterEntity $newsletter, string $optionName, $value, string $format, string $errorMessage): void {
+    if ($value !== null && $value !== '') {
+      $parsed = is_string($value) ? \DateTimeImmutable::createFromFormat("!{$format}", $value) : false;
+      if (!$parsed || $parsed->format($format) !== $value) {
+        throw new UnexpectedValueException($errorMessage);
+      }
+    }
+
+    $this->updateOption($newsletter, $optionName, $value);
   }
 
   private function updateScheduledAtOption($newsletter, $scheduledAtValue): void {
@@ -287,6 +345,9 @@ class EmailApiController {
       'preview_url' => Builder::string(),
       'deleted_at' => Builder::string()->nullable(),
       'scheduled_at' => Builder::string()->nullable(),
+      'schedule_mode' => Builder::string()->nullable(),
+      'scheduled_local_date' => Builder::string()->nullable(),
+      'scheduled_local_time' => Builder::string()->nullable(),
       'utm_campaign' => Builder::string(),
       'segment_ids' => Builder::array(),
       'is_automation_newsletter' => Builder::boolean(),

--- a/mailpoet/tests/javascript/newsletters/send/schedule-mode.spec.ts
+++ b/mailpoet/tests/javascript/newsletters/send/schedule-mode.spec.ts
@@ -4,9 +4,6 @@ import {
   SCHEDULE_MODE_WEBSITE_TIME,
   getScheduleMode,
   getScheduleModeOptionChanges,
-  getTomorrowLocalDate,
-  isLocalDateTimeInFuture,
-  normalizeLocalTime,
   snapLocalDateTimeToQuarterHour,
 } from '../../../../assets/js/src/common/newsletter-schedule-mode';
 
@@ -69,57 +66,6 @@ describe('newsletter schedule mode helpers', () => {
         scheduledLocalDate: '2026-08-01',
         scheduledLocalTime: '21:45:00',
       });
-    });
-  });
-
-  describe('normalizeLocalTime', () => {
-    it('pads HH:MM values with seconds', () => {
-      expect(normalizeLocalTime('08:15')).to.equal('08:15:00');
-    });
-
-    it('keeps HH:MM:SS values unchanged', () => {
-      expect(normalizeLocalTime('08:15:00')).to.equal('08:15:00');
-    });
-  });
-
-  describe('isLocalDateTimeInFuture', () => {
-    const now = new Date('2026-07-08T12:00:00');
-
-    it('returns false for missing values', () => {
-      expect(isLocalDateTimeInFuture(undefined, undefined, now)).to.equal(
-        false,
-      );
-      expect(isLocalDateTimeInFuture('2026-07-09', '', now)).to.equal(false);
-      expect(isLocalDateTimeInFuture('', '08:00:00', now)).to.equal(false);
-    });
-
-    it('returns false for invalid values', () => {
-      expect(isLocalDateTimeInFuture('not-a-date', '08:00:00', now)).to.equal(
-        false,
-      );
-    });
-
-    it('compares the local date and time against the reference date', () => {
-      expect(isLocalDateTimeInFuture('2026-07-08', '12:15:00', now)).to.equal(
-        true,
-      );
-      expect(isLocalDateTimeInFuture('2026-07-08', '11:45:00', now)).to.equal(
-        false,
-      );
-      expect(isLocalDateTimeInFuture('2026-07-09', '08:00', now)).to.equal(
-        true,
-      );
-    });
-  });
-
-  describe('getTomorrowLocalDate', () => {
-    it('returns the next day in Y-m-d format', () => {
-      expect(getTomorrowLocalDate(new Date('2026-07-08T12:00:00'))).to.equal(
-        '2026-07-09',
-      );
-      expect(getTomorrowLocalDate(new Date('2026-12-31T23:00:00'))).to.equal(
-        '2027-01-01',
-      );
     });
   });
 

--- a/mailpoet/tests/javascript/newsletters/send/schedule-mode.spec.ts
+++ b/mailpoet/tests/javascript/newsletters/send/schedule-mode.spec.ts
@@ -1,0 +1,137 @@
+import {
+  DEFAULT_SCHEDULED_LOCAL_TIME,
+  SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+  SCHEDULE_MODE_WEBSITE_TIME,
+  getLocalTimeOfDayItems,
+  getScheduleMode,
+  getScheduleModeOptionChanges,
+  getTomorrowLocalDate,
+  isLocalDateTimeInFuture,
+  normalizeLocalTime,
+} from '../../../../assets/js/src/common/newsletter-schedule-mode';
+
+describe('newsletter schedule mode helpers', () => {
+  describe('getScheduleMode', () => {
+    it('defaults missing and unknown values to website time', () => {
+      expect(getScheduleMode(undefined)).to.equal(SCHEDULE_MODE_WEBSITE_TIME);
+      expect(getScheduleMode(null)).to.equal(SCHEDULE_MODE_WEBSITE_TIME);
+      expect(getScheduleMode('')).to.equal(SCHEDULE_MODE_WEBSITE_TIME);
+      expect(getScheduleMode('something_else')).to.equal(
+        SCHEDULE_MODE_WEBSITE_TIME,
+      );
+    });
+
+    it('recognizes the subscriber timezone mode', () => {
+      expect(getScheduleMode(SCHEDULE_MODE_SUBSCRIBER_TIMEZONE)).to.equal(
+        SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+      );
+    });
+  });
+
+  describe('getScheduleModeOptionChanges', () => {
+    it('clears the local date and time when switching to website time', () => {
+      expect(
+        getScheduleModeOptionChanges(
+          SCHEDULE_MODE_WEBSITE_TIME,
+          { scheduledLocalDate: '2026-07-10', scheduledLocalTime: '09:15:00' },
+          '2026-07-09',
+        ),
+      ).to.deep.equal({
+        scheduleMode: SCHEDULE_MODE_WEBSITE_TIME,
+        scheduledLocalDate: '',
+        scheduledLocalTime: '',
+      });
+    });
+
+    it('seeds defaults when switching to subscriber timezone without values', () => {
+      expect(
+        getScheduleModeOptionChanges(
+          SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+          {},
+          '2026-07-09',
+        ),
+      ).to.deep.equal({
+        scheduleMode: SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+        scheduledLocalDate: '2026-07-09',
+        scheduledLocalTime: DEFAULT_SCHEDULED_LOCAL_TIME,
+      });
+    });
+
+    it('keeps existing local date and time when switching to subscriber timezone', () => {
+      expect(
+        getScheduleModeOptionChanges(
+          SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+          { scheduledLocalDate: '2026-08-01', scheduledLocalTime: '21:45:00' },
+          '2026-07-09',
+        ),
+      ).to.deep.equal({
+        scheduleMode: SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+        scheduledLocalDate: '2026-08-01',
+        scheduledLocalTime: '21:45:00',
+      });
+    });
+  });
+
+  describe('normalizeLocalTime', () => {
+    it('pads HH:MM values with seconds', () => {
+      expect(normalizeLocalTime('08:15')).to.equal('08:15:00');
+    });
+
+    it('keeps HH:MM:SS values unchanged', () => {
+      expect(normalizeLocalTime('08:15:00')).to.equal('08:15:00');
+    });
+  });
+
+  describe('isLocalDateTimeInFuture', () => {
+    const now = new Date('2026-07-08T12:00:00');
+
+    it('returns false for missing values', () => {
+      expect(isLocalDateTimeInFuture(undefined, undefined, now)).to.equal(
+        false,
+      );
+      expect(isLocalDateTimeInFuture('2026-07-09', '', now)).to.equal(false);
+      expect(isLocalDateTimeInFuture('', '08:00:00', now)).to.equal(false);
+    });
+
+    it('returns false for invalid values', () => {
+      expect(isLocalDateTimeInFuture('not-a-date', '08:00:00', now)).to.equal(
+        false,
+      );
+    });
+
+    it('compares the local date and time against the reference date', () => {
+      expect(isLocalDateTimeInFuture('2026-07-08', '12:15:00', now)).to.equal(
+        true,
+      );
+      expect(isLocalDateTimeInFuture('2026-07-08', '11:45:00', now)).to.equal(
+        false,
+      );
+      expect(isLocalDateTimeInFuture('2026-07-09', '08:00', now)).to.equal(
+        true,
+      );
+    });
+  });
+
+  describe('getTomorrowLocalDate', () => {
+    it('returns the next day in Y-m-d format', () => {
+      expect(getTomorrowLocalDate(new Date('2026-07-08T12:00:00'))).to.equal(
+        '2026-07-09',
+      );
+      expect(getTomorrowLocalDate(new Date('2026-12-31T23:00:00'))).to.equal(
+        '2027-01-01',
+      );
+    });
+  });
+
+  describe('getLocalTimeOfDayItems', () => {
+    it('generates 15-minute steps for the whole day', () => {
+      const items = getLocalTimeOfDayItems();
+      const keys = Object.keys(items);
+      expect(keys).to.have.length(96);
+      expect(keys[0]).to.equal('00:00:00');
+      expect(keys[1]).to.equal('00:15:00');
+      expect(keys[95]).to.equal('23:45:00');
+      expect(items['08:30:00']).to.equal('08:30');
+    });
+  });
+});

--- a/mailpoet/tests/javascript/newsletters/send/schedule-mode.spec.ts
+++ b/mailpoet/tests/javascript/newsletters/send/schedule-mode.spec.ts
@@ -2,12 +2,12 @@ import {
   DEFAULT_SCHEDULED_LOCAL_TIME,
   SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
   SCHEDULE_MODE_WEBSITE_TIME,
-  getLocalTimeOfDayItems,
   getScheduleMode,
   getScheduleModeOptionChanges,
   getTomorrowLocalDate,
   isLocalDateTimeInFuture,
   normalizeLocalTime,
+  snapLocalDateTimeToQuarterHour,
 } from '../../../../assets/js/src/common/newsletter-schedule-mode';
 
 describe('newsletter schedule mode helpers', () => {
@@ -123,15 +123,30 @@ describe('newsletter schedule mode helpers', () => {
     });
   });
 
-  describe('getLocalTimeOfDayItems', () => {
-    it('generates 15-minute steps for the whole day', () => {
-      const items = getLocalTimeOfDayItems();
-      const keys = Object.keys(items);
-      expect(keys).to.have.length(96);
-      expect(keys[0]).to.equal('00:00:00');
-      expect(keys[1]).to.equal('00:15:00');
-      expect(keys[95]).to.equal('23:45:00');
-      expect(items['08:30:00']).to.equal('08:30');
+  describe('snapLocalDateTimeToQuarterHour', () => {
+    it('keeps values already on a quarter hour', () => {
+      expect(
+        snapLocalDateTimeToQuarterHour('2026-07-10T08:15:00'),
+      ).to.deep.equal({ localDate: '2026-07-10', localTime: '08:15:00' });
+    });
+
+    it('snaps to the nearest quarter hour', () => {
+      expect(
+        snapLocalDateTimeToQuarterHour('2026-07-10T08:07:00'),
+      ).to.deep.equal({ localDate: '2026-07-10', localTime: '08:00:00' });
+      expect(
+        snapLocalDateTimeToQuarterHour('2026-07-10T08:08:00'),
+      ).to.deep.equal({ localDate: '2026-07-10', localTime: '08:15:00' });
+    });
+
+    it('rolls over to the next day when rounding up near midnight', () => {
+      expect(
+        snapLocalDateTimeToQuarterHour('2026-07-10T23:53:00'),
+      ).to.deep.equal({ localDate: '2026-07-11', localTime: '00:00:00' });
+    });
+
+    it('returns null for invalid values', () => {
+      expect(snapLocalDateTimeToQuarterHour('not-a-date')).to.equal(null);
     });
   });
 });


### PR DESCRIPTION
## Description

UI for a scheduling mode selector — "Website time" vs "Subscriber’s time zone" for both the legacy send page and the block email editor. Everything is still behind the `send_by_timezone` feature flag (default off).

## Code review notes

_N/A_

## QA notes

Needs the `send_by_timezone` flag enabled in `/wp-admin/admin.php?page=mailpoet-experimental`. With the flag off, both editors must behave exactly as before. With the flag on: scheduling in subscriber-timezone mode creates one queue per subscriber timezone (24h minimum lead time, enforced server-side).

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8008

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

| Before | After | 
| ----- | ----- | 
| <img width="426" height="157" alt="Screenshot 2026-07-09 at 08 56 28" src="https://github.com/user-attachments/assets/f0e1b7dc-9a67-4233-9e52-52c7ede523ca" /> | <img width="435" height="266" alt="Screenshot 2026-07-09 at 09 00 24" src="https://github.com/user-attachments/assets/59bc6a35-9ddc-4bcb-95af-7dc7a16a9a1a" /> <img width="425" height="294" alt="Screenshot 2026-07-09 at 09 28 57" src="https://github.com/user-attachments/assets/498156a2-9345-4e86-bef5-e3bbc3db1f42" /> |
| <img width="302" height="532" alt="Screenshot 2026-07-09 at 09 49 13" src="https://github.com/user-attachments/assets/7a3c7c51-faa8-40b0-873b-eab2b865626e" /> | <img width="306" height="587" alt="Screenshot 2026-07-09 at 10 00 11" src="https://github.com/user-attachments/assets/fc633ada-ee61-4653-99ec-42f6610ce0be" /> <img width="302" height="674" alt="Screenshot 2026-07-09 at 10 00 52" src="https://github.com/user-attachments/assets/34f2ac66-f35d-4a79-88ce-d100047425c5" /> |


## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`) — not needed, feature is behind a default-off flag
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8008-add-timezone-scheduling-mode-selector-to-newsletter-send-ui)

_The latest successful build from `stomail-8008-add-timezone-scheduling-mode-selector-to-newsletter-send-ui` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->