### PR TITLE
Display timezone scheduling status in listing and campaign stats

### DIFF
--- a/mailpoet/assets/js/src/common/dataviews/index.ts
+++ b/mailpoet/assets/js/src/common/dataviews/index.ts
@@ -7,6 +7,7 @@ export {
   getDataViewsPreference,
   getDataViewsPreferenceKey,
   getPersistedDataViewsPreference,
+  getStoredDataViewsFieldIds,
   persistDataViewsPreference,
   usePersistedDataViewsPreference,
 } from './preferences';

--- a/mailpoet/assets/js/src/common/dataviews/preferences.ts
+++ b/mailpoet/assets/js/src/common/dataviews/preferences.ts
@@ -112,6 +112,23 @@ function getFieldPreference(
   return undefined;
 }
 
+// Raw stored column selection, unfiltered by field availability. Lets pages
+// with fields that only exist for some items (e.g. the sending status time
+// zone column) distinguish "the user removed this column" from "the column
+// was unavailable when the preference was read".
+export function getStoredDataViewsFieldIds(name: string): string[] | undefined {
+  const preference = readPreference(
+    VIEW_PREFERENCES_SCOPE,
+    getDataViewsPreferenceKey(name),
+  );
+  if (!isRecord(preference) || !Array.isArray(preference.fields)) {
+    return undefined;
+  }
+  return preference.fields.filter(
+    (field): field is string => typeof field === 'string',
+  );
+}
+
 export function getDataViewsPreference<T>(
   name: string,
   defaultView: View,

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -260,7 +260,10 @@ function NewsletterStatsInfo({ newsletter }: Props) {
             {MailPoet.Date.time(newsletterDate)}
           </b>
           {isTimezoneCampaignQueue(newsletter.queue) && (
-            <TimezoneCampaignIcon newsletterId={newsletter.id} />
+            <TimezoneCampaignIcon
+              newsletterId={newsletter.id}
+              sent={newsletter.status === 'sent'}
+            />
           )}
         </div>
         {Array.isArray(newsletter.segments) && newsletter.segments.length && (

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -14,13 +14,13 @@ import { MailPoet } from 'mailpoet';
 import { Heading } from 'common/typography/heading/heading';
 import { Grid } from 'common/grid';
 import {
-  confirmAlert,
   FilterSegmentTag,
   SegmentTags,
   Tag,
   getNewsletterStatusString,
 } from 'common';
 import { duplicateNewsletter as duplicateNewsletterRest } from 'newsletters/api';
+import { confirmEdit } from 'newsletters/listings/utils.jsx';
 import { isTimezoneCampaignQueue } from 'newsletters/timezone-campaign';
 import { TimezoneCampaignIcon } from 'newsletters/timezone-campaign-icon';
 import { ExportButton } from './export-button';
@@ -40,28 +40,6 @@ const redirectToNewsletterHome = () => {
 
 const getEditorLink = (newsletter: NewsletterType) =>
   MailPoet.getActiveEmailEditorUrl(newsletter);
-
-const editNewsletter = (newsletter: NewsletterType) => {
-  const editorHref = getEditorLink(newsletter);
-
-  if (
-    !newsletter.queue ||
-    newsletter.status !== 'sending' ||
-    newsletter.queue.status !== null
-  ) {
-    window.location.href = editorHref;
-  } else {
-    confirmAlert({
-      message: __(
-        'Sending is in progress. Do you want to pause sending and edit the newsletter?',
-        'mailpoet',
-      ),
-      onConfirm: () => {
-        window.location.href = `${editorHref}&pauseConfirmed=yes`;
-      },
-    });
-  }
-};
 
 const duplicateNewsletter = (
   newsletter: NewsletterType,
@@ -341,7 +319,7 @@ function NewsletterStatsInfo({ newsletter }: Props) {
                 <Button
                   disabled={newsletter.type !== 'standard'}
                   onClick={() => {
-                    editNewsletter(newsletter);
+                    confirmEdit(newsletter);
                   }}
                   variant="primary"
                 >

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -21,6 +21,8 @@ import {
   getNewsletterStatusString,
 } from 'common';
 import { duplicateNewsletter as duplicateNewsletterRest } from 'newsletters/api';
+import { isTimezoneCampaignQueue } from 'newsletters/timezone-campaign';
+import { TimezoneCampaignIcon } from 'newsletters/timezone-campaign-icon';
 import { ExportButton } from './export-button';
 import { NewsletterType } from './newsletter-type';
 
@@ -279,6 +281,9 @@ function NewsletterStatsInfo({ newsletter }: Props) {
             {' • '}
             {MailPoet.Date.time(newsletterDate)}
           </b>
+          {isTimezoneCampaignQueue(newsletter.queue) && (
+            <TimezoneCampaignIcon newsletterId={newsletter.id} />
+          )}
         </div>
         {Array.isArray(newsletter.segments) && newsletter.segments.length && (
           <div>

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
@@ -8,17 +8,20 @@ import { RemoveWrapMargin } from 'common/remove-wrap-margin/remove-wrap-margin';
 import { Tabs } from 'common/tabs/tabs';
 import { Tab } from 'common/tabs/tab';
 import { ErrorBoundary } from 'common';
+import { isTimezoneCampaignQueue } from 'newsletters/timezone-campaign';
 import { NewsletterGeneralStats } from './newsletter-general-stats';
 import { NewsletterType } from './newsletter-type';
 import { NewsletterStatsInfo } from './newsletter-stats-info';
 import { PremiumBanner } from './premium-banner';
+import { TimezoneSchedule } from './timezone-schedule';
 
 type StatsTabKey =
   | 'clicked'
   | 'products'
   | 'engagement'
   | 'bounces'
-  | 'unsubscribe-reasons';
+  | 'unsubscribe-reasons'
+  | 'timezones';
 
 type State = {
   item?: NewsletterType;
@@ -31,6 +34,7 @@ const statsTabKeys: StatsTabKey[] = [
   'engagement',
   'bounces',
   'unsubscribe-reasons',
+  'timezones',
 ];
 
 const legacyListingParamKeys = [
@@ -125,7 +129,11 @@ export function CampaignStatsPage() {
       return;
     }
 
-    if (requestedTab === 'products' && !MailPoet.isWoocommerceActive) {
+    if (
+      (requestedTab === 'products' && !MailPoet.isWoocommerceActive) ||
+      (requestedTab === 'timezones' &&
+        !isTimezoneCampaignQueue(newsletter.queue))
+    ) {
       navigate(getStatsTabUrl(newsletter.id, 'clicked'), { replace: true });
     }
   }, [loading, navigate, newsletter, requestedTab]);
@@ -137,6 +145,9 @@ export function CampaignStatsPage() {
   }
 
   if (activeTab === 'products' && !MailPoet.isWoocommerceActive) {
+    activeTab = 'clicked';
+  }
+  if (activeTab === 'timezones' && !isTimezoneCampaignQueue(newsletter.queue)) {
     activeTab = 'clicked';
   }
 
@@ -229,6 +240,18 @@ export function CampaignStatsPage() {
               newsletter,
             )}
           </Tab>
+
+          {isTimezoneCampaignQueue(newsletter.queue) && (
+            <Tab
+              key="timezones"
+              title={__('Time zones', 'mailpoet')}
+              automationId="timezones-tab"
+            >
+              <ErrorBoundary>
+                <TimezoneSchedule newsletter={newsletter} />
+              </ErrorBoundary>
+            </Tab>
+          )}
         </Tabs>
       </div>
     </>

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/timezone-schedule.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/timezone-schedule.tsx
@@ -36,6 +36,24 @@ function formatDateTime(value: string): string {
   return `${MailPoet.Date.short(value)} ${MailPoet.Date.time(value)}`;
 }
 
+// Batch scheduled_at values are UTC; each row's send moment only makes sense
+// as the wall clock of that batch's recipient time zone. Falls back to site
+// time when the zone is not IANA-resolvable (e.g. an offset like "+02:00").
+function formatDateTimeInZone(value: string, timeZone: string | null): string {
+  if (timeZone) {
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+        timeZone,
+      }).format(new Date(`${value.replace(' ', 'T')}Z`));
+    } catch {
+      // fall through to site-time formatting
+    }
+  }
+  return formatDateTime(value);
+}
+
 const fields: Field<TimezoneRow>[] = [
   {
     id: 'timezone',
@@ -59,7 +77,9 @@ const fields: Field<TimezoneRow>[] = [
     enableGlobalSearch: false,
     getValue: ({ item }) => item.scheduledAt ?? '',
     render: ({ item }) =>
-      item.scheduledAt ? formatDateTime(item.scheduledAt) : '—',
+      item.scheduledAt
+        ? formatDateTimeInZone(item.scheduledAt, item.timezone)
+        : '—',
   },
   {
     id: 'status',

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/timezone-schedule.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/timezone-schedule.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState } from 'react';
+import { __ } from '@wordpress/i18n';
+import {
+  DataViews,
+  filterSortAndPaginate,
+  type Field,
+  type View,
+} from '@wordpress/dataviews';
+import { MailPoet } from 'mailpoet';
+import {
+  formatTimezoneLabel,
+  getBatchStatusLabel,
+  getScheduledWindow,
+  getTimezoneBreakdown,
+  type TimezoneBreakdownEntry,
+} from 'newsletters/timezone-campaign';
+import { NewsletterType } from './newsletter-type';
+
+type Props = {
+  newsletter: NewsletterType;
+};
+
+type TimezoneRow = TimezoneBreakdownEntry & { id: number };
+
+const DEFAULT_VIEW: View = {
+  type: 'table',
+  page: 1,
+  perPage: 25,
+  sort: { field: 'scheduledAt', direction: 'asc' },
+  fields: ['scheduledAt', 'status', 'sent'],
+  titleField: 'timezone',
+  showTitle: true,
+};
+
+function formatDateTime(value: string): string {
+  return `${MailPoet.Date.short(value)} ${MailPoet.Date.time(value)}`;
+}
+
+const fields: Field<TimezoneRow>[] = [
+  {
+    id: 'timezone',
+    label: __('Time zone', 'mailpoet'),
+    type: 'text',
+    enableSorting: true,
+    enableGlobalSearch: false,
+    getValue: ({ item }) =>
+      formatTimezoneLabel(item.timezone, item.fallbackUsed),
+    render: ({ item }) => (
+      <span data-automation-id={`timezone_schedule_zone_${item.id}`}>
+        {formatTimezoneLabel(item.timezone, item.fallbackUsed)}
+      </span>
+    ),
+  },
+  {
+    id: 'scheduledAt',
+    label: __('Scheduled for', 'mailpoet'),
+    type: 'datetime',
+    enableSorting: true,
+    enableGlobalSearch: false,
+    getValue: ({ item }) => item.scheduledAt ?? '',
+    render: ({ item }) =>
+      item.scheduledAt ? formatDateTime(item.scheduledAt) : '—',
+  },
+  {
+    id: 'status',
+    label: __('Status', 'mailpoet'),
+    type: 'text',
+    enableSorting: true,
+    enableGlobalSearch: false,
+    getValue: ({ item }) => getBatchStatusLabel(item.status),
+    render: ({ item }) => getBatchStatusLabel(item.status),
+  },
+  {
+    id: 'sent',
+    label: __('Sent', 'mailpoet'),
+    enableSorting: true,
+    enableGlobalSearch: false,
+    getValue: ({ item }) => item.countProcessed,
+    render: ({ item }) =>
+      `${MailPoet.Num.toLocaleFixed(
+        item.countProcessed,
+      )} / ${MailPoet.Num.toLocaleFixed(item.countTotal)}`,
+  },
+];
+
+export function TimezoneSchedule({ newsletter }: Props) {
+  const [view, setView] = useState<View>(DEFAULT_VIEW);
+
+  const rows = useMemo<TimezoneRow[]>(
+    () =>
+      getTimezoneBreakdown(newsletter.queue).map((entry, index) => ({
+        ...entry,
+        id: index,
+      })),
+    [newsletter.queue],
+  );
+
+  const { data, paginationInfo } = useMemo(
+    () => filterSortAndPaginate(rows, view, fields),
+    [rows, view],
+  );
+
+  const window = getScheduledWindow(newsletter.queue);
+
+  return (
+    <div
+      className="mailpoet-stats-timezone-schedule"
+      data-automation-id="timezone-schedule-stats"
+    >
+      {window && (
+        <p>
+          {
+            // translators: %1$s is the date and time when the first time zone batch sends, %2$s when the last one sends.
+            __('Sends from %1$s to %2$s', 'mailpoet')
+              .replace('%1$s', formatDateTime(window.first))
+              .replace('%2$s', formatDateTime(window.last))
+          }
+        </p>
+      )}
+      <div className="mailpoet-dataviews mailpoet-listing">
+        <DataViews<TimezoneRow>
+          data={data}
+          fields={fields}
+          view={view}
+          onChangeView={setView}
+          paginationInfo={paginationInfo}
+          defaultLayouts={{ table: {} }}
+          getItemId={(item) => String(item.id)}
+          empty={<p>{__('No time zone batches found.', 'mailpoet')}</p>}
+        >
+          <DataViews.Layout />
+          <DataViews.Footer />
+        </DataViews>
+      </div>
+    </div>
+  );
+}
+
+TimezoneSchedule.displayName = 'TimezoneSchedule';

--- a/mailpoet/assets/js/src/newsletters/listings/queue-status.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/queue-status.tsx
@@ -109,17 +109,25 @@ type QueueStatusProps = {
 function QueueStatus({ newsletter, mailerLog }: QueueStatusProps) {
   // A running timezone campaign (authoritative null status) aggregates
   // scheduled_at as the NEXT future batch; passing that date would classify
-  // the row as "scheduled" and hide the aggregate progress.
+  // the row as "scheduled" and hide the aggregate progress. Between batches
+  // the aggregate status falls back to "scheduled" even though recipients
+  // were already processed, so a started campaign counts as running too.
+  const isTimezoneCampaign = isTimezoneCampaignQueue(newsletter.queue);
+  const hasStartedSending =
+    parseInt(newsletter.queue.count_processed, 10) > 0 ||
+    newsletter.status === NewsletterStatusEnum.Sending;
   const isRunningTimezoneCampaign =
-    isTimezoneCampaignQueue(newsletter.queue) &&
-    newsletter.queue.status === null;
+    isTimezoneCampaign &&
+    (newsletter.queue.status === null ||
+      (newsletter.queue.status === 'scheduled' && hasStartedSending));
   const newsletterDate = isRunningTimezoneCampaign
     ? newsletter.sent_at
     : newsletter.sent_at || newsletter.queue.scheduled_at;
   const isNewsletterCancelled =
     newsletter.queue && newsletter.queue.status === 'cancelled';
   const isNewsletterSending =
-    newsletter.queue && newsletter.queue.status !== 'scheduled';
+    newsletter.queue &&
+    (newsletter.queue.status !== 'scheduled' || isRunningTimezoneCampaign);
   const isMtaPaused = mailerLog.status === 'paused';
 
   const renderSentNewsletter = (

--- a/mailpoet/assets/js/src/newsletters/listings/queue-status.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/queue-status.tsx
@@ -10,6 +10,7 @@ import {
   NewsLetter,
   NewsletterStatus as NewsletterStatusEnum,
 } from 'common/newsletter';
+import { isTimezoneCampaignQueue } from 'newsletters/timezone-campaign';
 
 type QueueSendingProps = {
   newsletter: NewsLetter;
@@ -106,7 +107,15 @@ type QueueStatusProps = {
 };
 
 function QueueStatus({ newsletter, mailerLog }: QueueStatusProps) {
-  const newsletterDate = newsletter.sent_at || newsletter.queue.scheduled_at;
+  // A running timezone campaign (authoritative null status) aggregates
+  // scheduled_at as the NEXT future batch; passing that date would classify
+  // the row as "scheduled" and hide the aggregate progress.
+  const isRunningTimezoneCampaign =
+    isTimezoneCampaignQueue(newsletter.queue) &&
+    newsletter.queue.status === null;
+  const newsletterDate = isRunningTimezoneCampaign
+    ? newsletter.sent_at
+    : newsletter.sent_at || newsletter.queue.scheduled_at;
   const isNewsletterCancelled =
     newsletter.queue && newsletter.queue.status === 'cancelled';
   const isNewsletterSending =

--- a/mailpoet/assets/js/src/newsletters/listings/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.tsx
@@ -156,7 +156,10 @@ function buildFields(
               </>
             )}
             {isTimezoneCampaign && (
-              <TimezoneCampaignIcon newsletterId={item.id} />
+              <TimezoneCampaignIcon
+                newsletterId={item.id}
+                sent={item.status === 'sent'}
+              />
             )}
           </>
         );

--- a/mailpoet/assets/js/src/newsletters/listings/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.tsx
@@ -9,6 +9,8 @@ import { ErrorBoundary, withBoundary } from 'common';
 import type { NewsLetter } from 'common/newsletter';
 import { NewsletterTypes } from 'newsletters/types';
 import { QueueStatus } from 'newsletters/listings/queue-status';
+import { isTimezoneCampaignQueue } from 'newsletters/timezone-campaign';
+import { TimezoneCampaignIcon } from 'newsletters/timezone-campaign-icon';
 import { Statistics } from 'newsletters/listings/statistics.jsx';
 import { addStatsCTAAction, confirmEdit } from 'newsletters/listings/utils.jsx';
 import {
@@ -139,14 +141,26 @@ function buildFields(
       type: 'datetime',
       enableSorting: true,
       enableGlobalSearch: false,
-      render: ({ item }) =>
-        item.sent_at ? (
+      render: ({ item }) => {
+        const isTimezoneCampaign = isTimezoneCampaignQueue(
+          asNewsLetter(item).queue,
+        );
+        if (!item.sent_at && !isTimezoneCampaign) return null;
+        return (
           <>
-            {MailPoet.Date.short(item.sent_at)}
-            <br />
-            {MailPoet.Date.time(item.sent_at)}
+            {item.sent_at && (
+              <>
+                {MailPoet.Date.short(item.sent_at)}
+                <br />
+                {MailPoet.Date.time(item.sent_at)}
+              </>
+            )}
+            {isTimezoneCampaign && (
+              <TimezoneCampaignIcon newsletterId={item.id} />
+            )}
           </>
-        ) : null,
+        );
+      },
     },
   ];
 }

--- a/mailpoet/assets/js/src/newsletters/listings/utils.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/utils.jsx
@@ -3,6 +3,10 @@ import { Hooks } from 'wp-js-hooks';
 import { MailPoet } from 'mailpoet';
 import jQuery from 'jquery';
 import { confirmAlert } from 'common/confirm-alert.jsx';
+import {
+  hasStartedTimezoneBatches,
+  isTimezoneCampaignQueue,
+} from 'newsletters/timezone-campaign';
 
 export const trackStatsCTAClicked = () => {
   MailPoet.trackEvent('User has clicked a CTA to view detailed stats');
@@ -92,6 +96,24 @@ export const automationTypes = ['automation', 'automation_transactional'];
 
 export const confirmEdit = (newsletter) => {
   const editorHref = MailPoet.getActiveEmailEditorUrl(newsletter);
+
+  // A subscriber time zone campaign can no longer be edited once one of its
+  // batches has started; the backend rejects the save with the same message
+  // (canReplaceScheduledCampaign guard), so surface it before opening the
+  // editor instead of failing on save.
+  if (
+    isTimezoneCampaignQueue(newsletter.queue) &&
+    hasStartedTimezoneBatches(newsletter.queue)
+  ) {
+    MailPoet.Notice.error(
+      __(
+        'This email can no longer be edited because one or more time zone batches have already started.',
+        'mailpoet',
+      ),
+      { scroll: true },
+    );
+    return;
+  }
 
   // A newsletter that is mid-send (status `sending`, queue not yet paused)
   // must be paused before it can be edited.

--- a/mailpoet/assets/js/src/newsletters/sending-status/api.ts
+++ b/mailpoet/assets/js/src/newsletters/sending-status/api.ts
@@ -34,6 +34,8 @@ export type SendingStatusItem = {
   processed: number;
   failed: number;
   error: string | null;
+  timezone: string | null;
+  timezoneFallbackUsed: boolean;
 };
 
 // Mailer / cron envelope fields the endpoint appends to the listing response;

--- a/mailpoet/assets/js/src/newsletters/sending-status/sending-status.tsx
+++ b/mailpoet/assets/js/src/newsletters/sending-status/sending-status.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import jQuery from 'jquery';
 import { Link, useParams } from 'react-router-dom';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Notice } from '@wordpress/components';
 import {
   DataViews,
@@ -24,6 +24,7 @@ import {
   checkCronStatus,
   checkMailerStatus,
 } from 'newsletters/listings/utils.jsx';
+import { formatTimezoneLabel } from 'newsletters/timezone-campaign';
 import { buildHash, parseHash } from 'newsletters/listings/hash-state';
 import {
   getSendingStatusSubscribers,
@@ -65,7 +66,7 @@ function StatsLink({ newsletter }: { newsletter: Newsletter }) {
   );
 }
 
-function buildFields(): Field<SendingStatusItem>[] {
+function buildFields(includeTimezone: boolean): Field<SendingStatusItem>[] {
   return [
     {
       id: 'subscriberId',
@@ -107,6 +108,28 @@ function buildFields(): Field<SendingStatusItem>[] {
         );
       },
     },
+    ...(includeTimezone
+      ? [
+          {
+            id: 'timezone',
+            label: __('Time zone', 'mailpoet'),
+            enableSorting: false,
+            enableGlobalSearch: false,
+            render: ({ item }) => (
+              <span
+                data-automation-id={`timezone_${item.taskId}_${item.subscriberId}`}
+              >
+                {item.timezone !== null
+                  ? formatTimezoneLabel(
+                      item.timezone,
+                      item.timezoneFallbackUsed,
+                    )
+                  : ''}
+              </span>
+            ),
+          } as Field<SendingStatusItem>,
+        ]
+      : []),
     {
       id: 'error',
       label: __('Failure reason (if applicable)', 'mailpoet'),
@@ -154,7 +177,8 @@ export function SendingStatus() {
     [baseUrl],
   );
   const [group, setGroup] = useState<string>(hashState.group ?? 'all');
-  const fields = useMemo(() => buildFields(), []);
+  const [includeTimezone, setIncludeTimezone] = useState(false);
+  const fields = useMemo(() => buildFields(includeTimezone), [includeTimezone]);
 
   const getPreferredView = useCallback(
     () =>
@@ -231,6 +255,29 @@ export function SendingStatus() {
     view,
     onChangeView,
   );
+
+  // The time zone column only exists for time zone campaigns, which is known
+  // once items arrive. Inject it into the visible columns a single time per
+  // mount so hiding it via the view config afterwards sticks.
+  const timezoneColumnInjected = useRef(false);
+  useEffect(() => {
+    if (timezoneColumnInjected.current) return;
+    if (!items.some((item) => item.timezone !== null)) return;
+    timezoneColumnInjected.current = true;
+    setIncludeTimezone(true);
+    setView((currentView) => {
+      const viewFields = currentView.fields ?? [];
+      if (viewFields.includes('timezone')) return currentView;
+      const failedIndex = viewFields.indexOf('failed');
+      const nextFields = [...viewFields];
+      nextFields.splice(
+        failedIndex >= 0 ? failedIndex + 1 : nextFields.length,
+        0,
+        'timezone',
+      );
+      return { ...currentView, fields: nextFields };
+    });
+  }, [items, setView]);
 
   useEffect(() => {
     // Compare against the preference-merged defaults, resolved at write time

--- a/mailpoet/assets/js/src/newsletters/sending-status/sending-status.tsx
+++ b/mailpoet/assets/js/src/newsletters/sending-status/sending-status.tsx
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import {
   getDataViewsPreference,
+  getStoredDataViewsFieldIds,
   usePersistedDataViewsPreference,
   useDataViewsQuery,
   type ListingGroup,
@@ -257,17 +258,46 @@ export function SendingStatus() {
   );
 
   // The time zone column only exists for time zone campaigns, which is known
-  // once items arrive. Inject it into the visible columns a single time per
-  // mount so hiding it via the view config afterwards sticks.
+  // once items arrive. The mount-time preference read filtered the column out
+  // (it was not an available field yet), so re-apply the user's raw stored
+  // choice: keep it hidden when they removed it, restore it when they kept
+  // it, and inject it after the status column when they never customized
+  // columns at all.
   const timezoneColumnInjected = useRef(false);
+
+  // The component stays mounted when the route id changes (e.g. navigating
+  // between sending status pages), so the time zone column state of the
+  // previous newsletter must not leak into the next one.
+  useEffect(() => {
+    timezoneColumnInjected.current = false;
+    setIncludeTimezone(false);
+    setView((currentView) =>
+      currentView.fields?.includes('timezone')
+        ? {
+            ...currentView,
+            fields: currentView.fields.filter((id) => id !== 'timezone'),
+          }
+        : currentView,
+    );
+  }, [newsletterId, setView]);
+
   useEffect(() => {
     if (timezoneColumnInjected.current) return;
     if (!items.some((item) => item.timezone !== null)) return;
     timezoneColumnInjected.current = true;
     setIncludeTimezone(true);
+    const storedFields = getStoredDataViewsFieldIds('sending-status');
     setView((currentView) => {
       const viewFields = currentView.fields ?? [];
       if (viewFields.includes('timezone')) return currentView;
+      if (storedFields) {
+        if (!storedFields.includes('timezone')) return currentView;
+        const knownIds = new Set([...viewFields, 'timezone']);
+        return {
+          ...currentView,
+          fields: storedFields.filter((id) => knownIds.has(id)),
+        };
+      }
       const failedIndex = viewFields.indexOf('failed');
       const nextFields = [...viewFields];
       nextFields.splice(

--- a/mailpoet/assets/js/src/newsletters/timezone-campaign-icon.tsx
+++ b/mailpoet/assets/js/src/newsletters/timezone-campaign-icon.tsx
@@ -1,0 +1,30 @@
+import { __ } from '@wordpress/i18n';
+import { Icon, globe } from '@wordpress/icons';
+import { Tooltip } from 'common/tooltip/tooltip';
+
+type Props = {
+  newsletterId: string;
+};
+
+export function TimezoneCampaignIcon({ newsletterId }: Props) {
+  const tooltipId = `timezone-campaign-${newsletterId}`;
+  return (
+    <span
+      data-tip
+      data-tooltip-id={tooltipId}
+      data-automation-id={`timezone_campaign_status_${newsletterId}`}
+      style={{ marginLeft: '4px' }}
+    >
+      <Icon
+        icon={globe}
+        size={20}
+        style={{ fill: 'currentColor', verticalAlign: 'middle' }}
+      />
+      <Tooltip place="right" id={tooltipId}>
+        {__("Sent in subscriber's time zone", 'mailpoet')}
+      </Tooltip>
+    </span>
+  );
+}
+
+TimezoneCampaignIcon.displayName = 'TimezoneCampaignIcon';

--- a/mailpoet/assets/js/src/newsletters/timezone-campaign-icon.tsx
+++ b/mailpoet/assets/js/src/newsletters/timezone-campaign-icon.tsx
@@ -4,9 +4,10 @@ import { Tooltip } from 'common/tooltip/tooltip';
 
 type Props = {
   newsletterId: string;
+  sent: boolean;
 };
 
-export function TimezoneCampaignIcon({ newsletterId }: Props) {
+export function TimezoneCampaignIcon({ newsletterId, sent }: Props) {
   const tooltipId = `timezone-campaign-${newsletterId}`;
   return (
     <span
@@ -21,7 +22,9 @@ export function TimezoneCampaignIcon({ newsletterId }: Props) {
         style={{ fill: 'currentColor', verticalAlign: 'middle' }}
       />
       <Tooltip place="right" id={tooltipId}>
-        {__("Sent in subscriber's time zone", 'mailpoet')}
+        {sent
+          ? __("Sent in subscriber's time zone", 'mailpoet')
+          : __("Sends in subscriber's time zone", 'mailpoet')}
       </Tooltip>
     </span>
   );

--- a/mailpoet/assets/js/src/newsletters/timezone-campaign.ts
+++ b/mailpoet/assets/js/src/newsletters/timezone-campaign.ts
@@ -1,0 +1,126 @@
+import { __ } from '@wordpress/i18n';
+
+export type TimezoneBreakdownEntry = {
+  timezone: string | null;
+  fallbackUsed: boolean;
+  scheduledAt: string | null;
+  status: string | null;
+  countTotal: number;
+  countProcessed: number;
+  countToProcess: number;
+};
+
+export type ScheduledWindow = {
+  first: string;
+  last: string;
+};
+
+// The listing and stats responses type `queue` loosely and use `false` when
+// a newsletter has no queue (legacy BC shape), so accept anything and narrow.
+type QueueLike = { meta?: unknown } | false | null | undefined;
+
+const getQueueMeta = (queue: QueueLike): Record<string, unknown> | null => {
+  if (!queue || typeof queue !== 'object') {
+    return null;
+  }
+  const { meta } = queue;
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+    return null;
+  }
+  return meta as Record<string, unknown>;
+};
+
+export const isTimezoneCampaignQueue = (queue: QueueLike): boolean =>
+  Boolean(getQueueMeta(queue)?.sendByTimezone);
+
+const toCount = (value: unknown): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0;
+};
+
+const toStringOrNull = (value: unknown): string | null =>
+  typeof value === 'string' && value !== '' ? value : null;
+
+export const getTimezoneBreakdown = (
+  queue: QueueLike,
+): TimezoneBreakdownEntry[] => {
+  const breakdown = getQueueMeta(queue)?.timezoneBreakdown;
+  if (!Array.isArray(breakdown)) {
+    return [];
+  }
+  return breakdown
+    .filter(
+      (entry): entry is Record<string, unknown> =>
+        Boolean(entry) && typeof entry === 'object' && !Array.isArray(entry),
+    )
+    .map((entry) => ({
+      timezone: toStringOrNull(entry.timezone),
+      fallbackUsed: Boolean(entry.fallback_used),
+      scheduledAt: toStringOrNull(entry.scheduled_at),
+      status: toStringOrNull(entry.status),
+      countTotal: toCount(entry.count_total),
+      countProcessed: toCount(entry.count_processed),
+      countToProcess: toCount(entry.count_to_process),
+    }));
+};
+
+export const getScheduledWindow = (
+  queue: QueueLike,
+): ScheduledWindow | null => {
+  const meta = getQueueMeta(queue);
+  const first = toStringOrNull(meta?.firstScheduledAt);
+  const last = toStringOrNull(meta?.lastScheduledAt);
+  return first && last ? { first, last } : null;
+};
+
+// A null batch status is authoritative and means the batch is actively
+// sending (the scheduler already picked its task up). It must not fall back
+// to any other label — see the response builders, which deliberately avoid
+// `??` for the same reason.
+export const getBatchStatusLabel = (status: string | null): string => {
+  if (status === null) {
+    return __('Sending', 'mailpoet');
+  }
+  switch (status) {
+    case 'scheduled':
+      return __('Scheduled', 'mailpoet');
+    case 'paused':
+      return __('Paused', 'mailpoet');
+    case 'completed':
+      return __('Sent', 'mailpoet');
+    case 'cancelled':
+      return __('Cancelled', 'mailpoet');
+    case 'invalid':
+      return __('Failed', 'mailpoet');
+    default:
+      return status;
+  }
+};
+
+export const formatTimezoneLabel = (
+  timezone: string | null,
+  fallbackUsed: boolean,
+): string => {
+  const name = timezone || __('Unknown', 'mailpoet');
+  if (!fallbackUsed) {
+    return name;
+  }
+  return (
+    // translators: %1$s is a time zone name. The suffix marks subscribers without a time zone of their own, who receive the email in the site's default time zone.
+    __('%1$s (site default)', 'mailpoet').replace('%1$s', name)
+  );
+};
+
+// Client-side mirror of the backend canReplaceScheduledCampaign() guard: a
+// batch is still replaceable while it is scheduled or paused with nothing
+// processed. Anything else (running, completed, cancelled, invalid, or a
+// batch with processed recipients) means the campaign can no longer be
+// edited. The server remains authoritative; this only enables a clean
+// message before the editor is opened.
+export const hasStartedTimezoneBatches = (queue: QueueLike): boolean =>
+  getTimezoneBreakdown(queue).some(
+    (entry) =>
+      entry.countProcessed > 0 ||
+      entry.status === null ||
+      !['scheduled', 'paused'].includes(entry.status),
+  );

--- a/mailpoet/assets/js/src/newsletters/timezone-campaign.ts
+++ b/mailpoet/assets/js/src/newsletters/timezone-campaign.ts
@@ -5,6 +5,7 @@ export type TimezoneBreakdownEntry = {
   fallbackUsed: boolean;
   scheduledAt: string | null;
   status: string | null;
+  inProgress: boolean;
   countTotal: number;
   countProcessed: number;
   countToProcess: number;
@@ -58,6 +59,7 @@ export const getTimezoneBreakdown = (
       fallbackUsed: Boolean(entry.fallback_used),
       scheduledAt: toStringOrNull(entry.scheduled_at),
       status: toStringOrNull(entry.status),
+      inProgress: Boolean(entry.in_progress),
       countTotal: toCount(entry.count_total),
       countProcessed: toCount(entry.count_processed),
       countToProcess: toCount(entry.count_to_process),
@@ -111,16 +113,18 @@ export const formatTimezoneLabel = (
   );
 };
 
-// Client-side mirror of the backend canReplaceScheduledCampaign() guard: a
+// Client-side mirror of the backend isReplaceableScheduledQueue() guard: a
 // batch is still replaceable while it is scheduled or paused with nothing
-// processed. Anything else (running, completed, cancelled, invalid, or a
-// batch with processed recipients) means the campaign can no longer be
-// edited. The server remains authoritative; this only enables a clean
-// message before the editor is opened.
+// processed and not picked up by a worker (in_progress). Anything else
+// (running, in progress, completed, cancelled, invalid, or a batch with
+// processed recipients) means the campaign can no longer be edited. The
+// server remains authoritative; this only enables a clean message before
+// the editor is opened.
 export const hasStartedTimezoneBatches = (queue: QueueLike): boolean =>
   getTimezoneBreakdown(queue).some(
     (entry) =>
       entry.countProcessed > 0 ||
+      entry.inProgress ||
       entry.status === null ||
       !['scheduled', 'paused'].includes(entry.status),
   );

--- a/mailpoet/lib/Newsletter/RestApi/Endpoints/SendingStatusListingEndpoint.php
+++ b/mailpoet/lib/Newsletter/RestApi/Endpoints/SendingStatusListingEndpoint.php
@@ -92,7 +92,15 @@ class SendingStatusListingEndpoint extends AbstractListingEndpoint {
   }
 
   protected function buildItems(array $rows, ListingDefinition $definition): array {
-    return $this->responseBuilder->buildForListing($rows);
+    $items = $this->responseBuilder->buildForListing($rows);
+    $taskIds = array_values(array_unique(array_filter(array_column($items, 'taskId'))));
+    $timezones = $this->sendingQueuesRepository->getGroupTimezonesByTaskIds($taskIds);
+    foreach ($items as &$item) {
+      $group = $timezones[$item['taskId']] ?? null;
+      $item['timezone'] = $group ? $group['timezone'] : null;
+      $item['timezoneFallbackUsed'] = $group ? $group['fallbackUsed'] : false;
+    }
+    return $items;
   }
 
   protected function getDefaultSortBy(): string {

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -108,6 +108,44 @@ class SendingQueuesRepository extends Repository {
     return array_map('intval', array_column($results, 'task_id'));
   }
 
+  /**
+   * Returns the time zone group each sending task belongs to, keyed by task id.
+   * Only tasks of time zone campaigns are included.
+   *
+   * @param int[] $taskIds
+   * @return array<int, array{timezone: string|null, fallbackUsed: bool}>
+   */
+  public function getGroupTimezonesByTaskIds(array $taskIds): array {
+    if (!$taskIds) {
+      return [];
+    }
+    $queues = $this->entityManager->createQueryBuilder()
+      ->select('s')
+      ->from(SendingQueueEntity::class, 's')
+      ->andWhere('s.task IN (:taskIds)')
+      ->setParameter('taskIds', $taskIds)
+      ->getQuery()
+      ->getResult();
+
+    $timezones = [];
+    foreach ($queues as $queue) {
+      $meta = $queue->getMeta() ?? [];
+      if (empty($meta[TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE])) {
+        continue;
+      }
+      $task = $queue->getTask();
+      if (!$task instanceof ScheduledTaskEntity) {
+        continue;
+      }
+      $timezone = $meta[TimeZoneCampaignScheduler::META_GROUP_TIMEZONE] ?? null;
+      $timezones[(int)$task->getId()] = [
+        'timezone' => is_string($timezone) && $timezone !== '' ? $timezone : null,
+        'fallbackUsed' => !empty($meta[TimeZoneCampaignScheduler::META_FALLBACK_USED]),
+      ];
+    }
+    return $timezones;
+  }
+
   public function isSubscriberProcessed(SendingQueueEntity $queue, SubscriberEntity $subscriber): bool {
     $task = $queue->getTask();
     if (is_null($task)) return false;

--- a/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
+++ b/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
@@ -311,6 +311,7 @@ class TimeZoneCampaignScheduler {
         'fallback_used' => $queueMeta[self::META_FALLBACK_USED] ?? false,
         'scheduled_at' => $scheduledAt ? $scheduledAt->format('Y-m-d H:i:s') : null,
         'status' => $task->getStatus(),
+        'in_progress' => (bool)$task->getInProgress(),
         'count_total' => $campaignQueue->getCountTotal(),
         'count_processed' => $campaignQueue->getCountProcessed(),
         'count_to_process' => $campaignQueue->getCountToProcess(),

--- a/mailpoet/tests/DataGenerator/Generators/SampleData.php
+++ b/mailpoet/tests/DataGenerator/Generators/SampleData.php
@@ -379,7 +379,9 @@ class SampleData implements Generator {
         ->withCreatedAt($this->randomPastDate()->toDateTimeString());
 
       if ($mode === TimeZoneCampaignScheduler::SCHEDULE_MODE_WEBSITE_TIME) {
-        $scheduledAt = Carbon::parse("{$localDate} {$localTime}");
+        // Production stores the scheduledAt option and queue scheduled_at in UTC;
+        // the site-local wall clock is converted before persisting.
+        $scheduledAt = Carbon::parse("{$localDate} {$localTime}", wp_timezone())->setTimezone('UTC');
         $newsletterFactory
           ->withOptions([
             NewsletterOptionFieldEntity::NAME_IS_SCHEDULED => '1',

--- a/mailpoet/tests/integration/REST/Newsletters/SendingStatusEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Newsletters/SendingStatusEndpointsTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\REST\Newsletters;
 use Codeception\Util\Fixtures;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\REST\Test;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\ScheduledTaskSubscriber as TaskSubscriberFactory;
@@ -129,6 +130,73 @@ class SendingStatusEndpointsTest extends Test {
     $this->assertArrayHasKey('mta_method', $payload);
     $this->assertArrayHasKey('cron_accessible', $payload);
     $this->assertArrayHasKey('current_time', $payload);
+  }
+
+  public function testListingCarriesTimezoneFieldsForTimezoneCampaigns(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Timezone_' . uniqid())
+      ->withBody(Fixtures::get('newsletter_body_template'))
+      ->withSendingQueue([
+        'meta' => [
+          TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE => true,
+          TimeZoneCampaignScheduler::META_GROUP_TIMEZONE => 'Europe/Prague',
+          TimeZoneCampaignScheduler::META_FALLBACK_USED => false,
+        ],
+      ])
+      ->create();
+    $task = $newsletter->getLatestQueue()->getTask();
+    $subscriber = (new SubscriberFactory())->withEmail('tz_' . uniqid() . '@example.com')->create();
+    (new TaskSubscriberFactory())->createProcessed($task, $subscriber);
+
+    $payload = $this->payload($this->get($this->listingPath((int)$newsletter->getId()), ['query' => ['per_page' => 10]]));
+    $items = $payload['items'];
+    $this->assertIsArray($items);
+    $this->assertCount(1, $items);
+    $this->assertIsArray($items[0]);
+    $this->assertSame('Europe/Prague', $items[0]['timezone']);
+    $this->assertFalse($items[0]['timezoneFallbackUsed']);
+  }
+
+  public function testListingCarriesFallbackFlagForSiteDefaultTimezoneBatches(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('TimezoneFallback_' . uniqid())
+      ->withBody(Fixtures::get('newsletter_body_template'))
+      ->withSendingQueue([
+        'meta' => [
+          TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE => true,
+          TimeZoneCampaignScheduler::META_GROUP_TIMEZONE => 'UTC',
+          TimeZoneCampaignScheduler::META_FALLBACK_USED => true,
+        ],
+      ])
+      ->create();
+    $task = $newsletter->getLatestQueue()->getTask();
+    $subscriber = (new SubscriberFactory())->withEmail('tzf_' . uniqid() . '@example.com')->create();
+    (new TaskSubscriberFactory())->createProcessed($task, $subscriber);
+
+    $payload = $this->payload($this->get($this->listingPath((int)$newsletter->getId()), ['query' => ['per_page' => 10]]));
+    $items = $payload['items'];
+    $this->assertIsArray($items);
+    $this->assertIsArray($items[0]);
+    $this->assertSame('UTC', $items[0]['timezone']);
+    $this->assertTrue($items[0]['timezoneFallbackUsed']);
+  }
+
+  public function testListingReturnsNullTimezoneForRegularNewsletters(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('NoTimezone_' . uniqid())
+      ->withBody(Fixtures::get('newsletter_body_template'))
+      ->withSendingQueue()
+      ->create();
+    $task = $newsletter->getLatestQueue()->getTask();
+    $subscriber = (new SubscriberFactory())->withEmail('ntz_' . uniqid() . '@example.com')->create();
+    (new TaskSubscriberFactory())->createProcessed($task, $subscriber);
+
+    $payload = $this->payload($this->get($this->listingPath((int)$newsletter->getId()), ['query' => ['per_page' => 10]]));
+    $items = $payload['items'];
+    $this->assertIsArray($items);
+    $this->assertIsArray($items[0]);
+    $this->assertNull($items[0]['timezone']);
+    $this->assertFalse($items[0]['timezoneFallbackUsed']);
   }
 
   public function testListingReturnsStatusGroups(): void {

--- a/mailpoet/tests/javascript/newsletters/timezone-campaign.spec.ts
+++ b/mailpoet/tests/javascript/newsletters/timezone-campaign.spec.ts
@@ -16,6 +16,7 @@ const breakdownEntry = (overrides: Record<string, unknown> = {}) => ({
   fallback_used: false,
   scheduled_at: '2026-07-20 09:00:00',
   status: 'scheduled',
+  in_progress: false,
   count_total: 10,
   count_processed: 0,
   count_to_process: 10,
@@ -60,6 +61,7 @@ describe('timezone campaign helpers', () => {
           fallbackUsed: false,
           scheduledAt: '2026-07-20 09:00:00',
           status: 'scheduled',
+          inProgress: false,
           countTotal: 10,
           countProcessed: 0,
           countToProcess: 10,
@@ -69,6 +71,7 @@ describe('timezone campaign helpers', () => {
           fallbackUsed: true,
           scheduledAt: '2026-07-20 09:00:00',
           status: null,
+          inProgress: false,
           countTotal: 10,
           countProcessed: 3,
           countToProcess: 10,
@@ -188,6 +191,13 @@ describe('timezone campaign helpers', () => {
     it('returns true when a batch has processed subscribers', () => {
       const queue = timezoneQueue({
         timezoneBreakdown: [breakdownEntry({ count_processed: 1 })],
+      });
+      expect(hasStartedTimezoneBatches(queue)).to.equal(true);
+    });
+
+    it('treats a batch picked up by a worker as started', () => {
+      const queue = timezoneQueue({
+        timezoneBreakdown: [breakdownEntry({ in_progress: true })],
       });
       expect(hasStartedTimezoneBatches(queue)).to.equal(true);
     });

--- a/mailpoet/tests/javascript/newsletters/timezone-campaign.spec.ts
+++ b/mailpoet/tests/javascript/newsletters/timezone-campaign.spec.ts
@@ -1,0 +1,210 @@
+import {
+  formatTimezoneLabel,
+  getBatchStatusLabel,
+  getScheduledWindow,
+  getTimezoneBreakdown,
+  hasStartedTimezoneBatches,
+  isTimezoneCampaignQueue,
+} from '../../../assets/js/src/newsletters/timezone-campaign';
+
+const timezoneQueue = (meta: Record<string, unknown>) => ({
+  meta: { sendByTimezone: true, ...meta },
+});
+
+const breakdownEntry = (overrides: Record<string, unknown> = {}) => ({
+  timezone: 'Europe/Prague',
+  fallback_used: false,
+  scheduled_at: '2026-07-20 09:00:00',
+  status: 'scheduled',
+  count_total: 10,
+  count_processed: 0,
+  count_to_process: 10,
+  ...overrides,
+});
+
+describe('timezone campaign helpers', () => {
+  describe('isTimezoneCampaignQueue', () => {
+    it('returns true when the queue meta has the sendByTimezone flag', () => {
+      expect(isTimezoneCampaignQueue(timezoneQueue({}))).to.equal(true);
+    });
+
+    it('returns false for regular queues', () => {
+      expect(isTimezoneCampaignQueue({ meta: {} })).to.equal(false);
+      expect(isTimezoneCampaignQueue({ meta: null })).to.equal(false);
+      expect(isTimezoneCampaignQueue({})).to.equal(false);
+    });
+
+    it('returns false for the legacy BC shapes without a queue', () => {
+      expect(isTimezoneCampaignQueue(false)).to.equal(false);
+      expect(isTimezoneCampaignQueue(null)).to.equal(false);
+      expect(isTimezoneCampaignQueue(undefined)).to.equal(false);
+    });
+  });
+
+  describe('getTimezoneBreakdown', () => {
+    it('parses breakdown entries from the aggregate queue meta', () => {
+      const queue = timezoneQueue({
+        timezoneBreakdown: [
+          breakdownEntry(),
+          breakdownEntry({
+            timezone: 'America/New_York',
+            fallback_used: true,
+            status: null,
+            count_processed: 3,
+          }),
+        ],
+      });
+      expect(getTimezoneBreakdown(queue)).to.deep.equal([
+        {
+          timezone: 'Europe/Prague',
+          fallbackUsed: false,
+          scheduledAt: '2026-07-20 09:00:00',
+          status: 'scheduled',
+          countTotal: 10,
+          countProcessed: 0,
+          countToProcess: 10,
+        },
+        {
+          timezone: 'America/New_York',
+          fallbackUsed: true,
+          scheduledAt: '2026-07-20 09:00:00',
+          status: null,
+          countTotal: 10,
+          countProcessed: 3,
+          countToProcess: 10,
+        },
+      ]);
+    });
+
+    it('coerces numeric strings and invalid counts', () => {
+      const queue = timezoneQueue({
+        timezoneBreakdown: [
+          breakdownEntry({
+            count_total: '25',
+            count_processed: 'oops',
+            count_to_process: -5,
+          }),
+        ],
+      });
+      const [entry] = getTimezoneBreakdown(queue);
+      expect(entry.countTotal).to.equal(25);
+      expect(entry.countProcessed).to.equal(0);
+      expect(entry.countToProcess).to.equal(0);
+    });
+
+    it('skips entries that are not objects', () => {
+      const queue = timezoneQueue({
+        timezoneBreakdown: [null, 'bogus', 42, breakdownEntry()],
+      });
+      expect(getTimezoneBreakdown(queue)).to.have.length(1);
+    });
+
+    it('returns an empty list when the breakdown is missing or invalid', () => {
+      expect(getTimezoneBreakdown(timezoneQueue({}))).to.deep.equal([]);
+      expect(
+        getTimezoneBreakdown(timezoneQueue({ timezoneBreakdown: 'bogus' })),
+      ).to.deep.equal([]);
+      expect(getTimezoneBreakdown(false)).to.deep.equal([]);
+    });
+  });
+
+  describe('getScheduledWindow', () => {
+    it('returns the first and last scheduled dates', () => {
+      const queue = timezoneQueue({
+        firstScheduledAt: '2026-07-20 07:00:00',
+        lastScheduledAt: '2026-07-21 06:00:00',
+      });
+      expect(getScheduledWindow(queue)).to.deep.equal({
+        first: '2026-07-20 07:00:00',
+        last: '2026-07-21 06:00:00',
+      });
+    });
+
+    it('returns null when either boundary is missing', () => {
+      expect(
+        getScheduledWindow(timezoneQueue({ firstScheduledAt: '2026-07-20' })),
+      ).to.equal(null);
+      expect(
+        getScheduledWindow(timezoneQueue({ lastScheduledAt: '2026-07-21' })),
+      ).to.equal(null);
+      expect(getScheduledWindow(false)).to.equal(null);
+    });
+  });
+
+  describe('getBatchStatusLabel', () => {
+    it('treats a null status as running (a batch is actively sending)', () => {
+      expect(getBatchStatusLabel(null)).to.equal('Sending');
+    });
+
+    it('maps the known task statuses', () => {
+      expect(getBatchStatusLabel('scheduled')).to.equal('Scheduled');
+      expect(getBatchStatusLabel('paused')).to.equal('Paused');
+      expect(getBatchStatusLabel('completed')).to.equal('Sent');
+      expect(getBatchStatusLabel('cancelled')).to.equal('Cancelled');
+      expect(getBatchStatusLabel('invalid')).to.equal('Failed');
+    });
+
+    it('passes unknown statuses through unchanged', () => {
+      expect(getBatchStatusLabel('something_new')).to.equal('something_new');
+    });
+  });
+
+  describe('formatTimezoneLabel', () => {
+    it('returns the time zone name as-is', () => {
+      expect(formatTimezoneLabel('Europe/Prague', false)).to.equal(
+        'Europe/Prague',
+      );
+    });
+
+    it('marks fallback groups with the site default suffix', () => {
+      expect(formatTimezoneLabel('Europe/Prague', true)).to.equal(
+        'Europe/Prague (site default)',
+      );
+    });
+
+    it('labels a missing time zone as unknown', () => {
+      expect(formatTimezoneLabel(null, false)).to.equal('Unknown');
+    });
+  });
+
+  describe('hasStartedTimezoneBatches', () => {
+    it('returns false while every batch is scheduled or paused and untouched', () => {
+      const queue = timezoneQueue({
+        timezoneBreakdown: [
+          breakdownEntry(),
+          breakdownEntry({ status: 'paused' }),
+        ],
+      });
+      expect(hasStartedTimezoneBatches(queue)).to.equal(false);
+    });
+
+    it('returns true when a batch is running (null status)', () => {
+      const queue = timezoneQueue({
+        timezoneBreakdown: [breakdownEntry({ status: null })],
+      });
+      expect(hasStartedTimezoneBatches(queue)).to.equal(true);
+    });
+
+    it('returns true when a batch has processed subscribers', () => {
+      const queue = timezoneQueue({
+        timezoneBreakdown: [breakdownEntry({ count_processed: 1 })],
+      });
+      expect(hasStartedTimezoneBatches(queue)).to.equal(true);
+    });
+
+    it('returns true when a batch is completed', () => {
+      const queue = timezoneQueue({
+        timezoneBreakdown: [
+          breakdownEntry(),
+          breakdownEntry({ status: 'completed', count_processed: 10 }),
+        ],
+      });
+      expect(hasStartedTimezoneBatches(queue)).to.equal(true);
+    });
+
+    it('returns false when there is no breakdown to inspect', () => {
+      expect(hasStartedTimezoneBatches(timezoneQueue({}))).to.equal(false);
+      expect(hasStartedTimezoneBatches(false)).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Surfaces subscriber-timezone campaigns across the email UIs — read-only rendering of the aggregate queue data shipped in STOMAIL-8007; non-timezone campaigns render exactly as before:

- **Newsletters listing** — timezone campaigns are marked with a globe icon in the "Sent on" column ("Sent in subscriber's time zone" tooltip). Running campaigns show the aggregate sending progress, and opening the editor is blocked once a batch has started (same message the backend guard would return on save).
- **Campaign stats** — the globe icon appears next to the sent date in the header, and a new "Time zones" tab renders a DataViews table with one row per time zone batch (time zone, scheduled time, batch status, sent counts) plus the overall first-to-last sending window. The tab exists only for timezone campaigns; direct links fall back to Clicked Links otherwise.
- **Sending status page** — a "Time zone" column shows the zone each recipient's batch was sent in (with "(site default)" for fallback subscribers). The sending-status endpoint exposes the group time zone per task; the column is added only for timezone campaigns.
- **Sample data generator** — website-time scheduled sample newsletters now parse the wall clock in the site timezone and store UTC, matching production (STOMAIL-8255).

## Code review notes

- A running timezone campaign's aggregate queue has `status: null` (authoritative — a sibling batch is sending) while `scheduled_at` points at the next future batch; the listing intentionally ignores that future date so the progress ring renders instead of "scheduled".
- On the sending status page the "Time zone" column is injected into the visible columns once per mount after items reveal a timezone campaign — so hiding it via the view config afterwards sticks, and the shared `sending-status` view preference doesn't force the column onto regular emails.
- With premium active the stats page loads via the premium `stats.get` endpoint, which needs the paired premium PR to return the aggregate queue meta — without it the "Time zones" tab has no data (the free `getWithStats` path works on its own).

## QA notes

Easiest with sample data: `pnpm generate:sample-data` creates subscribers with time zones plus sent and scheduled timezone campaigns (subjects `[Sample data sent N …]` with even N are timezone-based). Check the listing globe icon through the scheduled → sending → sent lifecycle, the "Time zones" tab and header icon on a sent campaign's stats page, and the "Time zone" column on its sending status page. Editing a campaign whose batches already started shows the error notice before the editor opens.

## Screenshots

<img width="1350" height="546" alt="Screenshot 2026-07-09 at 20 07 53" src="https://github.com/user-attachments/assets/3910d98a-8ec2-4c13-8386-c169fe212fde" />
<img width="1339" height="636" alt="Screenshot 2026-07-09 at 20 09 23" src="https://github.com/user-attachments/assets/393dd081-f4f6-4e1d-b5d2-617ddb2d735c" />
<img width="1798" height="878" alt="Screenshot 2026-07-09 at 21 52 50" src="https://github.com/user-attachments/assets/31dc2b31-8671-452d-8127-3b9041257db4" />


## Linked PRs

- https://github.com/mailpoet/mailpoet-premium/pull/1119

## Linked tickets

STOMAIL-8246

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8246-display-timezone-scheduling-status-in-listing-and-campaign)

_The latest successful build from `stomail-8246-display-timezone-scheduling-status-in-listing-and-campaign` will be used. If none is available, the link won't work._



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->