### PR TITLE
Add timezone headers to recipient stats export

### DIFF
--- a/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
+++ b/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
@@ -182,6 +182,34 @@ class TimeZoneCampaignScheduler {
     return $this->getCampaignQueuesById($newsletter, $campaignId);
   }
 
+  /** Resolves replay sources directly so newsletters with many replays stay cheap to inspect. */
+  public function resolveTimeZoneCampaignQueue(NewsletterEntity $newsletter): ?SendingQueueEntity {
+    $latestQueue = $newsletter->getLatestQueue();
+    if ($latestQueue === null) {
+      return null;
+    }
+    if ($this->isTimeZoneQueue($latestQueue)) {
+      return $latestQueue;
+    }
+
+    $meta = $latestQueue->getMeta() ?? [];
+    if (!NewsletterReplayMetadata::isLatestNewsletterReplayMeta($meta)) {
+      return null;
+    }
+    $sourceQueueId = (int)($meta[NewsletterReplayMetadata::REPLAY_SOURCE_QUEUE_ID] ?? 0);
+    if ($sourceQueueId <= 0) {
+      return null;
+    }
+
+    $sourceQueue = $this->sendingQueuesRepository->findOneBy([
+      'id' => $sourceQueueId,
+      'newsletter' => $newsletter,
+    ]);
+    return $sourceQueue instanceof SendingQueueEntity && $this->isTimeZoneQueue($sourceQueue)
+      ? $sourceQueue
+      : null;
+  }
+
   public function hasIncompleteCampaignQueues(SendingQueueEntity $queue): bool {
     foreach ($this->getCampaignQueues($queue) as $campaignQueue) {
       $task = $campaignQueue->getTask();

--- a/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
+++ b/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
@@ -108,6 +108,12 @@ class StatisticsExporter {
 
     /** @var array<array<int|string|float|null>> $rows */
     $rows = (array)$this->wp->applyFilters(self::FILTER_RECIPIENT_ROWS, [], $newsletter);
+    if (count($headers) > count($this->getRecipientHeaders())) {
+      $headerCount = count($headers);
+      foreach ($rows as $index => $row) {
+        $rows[$index] = array_pad($row, $headerCount, '');
+      }
+    }
 
     $this->ensureExportDirectory();
     $file = ExportDownload::createExportFile(self::FILE_PREFIX, $format);
@@ -122,9 +128,8 @@ class StatisticsExporter {
   /**
    * Recipient export headers. For subscriber-timezone campaigns three extra
    * delivery columns are appended; the premium plugin appends the matching
-   * row cells in `RecipientsExporter::getRows()` using the same
-   * `TimeZoneCampaignScheduler::isTimeZoneQueue()` predicate, so the two
-   * MUST stay in sync.
+   * row cells in `RecipientsExporter::getRows()` using the same resolver, so
+   * the two MUST stay in sync.
    *
    * @return string[]
    */
@@ -153,8 +158,7 @@ class StatisticsExporter {
   }
 
   private function isTimeZoneCampaign(NewsletterEntity $newsletter): bool {
-    $queue = $newsletter->getLatestQueue();
-    return $queue !== null && $this->timeZoneCampaignScheduler->isTimeZoneQueue($queue);
+    return $this->timeZoneCampaignScheduler->resolveTimeZoneCampaignQueue($newsletter) !== null;
   }
 
   /**

--- a/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
+++ b/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Newsletter\Statistics\Export;
 
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Newsletter\Statistics\NewsletterStatistics;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
@@ -27,14 +28,19 @@ class StatisticsExporter {
   /** @var NewsletterStatisticsRepository */
   private $statisticsRepository;
 
+  /** @var TimeZoneCampaignScheduler */
+  private $timeZoneCampaignScheduler;
+
   /** @var WPFunctions */
   private $wp;
 
   public function __construct(
     NewsletterStatisticsRepository $statisticsRepository,
+    TimeZoneCampaignScheduler $timeZoneCampaignScheduler,
     WPFunctions $wp
   ) {
     $this->statisticsRepository = $statisticsRepository;
+    $this->timeZoneCampaignScheduler = $timeZoneCampaignScheduler;
     $this->wp = $wp;
   }
 
@@ -98,7 +104,7 @@ class StatisticsExporter {
    */
   public function exportRecipients(NewsletterEntity $newsletter, string $format): array {
     $format = $this->normalizeFormat($format);
-    $headers = $this->getRecipientHeaders();
+    $headers = $this->getRecipientHeaders($newsletter);
 
     /** @var array<array<int|string|float|null>> $rows */
     $rows = (array)$this->wp->applyFilters(self::FILTER_RECIPIENT_ROWS, [], $newsletter);
@@ -114,10 +120,16 @@ class StatisticsExporter {
   }
 
   /**
+   * Recipient export headers. For subscriber-timezone campaigns three extra
+   * delivery columns are appended; the premium plugin appends the matching
+   * row cells in `RecipientsExporter::getRows()` using the same
+   * `TimeZoneCampaignScheduler::isTimeZoneQueue()` predicate, so the two
+   * MUST stay in sync.
+   *
    * @return string[]
    */
-  public function getRecipientHeaders(): array {
-    return [
+  public function getRecipientHeaders(?NewsletterEntity $newsletter = null): array {
+    $headers = [
       __('Subscriber ID', 'mailpoet'),
       __('Email', 'mailpoet'),
       __('First name', 'mailpoet'),
@@ -132,6 +144,17 @@ class StatisticsExporter {
       __('Bounced', 'mailpoet'),
       __('Unsubscribed', 'mailpoet'),
     ];
+    if ($newsletter && $this->isTimeZoneCampaign($newsletter)) {
+      $headers[] = __('Delivery timezone', 'mailpoet');
+      $headers[] = __('Timezone fallback used', 'mailpoet');
+      $headers[] = __('Local send time', 'mailpoet');
+    }
+    return $headers;
+  }
+
+  private function isTimeZoneCampaign(NewsletterEntity $newsletter): bool {
+    $queue = $newsletter->getLatestQueue();
+    return $queue !== null && $this->timeZoneCampaignScheduler->isTimeZoneQueue($queue);
   }
 
   /**

--- a/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
+++ b/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
@@ -4,6 +4,8 @@ namespace MailPoet\Newsletter\Statistics\Export;
 
 use MailPoet\Config\Env;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Newsletter\Statistics\NewsletterStatistics;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
@@ -175,7 +177,7 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
       },
       'homeUrl' => 'https://example.test',
     ]);
-    $exporter = new StatisticsExporter($repository, $wp);
+    $exporter = new StatisticsExporter($repository, $this->make(TimeZoneCampaignScheduler::class), $wp);
 
     $result = $exporter->exportRecipients($newsletter, StatisticsExporter::FORMAT_CSV);
     verify($result['totalExported'])->equals(1);
@@ -201,10 +203,118 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
       },
       'homeUrl' => 'https://example.test',
     ]);
-    $exporter = new StatisticsExporter($repository, $wp);
+    $exporter = new StatisticsExporter($repository, $this->make(TimeZoneCampaignScheduler::class), $wp);
 
     $result = $exporter->exportRecipients($newsletter, StatisticsExporter::FORMAT_CSV);
     verify($result['totalExported'])->equals(0);
+  }
+
+  public function testRecipientHeadersStayUnchangedForNonTimeZoneCampaigns() {
+    $stats = $this->createStats(0, 0, 0, 0, 0, 0, null);
+    $exporter = $this->createExporter($stats);
+
+    $expectedHeaders = [
+      'Subscriber ID',
+      'Email',
+      'First name',
+      'Last name',
+      'Status',
+      'Opened',
+      'First open at',
+      'Open count',
+      'Machine opened',
+      'Clicked',
+      'Click count',
+      'Bounced',
+      'Unsubscribed',
+    ];
+
+    verify($exporter->getRecipientHeaders())->equals($expectedHeaders);
+
+    $regularQueue = new SendingQueueEntity();
+    $newsletter = $this->createNewsletter(5, 'Regular', null, null, $regularQueue);
+    verify($exporter->getRecipientHeaders($newsletter))->equals($expectedHeaders);
+  }
+
+  public function testItAppendsTimezoneHeadersForTimeZoneCampaigns() {
+    $stats = $this->createStats(0, 0, 0, 0, 0, 0, null);
+    $exporter = $this->createExporter($stats);
+    $newsletter = $this->createNewsletter(6, 'Timezone', null, null, $this->createTimeZoneQueue());
+
+    $headers = $exporter->getRecipientHeaders($newsletter);
+
+    verify($headers)->arrayCount(16);
+    verify(array_slice($headers, 0, 13))->equals($exporter->getRecipientHeaders());
+    verify(array_slice($headers, 13))->equals([
+      'Delivery timezone',
+      'Timezone fallback used',
+      'Local send time',
+    ]);
+  }
+
+  public function testItExportsTimezoneRecipientCsvWithAlignedColumns() {
+    $newsletter = $this->createNewsletter(77, 'Timezone recipients', null, '2026-02-01 00:00:00', $this->createTimeZoneQueue());
+
+    $rows = [
+      [1, 'a@example.test', 'Alice', 'Smith', 'subscribed', 'Y', '', 0, 'N', 'N', 0, 'N', 'N', 'Europe/Prague', 'No', '2026-02-01 01:00:00'],
+    ];
+
+    $repository = $this->makeEmpty(NewsletterStatisticsRepository::class);
+    $wp = $this->makeEmpty(WPFunctions::class, [
+      'wpMkdirP' => function (string $dir) {
+        return mkdir($dir, 0777, true);
+      },
+      'applyFilters' => function (string $hook, $value) use ($rows) {
+        if ($hook === StatisticsExporter::FILTER_RECIPIENT_ROWS) {
+          return $rows;
+        }
+        return $value;
+      },
+      'homeUrl' => 'https://example.test',
+    ]);
+    $exporter = new StatisticsExporter($repository, $this->make(TimeZoneCampaignScheduler::class), $wp);
+
+    $result = $exporter->exportRecipients($newsletter, StatisticsExporter::FORMAT_CSV);
+    verify($result['totalExported'])->equals(1);
+
+    $files = glob(ExportDownload::getExportDirectory() . '/*.csv') ?: [];
+    verify($files)->arrayCount(1);
+    $exportedRows = $this->parseCsvRows(substr((string)file_get_contents($files[0]), 3));
+    verify($exportedRows)->arrayCount(2);
+    verify($exportedRows[0])->arrayCount(16);
+    verify($exportedRows[0][13])->equals('Delivery timezone');
+    verify($exportedRows[0][14])->equals('Timezone fallback used');
+    verify($exportedRows[0][15])->equals('Local send time');
+    verify($exportedRows[1])->arrayCount(16);
+    verify($exportedRows[1][13])->equals('Europe/Prague');
+    verify($exportedRows[1][15])->equals('2026-02-01 01:00:00');
+  }
+
+  public function testItExportsTimezoneRecipientsAsXlsx() {
+    $newsletter = $this->createNewsletter(78, 'Timezone xlsx', null, '2026-02-01 00:00:00', $this->createTimeZoneQueue());
+    $repository = $this->makeEmpty(NewsletterStatisticsRepository::class);
+    $wp = $this->makeEmpty(WPFunctions::class, [
+      'wpMkdirP' => function (string $dir) {
+        return mkdir($dir, 0777, true);
+      },
+      'applyFilters' => function (string $hook, $value) {
+        if ($hook === StatisticsExporter::FILTER_RECIPIENT_ROWS) {
+          return [
+            [1, 'a@example.test', 'Alice', 'Smith', 'subscribed', 'Y', '', 0, 'N', 'N', 0, 'N', 'N', 'Europe/Prague', 'No', '2026-02-01 01:00:00'],
+          ];
+        }
+        return $value;
+      },
+      'homeUrl' => 'https://example.test',
+    ]);
+    $exporter = new StatisticsExporter($repository, $this->make(TimeZoneCampaignScheduler::class), $wp);
+
+    $result = $exporter->exportRecipients($newsletter, StatisticsExporter::FORMAT_XLSX);
+
+    verify($result['totalExported'])->equals(1);
+    $files = glob(ExportDownload::getExportDirectory() . '/*.xlsx') ?: [];
+    verify($files)->arrayCount(1);
+    verify(filesize($files[0]))->greaterThan(0);
   }
 
   private function createExporter(NewsletterStatistics $stats): StatisticsExporter {
@@ -217,7 +327,18 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
       },
       'homeUrl' => 'https://example.test',
     ]);
-    return new StatisticsExporter($repository, $wp);
+    return new StatisticsExporter($repository, $this->make(TimeZoneCampaignScheduler::class), $wp);
+  }
+
+  private function createTimeZoneQueue(): SendingQueueEntity {
+    $queue = new SendingQueueEntity();
+    $queue->setMeta([
+      TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE => true,
+      TimeZoneCampaignScheduler::META_TIMEZONE_CAMPAIGN_ID => 'campaign1234567890',
+      TimeZoneCampaignScheduler::META_GROUP_TIMEZONE => 'Europe/Prague',
+      TimeZoneCampaignScheduler::META_FALLBACK_USED => false,
+    ]);
+    return $queue;
   }
 
   private function verifyStatisticsDownloadUrl(string $url, string $extension): void {
@@ -250,12 +371,13 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     );
   }
 
-  private function createNewsletter(int $id, string $subject, ?string $campaignName, ?string $sentAt): NewsletterEntity {
+  private function createNewsletter(int $id, string $subject, ?string $campaignName, ?string $sentAt, ?SendingQueueEntity $queue = null): NewsletterEntity {
     $newsletter = $this->makeEmpty(NewsletterEntity::class, [
       'getId' => $id,
       'getSubject' => $subject,
       'getCampaignName' => $campaignName,
       'getSentAt' => $sentAt ? new \DateTimeImmutable($sentAt) : null,
+      'getLatestQueue' => $queue,
     ]);
     return $newsletter;
   }

--- a/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
+++ b/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
@@ -187,6 +187,8 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     $body = substr((string)file_get_contents($files[0]), 3);
     $exportedRows = $this->parseCsvRows($body);
     verify($exportedRows)->arrayCount(2);
+    verify($exportedRows[0])->arrayCount(13);
+    verify($exportedRows[1])->arrayCount(13);
     verify($exportedRows[1][1])->equals('a@example.test');
     verify($exportedRows[1][2])->equals('Alice');
   }
@@ -290,6 +292,37 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     verify($exportedRows[1][15])->equals('2026-02-01 01:00:00');
   }
 
+  public function testItPadsLegacyRecipientFilterRowsForTimeZoneCampaigns() {
+    $newsletter = $this->createNewsletter(79, 'Legacy timezone rows', null, '2026-02-01 00:00:00', $this->createTimeZoneQueue());
+    $legacyRows = [
+      [1, 'legacy@example.test', 'Legacy', 'Subscriber', 'subscribed', 'Y', '', 0, 'N', 'N', 0, 'N', 'N'],
+    ];
+
+    $repository = $this->makeEmpty(NewsletterStatisticsRepository::class);
+    $wp = $this->makeEmpty(WPFunctions::class, [
+      'wpMkdirP' => function (string $dir) {
+        return mkdir($dir, 0777, true);
+      },
+      'applyFilters' => function (string $hook, $value) use ($legacyRows) {
+        if ($hook === StatisticsExporter::FILTER_RECIPIENT_ROWS) {
+          return $legacyRows;
+        }
+        return $value;
+      },
+      'homeUrl' => 'https://example.test',
+    ]);
+    $exporter = new StatisticsExporter($repository, $this->make(TimeZoneCampaignScheduler::class), $wp);
+
+    $exporter->exportRecipients($newsletter, StatisticsExporter::FORMAT_CSV);
+
+    $files = glob(ExportDownload::getExportDirectory() . '/*.csv') ?: [];
+    verify($files)->arrayCount(1);
+    $exportedRows = $this->parseCsvRows(substr((string)file_get_contents($files[0]), 3));
+    verify($exportedRows[0])->arrayCount(16);
+    verify($exportedRows[1])->arrayCount(16);
+    verify(array_slice($exportedRows[1], 13))->equals(['', '', '']);
+  }
+
   public function testItExportsTimezoneRecipientsAsXlsx() {
     $newsletter = $this->createNewsletter(78, 'Timezone xlsx', null, '2026-02-01 00:00:00', $this->createTimeZoneQueue());
     $repository = $this->makeEmpty(NewsletterStatisticsRepository::class);
@@ -314,7 +347,20 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     verify($result['totalExported'])->equals(1);
     $files = glob(ExportDownload::getExportDirectory() . '/*.xlsx') ?: [];
     verify($files)->arrayCount(1);
-    verify(filesize($files[0]))->greaterThan(0);
+    $exportedRows = $this->parseXlsxRows($files[0]);
+    verify($exportedRows)->arrayCount(2);
+    verify($exportedRows[0])->arrayCount(16);
+    verify(array_slice($exportedRows[0], 13))->equals([
+      'Delivery timezone',
+      'Timezone fallback used',
+      'Local send time',
+    ]);
+    verify($exportedRows[1])->arrayCount(16);
+    verify(array_slice($exportedRows[1], 13))->equals([
+      'Europe/Prague',
+      'No',
+      '2026-02-01 01:00:00',
+    ]);
   }
 
   private function createExporter(NewsletterStatistics $stats): StatisticsExporter {
@@ -357,6 +403,63 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
       glob(ExportDownload::getExportDirectory() . '/*') ?: [],
       glob(ExportDownload::getExportDirectory() . '/.htaccess') ?: []
     );
+  }
+
+  /**
+   * @return array<array<string>>
+   */
+  private function parseXlsxRows(string $file): array {
+    $archive = new \ZipArchive();
+    if ($archive->open($file) !== true) {
+      throw new \RuntimeException('Unable to open exported XLSX file.');
+    }
+    try {
+      $sharedStringsXml = $archive->getFromName('xl/sharedStrings.xml');
+      $worksheetXml = $archive->getFromName('xl/worksheets/sheet1.xml');
+    } finally {
+      $archive->close();
+    }
+    if (!is_string($sharedStringsXml) || !is_string($worksheetXml)) {
+      throw new \RuntimeException('Exported XLSX file is missing worksheet data.');
+    }
+
+    $sharedStringsDocument = new \DOMDocument();
+    $worksheetDocument = new \DOMDocument();
+    if (!$sharedStringsDocument->loadXML($sharedStringsXml) || !$worksheetDocument->loadXML($worksheetXml)) {
+      throw new \RuntimeException('Exported XLSX file contains invalid XML.');
+    }
+
+    $namespace = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+    $sharedStrings = [];
+    foreach ($sharedStringsDocument->getElementsByTagNameNS($namespace, 'si') as $sharedStringNode) {
+      if (!$sharedStringNode instanceof \DOMElement) {
+        throw new \RuntimeException('Unable to read exported XLSX shared string node.');
+      }
+      $sharedStrings[] = $sharedStringNode->textContent;
+    }
+
+    $rows = [];
+    foreach ($worksheetDocument->getElementsByTagNameNS($namespace, 'row') as $rowNode) {
+      if (!$rowNode instanceof \DOMElement) {
+        throw new \RuntimeException('Unable to read exported XLSX row node.');
+      }
+      $row = [];
+      foreach ($rowNode->childNodes as $cellNode) {
+        if (!$cellNode instanceof \DOMElement || $cellNode->localName !== 'c') {
+          continue;
+        }
+        $valueNode = $cellNode->getElementsByTagNameNS($namespace, 'v')->item(0);
+        if ($valueNode !== null && !$valueNode instanceof \DOMElement) {
+          throw new \RuntimeException('Unable to read exported XLSX cell value node.');
+        }
+        $value = $valueNode ? $valueNode->textContent : '';
+        $row[] = $cellNode->getAttribute('t') === 's'
+          ? ($sharedStrings[(int)$value] ?? '')
+          : $value;
+      }
+      $rows[] = $row;
+    }
+    return $rows;
   }
 
   /**


### PR DESCRIPTION
## Description

Free half of the recipient stats export timezone columns: appends `Delivery timezone`, `Timezone fallback used`, and `Local send time` headers for subscriber-timezone campaigns. The matching row cells come from the premium PR (linked below) — both sides use the same `TimeZoneCampaignScheduler::isTimeZoneQueue()` predicate and must land in the same release, otherwise timezone-campaign exports would emit headers without cells.

## Code review notes

_N/A_

## QA notes

Non-timezone campaign exports must stay byte-identical (unit-tested with an exact header regression guard).

## Linked PRs

Premium half: https://github.com/mailpoet/mailpoet-premium/pull/1118

## Linked tickets

STOMAIL-8248

## After-merge notes

Land together with the premium PR in the same release cycle.

## Screenshots or screencast <!-- if applicable -->

| Regular campaign | Timezone-based campaign | 
| ---- | ---- | 
| <img width="1421" height="1173" alt="Screenshot 2026-07-10 at 09 48 13" src="https://github.com/user-attachments/assets/6a4e5459-a852-4844-bbea-ed4ba76d28c2" /> | <img width="1757" height="1173" alt="Screenshot 2026-07-10 at 09 47 11" src="https://github.com/user-attachments/assets/d2e9b953-acf1-48e8-b317-febc261d3fdc" /> | 


## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`) — not needed, feature is behind a default-off flag
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes — PHP-only change

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8248-add-timezone-delivery-columns-to-recipient-stats-export)

_The latest successful build from `stomail-8248-add-timezone-delivery-columns-to-recipient-stats-export` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->