### PR TITLE
Add timezone field to the subscriber edit form

### DIFF
--- a/mailpoet/assets/js/src/subscribers/form.tsx
+++ b/mailpoet/assets/js/src/subscribers/form.tsx
@@ -60,6 +60,7 @@ declare global {
   interface Window {
     mailpoet_custom_fields: CustomField[];
     mailpoet_api_version: string;
+    mailpoet_timezone_list: string[];
   }
 }
 
@@ -164,10 +165,10 @@ const fields: FormField[] = [
     automationId: 'subscriber-timezone',
     placeholder: __('Not set', 'mailpoet'),
     values: Object.fromEntries(
-      (typeof Intl.supportedValuesOf === 'function'
-        ? Intl.supportedValuesOf('timeZone')
-        : []
-      ).map((timezone) => [timezone, timezone.replaceAll('_', ' ')]),
+      (window.mailpoet_timezone_list || []).map((timezone) => [
+        timezone,
+        timezone.replaceAll('_', ' '),
+      ]),
     ),
   },
   {

--- a/mailpoet/assets/js/src/subscribers/form.tsx
+++ b/mailpoet/assets/js/src/subscribers/form.tsx
@@ -77,6 +77,7 @@ interface TextField extends BaseField {
 interface SelectField extends BaseField {
   type: 'select';
   automationId?: string;
+  placeholder?: string;
   values: Record<string, string>;
 }
 
@@ -155,6 +156,19 @@ const fields: FormField[] = [
       inactive: MailPoet.I18n.t('inactive'),
       bounced: MailPoet.I18n.t('bounced'),
     },
+  },
+  {
+    name: 'timezone',
+    label: __('Timezone', 'mailpoet'),
+    type: 'select',
+    automationId: 'subscriber-timezone',
+    placeholder: __('Not set', 'mailpoet'),
+    values: Object.fromEntries(
+      (typeof Intl.supportedValuesOf === 'function'
+        ? Intl.supportedValuesOf('timeZone')
+        : []
+      ).map((timezone) => [timezone, timezone.replaceAll('_', ' ')]),
+    ),
   },
   {
     name: 'segments',

--- a/mailpoet/changelog/2026-07-09-14-16-48-added-timezone-field-in-the-subscriber-edit-form-for-vie.md
+++ b/mailpoet/changelog/2026-07-09-14-16-48-added-timezone-field-in-the-subscriber-edit-form-for-vie.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Timezone field in the subscriber edit form for viewing and editing a subscriber's timezone

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
@@ -108,6 +108,7 @@ class SubscribersResponseBuilder {
       'unsubscribe_token' => $subscriberEntity->getUnsubscribeToken(),
       'link_token' => $subscriberEntity->getLinkToken(),
       'tags' => $this->buildTags($subscriberEntity),
+      'timezone' => $subscriberEntity->getTimeZone(),
     ];
 
     return $this->buildCustomFields($subscriberEntity, $data);

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -95,6 +95,10 @@ class Subscribers {
       'signup_confirmation.enabled'
     );
     $data['bulk_confirmation_resend_limit'] = BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT;
+    // Same identifier list SubscriberEntity::isValidTimeZone() accepts when
+    // storing browser-detected timezones, so the selector can offer exactly
+    // the values that can be saved.
+    $data['timezone_list'] = \DateTimeZone::listIdentifiers();
     $this->assetsController->setupDataViewsDependencies();
     $this->pageRenderer->displayPage('subscribers/subscribers.html', $data);
   }

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -42,8 +42,10 @@ class SubscriberEntity {
   public const LINK_TOKEN_LENGTH = 32;
   public const TIME_ZONE_FIELD_NAME = 'mailpoet_subscriber_timezone';
   public const TIME_ZONE_SOURCE_FORM = 'form';
+  public const TIME_ZONE_SOURCE_MANUAL = 'manual';
   public const TIME_ZONE_SOURCE_SITE_FALLBACK = 'site_fallback';
   public const TIME_ZONE_CONFIDENCE_BROWSER = 90;
+  public const TIME_ZONE_CONFIDENCE_MANUAL = 100;
 
   /** @var array<string,bool>|null */
   private static $validTimeZones = null;

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -244,6 +244,9 @@ class SubscriberSaveController {
         $subscriber->setTimeZoneUpdatedAt(Carbon::now()->millisecond(0));
       }
     }
+    if (array_key_exists('timezone', $data)) {
+      $this->updateTimeZoneManually($subscriber, $data['timezone']);
+    }
     $createdAt = isset($data['created_at']) ? Carbon::createFromFormat('Y-m-d H:i:s', $data['created_at']) : null;
     if ($createdAt) $subscriber->setCreatedAt($createdAt);
     $confirmedAt = isset($data['confirmed_at']) ? Carbon::createFromFormat('Y-m-d H:i:s', $data['confirmed_at']) : null;
@@ -265,6 +268,31 @@ class SubscriberSaveController {
     }
 
     return $subscriber;
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function updateTimeZoneManually(SubscriberEntity $subscriber, $value): void {
+    if ($value === '' || $value === null) {
+      if ($subscriber->getTimeZone() === null) {
+        return;
+      }
+      $subscriber->setTimeZone(null);
+      $subscriber->setTimeZoneSource(null);
+      $subscriber->setTimeZoneConfidence(null);
+      $subscriber->setTimeZoneUpdatedAt(null);
+      return;
+    }
+
+    $timeZone = SubscriberEntity::sanitizeTimeZone($value);
+    if ($timeZone === null || $timeZone === $subscriber->getTimeZone()) {
+      return;
+    }
+    $subscriber->setTimeZone($timeZone);
+    $subscriber->setTimeZoneSource(SubscriberEntity::TIME_ZONE_SOURCE_MANUAL);
+    $subscriber->setTimeZoneConfidence(SubscriberEntity::TIME_ZONE_CONFIDENCE_MANUAL);
+    $subscriber->setTimeZoneUpdatedAt(Carbon::now()->millisecond(0));
   }
 
   private function isNewEmail(string $email, ?SubscriberEntity $subscriber): bool {

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/SubscribersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/SubscribersResponseBuilderTest.php
@@ -86,6 +86,7 @@ class SubscribersResponseBuilderTest extends \MailPoetTest {
     $this->assertArrayHasKey('count_confirmations', $response);
     $this->assertArrayHasKey('unsubscribe_token', $response);
     $this->assertArrayHasKey('link_token', $response);
+    $this->assertEquals($subscriber->getTimeZone(), $response['timezone']);
     // check subscriptions
     $this->assertCount(0, $response['unsubscribes']);
     $this->checkSubscription($response, $subscriber);

--- a/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
@@ -104,6 +104,69 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
     verify($subscriber->getTimeZoneUpdatedAt())->null();
   }
 
+  public function testItSavesManuallyEditedTimeZoneEvenWhenCollectionIsDisabled(): void {
+    $this->settings->set('collect_subscriber_timezones', ['enabled' => '']);
+
+    $subscriber = $this->saveController->save([
+      'email' => 'timezone-manual@test.com',
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      'timezone' => 'Europe/Prague',
+    ]);
+
+    verify($subscriber->getTimeZone())->equals('Europe/Prague');
+    verify($subscriber->getTimeZoneSource())->equals(SubscriberEntity::TIME_ZONE_SOURCE_MANUAL);
+    verify($subscriber->getTimeZoneConfidence())->equals(SubscriberEntity::TIME_ZONE_CONFIDENCE_MANUAL);
+    verify($subscriber->getTimeZoneUpdatedAt())->notNull();
+  }
+
+  public function testItClearsTimeZoneWhenManualValueIsEmpty(): void {
+    $subscriber = $this->saveController->save([
+      'email' => 'timezone-clear@test.com',
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      'timezone' => 'Europe/Prague',
+    ]);
+    verify($subscriber->getTimeZone())->equals('Europe/Prague');
+
+    $subscriber = $this->saveController->save([
+      'id' => $subscriber->getId(),
+      'timezone' => '',
+    ]);
+
+    verify($subscriber->getTimeZone())->null();
+    verify($subscriber->getTimeZoneSource())->null();
+    verify($subscriber->getTimeZoneConfidence())->null();
+    verify($subscriber->getTimeZoneUpdatedAt())->null();
+  }
+
+  public function testItIgnoresInvalidManualTimeZone(): void {
+    $subscriber = $this->saveController->save([
+      'email' => 'timezone-invalid@test.com',
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      'timezone' => 'Invalid/Zone',
+    ]);
+
+    verify($subscriber->getTimeZone())->null();
+    verify($subscriber->getTimeZoneSource())->null();
+  }
+
+  public function testItKeepsTimeZoneSourceWhenManualValueIsUnchanged(): void {
+    $subscriber = $this->saveController->save([
+      'email' => 'timezone-unchanged@test.com',
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      SubscriberEntity::TIME_ZONE_FIELD_NAME => 'Europe/Prague',
+    ]);
+    verify($subscriber->getTimeZoneSource())->equals(SubscriberEntity::TIME_ZONE_SOURCE_FORM);
+
+    $subscriber = $this->saveController->save([
+      'id' => $subscriber->getId(),
+      'timezone' => 'Europe/Prague',
+    ]);
+
+    verify($subscriber->getTimeZone())->equals('Europe/Prague');
+    verify($subscriber->getTimeZoneSource())->equals(SubscriberEntity::TIME_ZONE_SOURCE_FORM);
+    verify($subscriber->getTimeZoneConfidence())->equals(SubscriberEntity::TIME_ZONE_CONFIDENCE_BROWSER);
+  }
+
   public function testItCanUpdateASubscriber(): void {
     $subscriber = $this->createSubscriber('second@test.com', SubscriberEntity::STATUS_UNCONFIRMED);
     $segmentOne = $this->segmentsRepository->createOrUpdate('Segment One');

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -12,6 +12,7 @@
     var mailpoet_signup_confirmation_enabled = <%= json_encode(signup_confirmation_enabled) %>;
     var mailpoet_bulk_confirmation_resend_limit = <%= json_encode(bulk_confirmation_resend_limit) %>;
     var mailpoet_subscribers_api = <%= json_encode(api) %>;
+    var mailpoet_timezone_list = <%= json_encode(timezone_list) %>;
   </script>
 
   <%= localize({


### PR DESCRIPTION
## Description

Adds an editable Timezone field to the subscriber edit form. Since timezone is already collected from form signups, this is not hidden behind a feature flag and is present for everyone.

## Code review notes

- The manual save path reacts only to the new `timezone` data key, so the signup flow (`mailpoet_subscriber_timezone`) and the MP API (which filters incoming fields) are unaffected.
- Re-saving the form with an unchanged value keeps the existing source/confidence (for example `form`/90), so admin edits don't silently rewrite browser-collected provenance.
- Manual edits are stored with source `manual` and confidence 100; an empty selection clears all four timezone columns.

## QA notes

1. Go to MailPoet → Subscribers and edit a subscriber.
2. Set a timezone, save, reopen — the value should persist.
3. Select "Not set", save, reopen — the value should be cleared.
4. Works regardless of whether the timezone collection setting/flag is enabled.

## Screenshots

<img width="1078" height="712" alt="Screenshot 2026-07-09 at 17 15 54" src="https://github.com/user-attachments/assets/318502dd-94b2-4244-a3d7-492134a34aa0" />

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8254](https://linear.app/a8c/issue/STOMAIL-8254/allow-editing-subscriber-timezone-in-the-subscriber-edit-form)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8254-subscriber-timezone-edit-field)

_The latest successful build from `add/stomail-8254-subscriber-timezone-edit-field` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->