### PR TITLE
Generate timezone data in the sample data generator

### DIFF
--- a/mailpoet/tests/DataGenerator/Generators/SampleData.php
+++ b/mailpoet/tests/DataGenerator/Generators/SampleData.php
@@ -140,9 +140,9 @@ class SampleData implements Generator {
     );
 
     $sentEmails = [];
-    foreach ($this->createSentStandardNewsletters($lists, $subscribersByList, $runSuffix) as $messageAndEmail) {
-      $sentEmails[] = $messageAndEmail['email'];
-      yield $messageAndEmail['message'];
+    foreach ($this->createSentStandardNewsletters($lists, $subscribersByList, $allSubscribers, $runSuffix) as $messageAndEmails) {
+      $sentEmails = array_merge($sentEmails, $messageAndEmails['emails']);
+      yield $messageAndEmails['message'];
     }
     yield sprintf('Sent standard newsletters done (%d)', $this->config->getSentNewslettersCount());
 
@@ -425,33 +425,7 @@ class SampleData implements Generator {
     string $localTime
   ): void {
     $siteTimeZone = wp_timezone()->getName();
-    $groups = [];
-    foreach ($recipientIds as $subscriberId) {
-      $subscriber = $allSubscribers[$subscriberId] ?? null;
-      $timeZone = $subscriber ? $subscriber->getTimeZone() : null;
-      $fallbackUsed = $timeZone === null;
-      $resolvedTimeZone = $timeZone ?: $siteTimeZone;
-      $key = $resolvedTimeZone . ':' . (int)$fallbackUsed;
-      if (!isset($groups[$key])) {
-        $groups[$key] = [
-          'timeZone' => $resolvedTimeZone,
-          'fallbackUsed' => $fallbackUsed,
-          'subscriberIds' => [],
-        ];
-      }
-      $groups[$key]['subscriberIds'][] = $subscriberId;
-    }
-
-    $schedule = [];
-    foreach ($groups as $group) {
-      $scheduledAt = new \DateTimeImmutable("{$localDate} {$localTime}", new \DateTimeZone($group['timeZone']));
-      $group['scheduledAt'] = $scheduledAt->setTimezone(new \DateTimeZone('UTC'));
-      $schedule[] = $group;
-    }
-    usort($schedule, function(array $a, array $b): int {
-      return $a['scheduledAt'] <=> $b['scheduledAt'];
-    });
-
+    $schedule = $this->buildTimeZoneSchedule($recipientIds, $allSubscribers, $siteTimeZone, $localDate, $localTime);
     $campaignId = Security::generateRandomString(16);
     $firstScheduledAt = $schedule[0]['scheduledAt']->format('Y-m-d H:i:s');
     $lastScheduledAt = $schedule[count($schedule) - 1]['scheduledAt']->format('Y-m-d H:i:s');
@@ -488,11 +462,57 @@ class SampleData implements Generator {
   }
 
   /**
+   * Groups recipients by their time zone (site time zone as fallback) and computes
+   * the UTC send time of each group for the selected local date and time. Groups
+   * are ordered by send time.
+   *
+   * @param int[] $recipientIds
+   * @param array<int, SubscriberEntity> $allSubscribers
+   * @return array<int, array{timeZone: string, fallbackUsed: bool, subscriberIds: int[], scheduledAt: \DateTimeImmutable}>
+   */
+  private function buildTimeZoneSchedule(
+    array $recipientIds,
+    array $allSubscribers,
+    string $siteTimeZone,
+    string $localDate,
+    string $localTime
+  ): array {
+    $groups = [];
+    foreach ($recipientIds as $subscriberId) {
+      $subscriber = $allSubscribers[$subscriberId] ?? null;
+      $timeZone = $subscriber ? $subscriber->getTimeZone() : null;
+      $fallbackUsed = $timeZone === null;
+      $resolvedTimeZone = $timeZone ?: $siteTimeZone;
+      $key = $resolvedTimeZone . ':' . (int)$fallbackUsed;
+      if (!isset($groups[$key])) {
+        $groups[$key] = [
+          'timeZone' => $resolvedTimeZone,
+          'fallbackUsed' => $fallbackUsed,
+          'subscriberIds' => [],
+        ];
+      }
+      $groups[$key]['subscriberIds'][] = $subscriberId;
+    }
+
+    $schedule = [];
+    foreach ($groups as $group) {
+      $scheduledAt = new \DateTimeImmutable("{$localDate} {$localTime}", new \DateTimeZone($group['timeZone']));
+      $group['scheduledAt'] = $scheduledAt->setTimezone(new \DateTimeZone('UTC'));
+      $schedule[] = $group;
+    }
+    usort($schedule, function(array $a, array $b): int {
+      return $a['scheduledAt'] <=> $b['scheduledAt'];
+    });
+    return $schedule;
+  }
+
+  /**
    * @param array<int, SegmentEntity> $lists
    * @param array<int, int[]> $subscribersByList
-   * @return \Generator<array{message: string, email: array{newsletter_id: int, queue_id: int, sent_at: int, link_id: int}}>
+   * @param array<int, SubscriberEntity> $allSubscribers
+   * @return \Generator<array{message: string, emails: array<int, array{newsletter_id: int, queue_id: int, sent_at: int, link_id: int}>}>
    */
-  private function createSentStandardNewsletters(array $lists, array $subscribersByList, string $runSuffix): \Generator {
+  private function createSentStandardNewsletters(array $lists, array $subscribersByList, array $allSubscribers, string $runSuffix): \Generator {
     if (!$lists) {
       return;
     }
@@ -511,19 +531,155 @@ class SampleData implements Generator {
         return $lists[$id];
       }, $targetListIds);
       $recipientIds = $this->getRecipientsForLists($targetListIds, $subscribersByList);
-      $sentAt = $this->randomPastDate()->toDateTimeString();
 
-      $newsletter = (new NewsletterFactory())
-        ->withSubject(sprintf('[%s sent %d %s] Newsletter', $this->config->getPrefix(), $i, $runSuffix))
-        ->withSegments($targetLists)
-        ->withCreatedAt($sentAt)
-        ->create();
+      // Alternate so that both modes are present even for low counts. Time zone
+      // batches need recipients, so fall back to website time when there are none.
+      $byTimeZone = $i % 2 === 0 && $recipientIds;
+
+      if ($byTimeZone) {
+        // Send times spread up to ~26 hours around the local date across time zones,
+        // so keep the whole campaign at least two days in the past.
+        $localDate = Carbon::now()->subDays(random_int(2, max(2, $this->config->getMaxDaysAgo())))->format('Y-m-d');
+        $localTime = sprintf('%02d:%02d:00', random_int(8, 20), 15 * random_int(0, 3));
+        $newsletter = (new NewsletterFactory())
+          ->withSubject(sprintf('[%s sent %d %s] Newsletter', $this->config->getPrefix(), $i, $runSuffix))
+          ->withSegments($targetLists)
+          ->withCreatedAt(Carbon::parse($localDate)->subDays(random_int(1, 10))->toDateTimeString())
+          ->withOptions([
+            NewsletterOptionFieldEntity::NAME_IS_SCHEDULED => '1',
+            NewsletterOptionFieldEntity::NAME_SCHEDULE_MODE => TimeZoneCampaignScheduler::SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+            NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_DATE => $localDate,
+            NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_TIME => $localTime,
+          ])
+          ->create();
+        $emails = $this->createSentTimeZoneCampaignData($newsletter, $recipientIds, $allSubscribers, $localDate, $localTime);
+        $message = sprintf(
+          'Sent newsletter %d/%d (to %d recipients, by subscriber time zone)',
+          $i,
+          $this->config->getSentNewslettersCount(),
+          count($recipientIds)
+        );
+      } else {
+        $sentAt = $this->randomPastDate()->toDateTimeString();
+        $newsletter = (new NewsletterFactory())
+          ->withSubject(sprintf('[%s sent %d %s] Newsletter', $this->config->getPrefix(), $i, $runSuffix))
+          ->withSegments($targetLists)
+          ->withCreatedAt($sentAt)
+          ->create();
+        $emails = [$this->createSentEmailData($newsletter, $sentAt, $recipientIds)];
+        $message = sprintf('Sent newsletter %d/%d (to %d recipients)', $i, $this->config->getSentNewslettersCount(), count($recipientIds));
+      }
 
       yield [
-        'message' => sprintf('Sent newsletter %d/%d (to %d recipients)', $i, $this->config->getSentNewslettersCount(), count($recipientIds)),
-        'email' => $this->createSentEmailData($newsletter, $sentAt, $recipientIds),
+        'message' => $message,
+        'emails' => $emails,
       ];
     }
+  }
+
+  /**
+   * Creates the state a fully delivered time zone campaign is left in: one completed
+   * task and queue per time zone group with staggered send times, full time zone
+   * meta on each queue, and the newsletter marked as sent.
+   *
+   * @param int[] $recipientIds
+   * @param array<int, SubscriberEntity> $allSubscribers
+   * @return array<int, array{newsletter_id: int, queue_id: int, sent_at: int, link_id: int}>
+   */
+  private function createSentTimeZoneCampaignData(
+    NewsletterEntity $newsletter,
+    array $recipientIds,
+    array $allSubscribers,
+    string $localDate,
+    string $localTime
+  ): array {
+    $connection = $this->entityManager->getConnection();
+    $siteTimeZone = wp_timezone()->getName();
+    $schedule = $this->buildTimeZoneSchedule($recipientIds, $allSubscribers, $siteTimeZone, $localDate, $localTime);
+
+    $campaignId = Security::generateRandomString(16);
+    $firstScheduledAt = $schedule[0]['scheduledAt']->format('Y-m-d H:i:s');
+    $lastScheduledAt = $schedule[count($schedule) - 1]['scheduledAt']->format('Y-m-d H:i:s');
+
+    $taskSubscribersTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    $statsNewslettersTable = $this->entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName();
+    $newsletterId = $newsletter->getId();
+
+    $queueData = [];
+    $lastProcessedAt = null;
+    foreach ($schedule as $group) {
+      $processedAt = Carbon::instance($group['scheduledAt'])->addMinutes(random_int(1, 30));
+      $lastProcessedAt = $processedAt;
+      $sentAt = $processedAt->format('Y-m-d H:i:s');
+
+      $task = new ScheduledTaskEntity();
+      $task->setType(SendingQueue::TASK_TYPE);
+      $task->setPriority(ScheduledTaskEntity::PRIORITY_MEDIUM);
+      $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+      $task->setScheduledAt($group['scheduledAt']);
+      $task->setProcessedAt($processedAt);
+      $this->scheduledTasksRepository->persist($task);
+
+      $queue = new SendingQueueEntity();
+      $queue->setNewsletter($newsletter);
+      $queue->setTask($task);
+      $queue->setNewsletterRenderedSubject($newsletter->getSubject());
+      $queue->setCountTotal(count($group['subscriberIds']));
+      $queue->setCountProcessed(count($group['subscriberIds']));
+      $queue->setMeta([
+        TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE => true,
+        TimeZoneCampaignScheduler::META_TIMEZONE_CAMPAIGN_ID => $campaignId,
+        TimeZoneCampaignScheduler::META_SELECTED_LOCAL_DATE => $localDate,
+        TimeZoneCampaignScheduler::META_SELECTED_LOCAL_TIME => $localTime,
+        TimeZoneCampaignScheduler::META_GROUP_TIMEZONE => $group['timeZone'],
+        TimeZoneCampaignScheduler::META_FALLBACK_USED => $group['fallbackUsed'],
+        TimeZoneCampaignScheduler::META_SITE_TIMEZONE => $siteTimeZone,
+        TimeZoneCampaignScheduler::META_FIRST_SCHEDULED_AT => $firstScheduledAt,
+        TimeZoneCampaignScheduler::META_LAST_SCHEDULED_AT => $lastScheduledAt,
+      ]);
+      $this->sendingQueuesRepository->persist($queue);
+      $this->entityManager->flush();
+
+      $taskId = $task->getId();
+      $queueId = $queue->getId();
+      foreach (array_chunk($group['subscriberIds'], self::BULK_INSERT_BATCH_SIZE) as $subscriberIdsChunk) {
+        $taskBatch = [];
+        $statsBatch = [];
+        foreach ($subscriberIdsChunk as $subscriberId) {
+          $taskBatch[] = "($taskId, $subscriberId, 1, '$sentAt')";
+          $statsBatch[] = "($newsletterId, $subscriberId, $queueId, '$sentAt')";
+        }
+        $connection->executeStatement(
+          "INSERT INTO $taskSubscribersTable (`task_id`, `subscriber_id`, `processed`, `created_at`) VALUES " . implode(', ', $taskBatch)
+        );
+        $connection->executeStatement(
+          "INSERT INTO $statsNewslettersTable (`newsletter_id`, `subscriber_id`, `queue_id`, `sent_at`) VALUES " . implode(', ', $statsBatch)
+        );
+      }
+
+      $queueData[] = [
+        'queue_id' => $queueId,
+        'sent_at' => $processedAt->getTimestamp(),
+      ];
+    }
+
+    $this->entityManager->refresh($newsletter);
+    $link = (new NewsletterLinkFactory($newsletter))->withCreatedAt($firstScheduledAt)->create();
+
+    if ($newsletter->getStatus() === NewsletterEntity::STATUS_DRAFT && $lastProcessedAt !== null) {
+      $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
+      $newsletter->setSentAt($lastProcessedAt);
+      $this->entityManager->flush();
+    }
+
+    return array_map(function(array $data) use ($newsletterId, $link): array {
+      return [
+        'newsletter_id' => $newsletterId,
+        'queue_id' => $data['queue_id'],
+        'sent_at' => $data['sent_at'],
+        'link_id' => $link->getId(),
+      ];
+    }, $queueData);
   }
 
   /**

--- a/mailpoet/tests/DataGenerator/Generators/SampleData.php
+++ b/mailpoet/tests/DataGenerator/Generators/SampleData.php
@@ -54,6 +54,21 @@ class SampleData implements Generator {
     SubscriberEntity::STATUS_BOUNCED => 5,
   ];
 
+  private const SUBSCRIBER_TIME_ZONE_SHARE = 70;
+
+  private const SUBSCRIBER_TIME_ZONES = [
+    'America/New_York',
+    'America/Chicago',
+    'America/Los_Angeles',
+    'America/Sao_Paulo',
+    'Europe/London',
+    'Europe/Berlin',
+    'Europe/Prague',
+    'Asia/Kolkata',
+    'Asia/Tokyo',
+    'Australia/Sydney',
+  ];
+
   private const AUTOMATION_RUN_STATUS_DISTRIBUTION = [
     AutomationRunData::STATUS_COMPLETE => 78,
     AutomationRunData::STATUS_RUNNING => 8,
@@ -189,15 +204,28 @@ class SampleData implements Generator {
       $createdAt = $this->randomPastDate();
       $subscriberLists = $this->pickRandomElements($lists, random_int(1, min(3, count($lists))));
 
-      $subscriber = (new SubscriberFactory())
+      $subscriberFactory = (new SubscriberFactory())
         ->withEmail(sprintf('sample-%s-%05d@%s', $runSuffix, $i, $this->config->getEmailDomain()))
         ->withStatus($status)
         ->withFirstName('Sample')
         ->withLastName('Subscriber ' . $i)
         ->withSource('imported')
         ->withEngagementScore(random_int(0, 100))
-        ->withCreatedAt($createdAt)
-        ->create();
+        ->withCreatedAt($createdAt);
+
+      $timeZone = random_int(1, 100) <= self::SUBSCRIBER_TIME_ZONE_SHARE
+        ? self::SUBSCRIBER_TIME_ZONES[array_rand(self::SUBSCRIBER_TIME_ZONES)]
+        : null;
+      if ($timeZone !== null) {
+        $subscriberFactory->withTimeZone($timeZone);
+      }
+
+      $subscriber = $subscriberFactory->create();
+      if ($timeZone !== null) {
+        $subscriber->setTimeZoneSource(SubscriberEntity::TIME_ZONE_SOURCE_FORM);
+        $subscriber->setTimeZoneConfidence(SubscriberEntity::TIME_ZONE_CONFIDENCE_BROWSER);
+        $subscriber->setTimeZoneUpdatedAt($createdAt);
+      }
 
       $segmentStatus = $status === SubscriberEntity::STATUS_UNSUBSCRIBED
         ? SubscriberEntity::STATUS_UNSUBSCRIBED

--- a/mailpoet/tests/DataGenerator/Generators/SampleData.php
+++ b/mailpoet/tests/DataGenerator/Generators/SampleData.php
@@ -12,6 +12,7 @@ use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
@@ -23,7 +24,9 @@ use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Test\DataFactories\Automation as AutomationFactory;
 use MailPoet\Test\DataFactories\AutomationRun as AutomationRunFactory;
 use MailPoet\Test\DataFactories\AutomationRunLog as AutomationRunLogFactory;
@@ -32,6 +35,7 @@ use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\NewsletterLink as NewsletterLinkFactory;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\Util\Security;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -85,6 +89,9 @@ class SampleData implements Generator {
   /** @var ScheduledTasksRepository */
   private $scheduledTasksRepository;
 
+  /** @var ScheduledTaskSubscribersRepository */
+  private $scheduledTaskSubscribersRepository;
+
   /** @var SendingQueuesRepository */
   private $sendingQueuesRepository;
 
@@ -94,6 +101,7 @@ class SampleData implements Generator {
     $this->config = $config ?? SampleDataConfig::fromArray();
     $this->entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
     $this->scheduledTasksRepository = ContainerWrapper::getInstance()->get(ScheduledTasksRepository::class);
+    $this->scheduledTaskSubscribersRepository = ContainerWrapper::getInstance()->get(ScheduledTaskSubscribersRepository::class);
     $this->sendingQueuesRepository = ContainerWrapper::getInstance()->get(SendingQueuesRepository::class);
   }
 
@@ -123,6 +131,13 @@ class SampleData implements Generator {
 
     $this->createDraftNewsletters($lists, $runSuffix);
     yield sprintf('Draft newsletters done (%d)', $this->config->getDraftNewslettersCount());
+
+    $scheduledCounts = $this->createScheduledStandardNewsletters($lists, $subscribersByList, $allSubscribers, $runSuffix);
+    yield sprintf(
+      'Scheduled newsletters done (%d by subscriber time zone, %d by website time)',
+      $scheduledCounts[TimeZoneCampaignScheduler::SCHEDULE_MODE_SUBSCRIBER_TIMEZONE],
+      $scheduledCounts[TimeZoneCampaignScheduler::SCHEDULE_MODE_WEBSITE_TIME]
+    );
 
     $sentEmails = [];
     foreach ($this->createSentStandardNewsletters($lists, $subscribersByList, $runSuffix) as $messageAndEmail) {
@@ -322,6 +337,153 @@ class SampleData implements Generator {
         ->withSegments($targetLists)
         ->withCreatedAt($this->randomPastDate()->toDateTimeString())
         ->create();
+    }
+  }
+
+  /**
+   * @param array<int, SegmentEntity> $lists
+   * @param array<int, int[]> $subscribersByList
+   * @param array<int, SubscriberEntity> $allSubscribers
+   * @return array<string, int>
+   */
+  private function createScheduledStandardNewsletters(array $lists, array $subscribersByList, array $allSubscribers, string $runSuffix): array {
+    $counts = [
+      TimeZoneCampaignScheduler::SCHEDULE_MODE_SUBSCRIBER_TIMEZONE => 0,
+      TimeZoneCampaignScheduler::SCHEDULE_MODE_WEBSITE_TIME => 0,
+    ];
+    if (!$lists) {
+      return $counts;
+    }
+
+    $listIds = array_keys($lists);
+    for ($i = 1; $i <= $this->config->getScheduledNewslettersCount(); $i++) {
+      $targetListIds = $this->pickRandomValues($listIds, random_int(1, min(2, count($listIds))));
+      $targetLists = array_map(function($id) use ($lists) {
+        return $lists[$id];
+      }, $targetListIds);
+      $recipientIds = $this->getRecipientsForLists($targetListIds, $subscribersByList);
+
+      // Alternate so that both modes are present even for low counts. Time zone
+      // batches need recipients, so fall back to website time when there are none.
+      $mode = $i % 2 === 1 && $recipientIds
+        ? TimeZoneCampaignScheduler::SCHEDULE_MODE_SUBSCRIBER_TIMEZONE
+        : TimeZoneCampaignScheduler::SCHEDULE_MODE_WEBSITE_TIME;
+
+      $localDate = Carbon::now()->addDays(random_int(2, 14))->format('Y-m-d');
+      $localTime = sprintf('%02d:%02d:00', random_int(8, 20), 15 * random_int(0, 3));
+
+      $newsletterFactory = (new NewsletterFactory())
+        ->withSubject(sprintf('[%s scheduled %d %s] Newsletter', $this->config->getPrefix(), $i, $runSuffix))
+        ->withScheduledStatus()
+        ->withSegments($targetLists)
+        ->withCreatedAt($this->randomPastDate()->toDateTimeString());
+
+      if ($mode === TimeZoneCampaignScheduler::SCHEDULE_MODE_WEBSITE_TIME) {
+        $scheduledAt = Carbon::parse("{$localDate} {$localTime}");
+        $newsletterFactory
+          ->withOptions([
+            NewsletterOptionFieldEntity::NAME_IS_SCHEDULED => '1',
+            NewsletterOptionFieldEntity::NAME_SCHEDULED_AT => $scheduledAt->format('Y-m-d H:i:s'),
+            NewsletterOptionFieldEntity::NAME_SCHEDULE_MODE => TimeZoneCampaignScheduler::SCHEDULE_MODE_WEBSITE_TIME,
+          ])
+          ->withScheduledQueue([
+            'scheduled_at' => $scheduledAt,
+            'count_total' => 0,
+            'count_processed' => 0,
+          ])
+          ->create();
+      } else {
+        $newsletter = $newsletterFactory
+          ->withOptions([
+            NewsletterOptionFieldEntity::NAME_IS_SCHEDULED => '1',
+            NewsletterOptionFieldEntity::NAME_SCHEDULE_MODE => TimeZoneCampaignScheduler::SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+            NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_DATE => $localDate,
+            NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_TIME => $localTime,
+          ])
+          ->create();
+        $this->createTimeZoneCampaignQueues($newsletter, $recipientIds, $allSubscribers, $localDate, $localTime);
+      }
+
+      $counts[$mode]++;
+    }
+    return $counts;
+  }
+
+  /**
+   * Mirrors the queues created by TimeZoneCampaignScheduler::schedule() without its
+   * feature, capability, and lead-time checks so that sample data can be generated
+   * in any environment.
+   *
+   * @param int[] $recipientIds
+   * @param array<int, SubscriberEntity> $allSubscribers
+   */
+  private function createTimeZoneCampaignQueues(
+    NewsletterEntity $newsletter,
+    array $recipientIds,
+    array $allSubscribers,
+    string $localDate,
+    string $localTime
+  ): void {
+    $siteTimeZone = wp_timezone()->getName();
+    $groups = [];
+    foreach ($recipientIds as $subscriberId) {
+      $subscriber = $allSubscribers[$subscriberId] ?? null;
+      $timeZone = $subscriber ? $subscriber->getTimeZone() : null;
+      $fallbackUsed = $timeZone === null;
+      $resolvedTimeZone = $timeZone ?: $siteTimeZone;
+      $key = $resolvedTimeZone . ':' . (int)$fallbackUsed;
+      if (!isset($groups[$key])) {
+        $groups[$key] = [
+          'timeZone' => $resolvedTimeZone,
+          'fallbackUsed' => $fallbackUsed,
+          'subscriberIds' => [],
+        ];
+      }
+      $groups[$key]['subscriberIds'][] = $subscriberId;
+    }
+
+    $schedule = [];
+    foreach ($groups as $group) {
+      $scheduledAt = new \DateTimeImmutable("{$localDate} {$localTime}", new \DateTimeZone($group['timeZone']));
+      $group['scheduledAt'] = $scheduledAt->setTimezone(new \DateTimeZone('UTC'));
+      $schedule[] = $group;
+    }
+    usort($schedule, function(array $a, array $b): int {
+      return $a['scheduledAt'] <=> $b['scheduledAt'];
+    });
+
+    $campaignId = Security::generateRandomString(16);
+    $firstScheduledAt = $schedule[0]['scheduledAt']->format('Y-m-d H:i:s');
+    $lastScheduledAt = $schedule[count($schedule) - 1]['scheduledAt']->format('Y-m-d H:i:s');
+
+    foreach ($schedule as $group) {
+      $task = new ScheduledTaskEntity();
+      $task->setType(SendingQueue::TASK_TYPE);
+      $task->setPriority(ScheduledTaskEntity::PRIORITY_MEDIUM);
+      $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+      $task->setScheduledAt($group['scheduledAt']);
+      $this->scheduledTasksRepository->persist($task);
+
+      $queue = new SendingQueueEntity();
+      $queue->setNewsletter($newsletter);
+      $queue->setTask($task);
+      $queue->setNewsletterRenderedSubject($newsletter->getSubject());
+      $queue->setMeta([
+        TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE => true,
+        TimeZoneCampaignScheduler::META_TIMEZONE_CAMPAIGN_ID => $campaignId,
+        TimeZoneCampaignScheduler::META_SELECTED_LOCAL_DATE => $localDate,
+        TimeZoneCampaignScheduler::META_SELECTED_LOCAL_TIME => $localTime,
+        TimeZoneCampaignScheduler::META_GROUP_TIMEZONE => $group['timeZone'],
+        TimeZoneCampaignScheduler::META_FALLBACK_USED => $group['fallbackUsed'],
+        TimeZoneCampaignScheduler::META_SITE_TIMEZONE => $siteTimeZone,
+        TimeZoneCampaignScheduler::META_FIRST_SCHEDULED_AT => $firstScheduledAt,
+        TimeZoneCampaignScheduler::META_LAST_SCHEDULED_AT => $lastScheduledAt,
+      ]);
+      $this->sendingQueuesRepository->persist($queue);
+      $this->entityManager->flush();
+
+      $this->scheduledTaskSubscribersRepository->addSubscribersByIds($task, $group['subscriberIds']);
+      $this->sendingQueuesRepository->updateCounts($queue);
     }
   }
 

--- a/mailpoet/tests/DataGenerator/Generators/SampleDataConfig.php
+++ b/mailpoet/tests/DataGenerator/Generators/SampleDataConfig.php
@@ -11,6 +11,7 @@ class SampleDataConfig {
     'products' => null,
     'draft-newsletters' => null,
     'sent-newsletters' => null,
+    'scheduled-newsletters' => null,
     'post-notifications' => null,
     'automatic-emails' => null,
     'automations' => null,
@@ -35,6 +36,7 @@ class SampleDataConfig {
     'products' => 10,
     'draft-newsletters' => 5,
     'sent-newsletters' => 30,
+    'scheduled-newsletters' => 6,
     'post-notifications' => 6,
     'automatic-emails' => 5,
     'automations' => 3,
@@ -59,6 +61,7 @@ class SampleDataConfig {
     'products' => 5,
     'draft-newsletters' => 2,
     'sent-newsletters' => 5,
+    'scheduled-newsletters' => 2,
     'post-notifications' => 2,
     'automatic-emails' => 2,
     'automations' => 1,
@@ -72,6 +75,7 @@ class SampleDataConfig {
     'products' => 30,
     'draft-newsletters' => 10,
     'sent-newsletters' => 80,
+    'scheduled-newsletters' => 12,
     'post-notifications' => 20,
     'automatic-emails' => 8,
     'automations' => 5,
@@ -166,6 +170,10 @@ class SampleDataConfig {
     return $this->getInt('sent-newsletters');
   }
 
+  public function getScheduledNewslettersCount(): int {
+    return $this->getInt('scheduled-newsletters');
+  }
+
   public function getPostNotificationsCount(): int {
     return $this->getInt('post-notifications');
   }
@@ -234,6 +242,7 @@ class SampleDataConfig {
       'products',
       'draft-newsletters',
       'sent-newsletters',
+      'scheduled-newsletters',
       'post-notifications',
       'automatic-emails',
       'automations',


### PR DESCRIPTION
## Description

Makes the sample data generator produce timezone data so time-zone based sending (STOMAIL-8004) can be tested locally.

- ~70% of generated subscribers get a random IANA timezone (source `form`, confidence 90); the rest stay without one to cover the site-timezone fallback path.
- New `--scheduled-newsletters` option generates scheduled campaigns alternating between subscriber-timezone mode (per-timezone tasks/queues with campaign meta) and website-time mode.
- Every second sent newsletter is generated as a fully delivered subscriber-timezone campaign: one completed task/queue per timezone group with staggered send times and full timezone meta.

Queues are created directly instead of via `TimeZoneCampaignScheduler::schedule()`, which enforces a feature flag, a paid-plan capability, and a 24h lead time — the generator must work in any dev environment.

## QA notes

1. `pnpm generate:sample-data --preset=small`
2. Subscribers in DB: most have `time_zone`/`time_zone_source`/`time_zone_confidence` set, some NULL.
3. Emails list: scheduled and sent subscriber-timezone campaigns have multiple queues (one per timezone group) with `sendByTimezone` meta and staggered send times; website-time ones have a single queue.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8255](https://linear.app/a8c/issue/STOMAIL-8255/update-data-generator-to-include-timezone-data-for-subscribers-and)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`) — not user-facing (dev tooling only)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/stomail-8255-generator-timezone-data)

_The latest successful build from `update/stomail-8255-generator-timezone-data` will be used. If none is available, the link won't work._
