### PR TITLE
Guard custom-field email tags against missing schema column

### DIFF
--- a/mailpoet/changelog/2026-07-09-16-07-18-fixed-fatal-error-when-the-email-editor-read-custom-fiel.md
+++ b/mailpoet/changelog/2026-07-09-16-07-18-fixed-fatal-error-when-the-email-editor-read-custom-fiel.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fatal error when the email editor read custom fields before a database migration finished during a plugin update

--- a/mailpoet/changelog/2026-07-09-16-07-18-fixed-fatal-error-when-the-email-editor-read-custom-fiel.md
+++ b/mailpoet/changelog/2026-07-09-16-07-18-fixed-fatal-error-when-the-email-editor-read-custom-fiel.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Fatal error when the email editor read custom fields before a database migration finished during a plugin update
+Fatal error on some sites when the email editor loaded custom fields before a database migration finished during a plugin update

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -17,6 +17,8 @@ use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Site;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Subscriber;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Doctrine\DBAL\Exception\InvalidFieldNameException;
+use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 
 class PersonalizationTagManager {
   private Subscriber $subscriber;
@@ -314,7 +316,14 @@ class PersonalizationTagManager {
   }
 
   private function registerSubscriberCustomFieldTags(Personalization_Tags_Registry $registry): void {
-    $customFields = $this->customFieldsRepository->findAllActive();
+    try {
+      $customFields = $this->customFieldsRepository->findAllActive();
+    } catch (InvalidFieldNameException | TableNotFoundException $e) {
+      // The custom_fields schema may be mid-migration during a plugin update (e.g. the deleted_at
+      // column added in 5.33.1). Skip custom-field tags for this request rather than fataling; they
+      // register on the next request once the migration completes.
+      return;
+    }
     foreach ($customFields as $customField) {
       $customFieldId = (int)$customField->getId();
       $registry->register(new Personalization_Tag(

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
@@ -11,6 +11,7 @@ use MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter as NewsletterTask;
 use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\LinksToShortcodesConvertor;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\OrderReviewUrl;
+use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
@@ -197,5 +198,28 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
     );
 
     $this->assertSame('[Leave a review](https://example.com/review-order/abc)', $text);
+  }
+
+  public function testItSkipsCustomFieldTagsWhenDeletedAtColumnIsMissing(): void {
+    (new CustomFieldFactory())->create();
+
+    // Reproduce the plugin-update window: the deleted_at column the entity maps has not been added yet.
+    $table = $this->entityManager->getClassMetadata(CustomFieldEntity::class)->getTableName();
+    $connection = $this->entityManager->getConnection();
+    $connection->executeStatement("ALTER TABLE `{$table}` DROP COLUMN `deleted_at`");
+
+    try {
+      $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+      $personalizationManager->initialize();
+
+      $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
+      // Must not throw an uncaught QueryException / fatal.
+      WPFunctions::get()->applyFilters('woocommerce_email_editor_register_personalization_tags', $registry);
+
+      // Custom-field tags are skipped, but the static (non-DB) tags still register.
+      $this->assertNotNull($registry->get_by_token('[mailpoet/subscriber-email]'));
+    } finally {
+      $connection->executeStatement("ALTER TABLE `{$table}` ADD COLUMN `deleted_at` TIMESTAMP NULL DEFAULT NULL");
+    }
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
@@ -201,14 +201,17 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
   }
 
   public function testItSkipsCustomFieldTagsWhenDeletedAtColumnIsMissing(): void {
-    (new CustomFieldFactory())->create();
+    $customField = (new CustomFieldFactory())->create();
 
-    // Reproduce the plugin-update window: the deleted_at column the entity maps has not been added yet.
     $table = $this->entityManager->getClassMetadata(CustomFieldEntity::class)->getTableName();
     $connection = $this->entityManager->getConnection();
-    $connection->executeStatement("ALTER TABLE `{$table}` DROP COLUMN `deleted_at`");
+    $dropped = false;
 
     try {
+      // Reproduce the plugin-update window: the deleted_at column the entity maps has not been added yet.
+      $connection->executeStatement("ALTER TABLE `{$table}` DROP COLUMN `deleted_at`");
+      $dropped = true;
+
       $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
       $personalizationManager->initialize();
 
@@ -216,10 +219,14 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
       // Must not throw an uncaught QueryException / fatal.
       WPFunctions::get()->applyFilters('woocommerce_email_editor_register_personalization_tags', $registry);
 
-      // Custom-field tags are skipped, but the static (non-DB) tags still register.
+      // The custom-field tag is skipped because its query hit the missing column...
+      $this->assertNull($registry->get_by_token('[mailpoet/subscriber-cf-' . $customField->getId() . ']'));
+      // ...but the static (non-DB) tags still register.
       $this->assertNotNull($registry->get_by_token('[mailpoet/subscriber-email]'));
     } finally {
-      $connection->executeStatement("ALTER TABLE `{$table}` ADD COLUMN `deleted_at` TIMESTAMP NULL DEFAULT NULL");
+      if ($dropped) {
+        $connection->executeStatement("ALTER TABLE `{$table}` ADD COLUMN `deleted_at` TIMESTAMP NULL DEFAULT NULL");
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes a spike of PHP fatal errors on Atomic sites running MailPoet 5.33.1:

```
PHP Fatal error: Uncaught MailPoet\Doctrine\WPDBxceptions\QueryException:
Unknown column 't0.deleted_at' in 'SELECT'
```

**Root cause — a deploy-ordering race, not a broken query.** 5.33.1 (STOMAIL-8002) gave `CustomFieldEntity` a soft-delete `deleted_at` column via `DeletedAtTrait`, so `findAllActive()` now selects `deleted_at`. The migration that adds the column runs from the Activator, on the `init` hook, under a transient lock. During the update window a request that loses that lock keeps running (the lock exception is swallowed as a warning), the email editor bootstraps on `init`, and `PersonalizationTagManager::registerSubscriberCustomFieldTags()` queries the not-yet-added column → uncaught exception → fatal. This is why the failing requests are `wp-cron.php` and `xmlrpc.php` (background requests that lose the lock).

This is the **simple guard**: catch the DBAL unknown-column / missing-table exception and skip custom-field tag registration for that request. Tags register normally on the next request once the migration completes. A broader "schema readiness gate" for all init-time DB readers is planned as a separate follow-up.

## Code review notes

The catch is deliberately narrow — only `InvalidFieldNameException | TableNotFoundException`, not `\Throwable` — so a genuine DB error still surfaces loudly instead of silently dropping custom-field tags forever.

## QA notes

Reproduce the window without a real update: drop the column, then load an email-editor request.

```sql
ALTER TABLE wp_mailpoet_custom_fields DROP COLUMN deleted_at;
```

- Before: opening the email editor (or any `init`-triggering request like wp-cron/xmlrpc) fatals with `Unknown column 't0.deleted_at'`.
- After: no fatal; the editor loads, custom-field personalization tags are simply absent until the column is restored, other tags work.

Restore with `ALTER TABLE wp_mailpoet_custom_fields ADD COLUMN deleted_at TIMESTAMP NULL DEFAULT NULL;`.

Automated: `pnpm test:integration --file=tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php --wordpress-version=6.9` (new test `testItSkipsCustomFieldTagsWhenDeletedAtColumnIsMissing`; confirmed it fails without the guard with the exact production exception).

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8258

## After-merge notes

Follow-up planned: a general schema-readiness gate consulted by init-time DB readers, to retire the whole class of race rather than patch per-column.

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8258-custom-fields-personalization-tag-schema-guard)

_The latest successful build from `fix/stomail-8258-custom-fields-personalization-tag-schema-guard` will be used. If none is available, the link won't work._