### PR TITLE
Index statistics_newsletters for queue-based filtering

### DIFF
--- a/mailpoet/lib/Migrations/Db/Migration_20260709_120000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260709_120000_Db.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\StatisticsNewsletterEntity;
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20260709_120000_Db extends DbMigration {
+  public function run(): void {
+    $statisticsNewslettersTable = $this->getTableName(StatisticsNewsletterEntity::class);
+
+    // The campaign stats "Unopened" listing filters recipients of a
+    // subscriber-timezone campaign with `newsletter_id = ? AND queue_id IN (...)`.
+    // The other statistics tables already carry a queue_id index, but here the
+    // best existing index is (newsletter_id), which reads every recipient of
+    // the newsletter and discards the rows outside the selected batches.
+    // Leading with (newsletter_id, queue_id) binds both predicates, so only
+    // the selected batches are read; the trailing subscriber_id serves the
+    // per-row anti-join lookup against statistics_opens (subscriber_id,
+    // newsletter_id) from the index itself.
+    if (!$this->indexExists($statisticsNewslettersTable, 'newsletter_id_queue_id_subscriber_id')) {
+      $this->connection->executeQuery(
+        "ALTER TABLE `{$statisticsNewslettersTable}`
+          ADD INDEX `newsletter_id_queue_id_subscriber_id` (`newsletter_id`, `queue_id`, `subscriber_id`)"
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Description

The premium subscriber engagement stats gained a delivery timezone filter (mailpoet/mailpoet-premium#1117) that constrains the "Unopened" listing query with `newsletter_id = ? AND queue_id IN (...)`. The other statistics tables already index `queue_id`; on `statistics_newsletters` the best existing index is `(newsletter_id)`, so the filtered query reads every recipient row of the newsletter and discards those outside the selected timezone batches.

This adds a `(newsletter_id, queue_id, subscriber_id)` index: the leading pair binds both predicates, and the trailing `subscriber_id` serves the anti-join lookup against `statistics_opens` from the index itself.

`EXPLAIN` on seeded data (20 newsletters × 6.5k recipients, 40 batches): the filtered query goes from a `ref` scan of all 6,554 recipient rows of the newsletter to an index-only `range` scan of the selected batches (~330 rows).

## Code review notes

- **Not strictly required for the premium feature to ship.** Without the index the filtered query costs the same as the existing unfiltered "Unopened" listing (bounded by recipients-per-newsletter via the existing `newsletter_id` index), so there is no regression — this is an optimization for large sends, where the constraint is re-evaluated in up to ~6 queries per listing request.
- The migration is online DDL (`ADD INDEX` is `ALGORITHM=INPLACE, LOCK=NONE` on InnoDB), guarded by `indexExists` so interrupted runs retry safely. Same class of operation as `Migration_20230605_174836` (five ALTERs on `subscribers`, including table-rebuilding `ADD COLUMN`s) and lighter.
- The existing single-column `newsletter_id` index becomes a redundant prefix of the new one. Left in place deliberately to keep the migration minimal and zero-risk to other query plans; dropping it could be a follow-up.

## QA notes

Covered by the premium integration tests in mailpoet/mailpoet-premium#1117 (`SubscriberEngagementTest`, timezone filter cases) — the index changes no behavior, only the query plan. To verify manually, run the migration and `EXPLAIN SELECT ... FROM wp_mailpoet_statistics_newsletters WHERE newsletter_id = ? AND queue_id IN (...)`; it should use `newsletter_id_queue_id_subscriber_id`.

## Linked PRs

- mailpoet/mailpoet-premium#1117

## Linked tickets

- [STOMAIL-8247](https://linear.app/a8c/issue/STOMAIL-8247/add-delivery-timezone-column-and-filter-to-subscriber-engagement-stats)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8247-statistics-newsletters-timezone-filter-index)

_The latest successful build from `add/stomail-8247-statistics-newsletters-timezone-filter-index` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

1 issue found:
- Performance: The migration does not explicitly specify online DDL options such as `ALGORITHM=INPLACE` and `LOCK=NONE`, despite the stated objective.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->