### PR TITLE
Fire segment subscribed hook from bulk actions

### DIFF
--- a/mailpoet/changelog/2026-07-10-07-47-59-fixed-someone-subscribes-automation-triggers-now-fire-wh.md
+++ b/mailpoet/changelog/2026-07-10-07-47-59-fixed-someone-subscribes-automation-triggers-now-fire-wh.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+Someone subscribes automation triggers now fire when subscribers are added or moved to lists from the Subscribers page

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -808,9 +808,10 @@ class SubscribersRepository extends Repository {
    * @return int - number of processed ids
    */
   public function bulkAddToSegment(SegmentEntity $segment, array $ids): int {
-    $count = $this->addSubscribersToSegment($segment, $ids);
+    $subscriberSegments = $this->addSubscribersToSegment($segment, $ids);
     $this->changesNotifier->subscribersUpdated($ids);
-    return $count;
+    $this->fireSegmentSubscribedHooks($subscriberSegments);
+    return count($subscriberSegments);
   }
 
    /**
@@ -821,11 +822,27 @@ class SubscribersRepository extends Repository {
       return 0;
     }
 
+    /** @var string[] $subscriberIdsAlreadyInSegment */
+    $subscriberIdsAlreadyInSegment = $this->entityManager
+      ->createQueryBuilder()
+      ->select('IDENTITY(ss.subscriber)')
+      ->from(SubscriberSegmentEntity::class, 'ss')
+      ->where('ss.subscriber IN (:ids)')
+      ->andWhere('ss.segment = :segment')
+      ->andWhere('ss.status = :status')
+      ->setParameter('ids', $ids)
+      ->setParameter('segment', $segment)
+      ->setParameter('status', SubscriberEntity::STATUS_SUBSCRIBED)
+      ->getQuery()
+      ->getSingleColumnResult();
+    $subscriberIdsAlreadyInSegment = array_fill_keys(array_map('intval', $subscriberIdsAlreadyInSegment), true);
+
     $this->removeSubscribersFromAllSegments($ids);
-    $count = $this->addSubscribersToSegment($segment, $ids);
+    $subscriberSegments = $this->addSubscribersToSegment($segment, $ids);
 
     $this->changesNotifier->subscribersUpdated($ids);
-    return $count;
+    $this->fireSegmentSubscribedHooks($subscriberSegments, $subscriberIdsAlreadyInSegment);
+    return count($subscriberSegments);
   }
 
   public function bulkUnsubscribe(array $ids): int {
@@ -1381,11 +1398,12 @@ class SubscribersRepository extends Repository {
   }
 
   /**
-   * @return int - number of processed ids
+   * @param int[] $ids
+   * @return SubscriberSegmentEntity[]
    */
-  private function addSubscribersToSegment(SegmentEntity $segment, array $ids): int {
+  private function addSubscribersToSegment(SegmentEntity $segment, array $ids): array {
     if (empty($ids)) {
-      return 0;
+      return [];
     }
 
     $subscribers = $this->entityManager
@@ -1403,12 +1421,14 @@ class SubscribersRepository extends Repository {
       return $s instanceof SubscriberEntity;
     })) : [];
 
-    $this->entityManager->transactional(function (EntityManager $entityManager) use ($subscribers, $segment) {
+    $subscriberSegments = [];
+    $this->entityManager->transactional(function (EntityManager $entityManager) use ($subscribers, $segment, &$subscriberSegments) {
       foreach ($subscribers as $subscriber) {
         $subscriberSegment = new SubscriberSegmentEntity($segment, $subscriber, SubscriberEntity::STATUS_SUBSCRIBED);
-        $this->entityManager->persist($subscriberSegment);
+        $entityManager->persist($subscriberSegment);
+        $subscriberSegments[] = $subscriberSegment;
       }
-      $this->entityManager->flush();
+      $entityManager->flush();
     });
 
     if ($subscribers !== []) {
@@ -1417,7 +1437,28 @@ class SubscribersRepository extends Repository {
       }, $subscribers));
     }
 
-    return count($subscribers);
+    return $subscriberSegments;
+  }
+
+  /**
+   * @param SubscriberSegmentEntity[] $subscriberSegments
+   * @param array<int, true> $subscriberIdsToSkip
+   */
+  private function fireSegmentSubscribedHooks(
+    array $subscriberSegments,
+    array $subscriberIdsToSkip = []
+  ): void {
+    foreach ($subscriberSegments as $subscriberSegment) {
+      $subscriber = $subscriberSegment->getSubscriber();
+      if (
+        !$subscriber instanceof SubscriberEntity
+        || $subscriber->getStatus() !== SubscriberEntity::STATUS_SUBSCRIBED
+        || isset($subscriberIdsToSkip[(int)$subscriber->getId()])
+      ) {
+        continue;
+      }
+      $this->wp->doAction('mailpoet_segment_subscribed', $subscriberSegment);
+    }
   }
 
   /**

--- a/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Subscribers;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
@@ -328,6 +329,34 @@ class SubscribersRepositoryTest extends \MailPoetTest {
     verify($this->subscriberSegmentRepository->findBy(['subscriber' => $subscriberTwoId]))->arrayCount(0);
   }
 
+  public function testItBulkAddToSegmentFiresSubscribedHookOnlyForNewGloballySubscribedSubscribers(): void {
+    $segment = $this->segmentRepository->createOrUpdate('Bulk Add Hook');
+    $newSubscriber = $this->createSubscriber('new@bulk-add-hook.com');
+    $existingSubscriber = $this->createSubscriber('existing@bulk-add-hook.com');
+    $unsubscribedSubscriber = $this->createSubscriber('unsubscribed@bulk-add-hook.com');
+    $unsubscribedSubscriber->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $this->createSubscriberSegment($segment, $existingSubscriber);
+    $this->entityManager->flush();
+
+    $wp = new WPFunctions();
+    $wp->removeAllActions('mailpoet_segment_subscribed');
+    $firedFor = [];
+    $wp->addAction('mailpoet_segment_subscribed', function (SubscriberSegmentEntity $subscriberSegment) use (&$firedFor) {
+      $subscriber = $subscriberSegment->getSubscriber();
+      $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+      $firedFor[] = $subscriber->getEmail();
+    });
+
+    $count = $this->repository->bulkAddToSegment($segment, [
+      $newSubscriber->getId(),
+      $existingSubscriber->getId(),
+      $unsubscribedSubscriber->getId(),
+    ]);
+
+    verify($count)->equals(2);
+    verify($firedFor)->equals(['new@bulk-add-hook.com']);
+  }
+
   public function testItBulMoveSubscribersToSegment(): void {
     $subscriberOne = $this->createSubscriber('one@move.com', new DateTimeImmutable());
     $subscriberTwo = $this->createSubscriber('two@move.com', new DateTimeImmutable());
@@ -366,6 +395,104 @@ class SubscribersRepositoryTest extends \MailPoetTest {
       'subscriber' => $subscriberTwoId,
       'segment' => $segmentTwoId,
     ]))->notNull();
+  }
+
+  public function testItBulkMoveToSegmentFiresSubscribedHookOnlyForNewDestinationMemberships(): void {
+    $sourceSegment = $this->segmentRepository->createOrUpdate('Bulk Move Hook Source');
+    $targetSegment = $this->segmentRepository->createOrUpdate('Bulk Move Hook Target');
+    $newTargetSubscriber = $this->createSubscriber('new@bulk-move-hook.com');
+    $existingTargetSubscriber = $this->createSubscriber('existing@bulk-move-hook.com');
+    $this->createSubscriberSegment($sourceSegment, $newTargetSubscriber);
+    $this->createSubscriberSegment($sourceSegment, $existingTargetSubscriber);
+    $this->createSubscriberSegment($targetSegment, $existingTargetSubscriber);
+
+    $wp = new WPFunctions();
+    $wp->removeAllActions('mailpoet_segment_subscribed');
+    $firedFor = [];
+    $wp->addAction('mailpoet_segment_subscribed', function (SubscriberSegmentEntity $subscriberSegment) use (&$firedFor) {
+      $subscriber = $subscriberSegment->getSubscriber();
+      $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+      $firedFor[] = $subscriber->getEmail();
+    });
+
+    $count = $this->repository->bulkMoveToSegment($targetSegment, [
+      $newTargetSubscriber->getId(),
+      $existingTargetSubscriber->getId(),
+    ]);
+
+    verify($count)->equals(2);
+    verify($firedFor)->equals(['new@bulk-move-hook.com']);
+  }
+
+  public function testItBulkMoveToSegmentFiresSubscribedHookWhenDestinationMembershipWasUnsubscribed(): void {
+    $sourceSegment = $this->segmentRepository->createOrUpdate('Bulk Move Reactivation Source');
+    $targetSegment = $this->segmentRepository->createOrUpdate('Bulk Move Reactivation Target');
+    $subscriber = $this->createSubscriber('reactivated@bulk-move-hook.com');
+    $this->createSubscriberSegment($sourceSegment, $subscriber);
+    $targetMembership = $this->createSubscriberSegment($targetSegment, $subscriber);
+    $targetMembership->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $this->entityManager->flush();
+
+    $wp = new WPFunctions();
+    $wp->removeAllActions('mailpoet_segment_subscribed');
+    $firedFor = [];
+    $wp->addAction('mailpoet_segment_subscribed', function (SubscriberSegmentEntity $subscriberSegment) use (&$firedFor) {
+      $subscriber = $subscriberSegment->getSubscriber();
+      $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+      $firedFor[] = $subscriber->getEmail();
+    });
+
+    $count = $this->repository->bulkMoveToSegment($targetSegment, [$subscriber->getId()]);
+
+    verify($count)->equals(1);
+    verify($firedFor)->equals(['reactivated@bulk-move-hook.com']);
+    $this->entityManager->clear();
+    $targetMembership = $this->subscriberSegmentRepository->findOneBy([
+      'subscriber' => $subscriber->getId(),
+      'segment' => $targetSegment->getId(),
+    ]);
+    $this->assertInstanceOf(SubscriberSegmentEntity::class, $targetMembership);
+    verify($targetMembership->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+  }
+
+  public function testItRecalculatesCountsAndNotifiesChangesBeforeFailingSubscribedHook(): void {
+    $sourceSegment = $this->segmentRepository->createOrUpdate('Bulk Move Hook Failure Source');
+    $targetSegment = $this->segmentRepository->createOrUpdate('Bulk Move Hook Failure Target');
+    $subscriber = $this->createSubscriber('failure@bulk-move-hook.com');
+    $this->createSubscriberSegment($sourceSegment, $subscriber);
+    $subscriberId = (int)$subscriber->getId();
+    $events = [];
+    $notifiedIds = [];
+    $changesNotifier = $this->make(SubscriberChangesNotifier::class, [
+      'subscribersUpdated' => function (array $subscriberIds) use (&$events, &$notifiedIds): void {
+        $events[] = 'notified';
+        $notifiedIds = $subscriberIds;
+      },
+    ]);
+    $repository = $this->getServiceWithOverrides(SubscribersRepository::class, [
+      'changesNotifier' => $changesNotifier,
+    ]);
+
+    $wp = new WPFunctions();
+    $wp->removeAllActions('mailpoet_segment_subscribed');
+    $wp->addAction('mailpoet_segment_subscribed', function () use (&$events): void {
+      $events[] = 'hook';
+      throw new \RuntimeException('Subscribed hook failed');
+    });
+
+    try {
+      $repository->bulkMoveToSegment($targetSegment, [$subscriberId]);
+      $this->fail('Expected subscribed hook failure');
+    } catch (\RuntimeException $exception) {
+      verify($exception->getMessage())->equals('Subscribed hook failed');
+    }
+
+    $this->entityManager->clear();
+    $subscriber = $repository->findOneById($subscriberId);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    verify($subscriber->getSegmentsCount())->equals(1);
+    verify($notifiedIds)->equals([$subscriberId]);
+    verify($events)->equals(['notified', 'hook']);
   }
 
   public function testItDoesntRemovePermanentlyWordpressSubscriber(): void {


### PR DESCRIPTION
## Description

The "Add to list" and "Move to list" bulk actions on the Subscribers page never fired `mailpoet_segment_subscribed`, so the "Someone subscribes" and "WordPress user registers" automation triggers silently never ran for them — unlike the single-subscriber paths. Segment counterpart of STOMAIL-8245 (tag hooks, #6963).

`bulkAddToSegment()` and `bulkMoveToSegment()` now fire the hook once per newly created membership, with the same gating as `SubscriberSegmentRepository::createOrUpdate()`: only globally subscribed subscribers, only memberships that weren't already subscribed. Since bulk move is implemented as remove-from-all-lists + re-add, subscribers already subscribed in the target list are skipped so the hook doesn't re-fire for them. Hooks fire last — after the transaction, count recalculation, and changes notifier — so a throwing handler can't leave stale state.

## Code review notes

- Mirrors `SubscriberSegmentRepository::createOrUpdate()` (gating) and the tag-hook fix in #6963 (shape).
- Scale note: "select all" over a huge list fires the hook synchronously per new subscriber in one request; with an active "Someone subscribes" automation each call creates a run + Action Scheduler job, so very large bulk adds could hit `max_execution_time` - this will be addressed in STOMAIL-8262.
- Bulk move/remove still doesn't fire `mailpoet_segment_unsubscribed` — same gap in the inverse direction, follow-up ticket material.

## QA notes

1. Activate an automation with the "Someone subscribes" trigger.
2. On the Subscribers page, bulk "Add to list" / "Move to list" subscribers into the trigger's list → one automation run per newly added subscriber (previously none).
3. No run for subscribers already in the list or with global status other than "Subscribed".

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8252

## After-merge notes

KB article on automation triggers (https://kb.mailpoet.com/article/421-automation-triggers) documents bulk actions as not triggering automations — needs updating (also pending from STOMAIL-8245).

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->