### PR TITLE
Add trigger automations checkbox to bulk subscriber actions

### DIFF
--- a/mailpoet/assets/js/src/subscribers/bulk-action-payload.ts
+++ b/mailpoet/assets/js/src/subscribers/bulk-action-payload.ts
@@ -6,12 +6,24 @@ export type SubscriberBulkActionScope = {
   selectAll?: boolean;
 };
 
+const AUTOMATION_TRIGGERING_ACTIONS = new Set([
+  'moveToList',
+  'addToList',
+  'addTag',
+  'removeTag',
+]);
+
+export function canTriggerAutomations(action: string): boolean {
+  return AUTOMATION_TRIGGERING_ACTIONS.has(action);
+}
+
 export function buildBulkActionPayload(
   action: string,
   scope: SubscriberBulkActionScope,
   extra: Record<string, unknown> = {},
 ): Record<string, unknown> {
   const selectAll = Boolean(scope.selectAll);
+  const { trigger_automations: triggerAutomations, ...actionExtra } = extra;
   return {
     action,
     selection: selectAll ? [] : scope.selection,
@@ -19,6 +31,9 @@ export function buildBulkActionPayload(
     group: scope.group,
     search: scope.search,
     filter: scope.filter,
-    ...extra,
+    ...actionExtra,
+    ...(canTriggerAutomations(action) && typeof triggerAutomations === 'boolean'
+      ? { trigger_automations: triggerAutomations }
+      : {}),
   };
 }

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -41,6 +41,7 @@ import { getInitialPickerValue, type PickerConfig } from './picker-value';
 import { SelectAllBanner } from './select-all-banner';
 import { selectAllBannerState, shouldWarnLargeOperation } from './select-all';
 import { pruneUnavailableFilters } from './filter-sync';
+import { canTriggerAutomations } from './bulk-action-payload';
 import {
   bulkAction,
   getSubscribers,
@@ -533,6 +534,7 @@ function PickerModal({
   caveat,
   selectionNotice,
   requireChoice,
+  showAutomationOptIn,
   onApply,
   onClose,
 }: {
@@ -541,7 +543,8 @@ function PickerModal({
   caveat?: JSX.Element | null;
   selectionNotice?: JSX.Element | null;
   requireChoice?: boolean;
-  onApply: (value: number) => void;
+  showAutomationOptIn?: boolean;
+  onApply: (value: number, triggerAutomations: boolean) => void;
   onClose: () => void;
 }) {
   // The legacy `Selection` form widget wraps Select2 + jQuery. We treat it as
@@ -550,6 +553,7 @@ function PickerModal({
   const [value, setValue] = useState<number>(() =>
     requireChoice ? 0 : getInitialPickerValue(config),
   );
+  const [triggerAutomations, setTriggerAutomations] = useState(false);
   const fieldConfig = useMemo(
     () => ({
       id: config.fieldId,
@@ -571,7 +575,7 @@ function PickerModal({
 
   const handleApply = (): void => {
     if (!value) return;
-    onApply(value);
+    onApply(value, triggerAutomations);
   };
 
   return (
@@ -591,6 +595,19 @@ function PickerModal({
           setValue(Number.isFinite(next) ? next : 0);
         }}
       />
+      {showAutomationOptIn && (
+        <div data-automation-id="bulk-trigger-automations-checkbox">
+          <CheckboxControl
+            label={__('Trigger automations', 'mailpoet')}
+            help={__(
+              'Matching automations may send emails to these subscribers.',
+              'mailpoet',
+            )}
+            checked={triggerAutomations}
+            onChange={setTriggerAutomations}
+          />
+        </div>
+      )}
       <div className="mailpoet-subscribers-bulk-confirm-actions">
         <Button onClick={handleApply} isDisabled={!value}>
           {__('Apply', 'mailpoet')}
@@ -1425,6 +1442,7 @@ function SubscriberList() {
       return null;
     }
     const config = PICKERS[action];
+    const showAutomationOptIn = canTriggerAutomations(action);
     const selectAllScopeNotice = pendingSelectAll ? (
       <p>
         {__(
@@ -1440,13 +1458,19 @@ function SubscriberList() {
         caveat={largeOpCaveat}
         selectionNotice={selectAllScopeNotice}
         requireChoice={pendingSelectAll}
-        onApply={(value) =>
-          handlePendingActionSubmit(
+        showAutomationOptIn={showAutomationOptIn}
+        onApply={(value, triggerAutomations) => {
+          const target =
             config.kind === 'segment'
               ? { segment_id: value }
-              : { tag_id: value },
-          )
-        }
+              : { tag_id: value };
+          // `buildBulkActionPayload` drops `trigger_automations` for actions
+          // that cannot trigger automations, so it is safe to always pass it.
+          void handlePendingActionSubmit({
+            ...target,
+            trigger_automations: triggerAutomations,
+          });
+        }}
         onClose={closePendingAction}
       />
     );

--- a/mailpoet/changelog/2026-07-08-13-59-55-fixed-tag-added-and-tag-removed-automation-triggers-now-.md
+++ b/mailpoet/changelog/2026-07-08-13-59-55-fixed-tag-added-and-tag-removed-automation-triggers-now-.md
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-Tag added and Tag removed automation triggers now fire when tags are changed from the Subscribers list page

--- a/mailpoet/changelog/2026-07-10-07-47-59-fixed-someone-subscribes-automation-triggers-now-fire-wh.md
+++ b/mailpoet/changelog/2026-07-10-07-47-59-fixed-someone-subscribes-automation-triggers-now-fire-wh.md
@@ -1,5 +1,0 @@
-# Type: Changed
-
-# Description
-
-Someone subscribes automation triggers now fire when subscribers are added or moved to lists from the Subscribers page

--- a/mailpoet/changelog/2026-07-10-10-28-26-added-control-over-whether-subscriber-list-and-tag-bulk-.md
+++ b/mailpoet/changelog/2026-07-10-10-28-26-added-control-over-whether-subscriber-list-and-tag-bulk-.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Option to trigger automations when bulk adding or moving subscribers to lists or adding or removing tags

--- a/mailpoet/lib/Subscribers/BulkActionController.php
+++ b/mailpoet/lib/Subscribers/BulkActionController.php
@@ -83,7 +83,7 @@ class BulkActionController {
   }
 
   /**
-   * @param array{segment_id?: int|string, tag_id?: int|string} $data
+   * @param array{segment_id?: int|string, tag_id?: int|string, trigger_automations?: bool} $data
    * @return array{count: int, segment?: array{id: int, name: string}, tag?: array{id: int, name: string}}
    * @throws BulkActionException
    */
@@ -103,9 +103,10 @@ class BulkActionController {
     $tag = in_array($action, self::ACTIONS_REQUIRING_TAG, true) || isset($data['tag_id'])
       ? $this->resolveTag($data)
       : null;
+    $skipHooks = !($data['trigger_automations'] ?? false);
 
     $ids = $this->subscriberListingRepository->getActionableIds($definition);
-    $count = $this->dispatch($action, $ids, $segment, $tag);
+    $count = $this->dispatch($action, $ids, $segment, $tag, $skipHooks);
 
     $result = ['count' => $count];
     if ($segment instanceof SegmentEntity) {
@@ -120,7 +121,13 @@ class BulkActionController {
   /**
    * @param int[] $ids
    */
-  private function dispatch(string $action, array $ids, ?SegmentEntity $segment, ?TagEntity $tag): int {
+  private function dispatch(
+    string $action,
+    array $ids,
+    ?SegmentEntity $segment,
+    ?TagEntity $tag,
+    bool $skipHooks
+  ): int {
     switch ($action) {
       case self::ACTION_TRASH:
         return $this->subscribersRepository->bulkTrash($ids);
@@ -134,15 +141,23 @@ class BulkActionController {
         $this->trackBulkUnsubscribe($ids);
         return $this->subscribersRepository->bulkUnsubscribe($ids);
       case self::ACTION_MOVE_TO_LIST:
-        return $this->subscribersRepository->bulkMoveToSegment($this->requireSegment($segment, $action), $ids);
+        return $this->subscribersRepository->bulkMoveToSegment(
+          $this->requireSegment($segment, $action),
+          $ids,
+          $skipHooks
+        );
       case self::ACTION_ADD_TO_LIST:
-        return $this->subscribersRepository->bulkAddToSegment($this->requireSegment($segment, $action), $ids);
+        return $this->subscribersRepository->bulkAddToSegment(
+          $this->requireSegment($segment, $action),
+          $ids,
+          $skipHooks
+        );
       case self::ACTION_REMOVE_FROM_LIST:
         return $this->subscribersRepository->bulkRemoveFromSegment($this->requireSegment($segment, $action), $ids);
       case self::ACTION_ADD_TAG:
-        return $this->subscribersRepository->bulkAddTag($this->requireTag($tag, $action), $ids);
+        return $this->subscribersRepository->bulkAddTag($this->requireTag($tag, $action), $ids, $skipHooks);
       case self::ACTION_REMOVE_TAG:
-        return $this->subscribersRepository->bulkRemoveTag($this->requireTag($tag, $action), $ids);
+        return $this->subscribersRepository->bulkRemoveTag($this->requireTag($tag, $action), $ids, $skipHooks);
       default:
         // Reachable only if SUPPORTED_ACTIONS and this switch drift out of sync.
         throw new BulkActionException(

--- a/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
+++ b/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
@@ -96,7 +96,9 @@ class SubscribersBulkActionEndpoint extends Endpoint {
       $this->validateSelectAllScope($action, $definition);
     }
 
-    $data = [];
+    $data = [
+      'trigger_automations' => $request->getParam('trigger_automations') === true,
+    ];
     $segmentIdParam = $request->getParam('segment_id');
     if (is_numeric($segmentIdParam)) {
       $data['segment_id'] = (int)$segmentIdParam;
@@ -134,6 +136,7 @@ class SubscribersBulkActionEndpoint extends Endpoint {
       'filter' => Builder::object(),
       'segment_id' => Builder::integer(),
       'tag_id' => Builder::integer(),
+      'trigger_automations' => Builder::boolean(),
     ];
   }
 

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -807,41 +807,48 @@ class SubscribersRepository extends Repository {
   /**
    * @return int - number of processed ids
    */
-  public function bulkAddToSegment(SegmentEntity $segment, array $ids): int {
+  public function bulkAddToSegment(SegmentEntity $segment, array $ids, bool $skipHooks): int {
     $subscriberSegments = $this->addSubscribersToSegment($segment, $ids);
     $this->changesNotifier->subscribersUpdated($ids);
-    $this->fireSegmentSubscribedHooks($subscriberSegments);
+    if (!$skipHooks) {
+      $this->fireSegmentSubscribedHooks($subscriberSegments);
+    }
     return count($subscriberSegments);
   }
 
    /**
    * @return int - number of processed ids
    */
-  public function bulkMoveToSegment(SegmentEntity $segment, array $ids): int {
+  public function bulkMoveToSegment(SegmentEntity $segment, array $ids, bool $skipHooks): int {
     if (empty($ids)) {
       return 0;
     }
 
-    /** @var string[] $subscriberIdsAlreadyInSegment */
-    $subscriberIdsAlreadyInSegment = $this->entityManager
-      ->createQueryBuilder()
-      ->select('IDENTITY(ss.subscriber)')
-      ->from(SubscriberSegmentEntity::class, 'ss')
-      ->where('ss.subscriber IN (:ids)')
-      ->andWhere('ss.segment = :segment')
-      ->andWhere('ss.status = :status')
-      ->setParameter('ids', $ids)
-      ->setParameter('segment', $segment)
-      ->setParameter('status', SubscriberEntity::STATUS_SUBSCRIBED)
-      ->getQuery()
-      ->getSingleColumnResult();
-    $subscriberIdsAlreadyInSegment = array_fill_keys(array_map('intval', $subscriberIdsAlreadyInSegment), true);
+    $subscriberIdsAlreadyInSegment = [];
+    if (!$skipHooks) {
+      /** @var string[] $subscriberIdsAlreadyInSegment */
+      $subscriberIdsAlreadyInSegment = $this->entityManager
+        ->createQueryBuilder()
+        ->select('IDENTITY(ss.subscriber)')
+        ->from(SubscriberSegmentEntity::class, 'ss')
+        ->where('ss.subscriber IN (:ids)')
+        ->andWhere('ss.segment = :segment')
+        ->andWhere('ss.status = :status')
+        ->setParameter('ids', $ids)
+        ->setParameter('segment', $segment)
+        ->setParameter('status', SubscriberEntity::STATUS_SUBSCRIBED)
+        ->getQuery()
+        ->getSingleColumnResult();
+      $subscriberIdsAlreadyInSegment = array_fill_keys(array_map('intval', $subscriberIdsAlreadyInSegment), true);
+    }
 
     $this->removeSubscribersFromAllSegments($ids);
     $subscriberSegments = $this->addSubscribersToSegment($segment, $ids);
 
     $this->changesNotifier->subscribersUpdated($ids);
-    $this->fireSegmentSubscribedHooks($subscriberSegments, $subscriberIdsAlreadyInSegment);
+    if (!$skipHooks) {
+      $this->fireSegmentSubscribedHooks($subscriberSegments, $subscriberIdsAlreadyInSegment);
+    }
     return count($subscriberSegments);
   }
 
@@ -1120,8 +1127,8 @@ class SubscribersRepository extends Repository {
   /**
    * @return int - number of processed ids
    */
-  public function bulkAddTag(TagEntity $tag, array $ids): int {
-    $count = $this->addTagToSubscribers($tag, $ids);
+  public function bulkAddTag(TagEntity $tag, array $ids, bool $skipHooks): int {
+    $count = $this->addTagToSubscribers($tag, $ids, $skipHooks);
     $this->changesNotifier->subscribersUpdated($ids);
     return $count;
   }
@@ -1129,21 +1136,24 @@ class SubscribersRepository extends Repository {
   /**
    * @return int - number of processed ids
    */
-  public function bulkRemoveTag(TagEntity $tag, array $ids): int {
+  public function bulkRemoveTag(TagEntity $tag, array $ids, bool $skipHooks): int {
     if (empty($ids)) {
       return 0;
     }
 
-    /** @var SubscriberTagEntity[] $subscriberTags */
-    $subscriberTags = $this->entityManager
-      ->createQueryBuilder()
-      ->select('st')
-      ->from(SubscriberTagEntity::class, 'st')
-      ->where('st.subscriber IN (:ids)')
-      ->andWhere('st.tag = :tag')
-      ->setParameter('ids', $ids)
-      ->setParameter('tag', $tag)
-      ->getQuery()->execute();
+    $subscriberTags = [];
+    if (!$skipHooks) {
+      /** @var SubscriberTagEntity[] $subscriberTags */
+      $subscriberTags = $this->entityManager
+        ->createQueryBuilder()
+        ->select('st')
+        ->from(SubscriberTagEntity::class, 'st')
+        ->where('st.subscriber IN (:ids)')
+        ->andWhere('st.tag = :tag')
+        ->setParameter('ids', $ids)
+        ->setParameter('tag', $tag)
+        ->getQuery()->execute();
+    }
 
     $subscriberTagsTable = $this->entityManager->getClassMetadata(SubscriberTagEntity::class)->getTableName();
     $count = (int)$this->entityManager->getConnection()->executeStatement("
@@ -1152,10 +1162,12 @@ class SubscribersRepository extends Repository {
        AND st.`tag_id` = :tag_id
     ", ['ids' => $ids, 'tag_id' => $tag->getId()], ['ids' => ArrayParameterType::INTEGER]);
 
-    // Fires the hook that triggers "Tag removed" automations (see SubscriberSaveController::updateTags()).
-    foreach ($subscriberTags as $subscriberTag) {
-      $this->entityManager->detach($subscriberTag);
-      $this->wp->doAction('mailpoet_subscriber_tag_removed', $subscriberTag);
+    if (!$skipHooks) {
+      // Fires the hook that triggers "Tag removed" automations (see SubscriberSaveController::updateTags()).
+      foreach ($subscriberTags as $subscriberTag) {
+        $this->entityManager->detach($subscriberTag);
+        $this->wp->doAction('mailpoet_subscriber_tag_removed', $subscriberTag);
+      }
     }
 
     $this->changesNotifier->subscribersUpdated($ids);
@@ -1464,7 +1476,7 @@ class SubscribersRepository extends Repository {
   /**
    * @return int - number of processed ids
    */
-  private function addTagToSubscribers(TagEntity $tag, array $ids): int {
+  private function addTagToSubscribers(TagEntity $tag, array $ids, bool $skipHooks): int {
     if (empty($ids)) {
       return 0;
     }
@@ -1491,9 +1503,11 @@ class SubscribersRepository extends Repository {
       $entityManager->flush();
     });
 
-    // Fires the hook that triggers "Tag added" automations (see SubscriberSaveController::updateTags()).
-    foreach ($subscriberTags as $subscriberTag) {
-      $this->wp->doAction('mailpoet_subscriber_tag_added', $subscriberTag);
+    if (!$skipHooks) {
+      // Fires the hook that triggers "Tag added" automations (see SubscriberSaveController::updateTags()).
+      foreach ($subscriberTags as $subscriberTag) {
+        $this->wp->doAction('mailpoet_subscriber_tag_added', $subscriberTag);
+      }
     }
 
     return count($subscribers);

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
@@ -204,6 +204,13 @@ class ManageSubscribersCest {
     $i->wantTo('Add a subscriber to a list from the listing page');
     $i->checkWooTableCheckboxForItemName($newSubscriberEmail);
     $i->selectListingBulkAction('Add to list...');
+    $triggerAutomationsCheckbox = '[data-automation-id="bulk-trigger-automations-checkbox"]';
+    $i->waitForElement($triggerAutomationsCheckbox);
+    $i->see('Trigger automations', $triggerAutomationsCheckbox);
+    $i->see('Matching automations may send emails', $triggerAutomationsCheckbox);
+    $i->dontSeeCheckboxIsChecked($triggerAutomationsCheckbox . ' input');
+    $i->checkOption($triggerAutomationsCheckbox . ' input');
+    $i->seeCheckboxIsChecked($triggerAutomationsCheckbox . ' input');
     // The picker modal wraps a Select2 widget. Selenium's `selectOption` works
     // by clicking the option, but Select2 hides the underlying <select> and
     // the click on the hidden option doesn't reliably propagate the change up
@@ -258,6 +265,8 @@ class ManageSubscribersCest {
     $i->waitForText($newSubscriberEmail);
     $i->checkWooTableCheckboxForItemName($newSubscriberEmail);
     $i->selectListingBulkAction('Remove from list...');
+    $i->waitForElement('#remove_from_segment');
+    $i->dontSeeElement('[data-automation-id="bulk-trigger-automations-checkbox"]');
     $this->setPickerModalSegment($i, 'remove_from_segment', self::SINGLE_SEGMENT_NAME);
     $i->waitForNoticeAndClose('1 subscribers were removed from list ' . self::SINGLE_SEGMENT_NAME);
     $i->waitForListingItemsToLoad();

--- a/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
@@ -3,10 +3,13 @@
 namespace MailPoet\Test\REST\Subscribers;
 
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\REST\Test;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\WP\Functions as WPFunctions;
 
 require_once __DIR__ . '/../Test.php';
 
@@ -110,6 +113,54 @@ class SubscribersEndpointsTest extends Test {
 
     $this->subscribersRepository->refresh($subscriber);
     $this->assertNotNull($subscriber->getDeletedAt());
+  }
+
+  public function testBulkAutomationHooksRequireExplicitOptIn(): void {
+    $segment = (new SegmentFactory())->withName('REST Bulk Automation Opt-In')->create();
+    $omitted = (new SubscriberFactory())
+      ->withEmail('rest-bulk-automation-omitted-' . uniqid() . '@example.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $disabled = (new SubscriberFactory())
+      ->withEmail('rest-bulk-automation-disabled-' . uniqid() . '@example.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $enabled = (new SubscriberFactory())
+      ->withEmail('rest-bulk-automation-enabled-' . uniqid() . '@example.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+
+    $wp = new WPFunctions();
+    $wp->removeAllActions('mailpoet_segment_subscribed');
+    $firedFor = [];
+    $wp->addAction('mailpoet_segment_subscribed', function (SubscriberSegmentEntity $subscriberSegment) use (&$firedFor): void {
+      $subscriber = $subscriberSegment->getSubscriber();
+      $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+      $firedFor[] = (int)$subscriber->getId();
+    });
+
+    $baseRequest = [
+      'action' => 'addToList',
+      'group' => 'subscribed',
+      'segment_id' => (int)$segment->getId(),
+    ];
+    $omittedResponse = $this->post(self::BULK_ACTION_PATH, ['json' => $baseRequest + [
+      'selection' => [(int)$omitted->getId()],
+    ]]);
+    $disabledResponse = $this->post(self::BULK_ACTION_PATH, ['json' => $baseRequest + [
+      'selection' => [(int)$disabled->getId()],
+      'trigger_automations' => false,
+    ]]);
+    $enabledResponse = $this->post(self::BULK_ACTION_PATH, ['json' => $baseRequest + [
+      'selection' => [(int)$enabled->getId()],
+      'trigger_automations' => true,
+    ]]);
+
+    $this->assertSame(1, $omittedResponse['data']['count']);
+    $this->assertSame(1, $disabledResponse['data']['count']);
+    $this->assertSame(1, $enabledResponse['data']['count']);
+    $this->assertSame([(int)$enabled->getId()], $firedFor);
+    $wp->removeAllActions('mailpoet_segment_subscribed');
   }
 
   public function testBulkActionWithEmptySelectionAndNoSelectAllReturnsError(): void {

--- a/mailpoet/tests/integration/Subscribers/BulkActionControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/BulkActionControllerTest.php
@@ -13,6 +13,7 @@ use MailPoet\Statistics\StatisticsUnsubscribesRepository;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\Test\DataFactories\Tag as TagFactory;
+use MailPoet\WP\Functions as WPFunctions;
 
 /**
  * Focused coverage of {@see BulkActionController}. The HTTP-layer tests in
@@ -160,6 +161,127 @@ class BulkActionControllerTest extends \MailPoetTest {
     verify($this->subscriberTagIds($subscriberId))->equals([]);
   }
 
+  public function testItSuppressesBulkAutomationHooksByDefault(): void {
+    $sourceSegment = (new SegmentFactory())->withName('Default Hook Source')->create();
+    $addedSegment = (new SegmentFactory())->withName('Default Hook Added')->create();
+    $movedSegment = (new SegmentFactory())->withName('Default Hook Moved')->create();
+    $existingTag = (new TagFactory())->withName('Default Hook Existing Tag')->create();
+    $addedTag = (new TagFactory())->withName('Default Hook Added Tag')->create();
+    $subscriber = $this->createSubscriber(
+      'default-hooks@example.com',
+      SubscriberEntity::STATUS_SUBSCRIBED,
+      [$sourceSegment]
+    );
+    $this->createSubscriberTag($subscriber, $existingTag);
+    $definition = $this->definition([(int)$subscriber->getId()]);
+
+    $wp = new WPFunctions();
+    $hookCalls = ['segment' => 0, 'tagAdded' => 0, 'tagRemoved' => 0];
+    $wp->removeAllActions('mailpoet_segment_subscribed');
+    $wp->removeAllActions('mailpoet_subscriber_tag_added');
+    $wp->removeAllActions('mailpoet_subscriber_tag_removed');
+    $wp->addAction('mailpoet_segment_subscribed', function () use (&$hookCalls): void {
+      $hookCalls['segment']++;
+    });
+    $wp->addAction('mailpoet_subscriber_tag_added', function () use (&$hookCalls): void {
+      $hookCalls['tagAdded']++;
+    });
+    $wp->addAction('mailpoet_subscriber_tag_removed', function () use (&$hookCalls): void {
+      $hookCalls['tagRemoved']++;
+    });
+
+    $addResult = $this->controller->execute(
+      BulkActionController::ACTION_ADD_TO_LIST,
+      $definition,
+      ['segment_id' => (int)$addedSegment->getId()]
+    );
+    $moveResult = $this->controller->execute(
+      BulkActionController::ACTION_MOVE_TO_LIST,
+      $definition,
+      ['segment_id' => (int)$movedSegment->getId()]
+    );
+    $addTagResult = $this->controller->execute(
+      BulkActionController::ACTION_ADD_TAG,
+      $definition,
+      ['tag_id' => (int)$addedTag->getId()]
+    );
+    $removeTagResult = $this->controller->execute(
+      BulkActionController::ACTION_REMOVE_TAG,
+      $definition,
+      ['tag_id' => (int)$existingTag->getId()]
+    );
+
+    verify($addResult['count'])->equals(1);
+    verify($moveResult['count'])->equals(1);
+    verify($addTagResult['count'])->equals(1);
+    verify($removeTagResult['count'])->equals(1);
+    verify($hookCalls)->equals(['segment' => 0, 'tagAdded' => 0, 'tagRemoved' => 0]);
+    $wp->removeAllActions('mailpoet_segment_subscribed');
+    $wp->removeAllActions('mailpoet_subscriber_tag_added');
+    $wp->removeAllActions('mailpoet_subscriber_tag_removed');
+  }
+
+  public function testItFiresBulkAutomationHooksWhenExplicitlyEnabled(): void {
+    $sourceSegment = (new SegmentFactory())->withName('Enabled Hook Source')->create();
+    $addedSegment = (new SegmentFactory())->withName('Enabled Hook Added')->create();
+    $movedSegment = (new SegmentFactory())->withName('Enabled Hook Moved')->create();
+    $existingTag = (new TagFactory())->withName('Enabled Hook Existing Tag')->create();
+    $addedTag = (new TagFactory())->withName('Enabled Hook Added Tag')->create();
+    $subscriber = $this->createSubscriber(
+      'enabled-hooks@example.com',
+      SubscriberEntity::STATUS_SUBSCRIBED,
+      [$sourceSegment]
+    );
+    $this->createSubscriberTag($subscriber, $existingTag);
+    $definition = $this->definition([(int)$subscriber->getId()]);
+    $triggerAutomations = ['trigger_automations' => true];
+
+    $wp = new WPFunctions();
+    $hookCalls = ['segment' => 0, 'tagAdded' => 0, 'tagRemoved' => 0];
+    $wp->removeAllActions('mailpoet_segment_subscribed');
+    $wp->removeAllActions('mailpoet_subscriber_tag_added');
+    $wp->removeAllActions('mailpoet_subscriber_tag_removed');
+    $wp->addAction('mailpoet_segment_subscribed', function () use (&$hookCalls): void {
+      $hookCalls['segment']++;
+    });
+    $wp->addAction('mailpoet_subscriber_tag_added', function () use (&$hookCalls): void {
+      $hookCalls['tagAdded']++;
+    });
+    $wp->addAction('mailpoet_subscriber_tag_removed', function () use (&$hookCalls): void {
+      $hookCalls['tagRemoved']++;
+    });
+
+    $addResult = $this->controller->execute(
+      BulkActionController::ACTION_ADD_TO_LIST,
+      $definition,
+      $triggerAutomations + ['segment_id' => (int)$addedSegment->getId()]
+    );
+    $moveResult = $this->controller->execute(
+      BulkActionController::ACTION_MOVE_TO_LIST,
+      $definition,
+      $triggerAutomations + ['segment_id' => (int)$movedSegment->getId()]
+    );
+    $addTagResult = $this->controller->execute(
+      BulkActionController::ACTION_ADD_TAG,
+      $definition,
+      $triggerAutomations + ['tag_id' => (int)$addedTag->getId()]
+    );
+    $removeTagResult = $this->controller->execute(
+      BulkActionController::ACTION_REMOVE_TAG,
+      $definition,
+      $triggerAutomations + ['tag_id' => (int)$existingTag->getId()]
+    );
+
+    verify($addResult['count'])->equals(1);
+    verify($moveResult['count'])->equals(1);
+    verify($addTagResult['count'])->equals(1);
+    verify($removeTagResult['count'])->equals(1);
+    verify($hookCalls)->equals(['segment' => 2, 'tagAdded' => 1, 'tagRemoved' => 1]);
+    $wp->removeAllActions('mailpoet_segment_subscribed');
+    $wp->removeAllActions('mailpoet_subscriber_tag_added');
+    $wp->removeAllActions('mailpoet_subscriber_tag_removed');
+  }
+
   public function testItRequiresSegmentForListActions(): void {
     $subscriber = $this->createSubscriber('needs-list@example.com', SubscriberEntity::STATUS_SUBSCRIBED);
     $definition = $this->definition([(int)$subscriber->getId()]);
@@ -243,7 +365,7 @@ class BulkActionControllerTest extends \MailPoetTest {
   }
 
   /**
-   * @param array{segment_id?: int|string, tag_id?: int|string} $data
+   * @param array{segment_id?: int|string, tag_id?: int|string, trigger_automations?: bool} $data
    */
   private function captureException(string $action, ListingDefinition $definition, array $data = []): ?\Throwable {
     try {
@@ -287,5 +409,11 @@ class BulkActionControllerTest extends \MailPoetTest {
     }
     sort($ids);
     return $ids;
+  }
+
+  private function createSubscriberTag(SubscriberEntity $subscriber, TagEntity $tag): void {
+    $subscriberTag = new SubscriberTagEntity($tag, $subscriber);
+    $this->entityManager->persist($subscriberTag);
+    $this->entityManager->flush();
   }
 }

--- a/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
@@ -313,7 +313,7 @@ class SubscribersRepositoryTest extends \MailPoetTest {
     $subscriberTwoId = $subscriberTwo->getId();
     $segmentOneId = $segmentOne->getId();
 
-    $this->repository->bulkAddToSegment($segmentOne, [$subscriberOneId]);
+    $this->repository->bulkAddToSegment($segmentOne, [$subscriberOneId], false);
 
     $this->entityManager->clear();
 
@@ -351,10 +351,33 @@ class SubscribersRepositoryTest extends \MailPoetTest {
       $newSubscriber->getId(),
       $existingSubscriber->getId(),
       $unsubscribedSubscriber->getId(),
-    ]);
+    ], false);
 
     verify($count)->equals(2);
     verify($firedFor)->equals(['new@bulk-add-hook.com']);
+  }
+
+  public function testItBulkAddToSegmentCanSkipSubscribedHook(): void {
+    $segment = $this->segmentRepository->createOrUpdate('Bulk Add Skip Hook');
+    $subscriber = $this->createSubscriber('skip@bulk-add-hook.com');
+
+    $wp = new WPFunctions();
+    $wp->removeAllActions('mailpoet_segment_subscribed');
+    $hookCalls = 0;
+    $wp->addAction('mailpoet_segment_subscribed', function () use (&$hookCalls): void {
+      $hookCalls++;
+    });
+
+    $count = $this->repository->bulkAddToSegment($segment, [$subscriber->getId()], true);
+
+    verify($count)->equals(1);
+    verify($hookCalls)->equals(0);
+    $this->entityManager->clear();
+    verify($this->subscriberSegmentRepository->findOneBy([
+      'subscriber' => $subscriber->getId(),
+      'segment' => $segment->getId(),
+    ]))->notNull();
+    $wp->removeAllActions('mailpoet_segment_subscribed');
   }
 
   public function testItBulMoveSubscribersToSegment(): void {
@@ -370,7 +393,7 @@ class SubscribersRepositoryTest extends \MailPoetTest {
     $segmentOneId = $segmentOne->getId();
     $segmentTwoId = $segmentTwo->getId();
 
-    $this->repository->bulkMoveToSegment($segmentTwo, [$subscriberOneId]);
+    $this->repository->bulkMoveToSegment($segmentTwo, [$subscriberOneId], false);
 
     $this->entityManager->clear();
 
@@ -418,10 +441,42 @@ class SubscribersRepositoryTest extends \MailPoetTest {
     $count = $this->repository->bulkMoveToSegment($targetSegment, [
       $newTargetSubscriber->getId(),
       $existingTargetSubscriber->getId(),
-    ]);
+    ], false);
 
     verify($count)->equals(2);
     verify($firedFor)->equals(['new@bulk-move-hook.com']);
+  }
+
+  public function testItBulkMoveToSegmentCanSkipSubscribedHook(): void {
+    $sourceSegment = $this->segmentRepository->createOrUpdate('Bulk Move Skip Hook Source');
+    $targetSegment = $this->segmentRepository->createOrUpdate('Bulk Move Skip Hook Target');
+    $subscriber = $this->createSubscriber('skip@bulk-move-hook.com');
+    $this->createSubscriberSegment($sourceSegment, $subscriber);
+    $subscriberId = (int)$subscriber->getId();
+    $sourceSegmentId = (int)$sourceSegment->getId();
+    $targetSegmentId = (int)$targetSegment->getId();
+
+    $wp = new WPFunctions();
+    $wp->removeAllActions('mailpoet_segment_subscribed');
+    $hookCalls = 0;
+    $wp->addAction('mailpoet_segment_subscribed', function () use (&$hookCalls): void {
+      $hookCalls++;
+    });
+
+    $count = $this->repository->bulkMoveToSegment($targetSegment, [$subscriberId], true);
+
+    verify($count)->equals(1);
+    verify($hookCalls)->equals(0);
+    $this->entityManager->clear();
+    verify($this->subscriberSegmentRepository->findOneBy([
+      'subscriber' => $subscriberId,
+      'segment' => $sourceSegmentId,
+    ]))->null();
+    verify($this->subscriberSegmentRepository->findOneBy([
+      'subscriber' => $subscriberId,
+      'segment' => $targetSegmentId,
+    ]))->notNull();
+    $wp->removeAllActions('mailpoet_segment_subscribed');
   }
 
   public function testItBulkMoveToSegmentFiresSubscribedHookWhenDestinationMembershipWasUnsubscribed(): void {
@@ -442,7 +497,7 @@ class SubscribersRepositoryTest extends \MailPoetTest {
       $firedFor[] = $subscriber->getEmail();
     });
 
-    $count = $this->repository->bulkMoveToSegment($targetSegment, [$subscriber->getId()]);
+    $count = $this->repository->bulkMoveToSegment($targetSegment, [$subscriber->getId()], false);
 
     verify($count)->equals(1);
     verify($firedFor)->equals(['reactivated@bulk-move-hook.com']);
@@ -481,7 +536,7 @@ class SubscribersRepositoryTest extends \MailPoetTest {
     });
 
     try {
-      $repository->bulkMoveToSegment($targetSegment, [$subscriberId]);
+      $repository->bulkMoveToSegment($targetSegment, [$subscriberId], false);
       $this->fail('Expected subscribed hook failure');
     } catch (\RuntimeException $exception) {
       verify($exception->getMessage())->equals('Subscribed hook failed');
@@ -813,12 +868,35 @@ class SubscribersRepositoryTest extends \MailPoetTest {
       $firedFor[] = $subscriber->getEmail();
     });
 
-    $count = $this->repository->bulkAddTag($tag, [$subscriberOne->getId(), $subscriberTwo->getId()]);
+    $count = $this->repository->bulkAddTag($tag, [$subscriberOne->getId(), $subscriberTwo->getId()], false);
 
     verify($count)->equals(1);
     verify($firedFor)->equals(['one@bulk-add-tag.com']);
     $subscriberTags = $this->entityManager->getRepository(SubscriberTagEntity::class)->findBy(['tag' => $tag]);
     verify($subscriberTags)->arrayCount(2);
+    $wp->removeAllActions('mailpoet_subscriber_tag_added');
+  }
+
+  public function testItBulkAddTagCanSkipTagAddedHook(): void {
+    $tag = $this->createTag('Bulk added tag without hook');
+    $subscriber = $this->createSubscriber('skip@bulk-add-tag.com');
+
+    $wp = new WPFunctions();
+    $wp->removeAllActions('mailpoet_subscriber_tag_added');
+    $hookCalls = 0;
+    $wp->addAction('mailpoet_subscriber_tag_added', function () use (&$hookCalls): void {
+      $hookCalls++;
+    });
+
+    $count = $this->repository->bulkAddTag($tag, [$subscriber->getId()], true);
+
+    verify($count)->equals(1);
+    verify($hookCalls)->equals(0);
+    $subscriberTags = $this->entityManager->getRepository(SubscriberTagEntity::class)->findBy([
+      'subscriber' => $subscriber,
+      'tag' => $tag,
+    ]);
+    verify($subscriberTags)->arrayCount(1);
     $wp->removeAllActions('mailpoet_subscriber_tag_added');
   }
 
@@ -837,12 +915,37 @@ class SubscribersRepositoryTest extends \MailPoetTest {
       $firedFor[] = $subscriber->getEmail();
     });
 
-    $count = $this->repository->bulkRemoveTag($tag, [$subscriberOne->getId(), $subscriberTwo->getId()]);
+    $count = $this->repository->bulkRemoveTag($tag, [$subscriberOne->getId(), $subscriberTwo->getId()], false);
 
     verify($count)->equals(1);
     verify($firedFor)->equals(['one@bulk-remove-tag.com']);
     $this->entityManager->clear();
     $subscriberTags = $this->entityManager->getRepository(SubscriberTagEntity::class)->findBy(['tag' => $tag]);
+    verify($subscriberTags)->arrayCount(0);
+    $wp->removeAllActions('mailpoet_subscriber_tag_removed');
+  }
+
+  public function testItBulkRemoveTagCanSkipTagRemovedHook(): void {
+    $tag = $this->createTag('Bulk removed tag without hook');
+    $subscriber = $this->createSubscriber('skip@bulk-remove-tag.com');
+    $this->createSubscriberTag($subscriber, $tag);
+
+    $wp = new WPFunctions();
+    $wp->removeAllActions('mailpoet_subscriber_tag_removed');
+    $hookCalls = 0;
+    $wp->addAction('mailpoet_subscriber_tag_removed', function () use (&$hookCalls): void {
+      $hookCalls++;
+    });
+
+    $count = $this->repository->bulkRemoveTag($tag, [$subscriber->getId()], true);
+
+    verify($count)->equals(1);
+    verify($hookCalls)->equals(0);
+    $this->entityManager->clear();
+    $subscriberTags = $this->entityManager->getRepository(SubscriberTagEntity::class)->findBy([
+      'subscriber' => $subscriber->getId(),
+      'tag' => $tag->getId(),
+    ]);
     verify($subscriberTags)->arrayCount(0);
     $wp->removeAllActions('mailpoet_subscriber_tag_removed');
   }

--- a/mailpoet/tests/javascript/subscribers/bulk-action-payload.spec.ts
+++ b/mailpoet/tests/javascript/subscribers/bulk-action-payload.spec.ts
@@ -28,11 +28,40 @@ describe('Subscribers bulk-action payload', () => {
     const payload = buildBulkActionPayload(
       'moveToList',
       { ...scope, group: 'subscribed', search: 'foo', selectAll: true },
-      { segment_id: 5 },
+      { segment_id: 5, trigger_automations: true },
     );
     expect(payload.segment_id).to.equal(5);
+    expect(payload.trigger_automations).to.equal(true);
     expect(payload.select_all).to.equal(true);
     expect(payload.group).to.equal('subscribed');
     expect(payload.search).to.equal('foo');
+  });
+
+  it('forwards the automation opt-in for supported actions', () => {
+    const addToListPayload = buildBulkActionPayload('addToList', scope, {
+      segment_id: 5,
+      trigger_automations: false,
+    });
+    const addTagPayload = buildBulkActionPayload('addTag', scope, {
+      tag_id: 7,
+      trigger_automations: true,
+    });
+    const removeTagPayload = buildBulkActionPayload('removeTag', scope, {
+      tag_id: 7,
+      trigger_automations: false,
+    });
+
+    expect(addToListPayload.trigger_automations).to.equal(false);
+    expect(addTagPayload.trigger_automations).to.equal(true);
+    expect(removeTagPayload.trigger_automations).to.equal(false);
+  });
+
+  it('does not forward the automation opt-in for unsupported actions', () => {
+    const payload = buildBulkActionPayload('removeFromList', scope, {
+      segment_id: 5,
+      trigger_automations: true,
+    });
+
+    expect(payload).not.to.have.property('trigger_automations');
   });
 });


### PR DESCRIPTION
## Description

Bulk actions on the Subscribers page can touch thousands of subscribers at once. With the recent fixes that made the "Someone subscribes", "Tag added", and "Tag removed" automation triggers fire from bulk actions, a single bulk add/move/tag could mass-enroll subscribers into automations and send unexpected emails.

This adds a "Trigger automations" checkbox to the bulk list and tag picker modals. It is off by default, so triggering automations from a bulk action is an explicit, informed choice.

## Code review notes

- The repository `skipHooks` parameter is required (no default) so every future caller has to make the sends-or-not decision explicitly.
- Suppressing the hooks silences them for *all* listeners, not only MailPoet automations — this includes the AutomateWoo opt-in sync and the hooks documented as public integration points in `doc/api_methods/`. Since these hooks never fired from bulk actions in any released version, nothing regresses, but the suppression scope is broader than the checkbox label suggests.
- "Remove from list" gets no checkbox because no automation trigger exists for list removal.

## QA notes

1. Create an active automation with the "Someone subscribes" trigger for a list.
2. On the Subscribers page, select subscribers and choose "Add to list..." — the modal shows an unchecked "Trigger automations" checkbox.
3. Apply with the checkbox unchecked → subscribers are added, no automation run starts.
4. Repeat with the checkbox checked → automation runs start for the added subscribers.
5. Same applies to "Move to list...", "Add tag...", and "Remove tag..." (with tag-based triggers). "Remove from list..." shows no checkbox.

## Screenshots

| Before | After | 
| ---- | ---- | 
| <img width="409" height="244" alt="Screenshot 2026-07-10 at 14 04 29" src="https://github.com/user-attachments/assets/c72a6650-4cc3-49a3-8bd4-ebaf57d8beb1" /> | <img width="435" height="278" alt="Screenshot 2026-07-10 at 13 38 00" src="https://github.com/user-attachments/assets/181491d4-82b4-4781-88ef-62fe21cdde8a" /> |
| <img width="382" height="230" alt="Screenshot 2026-07-10 at 14 04 31" src="https://github.com/user-attachments/assets/6757bf9f-13ee-466c-8ddc-0d73464ae11f" /> | <img width="449" height="282" alt="Screenshot 2026-07-10 at 13 38 01" src="https://github.com/user-attachments/assets/9505743b-4bbd-4600-8116-bec8d9c95dce" /> |
| <img width="378" height="221" alt="Screenshot 2026-07-10 at 14 04 41" src="https://github.com/user-attachments/assets/4d86433f-e51d-467a-938a-69e7365a6f06" /> | <img width="423" height="271" alt="Screenshot 2026-07-10 at 13 38 11" src="https://github.com/user-attachments/assets/86e2b456-cbbd-457c-bd96-d5773761a408" /> | 
| <img width="379" height="224" alt="Screenshot 2026-07-10 at 14 04 46" src="https://github.com/user-attachments/assets/a12019ad-8cc2-4d7e-8615-a2054ef56571" /> | <img width="426" height="271" alt="Screenshot 2026-07-10 at 13 38 15" src="https://github.com/user-attachments/assets/a78abe6e-9f94-42e1-846e-c3fd016b3d25" /> | 


## Linked PRs

_N/A_

## Linked tickets

- [STOMAIL-8262](https://linear.app/a8c/issue/STOMAIL-8262/add-checkbox-to-bulk-subscriber-actions-whether-it-should-trigger)

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8262-bulk-automation-checkbox)

_The latest successful build from `add/stomail-8262-bulk-automation-checkbox` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->