### PR TITLE
Add default to skipHooks param in bulk subscriber methods

### DIFF
--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -807,7 +807,7 @@ class SubscribersRepository extends Repository {
   /**
    * @return int - number of processed ids
    */
-  public function bulkAddToSegment(SegmentEntity $segment, array $ids, bool $skipHooks): int {
+  public function bulkAddToSegment(SegmentEntity $segment, array $ids, bool $skipHooks = true): int {
     $subscriberSegments = $this->addSubscribersToSegment($segment, $ids);
     $this->changesNotifier->subscribersUpdated($ids);
     if (!$skipHooks) {
@@ -819,7 +819,7 @@ class SubscribersRepository extends Repository {
    /**
    * @return int - number of processed ids
    */
-  public function bulkMoveToSegment(SegmentEntity $segment, array $ids, bool $skipHooks): int {
+  public function bulkMoveToSegment(SegmentEntity $segment, array $ids, bool $skipHooks = true): int {
     if (empty($ids)) {
       return 0;
     }
@@ -1127,7 +1127,7 @@ class SubscribersRepository extends Repository {
   /**
    * @return int - number of processed ids
    */
-  public function bulkAddTag(TagEntity $tag, array $ids, bool $skipHooks): int {
+  public function bulkAddTag(TagEntity $tag, array $ids, bool $skipHooks = true): int {
     $count = $this->addTagToSubscribers($tag, $ids, $skipHooks);
     $this->changesNotifier->subscribersUpdated($ids);
     return $count;
@@ -1136,7 +1136,7 @@ class SubscribersRepository extends Repository {
   /**
    * @return int - number of processed ids
    */
-  public function bulkRemoveTag(TagEntity $tag, array $ids, bool $skipHooks): int {
+  public function bulkRemoveTag(TagEntity $tag, array $ids, bool $skipHooks = true): int {
     if (empty($ids)) {
       return 0;
     }


### PR DESCRIPTION
## Description

Four public `SubscribersRepository` bulk methods (`bulkAddToSegment`, `bulkMoveToSegment`, `bulkAddTag`, `bulkRemoveTag`) gained a required `bool $skipHooks` parameter in #6972, which would fatal external callers using the previous arity with an `ArgumentCountError`. This adds `= true` defaults, preserving the previously released behavior (no subscription hooks fired) for existing callers.

## Code review notes

_N/A_

## QA notes

No behavior change for in-repo callers — all pass the argument explicitly.

## Linked PRs

- #6972

## Linked tickets

- [STOMAIL-8264](https://linear.app/a8c/issue/STOMAIL-8264)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8264-skiphooks-param-default)

_The latest successful build from `fix/stomail-8264-skiphooks-param-default` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->