### PR TITLE
Update WordPress and plugins in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ jobs:
           name: Download additional WP Plugins for tests
           command: |
             ./do download:woo-commerce-zip 10.9.4
-            ./do download:woo-commerce-subscriptions-zip 9.0.0
+            ./do download:woo-commerce-subscriptions-zip 9.0.1
             ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.6.0
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 10.9.3
+            ./do download:woo-commerce-zip 10.9.4
             ./do download:woo-commerce-subscriptions-zip 9.0.0
             ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.6.0

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: wordpress:${WORDPRESS_IMAGE_VERSION:-7.0.0-php8.4}
+    image: wordpress:${WORDPRESS_IMAGE_VERSION:-7.0.1-php8.4}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
       smtp:


### PR DESCRIPTION
1. If all checks passed, you can merge this PR.
2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-plugins-and-wordpress)

_The latest successful build from `update-plugins-and-wordpress` will be used. If none is available, the link won't work._