### PR TITLE
Prevent full-page caching of the manage subscription form

### DIFF
--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -23,6 +23,7 @@ use MailPoet\Subscribers\NewSubscriberNotificationMailer;
 use MailPoet\Subscribers\SubscriberSaveController;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Util\Headers;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\Request;
 use MailPoet\WP\Functions as WPFunctions;
@@ -515,6 +516,15 @@ class Pages {
       $formStatus = ManageSubscriptionFormRenderer::FORM_STATE_SUCCESS;
     } else {
       $formStatus = ManageSubscriptionFormRenderer::FORM_STATE_NOT_SUBMITTED;
+    }
+
+    // The manage form embeds the subscriber's email and link token in the page
+    // body. On an ordinary post/page (block or [mailpoet_manage_subscription]
+    // shortcode) that markup is otherwise cacheable, so a full-page cache could
+    // serve one subscriber's token to another visitor. Preview renders only
+    // demo data, so they don't need this.
+    if (!$this->isPreview()) {
+      Headers::preventPageCaching();
     }
 
     return $this->wp->applyFilters(

--- a/mailpoet/lib/Util/Headers.php
+++ b/mailpoet/lib/Util/Headers.php
@@ -21,4 +21,26 @@ class Headers {
     // Use WP-native nocache_headers(). This can override the defaults above.
     $wp->nocacheHeaders();
   }
+
+  /**
+   * Marks the current response as non-cacheable at both the HTTP layer and the
+   * full-page-cache-plugin layer.
+   *
+   * Use this for responses that embed per-visitor personal data (e.g. a
+   * subscriber's email and link token) into the page body. The HTTP no-cache
+   * headers only take effect when they are sent before output starts, which is
+   * not guaranteed when the markup is produced mid-`the_content` (blocks and
+   * shortcodes). Defining DONOTCACHEPAGE is honoured by page-cache plugins
+   * (Batcache/WP.com VIP, WP Super Cache, W3TC, WP Rocket, LiteSpeed) at their
+   * own shutdown stage, so it still prevents caching after output has started.
+   *
+   * Unlike ThirdPartyOutput::preventHtmlRewriting(), this does not discard
+   * output buffers, so it is safe to call while rendering inside a host page.
+   */
+  public static function preventPageCaching(): void {
+    self::setNoCacheHeaders();
+    if (!defined('DONOTCACHEPAGE')) {
+      define('DONOTCACHEPAGE', true);
+    }
+  }
 }

--- a/mailpoet/tests/integration/Subscription/PagesTest.php
+++ b/mailpoet/tests/integration/Subscription/PagesTest.php
@@ -428,6 +428,16 @@ class PagesTest extends \MailPoetTest {
     verify($content)->stringNotContainsString('Your subscription settings have been saved.');
   }
 
+  public function testItPreventsCachingOfManageSubscriptionPageForRealSubscriber(): void {
+    // The manage form embeds the subscriber's email and link token in the page
+    // body, so the response must not be stored by a full-page cache. Rendering
+    // it for a real subscriber signals that by defining DONOTCACHEPAGE.
+    // Smoke check: the constant is process-global, so this asserts the wire-up
+    // rather than isolating this single call.
+    $this->getPages()->init(Pages::ACTION_MANAGE, $this->testData)->getManageContent();
+    verify(defined('DONOTCACHEPAGE'))->true();
+  }
+
   public function testItDoesNotSaveUnsubscribeReasonForPreview() {
     SettingsController::getInstance()->set('subscription.unsubscribe_survey.enabled', '1');
     $this->testData['preview'] = 1;


### PR DESCRIPTION
## What

The manage subscription form renders the current subscriber's **email and link token into the page body**. Three surfaces render it:

- the new "Manage Subscription" Gutenberg block (`ManageSubscriptionBlock`)
- the pre-existing `[mailpoet_manage_subscription]` shortcode
- the dedicated subscription page (email-link flow)

All three go through `Pages::getManageContent()`. The dedicated page sets `X-Robots-Tag: noindex` + `Referrer-Policy: no-referrer`, but **nothing marks the response as non-cacheable**. On an ordinary post or page carrying the block/shortcode, that personalized markup is cacheable, so a full-page cache could store one subscriber's tokenized page and serve it to another visitor.

This adds a no-cache signal for real-subscriber renders.

## Why the `DONOTCACHEPAGE` constant (and not just headers)

`getManageContent()` runs mid-`the_content` (block/shortcode render), so HTTP response headers are often already flushed and `nocache_headers()` would no-op. `DONOTCACHEPAGE` is read by page-cache plugins (Batcache/WP.com VIP, WP Super Cache, W3TC, WP Rocket, LiteSpeed) at their own shutdown stage, so it still works after output has started. The new `Headers::preventPageCaching()` sends the existing no-cache headers **and** defines the constant. It deliberately does **not** call `ThirdPartyOutput::preventHtmlRewriting()`, which flushes output buffers — unsafe when rendering inside a host page.

## Scope / severity

This is **defense-in-depth (Low)**, not a live exploit:

- The block only ever renders the **current logged-in user's own** email + token (resolved by `wpUserId`); anonymous visitors and crawlers get a "subscribers only" message with no token.
- The token is in the page **body**, not the URL, so `Referrer-Policy` adds nothing here.
- Standard WP / WordPress.com-Atomic caches already bypass logged-in users, so the leak channel is closed on a normal install.
- The behavior is **parity with the years-old shortcode**, not a regression the block introduced — putting the fix in `getManageContent()` hardens the block and the shortcode at once.

## Testing

- `php -l` clean on all three files; pre-commit PHP lint-staged hooks pass.
- Added `testItPreventsCachingOfManageSubscriptionPageForRealSubscriber` (smoke check — `DONOTCACHEPAGE` is a process-global constant, so it asserts the wire-up rather than isolating the single call).

**Open question for reviewers:** the constant is genuinely awkward to unit-test (global, irreversible; headers no-op in CLI). If you'd prefer a stronger test (e.g. a header spy or extracting the signal behind an injectable seam), say so and I'll adjust. Also happy to drop `noindex`/`no-referrer` parity onto the block path via an early `template_redirect` detector if we want index-time hardening too — kept out of here to stay minimal.

Refs STOMAIL-8250, STOMAIL-8251.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8250-manage-subscription-cache-hardening)

_The latest successful build from `stomail-8250-manage-subscription-cache-hardening` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->