### PR TITLE
Add filter to exclude subscribers from a newsletter send

### DIFF
--- a/mailpoet/changelog/2026-07-15-09-52-00-added-a-filter-to-exclude-subscribers-from-a-specific-ne.md
+++ b/mailpoet/changelog/2026-07-15-09-52-00-added-a-filter-to-exclude-subscribers-from-a-specific-ne.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+A filter to exclude subscribers from a specific newsletter send

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -296,22 +296,40 @@ class SendingQueue {
         }
 
         $foundSubscribers = $queryBuilder->getQuery()->getResult();
-        $foundSubscribersIds = array_map(function(SubscriberEntity $subscriber) {
-          return $subscriber->getId();
-        }, $foundSubscribers);
       }
 
       // Allow extensions to exclude subscribers from this specific send (e.g. custom
       // frequency capping or cross-newsletter suppression). Excluded subscribers are
       // dropped below via the same path used for "not found" subscribers, so queue
       // counts and the scheduled task stay consistent.
-      /** @var array<SubscriberEntity> $foundSubscribers */
-      $foundSubscribers = (array)$this->wp->applyFilters(
+      // The filter result is normalized defensively: a misbehaving callback could
+      // return non-SubscriberEntity values, duplicates, or subscribers that were
+      // never part of the resolved batch (e.g. not in this segment/task), any of
+      // which would otherwise reach processQueue() and either fatal or send to an
+      // unintended recipient.
+      $resolvedSubscribersById = [];
+      foreach ($foundSubscribers as $subscriber) {
+        $resolvedSubscribersById[$subscriber->getId()] = $subscriber;
+      }
+      $filteredSubscribers = (array)$this->wp->applyFilters(
         'mailpoet_sending_queue_subscribers_to_process',
         $foundSubscribers,
         $newsletter,
         $task
       );
+      $foundSubscribers = [];
+      foreach ($filteredSubscribers as $filteredSubscriber) {
+        if (!$filteredSubscriber instanceof SubscriberEntity) {
+          continue;
+        }
+        $subscriberId = $filteredSubscriber->getId();
+        // Keep only subscribers that were already in the resolved batch (by id), and
+        // use the original entity instance rather than trusting whatever the filter returned.
+        if (isset($resolvedSubscribersById[$subscriberId])) {
+          $foundSubscribers[$subscriberId] = $resolvedSubscribersById[$subscriberId];
+        }
+      }
+      $foundSubscribers = array_values($foundSubscribers);
       $foundSubscribersIds = array_map(function(SubscriberEntity $subscriber) {
         return $subscriber->getId();
       }, $foundSubscribers);

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -301,6 +301,21 @@ class SendingQueue {
         }, $foundSubscribers);
       }
 
+      // Allow extensions to exclude subscribers from this specific send (e.g. custom
+      // frequency capping or cross-newsletter suppression). Excluded subscribers are
+      // dropped below via the same path used for "not found" subscribers, so queue
+      // counts and the scheduled task stay consistent.
+      /** @var array<SubscriberEntity> $foundSubscribers */
+      $foundSubscribers = (array)$this->wp->applyFilters(
+        'mailpoet_sending_queue_subscribers_to_process',
+        $foundSubscribers,
+        $newsletter,
+        $task
+      );
+      $foundSubscribersIds = array_map(function(SubscriberEntity $subscriber) {
+        return $subscriber->getId();
+      }, $foundSubscribers);
+
       // if some subscribers weren't found, remove them from the processing list
       if (count($foundSubscribersIds) !== count($subscribersToProcessIds)) {
         $subscribersToRemove = array_diff(

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -982,6 +982,51 @@ class SendingQueueTest extends \MailPoetTest {
     verify(count($statistics))->equals(1);
   }
 
+  public function testItAllowsExtensionsToExcludeSubscribersFromSending() {
+    $excludedSubscriber = $this->createSubscriber('subscriber1@mailpoet.com', 'Subscriber', 'One');
+
+    $this->scheduledTaskSubscribersRepository->setSubscribers(
+      $this->scheduledTask,
+      [$this->subscriber->getId(), $excludedSubscriber->getId()]
+    );
+
+    $excludedSubscriberId = $excludedSubscriber->getId();
+    $filter = function(array $subscribers) use ($excludedSubscriberId) {
+      return array_values(array_filter($subscribers, function(SubscriberEntity $subscriber) use ($excludedSubscriberId) {
+        return $subscriber->getId() !== $excludedSubscriberId;
+      }));
+    };
+    $wp = new WPFunctions;
+    $wp->addFilter('mailpoet_sending_queue_subscribers_to_process', $filter);
+
+    $sendingQueueWorker = $this->sendingQueueWorker;
+    $sendingQueueWorker->mailerTask = $this->construct(
+      MailerTask::class,
+      [$this->diContainer->get(MailerFactory::class)],
+      [
+        'send' => Expected::exactly(1, function() {
+          return $this->mailerTaskDummyResponse;
+        }),
+      ]
+    );
+    $sendingQueueWorker->process();
+
+    $wp->removeFilter('mailpoet_sending_queue_subscribers_to_process', $filter);
+
+    // the filtered-out subscriber is dropped from the task, same as a "not found" subscriber
+    verify($this->scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
+      ->equals([]);
+    verify($this->scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
+      ->equals([$this->subscriber]);
+    verify($this->sendingQueue->getCountTotal())->equals(1);
+    verify($this->sendingQueue->getCountProcessed())->equals(1);
+    verify($this->sendingQueue->getCountToProcess())->equals(0);
+
+    // statistics entry should be created only for the non-excluded subscriber
+    $statistics = $this->statisticsNewslettersRepository->findAll();
+    verify(count($statistics))->equals(1);
+  }
+
   public function testItDoesNotCallMailerWithEmptyBatch() {
     $subscribers = [];
     while (count($subscribers) < 2 * SendingThrottlingHandler::BATCH_SIZE) {

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -996,22 +996,23 @@ class SendingQueueTest extends \MailPoetTest {
         return $subscriber->getId() !== $excludedSubscriberId;
       }));
     };
-    $wp = new WPFunctions;
-    $wp->addFilter('mailpoet_sending_queue_subscribers_to_process', $filter);
+    $this->wp->addFilter('mailpoet_sending_queue_subscribers_to_process', $filter);
 
-    $sendingQueueWorker = $this->sendingQueueWorker;
-    $sendingQueueWorker->mailerTask = $this->construct(
-      MailerTask::class,
-      [$this->diContainer->get(MailerFactory::class)],
-      [
-        'send' => Expected::exactly(1, function() {
-          return $this->mailerTaskDummyResponse;
-        }),
-      ]
-    );
-    $sendingQueueWorker->process();
-
-    $wp->removeFilter('mailpoet_sending_queue_subscribers_to_process', $filter);
+    try {
+      $sendingQueueWorker = $this->sendingQueueWorker;
+      $sendingQueueWorker->mailerTask = $this->construct(
+        MailerTask::class,
+        [$this->diContainer->get(MailerFactory::class)],
+        [
+          'send' => Expected::exactly(1, function() {
+            return $this->mailerTaskDummyResponse;
+          }),
+        ]
+      );
+      $sendingQueueWorker->process();
+    } finally {
+      $this->wp->removeFilter('mailpoet_sending_queue_subscribers_to_process', $filter);
+    }
 
     // the filtered-out subscriber is dropped from the task, same as a "not found" subscriber
     verify($this->scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED))
@@ -1025,6 +1026,49 @@ class SendingQueueTest extends \MailPoetTest {
     // statistics entry should be created only for the non-excluded subscriber
     $statistics = $this->statisticsNewslettersRepository->findAll();
     verify(count($statistics))->equals(1);
+  }
+
+  public function testItIgnoresSubscribersInjectedByExtensionsThatWereNotInTheResolvedBatch() {
+    $strangerSubscriber = $this->createSubscriber('stranger@mailpoet.com', 'Stranger', 'Danger');
+
+    $this->scheduledTaskSubscribersRepository->setSubscribers(
+      $this->scheduledTask,
+      [$this->subscriber->getId()]
+    );
+
+    // A misbehaving callback returns a subscriber that was never part of this
+    // task's resolved batch, plus a non-SubscriberEntity value and a duplicate.
+    // None of this should reach mailer/processQueue.
+    $filter = function(array $subscribers) use ($strangerSubscriber) {
+      return array_merge($subscribers, $subscribers, [$strangerSubscriber, 'not-a-subscriber', null]);
+    };
+    $this->wp->addFilter('mailpoet_sending_queue_subscribers_to_process', $filter);
+
+    try {
+      $sendingQueueWorker = $this->sendingQueueWorker;
+      $sendingQueueWorker->mailerTask = $this->construct(
+        MailerTask::class,
+        [$this->diContainer->get(MailerFactory::class)],
+        [
+          'send' => Expected::exactly(1, function() {
+            return $this->mailerTaskDummyResponse;
+          }),
+        ]
+      );
+      $sendingQueueWorker->process();
+    } finally {
+      $this->wp->removeFilter('mailpoet_sending_queue_subscribers_to_process', $filter);
+    }
+
+    verify($this->scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
+      ->equals([$this->subscriber]);
+    verify($this->sendingQueue->getCountTotal())->equals(1);
+    verify($this->sendingQueue->getCountProcessed())->equals(1);
+
+    // only the originally resolved subscriber should have received the email
+    $statistics = $this->statisticsNewslettersRepository->findAll();
+    verify(count($statistics))->equals(1);
+    verify($statistics[0]->getSubscriber())->equals($this->subscriber);
   }
 
   public function testItDoesNotCallMailerWithEmptyBatch() {


### PR DESCRIPTION
## Description

Adds a new filter, `mailpoet_sending_queue_subscribers_to_process`, in `SendingQueue::processSending()`. It runs right after subscribers are resolved for a batch and lets an extension remove subscribers from that specific send. Excluded subscribers are dropped through the same path already used for subscribers not found (deleted, unsubscribed, not in a required segment, etc.), so queue counts and the scheduled task stay consistent.

This came out of a support case: a customer wants to suppress a post-notification email for a subscriber when they already received the same post via a different notification the same day (e.g. an instant author-based notification and a daily category-based one). MailPoet renders a post notification once per batch and sends the same content to every recipient, so there's no way to drop a single post for one subscriber. The closest safe fix is letting a subscriber be skipped from a send entirely, which this filter enables. It's general-purpose (also usable for frequency capping or other custom suppression), not a one-off for this customer.

## Code review notes

`(array)` cast on the filter result plus a `@var array<SubscriberEntity>` annotation are needed to keep PHPStan happy, since `applyFilters()` returns `mixed`. This mirrors the existing pattern used elsewhere in the codebase (e.g. `WooCommerce/Helper.php`, `NewsletterTemplates/TemplateImageLoader.php`).

## QA notes

- `pnpm test:integration --file=tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php` — 50 tests, 410 assertions, all green (added one new test: `testItAllowsExtensionsToExcludeSubscribersFromSending`).
- `./do qa` (lint + PHPCS + ESLint + Stylelint) — clean.
- `./do qa:phpstan` — no errors.

## Linked PRs

_N/A_

## Linked tickets

_N/A_ (not yet filed in Linear — this was scoped ad hoc while investigating a customer support request; happy to file one if useful for tracking)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_ (backend-only filter, no UI change)

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed best practices for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/sending-queue-subscribers-to-process-filter)

_The latest successful build from `add/sending-queue-subscribers-to-process-filter` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found (0 total).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->