### PR TITLE
Fix WooCommerce segment tests on WooCommerce 11.0

### DIFF
--- a/mailpoet/tests/_support/DefaultsExtension.php
+++ b/mailpoet/tests/_support/DefaultsExtension.php
@@ -99,6 +99,12 @@ class DefaultsExtension extends Extension {
     update_option('woocommerce_task_list_hidden', 'yes');
     delete_transient('_wc_activation_redirect');
 
+    // Fill WooCommerce analytics tables right after each order instead of via a
+    // background batch. Tests place an order and drain Action Scheduler expecting
+    // the data to be there immediately, but Action Scheduler 4.0 (WC 11.0) no
+    // longer runs that batch during the drain. Immediate import keeps tests stable.
+    update_option('woocommerce_analytics_scheduled_import', 'no', false);
+
     // mark all WC cron actions complete
     update_option('wc_pending_batch_processes', []);
     $tableName = !empty($wpdb->actionscheduler_actions) ? $wpdb->actionscheduler_actions : $wpdb->prefix . 'actionscheduler_actions';// phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps


### PR DESCRIPTION
## Description

Fixes the WooCommerce dynamic-segment acceptance tests on WooCommerce 11.0 (see the [failing nightly](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/24330/workflows/96964eb2-6de9-4047-b37f-41f1069617b3/jobs/428734/steps) `acceptance_tests_woocommerce_beta` job).

These tests place an order, drain Action Scheduler, and expect WooCommerce's analytics tables to be filled so the segment counts show up. That worked with Action Scheduler 3.x, but WC 11.0 ships Action Scheduler 4.0, which changed how jobs are claimed - so the forced drain no longer runs the analytics import. The tables stay empty, the counts render `0`, and every count assertion fails.

The fix tells WooCommerce (in the test env only) to import analytics immediately instead of via a background batch, so each order's import runs during the drain like before. This is test-only - MailPoet's production code shouldn't be affected by this and therefore doesn't require any changes.

## Code review notes

- Test-only change in `tests/_support/DefaultsExtension.php`.
- Root cause - Action Scheduler 4.0 bump in WC 11.0 (https://github.com/woocommerce/woocommerce/pull/65790). The scheduled import default itself dates back to WC 10.5 (https://github.com/woocommerce/woocommerce/pull/62331).

## QA notes

- Run `WooCommerceDynamicSegmentsCest` against WooCommerce 11.0.0-beta.1 - `pnpm test:acceptance --file=tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php`

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/acceptance-tests-with-wc11-as4)

_The latest successful build from `fix/acceptance-tests-with-wc11-as4` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->