### PR TITLE
Updater: Gate premium auto-update on installed free version

### DIFF
--- a/mailpoet/changelog/2026-07-15-12-35-10-fixed-prevent-the-premium-plugin-from-auto-updating-ahea.md
+++ b/mailpoet/changelog/2026-07-15-12-35-10-fixed-prevent-the-premium-plugin-from-auto-updating-ahea.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Prevent the Premium plugin from auto-updating ahead of the free plugin, which could disable Premium features when the free update was delayed

--- a/mailpoet/lib/Config/Updater.php
+++ b/mailpoet/lib/Config/Updater.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\Config;
 
-use MailPoet\Config\Env;
 use MailPoet\Services\Bridge;
 use MailPoet\Services\Release\API;
 use MailPoet\Settings\SettingsController;
@@ -48,12 +47,7 @@ class Updater {
       unset($updateTransient->response[$this->plugin]); // remove the cached version from the transient.
     }
 
-    $latestFreeVersion = null;
-    if (property_exists($updateTransient, 'response') && isset($updateTransient->response[Env::$pluginPath]->new_version)) {
-      $latestFreeVersion = $updateTransient->response[Env::$pluginPath]->new_version;
-    }
-
-    if (!$this->shouldShowUpdateNotice($latestVersion->new_version, $latestFreeVersion)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    if (!$this->shouldShowUpdateNotice($latestVersion->new_version)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       return $updateTransient; // skip update notice.
     }
 
@@ -96,13 +90,12 @@ class Updater {
     return version_compare($currentMainVersion, $requiredMainVersion, '>=');
   }
 
-  public function shouldShowUpdateNotice($premiumLatestVersion, $latestFreeVersion = null): bool {
-    // first check if the free version in the update transient is compatible with the premium latest version
-    if (!empty($latestFreeVersion) && $this->isVersionCompatible($premiumLatestVersion, $latestFreeVersion)) {
-      return true;
-    }
-
-    // then check if the current free version is compatible with the premium latest version
+  public function shouldShowUpdateNotice($premiumLatestVersion): bool {
+    // Compare against the free version that's actually installed, not one that's
+    // merely available. Since wordpress.org now holds new releases for up to 24h
+    // before distributing them (https://wordpress.org/news/2026/06/pts/), the free
+    // update can lag behind Premium. Gating on the installed version keeps Premium
+    // from jumping ahead and disabling itself.
     return $this->isVersionCompatible($premiumLatestVersion, $this->currentFreeVersion);
   }
 }

--- a/mailpoet/tests/integration/Config/UpdaterTest.php
+++ b/mailpoet/tests/integration/Config/UpdaterTest.php
@@ -188,11 +188,11 @@ class UpdaterTest extends \MailPoetTest {
     verify(isset($result->no_update[$this->pluginName]))->false(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
-  public function testItChecksForUpdatesWithFreeVersionInTransient() {
+  public function testItSkipsUpdateWhenFreeUpdateIsPendingButNotInstalled() {
     $updateTransient = new \stdClass;
     $updateTransient->last_checked = time(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
-    // Mock free plugin update in transient
+    // A compatible free update is available in the transient, but not yet installed
     $updateTransient->response = [];
     $updateTransient->response[Env::$pluginPath] = (object)[
       'id' => 'w.org/plugins/mailpoet',
@@ -225,8 +225,10 @@ class UpdaterTest extends \MailPoetTest {
     $updater->currentFreeVersion = '5.16.0';
     $result = $updater->checkForUpdate($updateTransient);
 
-    // Should process the update since versions are compatible
-    verify($result->response[$this->pluginName]->new_version)->equals('5.17.0'); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    // Premium must not be offered while the installed free version is incompatible,
+    // even though a compatible free update is pending in the transient.
+    verify(isset($result->response[$this->pluginName]))->false();
+    verify(isset($result->no_update[$this->pluginName]))->false(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
   public function testIsVersionCompatibleReturnsTrueForCompatibleVersions() {
@@ -269,7 +271,7 @@ class UpdaterTest extends \MailPoetTest {
     verify($this->updater->isVersionCompatible('5.17.0', '5.17.0-alpha'))->true();
   }
 
-  public function testShouldShowUpdateNoticeReturnsTrueWhenFreeVersionInTransientIsCompatible() {
+  public function testShouldShowUpdateNoticeReturnsTrueWhenInstalledFreeVersionIsCompatible() {
     $updater = Stub::construct(
       $this->updater,
       [
@@ -278,36 +280,17 @@ class UpdaterTest extends \MailPoetTest {
         $this->version,
       ],
       [
-        'isVersionCompatible' => Expected::exactly(1, true), // Should only call once and return true
-      ],
-      $this
-    );
-
-    $result = $updater->shouldShowUpdateNotice('5.17.0', '5.17.0');
-    verify($result)->true();
-  }
-
-  public function testShouldShowUpdateNoticeReturnsTrueWhenCurrentFreeVersionIsCompatible() {
-    $updater = Stub::construct(
-      $this->updater,
-      [
-        $this->pluginName,
-        $this->slug,
-        $this->version,
-      ],
-      [
-
+        'isVersionCompatible' => Expected::once(true), // Should only check the installed free version
       ],
       $this
     );
     $updater->currentFreeVersion = '5.17.0';
 
-    // Latest free version in transient is lower than required, but the currently installed free version is compatible.
-    $result = $updater->shouldShowUpdateNotice('5.17.0', '5.16.0');
+    $result = $updater->shouldShowUpdateNotice('5.17.0');
     verify($result)->true();
   }
 
-  public function testShouldShowUpdateNoticeReturnsFalseWhenCurrentFreeVersionIsIncompatible() {
+  public function testShouldShowUpdateNoticeReturnsFalseWhenInstalledFreeVersionIsIncompatible() {
     $updater = Stub::construct(
       $this->updater,
       [
@@ -316,66 +299,13 @@ class UpdaterTest extends \MailPoetTest {
         $this->version,
       ],
       [
+        'isVersionCompatible' => Expected::once(false),
       ],
       $this
     );
     $updater->currentFreeVersion = '5.16.0';
 
-    $result = $updater->shouldShowUpdateNotice('5.17.0', null); // no free version in transient and current free version is incompatible
+    $result = $updater->shouldShowUpdateNotice('5.17.0');
     verify($result)->false();
-  }
-
-  public function testShouldShowUpdateNoticeReturnsFalseWhenNoVersionsAreCompatible() {
-    $updater = Stub::construct(
-      $this->updater,
-      [
-        $this->pluginName,
-        $this->slug,
-        $this->version,
-      ],
-      [
-        'isVersionCompatible' => Expected::exactly(2, false), // Both calls should return false
-      ],
-      $this
-    );
-
-    $result = $updater->shouldShowUpdateNotice('6.0.0', '5.18.0'); // Both incompatible
-    verify($result)->false();
-  }
-
-  public function testShouldShowUpdateNoticeHandlesNullLatestFreeVersion() {
-    $updater = Stub::construct(
-      $this->updater,
-      [
-        $this->pluginName,
-        $this->slug,
-        $this->version,
-      ],
-      [
-        'isVersionCompatible' => Expected::once(true), // Should only call once with MAILPOET_VERSION
-      ],
-      $this
-    );
-
-    $result = $updater->shouldShowUpdateNotice('5.17.0', null);
-    verify($result)->true();
-  }
-
-  public function testShouldShowUpdateNoticeHandlesEmptyLatestFreeVersion() {
-    $updater = Stub::construct(
-      $this->updater,
-      [
-        $this->pluginName,
-        $this->slug,
-        $this->version,
-      ],
-      [
-        'isVersionCompatible' => Expected::once(true), // Should only call once with MAILPOET_VERSION
-      ],
-      $this
-    );
-
-    $result = $updater->shouldShowUpdateNotice('5.17.0', '');
-    verify($result)->true();
   }
 }


### PR DESCRIPTION
## Description

MailPoet Premium could auto-update before the MailPoet free plugin and then turn itself off until free caught up.

The updater checked the free version that was available, not the one actually installed. Since wordpress.org now [holds auto-updates for new releases for up to 24h](https://wordpress.org/news/2026/06/pts/), MailPoet Premium could update while free was still on the old version.

To prevent this, this updates changes the updater to only offer the MailPoet Premium update when the *installed* MailPoet free version is compatible, so premium can't get ahead of free.

## Code review notes

- `shouldShowUpdateNotice()` no longer uses the available (transient) MailPoet free version. It now checks only the installed one.
- Updated the tests and added one for this exact case.

## QA notes

* On a test site, install an older version of MailPoet Premium (e.g. 5.33.0).
* Manually change the version of MailPoet (free) to simulate incompatibility with the latest MailPoet Premium release:
```diff
diff --git a/mailpoet/mailpoet.php b/mailpoet/mailpoet.php
index 302de1a465..20e8d10375 100644
--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@

 /*
  * Plugin Name: MailPoet
- * Version: 5.34.0
+ * Version: 5.33.0
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */

 $mailpoetPlugin = [
-  'version' => '5.34.0',
+  'version' => '5.33.0',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload_packages.php',
```

* Navigate to the plugins page and confirm MailPoet Premium doesn't show an update notice.
* Revert the MailPoet (free) version changes and refresh the plugins page.
* Confirm MailPoet Premium now has the update notice.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8270: Keep MailPoet Premium and Free auto-updates in lockstep](https://linear.app/a8c/issue/STOMAIL-8270/keep-mailpoet-premium-and-free-auto-updates-in-lockstep)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8270-keep-mailpoet-premium-and-free-auto-updates-in-lockstep)

_The latest successful build from `stomail-8270-keep-mailpoet-premium-and-free-auto-updates-in-lockstep` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->