### PR TITLE
Fix filter callback returning null/non-array dropping entire subscriber batch

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -302,34 +302,33 @@ class SendingQueue {
       // frequency capping or cross-newsletter suppression). Excluded subscribers are
       // dropped below via the same path used for "not found" subscribers, so queue
       // counts and the scheduled task stay consistent.
-      // The filter result is normalized defensively: a misbehaving callback could
-      // return non-SubscriberEntity values, duplicates, or subscribers that were
-      // never part of the resolved batch (e.g. not in this segment/task), any of
-      // which would otherwise reach processQueue() and either fatal or send to an
-      // unintended recipient.
       $resolvedSubscribersById = [];
       foreach ($foundSubscribers as $subscriber) {
         $resolvedSubscribersById[$subscriber->getId()] = $subscriber;
       }
-      $filteredSubscribers = (array)$this->wp->applyFilters(
+      $filteredSubscribers = $this->wp->applyFilters(
         'mailpoet_sending_queue_subscribers_to_process',
         $foundSubscribers,
         $newsletter,
         $task
       );
-      $foundSubscribers = [];
-      foreach ($filteredSubscribers as $filteredSubscriber) {
-        if (!$filteredSubscriber instanceof SubscriberEntity) {
-          continue;
+
+      if (is_array($filteredSubscribers)) {
+        $foundSubscribers = [];
+        foreach ($filteredSubscribers as $filteredSubscriber) {
+          if (!$filteredSubscriber instanceof SubscriberEntity) {
+            continue;
+          }
+          $subscriberId = $filteredSubscriber->getId();
+          // Keep only subscribers that were already in the resolved batch (by id), and
+          // use the original entity instance rather than trusting whatever the filter returned.
+          if (isset($resolvedSubscribersById[$subscriberId])) {
+            $foundSubscribers[$subscriberId] = $resolvedSubscribersById[$subscriberId];
+          }
         }
-        $subscriberId = $filteredSubscriber->getId();
-        // Keep only subscribers that were already in the resolved batch (by id), and
-        // use the original entity instance rather than trusting whatever the filter returned.
-        if (isset($resolvedSubscribersById[$subscriberId])) {
-          $foundSubscribers[$subscriberId] = $resolvedSubscribersById[$subscriberId];
-        }
+        $foundSubscribers = array_values($foundSubscribers);
       }
-      $foundSubscribers = array_values($foundSubscribers);
+
       $foundSubscribersIds = array_map(function(SubscriberEntity $subscriber) {
         return $subscriber->getId();
       }, $foundSubscribers);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -983,7 +983,9 @@ class SendingQueueTest extends \MailPoetTest {
   }
 
   public function testItAllowsExtensionsToExcludeSubscribersFromSending() {
-    $excludedSubscriber = $this->createSubscriber('subscriber1@mailpoet.com', 'Subscriber', 'One');
+    // Must be in the newsletter's segment so it reaches the filter instead of being
+    // dropped earlier by segment resolution (which would make this test a no-op).
+    $excludedSubscriber = $this->createSubscriber('subscriber1@mailpoet.com', 'Subscriber', 'One', [$this->segment]);
 
     $this->scheduledTaskSubscribersRepository->setSubscribers(
       $this->scheduledTask,
@@ -1028,6 +1030,47 @@ class SendingQueueTest extends \MailPoetTest {
     verify(count($statistics))->equals(1);
   }
 
+  public function testItAllowsExtensionsToExcludeTheEntireBatch() {
+    // A legitimate callback can exclude every subscriber in the batch (e.g. a
+    // frequency cap that applies to all of them). This must be respected as-is,
+    // not treated as if the filter had misbehaved and the original batch restored.
+    $filter = function() {
+      return [];
+    };
+    $this->wp->addFilter('mailpoet_sending_queue_subscribers_to_process', $filter);
+
+    try {
+      $sendingQueueWorker = $this->sendingQueueWorker;
+      $sendingQueueWorker->mailerTask = $this->construct(
+        MailerTask::class,
+        [$this->diContainer->get(MailerFactory::class)],
+        [
+          'send' => Expected::exactly(0),
+        ]
+      );
+      $sendingQueueWorker->process();
+    } finally {
+      $this->wp->removeFilter('mailpoet_sending_queue_subscribers_to_process', $filter);
+    }
+
+    $sendingQueue = $this->sendingQueuesRepository->findOneById($this->sendingQueue->getId());
+    $this->assertInstanceOf(SendingQueueEntity::class, $sendingQueue);
+    $scheduledTask = $this->scheduledTasksRepository->findOneBySendingQueue($sendingQueue);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $scheduledTask);
+    $this->sendingQueuesRepository->refresh($sendingQueue);
+    $this->scheduledTasksRepository->refresh($scheduledTask);
+
+    // the whole batch is dropped, same as if none of the subscribers were found
+    verify($scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
+      ->equals([]);
+    verify($sendingQueue->getCountTotal())->equals(0);
+    verify($sendingQueue->getCountProcessed())->equals(0);
+    verify($scheduledTask->getStatus())->equals(SendingQueueEntity::STATUS_COMPLETED);
+
+    $statistics = $this->statisticsNewslettersRepository->findAll();
+    verify(count($statistics))->equals(0);
+  }
+
   public function testItIgnoresSubscribersInjectedByExtensionsThatWereNotInTheResolvedBatch() {
     $strangerSubscriber = $this->createSubscriber('stranger@mailpoet.com', 'Stranger', 'Danger');
 
@@ -1066,6 +1109,43 @@ class SendingQueueTest extends \MailPoetTest {
     verify($this->sendingQueue->getCountProcessed())->equals(1);
 
     // only the originally resolved subscriber should have received the email
+    $statistics = $this->statisticsNewslettersRepository->findAll();
+    verify(count($statistics))->equals(1);
+    verify($statistics[0]->getSubscriber())->equals($this->subscriber);
+  }
+
+  public function testItDoesNotDropTheBatchWhenFilterCallbackReturnsNonArray() {
+    // A misbehaving callback (e.g. a forgotten `return`) returns null instead of
+    // an array. Casting that to an array used to silently empty the whole batch,
+    // which made the "not found" logic remove every subscriber from the task.
+    $filter = function() {
+      return null;
+    };
+    $this->wp->addFilter('mailpoet_sending_queue_subscribers_to_process', $filter);
+
+    try {
+      $sendingQueueWorker = $this->sendingQueueWorker;
+      $sendingQueueWorker->mailerTask = $this->construct(
+        MailerTask::class,
+        [$this->diContainer->get(MailerFactory::class)],
+        [
+          'send' => Expected::exactly(1, function() {
+            return $this->mailerTaskDummyResponse;
+          }),
+        ]
+      );
+      $sendingQueueWorker->process();
+    } finally {
+      $this->wp->removeFilter('mailpoet_sending_queue_subscribers_to_process', $filter);
+    }
+
+    // the batch is processed as if no filter had run, instead of being dropped
+    verify($this->scheduledTask->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED))
+      ->equals([$this->subscriber]);
+    verify($this->sendingQueue->getCountTotal())->equals(1);
+    verify($this->sendingQueue->getCountProcessed())->equals(1);
+    verify($this->sendingQueue->getCountToProcess())->equals(0);
+
     $statistics = $this->statisticsNewslettersRepository->findAll();
     verify(count($statistics))->equals(1);
     verify($statistics[0]->getSubscriber())->equals($this->subscriber);


### PR DESCRIPTION
## Description

A callback attached to `mailpoet_sending_queue_subscribers_to_process` (added in #6979) that returns `null` or any other non-array value (e.g. a forgotten `return`) was being cast to an empty array. That empty result made the existing "not found" removal logic treat every subscriber in the batch as missing, delete them all from the scheduled task, and continue — so the newsletter would complete as "sent" with zero emails delivered and no error surfaced anywhere.

This fix only replaces the resolved subscriber batch with the filter's result when that result is actually an array. Otherwise the batch is left unchanged, exactly as if no filter had run. A callback that legitimately returns an empty array to intentionally exclude every subscriber in the batch is still respected as-is (that case is not treated as misbehavior).

While in there, I also fixed a test coverage gap: the excluded subscriber in `testItAllowsExtensionsToExcludeSubscribersFromSending` had no segment membership, so it was being dropped by segment resolution *before* the filter even ran — the test passed regardless of whether the filter logic worked at all.

## Code review notes

- `SendingQueue.php`: replaced `(array)$this->wp->applyFilters(...)` with an `is_array()` check; the resolved batch is only reassigned when the filter result is an array.
- Added `testItAllowsExtensionsToExcludeTheEntireBatch` covering the legitimate full-exclusion case (must not be treated as a bug).
- Added `testItDoesNotDropTheBatchWhenFilterCallbackReturnsNonArray` covering the reported regression (`null` return must not drop the batch).
- Fixed `testItAllowsExtensionsToExcludeSubscribersFromSending` so the excluded subscriber is actually reachable by the filter (added to the newsletter's segment).

## QA notes

- Verified each new/fixed test actually exercises the intended behavior by temporarily reverting the corresponding fix and confirming the test fails, then restoring the fix and confirming it passes again.
- `./do qa:php` (lint + PHPCS): clean.
- `./do qa:phpstan`: clean (pre-existing unrelated warning in `MetadataCache.php` only).
- `pnpm test:integration --file=tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php`: 53/53 passing.

## Linked PRs

#6979 (introduced the filter this fixes)

## Linked tickets

Fixes [STOMAIL-8274](https://linear.app/a8c/issue/STOMAIL-8274/ai-regression-reviewtrunk-a-filter-callback-returning-nullnon-array-eg)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| -------------------------------- | ------------------------------- |
| <!-- Before screenshot here --> | <!-- After screenshot here --> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`) — not added: this fixes a bug in the filter added in #6979, which has not shipped in any release yet, so there is nothing user-facing to describe separately from the original changelog entry.
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8274-filter-null-return)

_The latest successful build from `fix/stomail-8274-filter-null-return` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

1 issue found:
- Bug: Non-array filter results could remove the entire subscriber batch and deliver zero emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->