### PR TITLE
Stop retrying bounce reports with a rejected key

### DIFF
--- a/mailpoet/changelog/2026-07-16-09-06-49-fixed-repeated-bounce-report-requests-when-the-mailpoet-.md
+++ b/mailpoet/changelog/2026-07-16-09-06-49-fixed-repeated-bounce-report-requests-when-the-mailpoet-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Repeated bounce report requests when the MailPoet API key is no longer valid

--- a/mailpoet/lib/Cron/Workers/Bounce.php
+++ b/mailpoet/lib/Cron/Workers/Bounce.php
@@ -86,6 +86,14 @@ class Bounce extends SimpleWorker {
     // instead of requesting one on every cron tick. SendingServiceKeyCheck owns
     // this state and flips it back once the key works again, which re-enables
     // the worker without any bounce-specific recovery path.
+    //
+    // Returning false makes CronWorkerRunner delete the due and running tasks
+    // rather than pause them, so the in-progress range and page cursor on the
+    // task meta are lost. That costs nothing: LAST_REPORT_TO_SETTING_KEY only
+    // advances once a range is fully consumed, so the next task re-derives the
+    // same `from` and replays the range. The real cost is time — a key left
+    // rejected for longer than MAX_LOOKBACK_DAYS pushes `from` past what the
+    // service will report on, and the bounces in that gap are never recovered.
     return $this->bridge->isMailpoetSendingServiceEnabled()
       && $this->servicesChecker->isMailPoetAPIKeyValid(false) === true;
   }

--- a/mailpoet/lib/Cron/Workers/Bounce.php
+++ b/mailpoet/lib/Cron/Workers/Bounce.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\Cron\Workers;
 
+use MailPoet\Config\ServicesChecker;
+use MailPoet\Cron\Workers\KeyCheck\SendingServiceKeyCheck;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\StatisticsBounceEntity;
@@ -10,6 +12,7 @@ use MailPoet\Mailer\Mailer;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Services\Bridge;
 use MailPoet\Services\Bridge\API;
+use MailPoet\Services\Bridge\BouncesReportException;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Statistics\StatisticsBouncesRepository;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -52,12 +55,16 @@ class Bounce extends SimpleWorker {
   /** @var StatisticsBouncesRepository */
   private $statisticsBouncesRepository;
 
+  /** @var ServicesChecker */
+  private $servicesChecker;
+
   public function __construct(
     SettingsController $settings,
     SubscribersRepository $subscribersRepository,
     SendingQueuesRepository $sendingQueuesRepository,
     StatisticsBouncesRepository $statisticsBouncesRepository,
-    Bridge $bridge
+    Bridge $bridge,
+    ServicesChecker $servicesChecker
   ) {
     $this->settings = $settings;
     $this->bridge = $bridge;
@@ -65,6 +72,7 @@ class Bounce extends SimpleWorker {
     $this->subscribersRepository = $subscribersRepository;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->statisticsBouncesRepository = $statisticsBouncesRepository;
+    $this->servicesChecker = $servicesChecker;
   }
 
   public function init() {
@@ -74,7 +82,12 @@ class Bounce extends SimpleWorker {
   }
 
   public function checkProcessingRequirements() {
-    return $this->bridge->isMailpoetSendingServiceEnabled();
+    // A key the service rejects can never produce a report, so stop the worker
+    // instead of requesting one on every cron tick. SendingServiceKeyCheck owns
+    // this state and flips it back once the key works again, which re-enables
+    // the worker without any bounce-specific recovery path.
+    return $this->bridge->isMailpoetSendingServiceEnabled()
+      && $this->servicesChecker->isMailPoetAPIKeyValid(false) === true;
   }
 
   public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
@@ -85,11 +98,10 @@ class Bounce extends SimpleWorker {
       // abort if execution limit is reached
       $this->cronHelper->enforceExecutionLimit($timer);
 
-      $report = $this->api->getBouncesReport($from, $to, $page);
-      if (!is_array($report)) {
-        // Transient failure: leave the task running so it retries with the
-        // same range and page on the next cron tick.
-        return false;
+      try {
+        $report = $this->api->getBouncesReport($from, $to, $page);
+      } catch (BouncesReportException $e) {
+        return $this->handleReportFailure($task, $e);
       }
 
       $recipients = isset($report['recipients']) && is_array($report['recipients']) ? $report['recipients'] : [];
@@ -117,6 +129,27 @@ class Bounce extends SimpleWorker {
       $this->settings->set(self::LAST_REPORT_TO_SETTING_KEY, $to->format(\DateTimeInterface::ATOM));
     }
     return true;
+  }
+
+  /**
+   * Backs the task off instead of letting it retry on the very next cron tick.
+   * The report range is frozen on the task meta, so the delayed retry still
+   * covers exactly the same window.
+   */
+  private function handleReportFailure(ScheduledTaskEntity $task, BouncesReportException $e): bool {
+    $code = $e->getCode();
+    if ($code === API::RESPONSE_CODE_KEY_INVALID || $code === API::RESPONSE_CODE_CAN_NOT_SEND) {
+      // The report endpoint rejected the key, but it is not the authority on key
+      // state: it is registered on WPCOM, while keys are issued and validated by
+      // bridge.mailpoet.com. So ask the authority to re-check now rather than
+      // waiting up to a day for the scheduled check, and let the key state it
+      // stores decide (via checkProcessingRequirements) whether this worker keeps
+      // running. Writing the state from here instead would let a WPCOM-side fault
+      // pause all sending on evidence from a service that does not issue keys.
+      $this->cronWorkerScheduler->scheduleImmediatelyIfNotRunning(SendingServiceKeyCheck::TASK_TYPE);
+    }
+    $this->cronWorkerScheduler->rescheduleProgressively($task);
+    return false;
   }
 
   /**

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -150,7 +150,7 @@ class API {
     );
     remove_action('requests-curl.after_request', [$this, 'logCurlInformation']);
     remove_action('requests-curl.before_request', [$this, 'setCurlHandle']);
-    if (is_wp_error($result)) {
+    if ($this->wp->isWpError($result)) {
       $this->logCurlError($result);
       return [
         'status' => self::SENDING_STATUS_CONNECTION_ERROR,
@@ -199,7 +199,7 @@ class API {
     $result = $this->request($url, null, 'GET');
     $responseCode = (int)$this->wp->wpRemoteRetrieveResponseCode($result);
     if ($responseCode !== 200) {
-      $isWpError = is_wp_error($result);
+      $isWpError = $this->wp->isWpError($result);
       $logData = [
         'code' => $responseCode,
         'error' => $isWpError ? $result->get_error_message() : $this->wp->wpRemoteRetrieveBody($result),
@@ -267,7 +267,7 @@ class API {
     if (!$isSuccess) {
       $logData = [
         'code' => $code,
-        'error' => is_wp_error($result) ? $result->get_error_message() : null,
+        'error' => $this->wp->isWpError($result) ? $result->get_error_message() : null,
       ];
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_BRIDGE)->error('Stats API call failed.', $logData);
     }
@@ -306,7 +306,7 @@ class API {
       $errorBody = $this->wp->wpRemoteRetrieveBody($result);
       $logData = [
         'code' => $responseCode,
-        'error' => is_wp_error($result) ? $result->get_error_message() : $errorBody,
+        'error' => $this->wp->isWpError($result) ? $result->get_error_message() : $errorBody,
       ];
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_BRIDGE)->error('CreateAuthorizedEmailAddress API call failed.', $logData);
 
@@ -415,7 +415,7 @@ class API {
       }
       $logData = [
         'code' => $responseCode,
-        'error' => is_wp_error($result) ? $result->get_error_message() : $rawResponseBody,
+        'error' => $this->wp->isWpError($result) ? $result->get_error_message() : $rawResponseBody,
       ];
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_BRIDGE)->error('verifyAuthorizedSenderDomain API call failed.', $logData);
 

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -175,12 +175,14 @@ class API {
    * `from`/`to` datetime range, 1-based `p` pagination, and a response of the
    * shape `{ recipients: array<{email: string, type: string}>, page: int,
    * has_more: bool }`. The returned `recipients` are flattened to their email
-   * addresses so callers receive a plain list of strings. Returns null on a
-   * failed request.
+   * addresses so callers receive a plain list of strings.
    *
-   * @return array{recipients: string[], page: int, has_more: bool}|null
+   * @return array{recipients: string[], page: int, has_more: bool}
+   * @throws BouncesReportException The response status is carried on the
+   *   exception code so callers can distinguish a rejected key (401/403), which
+   *   no amount of retrying will fix, from a transient failure.
    */
-  public function getBouncesReport(\DateTimeInterface $from, \DateTimeInterface $to, int $page = 1): ?array {
+  public function getBouncesReport(\DateTimeInterface $from, \DateTimeInterface $to, int $page = 1): array {
     $utc = new \DateTimeZone('UTC');
     $fromUtc = (new \DateTimeImmutable('@' . $from->getTimestamp()))->setTimezone($utc);
     $toUtc = (new \DateTimeImmutable('@' . $to->getTimestamp()))->setTimezone($utc);
@@ -195,8 +197,17 @@ class API {
     );
 
     $result = $this->request($url, null, 'GET');
-    if ($this->wp->wpRemoteRetrieveResponseCode($result) !== 200) {
-      return null;
+    $responseCode = (int)$this->wp->wpRemoteRetrieveResponseCode($result);
+    if ($responseCode !== 200) {
+      $logData = [
+        'code' => $responseCode,
+        'error' => is_wp_error($result) ? $result->get_error_message() : $this->wp->wpRemoteRetrieveBody($result),
+      ];
+      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_BRIDGE)->error('getBouncesReport API call failed.', $logData);
+      throw BouncesReportException::create()
+        ->withCode($responseCode)
+        // translators: %d is the HTTP response code.
+        ->withMessage(sprintf(__('The bounces report request failed with response code %d', 'mailpoet'), $responseCode));
     }
     $body = $this->wp->wpRemoteRetrieveBody($result);
     $data = json_decode($body, true);
@@ -204,7 +215,8 @@ class API {
       // A 200 with a malformed payload must not be treated as a successful empty
       // page: that would advance the report window and silently skip bounces.
       $this->logInvalidDataFormat('getBouncesReport', is_string($body) ? $body : null);
-      return null;
+      throw BouncesReportException::create()
+        ->withMessage(__('The bounces report response was not in the expected format', 'mailpoet'));
     }
     $data['recipients'] = array_map(
       function (array $recipient): string {

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -199,15 +199,22 @@ class API {
     $result = $this->request($url, null, 'GET');
     $responseCode = (int)$this->wp->wpRemoteRetrieveResponseCode($result);
     if ($responseCode !== 200) {
+      $isWpError = is_wp_error($result);
       $logData = [
         'code' => $responseCode,
-        'error' => is_wp_error($result) ? $result->get_error_message() : $this->wp->wpRemoteRetrieveBody($result),
+        'error' => $isWpError ? $result->get_error_message() : $this->wp->wpRemoteRetrieveBody($result),
       ];
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_BRIDGE)->error('getBouncesReport API call failed.', $logData);
+      // The request never reached the service, so there is no status to report:
+      // say so rather than describing it as "response code 0". The code stays 0
+      // either way, which is what marks the failure as transient for callers.
+      $message = $isWpError
+        ? __('The bounces report request failed without a response', 'mailpoet')
+        // translators: %d is the HTTP response code.
+        : sprintf(__('The bounces report request failed with response code %d', 'mailpoet'), $responseCode);
       throw BouncesReportException::create()
         ->withCode($responseCode)
-        // translators: %d is the HTTP response code.
-        ->withMessage(sprintf(__('The bounces report request failed with response code %d', 'mailpoet'), $responseCode));
+        ->withMessage($message);
     }
     $body = $this->wp->wpRemoteRetrieveBody($result);
     $data = json_decode($body, true);

--- a/mailpoet/lib/Services/Bridge/BouncesReportException.php
+++ b/mailpoet/lib/Services/Bridge/BouncesReportException.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Services\Bridge;
+
+use MailPoet\RuntimeException;
+
+/**
+ * Thrown when a bounces report request does not yield a usable report. The code
+ * carries the HTTP status the endpoint responded with, or 0 when there was no
+ * response to read a status from (connection error, malformed payload), so
+ * callers can tell a permanent rejection from a transient failure.
+ */
+class BouncesReportException extends RuntimeException {
+}

--- a/mailpoet/tests/integration/Cron/Workers/BounceTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/BounceTest.php
@@ -2,14 +2,17 @@
 
 namespace MailPoet\Test\Cron\Workers;
 
+use MailPoet\Config\ServicesChecker;
 use MailPoet\Cron\Workers\Bounce;
 use MailPoet\Cron\Workers\Bounce\BounceTestMockAPI as MockAPI;
+use MailPoet\Cron\Workers\KeyCheck\SendingServiceKeyCheck;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Mailer\Mailer;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Services\Bridge;
 use MailPoet\Services\Bridge\API;
@@ -80,9 +83,87 @@ class BounceTest extends \MailPoetTest {
   }
 
   public function testItRequiresMailPoetMethodToBeSetUp() {
+    $this->setKeyState(Bridge::KEY_VALID);
     verify($this->worker->checkProcessingRequirements())->false();
     $this->setMailPoetSendingMethod();
     verify($this->worker->checkProcessingRequirements())->true();
+  }
+
+  public function testItDoesNotRunWhenTheKeyIsNotUsable() {
+    $this->setMailPoetSendingMethod();
+
+    // A deleted key: nothing the worker does can make the report succeed, so the
+    // runner must drop the tasks rather than keep them retrying.
+    $this->setKeyState(Bridge::KEY_INVALID);
+    verify($this->worker->checkProcessingRequirements())->false();
+
+    // The key authenticates but the plan does not cover the feature.
+    $this->setKeyState(Bridge::KEY_VALID_UNDERPRIVILEGED);
+    verify($this->worker->checkProcessingRequirements())->false();
+
+    $this->setKeyState(Bridge::KEY_VALID);
+    verify($this->worker->checkProcessingRequirements())->true();
+  }
+
+  public function testItRunsForAnExpiringKey() {
+    $this->setMailPoetSendingMethod();
+    $this->setKeyState(Bridge::KEY_EXPIRING);
+    verify($this->worker->checkProcessingRequirements())->true();
+  }
+
+  public function testItTriggersAKeyCheckAndBacksOffWhenTheKeyIsRejected() {
+    $this->setKeyState(Bridge::KEY_VALID);
+    $this->api->failResponse = true;
+    $this->api->failResponseCode = API::RESPONSE_CODE_KEY_INVALID;
+    $task = $this->createRunningTask();
+
+    verify($this->worker->processTaskStrategy($task, microtime(true)))->false();
+
+    // The report endpoint is not the authority on key state, so the worker asks
+    // the bridge to re-check instead of writing the state itself.
+    $keyCheckTask = $this->findKeyCheckTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $keyCheckTask);
+    verify($keyCheckTask->getStatus())->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
+
+    $this->assertKeyStateUntouched();
+    $this->assertBackedOff($task);
+  }
+
+  public function testItTriggersAKeyCheckAndBacksOffWhenTheReportIsForbidden() {
+    $this->setKeyState(Bridge::KEY_VALID);
+    $this->api->failResponse = true;
+    $this->api->failResponseCode = API::RESPONSE_CODE_CAN_NOT_SEND;
+    $task = $this->createRunningTask();
+
+    verify($this->worker->processTaskStrategy($task, microtime(true)))->false();
+
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $this->findKeyCheckTask());
+    $this->assertKeyStateUntouched();
+    $this->assertBackedOff($task);
+  }
+
+  public function testItBacksOffWithoutAKeyCheckOnATransientFailure() {
+    $this->api->failResponse = true;
+    $this->api->failResponseCode = API::RESPONSE_CODE_INTERNAL_SERVER_ERROR;
+    $task = $this->createRunningTask();
+
+    verify($this->worker->processTaskStrategy($task, microtime(true)))->false();
+
+    // A 500 says nothing about the key, so it must not provoke a key check.
+    verify($this->findKeyCheckTask())->null();
+    $this->assertBackedOff($task);
+  }
+
+  public function testItBacksOffProgressivelyAcrossRepeatedFailures() {
+    $this->api->failResponse = true;
+    $task = $this->createRunningTask();
+
+    $this->worker->processTaskStrategy($task, microtime(true));
+    $firstDelay = $this->getRescheduleDelayInMinutes($task);
+    $this->worker->processTaskStrategy($task, microtime(true));
+    $secondDelay = $this->getRescheduleDelayInMinutes($task);
+
+    verify($secondDelay > $firstDelay)->true();
   }
 
   public function testItMarksReturnedRecipientsAsBounced() {
@@ -297,8 +378,40 @@ class BounceTest extends \MailPoetTest {
       $this->subscribersRepository,
       $this->diContainer->get(SendingQueuesRepository::class),
       $this->diContainer->get(StatisticsBouncesRepository::class),
-      $this->diContainer->get(Bridge::class)
+      $this->diContainer->get(Bridge::class),
+      $this->diContainer->get(ServicesChecker::class)
     );
+  }
+
+  private function setKeyState(string $state) {
+    $this->settings->set(Bridge::API_KEY_SETTING_NAME, 'some_key');
+    $this->settings->set(Bridge::API_KEY_STATE_SETTING_NAME, ['state' => $state]);
+  }
+
+  private function findKeyCheckTask(): ?ScheduledTaskEntity {
+    return $this->diContainer->get(ScheduledTasksRepository::class)
+      ->findOneBy(['type' => SendingServiceKeyCheck::TASK_TYPE]);
+  }
+
+  /**
+   * The bounces report endpoint runs on WPCOM while keys are issued and
+   * validated by the bridge, so a rejection there must not rewrite the key state
+   * directly; only SendingServiceKeyCheck may.
+   */
+  private function assertKeyStateUntouched() {
+    verify($this->settings->get(Bridge::API_KEY_STATE_SETTING_NAME))->equals(['state' => Bridge::KEY_VALID]);
+  }
+
+  private function assertBackedOff(ScheduledTaskEntity $task) {
+    verify($task->getStatus())->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
+    verify($task->getRescheduleCount())->equals(1);
+    verify($this->getRescheduleDelayInMinutes($task) > 0)->true();
+  }
+
+  private function getRescheduleDelayInMinutes(ScheduledTaskEntity $task): int {
+    $scheduledAt = $task->getScheduledAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $scheduledAt);
+    return (int)round(($scheduledAt->getTimestamp() - Carbon::now()->getTimestamp()) / 60);
   }
 
   private function getSubscriberStatus(string $email): string {

--- a/mailpoet/tests/integration/Cron/Workers/BounceTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/BounceTest.php
@@ -83,9 +83,11 @@ class BounceTest extends \MailPoetTest {
   }
 
   public function testItRequiresMailPoetMethodToBeSetUp() {
-    $this->setKeyState(Bridge::KEY_VALID);
     verify($this->worker->checkProcessingRequirements())->false();
+    // The sending method lives in the same `mta` settings tree as the key state,
+    // so it has to be written before the state or it wipes it.
     $this->setMailPoetSendingMethod();
+    $this->setKeyState(Bridge::KEY_VALID);
     verify($this->worker->checkProcessingRequirements())->true();
   }
 
@@ -107,7 +109,9 @@ class BounceTest extends \MailPoetTest {
 
   public function testItRunsForAnExpiringKey() {
     $this->setMailPoetSendingMethod();
-    $this->setKeyState(Bridge::KEY_EXPIRING);
+    // An expiring key still sends, so it must still report bounces. It only
+    // counts as usable while it carries the expiry date the service returned.
+    $this->setKeyState(Bridge::KEY_EXPIRING, ['expire_at' => Carbon::now()->addMonth()->toDateTimeString()]);
     verify($this->worker->checkProcessingRequirements())->true();
   }
 
@@ -383,9 +387,17 @@ class BounceTest extends \MailPoetTest {
     );
   }
 
-  private function setKeyState(string $state) {
+  /**
+   * Must be called after setMailPoetSendingMethod(): both write under the `mta`
+   * settings tree, and setting the mailer config replaces the whole tree.
+   */
+  private function setKeyState(string $state, array $data = []) {
     $this->settings->set(Bridge::API_KEY_SETTING_NAME, 'some_key');
-    $this->settings->set(Bridge::API_KEY_STATE_SETTING_NAME, ['state' => $state]);
+    $keyState = ['state' => $state];
+    if ($data) {
+      $keyState['data'] = $data;
+    }
+    $this->settings->set(Bridge::API_KEY_STATE_SETTING_NAME, $keyState);
   }
 
   private function findKeyCheckTask(): ?ScheduledTaskEntity {

--- a/mailpoet/tests/integration/Cron/Workers/BounceTestMockAPI.php
+++ b/mailpoet/tests/integration/Cron/Workers/BounceTestMockAPI.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\Cron\Workers\Bounce;
 
+use MailPoet\Services\Bridge\BouncesReportException;
+
 class BounceTestMockAPI {
   /** @var array<int, array{from: \DateTimeInterface, to: \DateTimeInterface, page: int}> */
   public $getBouncesReportCalls = [];
@@ -19,11 +21,22 @@ class BounceTestMockAPI {
   /** @var bool When true, getBouncesReport() simulates a failed request. */
   public $failResponse = false;
 
-  /** @return array{recipients: string[], page: int, has_more: bool}|null */
-  public function getBouncesReport(\DateTimeInterface $from, \DateTimeInterface $to, int $page = 1): ?array {
+  /**
+   * Status the simulated failure carries; 0 stands for a failure with no
+   * response to read a status from, matching the real API.
+   *
+   * @var int
+   */
+  public $failResponseCode = 0;
+
+  /**
+   * @return array{recipients: string[], page: int, has_more: bool}
+   * @throws BouncesReportException
+   */
+  public function getBouncesReport(\DateTimeInterface $from, \DateTimeInterface $to, int $page = 1): array {
     $this->getBouncesReportCalls[] = ['from' => $from, 'to' => $to, 'page' => $page];
     if ($this->failResponse) {
-      return null;
+      throw BouncesReportException::create()->withCode($this->failResponseCode);
     }
     $recipients = $this->reportPages[$page] ?? [];
     return [

--- a/mailpoet/tests/integration/Services/BridgeApiTest.php
+++ b/mailpoet/tests/integration/Services/BridgeApiTest.php
@@ -254,7 +254,7 @@ class BridgeApiTest extends \MailPoetTest {
     $this->api->getBouncesReport($from, $to);
   }
 
-  public function testItReturnsNullWhenBouncesReportRequestFails() {
+  public function testItThrowsWithTheResponseCodeWhenBouncesReportRequestFails() {
     $from = new \DateTimeImmutable('2026-06-15 23:59:59', new \DateTimeZone('UTC'));
     $to = new \DateTimeImmutable('2026-06-16 23:59:59', new \DateTimeZone('UTC'));
     $this->wpMock
@@ -264,10 +264,43 @@ class BridgeApiTest extends \MailPoetTest {
       ->expects($this->once())
       ->method('wpRemoteRetrieveResponseCode')
       ->willReturn(500);
-    verify($this->api->getBouncesReport($from, $to))->null();
+
+    $this->expectException(BouncesReportException::class);
+    $this->expectExceptionCode(500);
+    $this->api->getBouncesReport($from, $to);
   }
 
-  public function testItReturnsNullAndLogsWhenBouncesReportPayloadIsMalformed() {
+  public function testItCarriesTheKeyRejectionCodeOnTheBouncesReportException() {
+    $from = new \DateTimeImmutable('2026-06-15 23:59:59', new \DateTimeZone('UTC'));
+    $to = new \DateTimeImmutable('2026-06-16 23:59:59', new \DateTimeZone('UTC'));
+    $this->wpMock
+      ->method('addQueryArg')
+      ->willReturn('https://bridge.example/report');
+    $this->wpMock
+      ->method('wpRemoteRetrieveResponseCode')
+      ->willReturn(API::RESPONSE_CODE_KEY_INVALID);
+    $this->wpMock
+      ->method('wpRemoteRetrieveBody')
+      ->willReturn('No valid API key provided');
+
+    // The caller can only tell a dead key from a transient outage if the status
+    // survives; a deleted key must not read as a retryable failure.
+    try {
+      $this->api->getBouncesReport($from, $to);
+      $this->fail('Expected a BouncesReportException.');
+    } catch (BouncesReportException $e) {
+      verify($e->getCode())->equals(API::RESPONSE_CODE_KEY_INVALID);
+    }
+
+    $logs = $this->logRepository->findAll();
+    verify($logs)->arrayCount(1);
+    $errorLog = $logs[0];
+    $this->assertInstanceOf(LogEntity::class, $errorLog);
+    verify($errorLog->getLevel())->equals(Logger::ERROR);
+    verify($errorLog->getMessage())->stringContainsString('getBouncesReport API call failed.');
+  }
+
+  public function testItThrowsWithoutACodeWhenBouncesReportPayloadIsMalformed() {
     $from = new \DateTimeImmutable('2026-06-15 23:59:59', new \DateTimeZone('UTC'));
     $to = new \DateTimeImmutable('2026-06-16 23:59:59', new \DateTimeZone('UTC'));
     $this->wpMock
@@ -282,7 +315,14 @@ class BridgeApiTest extends \MailPoetTest {
       ->method('wpRemoteRetrieveBody')
       ->willReturn((string)json_encode(['recipients' => [['email' => 'bob@example.com', 'type' => 'hard']], 'page' => 1]));
 
-    verify($this->api->getBouncesReport($from, $to))->null();
+    // A malformed body is not a key problem, so it carries no status: the caller
+    // must treat it as transient and retry the same window.
+    try {
+      $this->api->getBouncesReport($from, $to);
+      $this->fail('Expected a BouncesReportException.');
+    } catch (BouncesReportException $e) {
+      verify($e->getCode())->equals(0);
+    }
 
     $logs = $this->logRepository->findAll();
     verify($logs)->arrayCount(1);
@@ -307,7 +347,8 @@ class BridgeApiTest extends \MailPoetTest {
       ->method('wpRemoteRetrieveBody')
       ->willReturn((string)json_encode(['recipients' => ['bob@example.com'], 'page' => 1, 'has_more' => false]));
 
-    verify($this->api->getBouncesReport($from, $to))->null();
+    $this->expectException(BouncesReportException::class);
+    $this->api->getBouncesReport($from, $to);
   }
 
   public function testVerifyDomainLogsErrorWhenResponseHasUnexpectedFormat() {


### PR DESCRIPTION
The bounces report checks only for the MSS sending being active. It does not account for invalid api keys (e.g. old, deleted ones). We actually had the same issue with the old bounces system.

This PR will
1. check that the key is valid
2. will not immediately retry on failures but with a time interval (even `500` can take some time to resolve)
3. will schedule the SendingServiceKeyCheck immediately when the bridge returns authentication issues so we update the key state quickly

mpi-495

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:mpi-495-validate-bounce-report-key-state-and-add-progressive-backoff)

_The latest successful build from `mpi-495-validate-bounce-report-key-state-and-add-progressive-backoff` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->