### PR TITLE
Add per-subscriber email tracking opt-out (CNIL/Garante compliance)

### DIFF
--- a/mailpoet/assets/js/src/settings/pages/advanced/advanced.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/advanced.tsx
@@ -3,6 +3,7 @@ import { useSetting } from 'settings/store/hooks';
 import { TaskScheduler } from './task-scheduler';
 import { Roles } from './roles';
 import { EngagementTracking } from './engagement-tracking';
+import { TrackUnknownConsent } from './track-unknown-consent';
 import { HumanAndMachineOpens } from './human-and-machine-opens';
 import { Transactional } from './transactional';
 import { InactiveSubscribers } from './inactive-subscribers';
@@ -29,6 +30,7 @@ export function Advanced() {
       <TaskScheduler />
       <Roles />
       <EngagementTracking />
+      <TrackUnknownConsent />
       <HumanAndMachineOpens />
       <Transactional />
       <RecalculateSubscriberScore />

--- a/mailpoet/assets/js/src/settings/pages/advanced/track-unknown-consent.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/track-unknown-consent.tsx
@@ -1,0 +1,41 @@
+import { t } from 'common/functions';
+import { Radio } from 'common/form/radio/radio';
+import { useSetting } from 'settings/store/hooks';
+import { Label, Inputs } from 'settings/components';
+
+export function TrackUnknownConsent() {
+  const [trackUnknown, setTrackUnknown] = useSetting(
+    'tracking',
+    'consent',
+    'track_unknown',
+  );
+
+  return (
+    <>
+      <Label
+        title={t('trackUnknownConsentTitle')}
+        description={t('trackUnknownConsentDescription')}
+        htmlFor=""
+      />
+      <Inputs>
+        <Radio
+          id="track-unknown-consent-yes"
+          value="1"
+          checked={trackUnknown === '1'}
+          onCheck={setTrackUnknown}
+          automationId="track-unknown-consent-yes"
+        />
+        <label htmlFor="track-unknown-consent-yes">{t('yes')}</label>
+        <span className="mailpoet-gap" />
+        <Radio
+          id="track-unknown-consent-no"
+          value=""
+          checked={trackUnknown === ''}
+          onCheck={setTrackUnknown}
+          automationId="track-unknown-consent-no"
+        />
+        <label htmlFor="track-unknown-consent-no">{t('no')}</label>
+      </Inputs>
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/settings/store/normalize-settings.ts
+++ b/mailpoet/assets/js/src/settings/store/normalize-settings.ts
@@ -124,6 +124,7 @@ export function normalizeSettings(data: Record<string, unknown>): Settings {
     tracking: asObject({
       level: asEnum(['full', 'partial', 'basic'], 'full'),
       opens: asEnum(['merged', 'separated'], 'merged'),
+      consent: asObject({ track_unknown: enabledRadio }),
     }),
     send_transactional_emails: disabledRadio,
     deactivate_subscriber_after_inactive_days: asEnum(

--- a/mailpoet/assets/js/src/settings/store/types.ts
+++ b/mailpoet/assets/js/src/settings/store/types.ts
@@ -55,6 +55,9 @@ export type Settings = {
   tracking: {
     level: 'full' | 'basic' | 'partial';
     opens: 'merged' | 'separated';
+    consent: {
+      track_unknown: '' | '1';
+    };
   };
   '3rd_party_libs': {
     enabled: '' | '1';

--- a/mailpoet/assets/js/src/settings/store/types.ts
+++ b/mailpoet/assets/js/src/settings/store/types.ts
@@ -55,7 +55,10 @@ export type Settings = {
   tracking: {
     level: 'full' | 'basic' | 'partial';
     opens: 'merged' | 'separated';
-    consent: {
+    // Always present once settings are loaded (normalize-settings fills the
+    // default); optional only so callers that write level/opens need not
+    // re-supply it. The default lives in SettingsController::getAllDefaults().
+    consent?: {
       track_unknown: '' | '1';
     };
   };

--- a/mailpoet/assets/js/src/wizard/woocommerce-controller.tsx
+++ b/mailpoet/assets/js/src/wizard/woocommerce-controller.tsx
@@ -65,6 +65,7 @@ function WooCommerceController({
     const trackingData: Settings['tracking'] = {
       level: allowed ? 'full' : trackingLevelForDisabledCookies,
       opens: 'merged',
+      consent: { track_unknown: '1' },
     };
     const subscribeOldCustomersData: Settings['mailpoet_subscribe_old_woocommerce_customers'] =
       {

--- a/mailpoet/assets/js/src/wizard/woocommerce-controller.tsx
+++ b/mailpoet/assets/js/src/wizard/woocommerce-controller.tsx
@@ -65,7 +65,6 @@ function WooCommerceController({
     const trackingData: Settings['tracking'] = {
       level: allowed ? 'full' : trackingLevelForDisabledCookies,
       opens: 'merged',
-      consent: { track_unknown: '1' },
     };
     const subscribeOldCustomersData: Settings['mailpoet_subscribe_old_woocommerce_customers'] =
       {

--- a/mailpoet/changelog/2026-07-17-00-15-41-added-ability-for-subscribers-to-opt-out-of-email-open-a.md
+++ b/mailpoet/changelog/2026-07-17-00-15-41-added-ability-for-subscribers-to-opt-out-of-email-open-a.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Ability for subscribers to opt out of email open and click tracking

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -29,6 +29,8 @@ use MailPoet\Tasks\Subscribers\BatchIterator;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
+use MailPoetVendor\Doctrine\DBAL\Exception\InvalidFieldNameException;
+use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use Throwable;
 
@@ -163,6 +165,13 @@ class SendingQueue {
       try {
         $this->scheduledTasksRepository->touchAllByIds([$task->getId()]);
         $this->processSending($task, (int)$timer);
+      } catch (InvalidFieldNameException | TableNotFoundException $e) {
+        // The subscribers schema may be mid-migration during a plugin update (e.g. the
+        // tracking_consent column added in STOMAIL-8268). Leave this task for the next
+        // cron run rather than crashing the sending worker; it resumes once the migration
+        // completes.
+        $this->stopProgress($task);
+        continue;
       } catch (\Exception $e) {
         $this->stopProgress($task);
         throw $e;

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -31,6 +31,7 @@ use MailPoet\RuntimeException;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\GATracking;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\pQuery\pQuery;
 use MailPoet\WP\Emoji;
@@ -89,6 +90,8 @@ class Newsletter {
   private CouponBlockDetector $couponBlockDetector;
   private OrderReviewUrl $orderReviewUrl;
 
+  private TrackingConsentController $trackingConsentController;
+
   public function __construct(
     ?WPFunctions $wp = null,
     ?PostsTask $postsTask = null,
@@ -126,6 +129,7 @@ class Newsletter {
     $this->automationRunStorage = ContainerWrapper::getInstance()->get(AutomationRunStorage::class);
     $this->couponBlockDetector = ContainerWrapper::getInstance()->get(CouponBlockDetector::class);
     $this->orderReviewUrl = ContainerWrapper::getInstance()->get(OrderReviewUrl::class);
+    $this->trackingConsentController = ContainerWrapper::getInstance()->get(TrackingConsentController::class);
   }
 
   public function getNewsletterFromQueue(ScheduledTaskEntity $task): ?NewsletterEntity {
@@ -372,6 +376,13 @@ class Newsletter {
       $queue
     );
     if ($this->trackingEnabled) {
+      if (!$this->trackingConsentController->isTrackingAllowed($subscriber)) {
+        // CNIL/Garante: withdrawal must stop the reading operation on future
+        // emails, not merely the recording. Remove the pixel before it is
+        // given a real tracking URL below. Click links are still rewritten —
+        // Clicks::track suppresses their recording (see follow-up note).
+        $preparedNewsletter = OpenTracking::removeTrackingImage($preparedNewsletter);
+      }
       $preparedNewsletter = $this->newsletterLinks->replaceSubscriberData(
         $subscriber->getId(),
         $queue->getId(),

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -540,6 +540,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Subscribers\SubscribersCountsController::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\ConfirmationEmailCustomizer::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\ConfirmationEmailResolver::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\TrackingConsentController::class)->setPublic(true);
     // Segments
     $container->autowire(\MailPoet\Segments\WooCommerce::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\WP::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -303,6 +303,15 @@ class PersonalizationTagManager {
         null,
         [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
       ));
+      $registry->register(new Personalization_Tag(
+        __('Tracking opt-out URL', 'mailpoet'),
+        'mailpoet/subscription-tracking-opt-out-url',
+        __('Link', 'mailpoet'),
+        [$this->link, 'getSubscriptionTrackingOptOutUrl'],
+        [],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
       return $registry;
     });
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Link.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Link.php
@@ -67,6 +67,13 @@ class Link {
     );
   }
 
+  public function getSubscriptionTrackingOptOutUrl(array $context, array $args = []): string {
+    $isPreview = $context['is_preview'] ?? false;
+    $subscriber = !$isPreview ? $this->getSubscriber($context) : null;
+
+    return (string)$this->subscriptionUrlFactory->getTrackingOptOutUrl($subscriber);
+  }
+
   private function getNewsletter(array $context): ?NewsletterEntity {
     $newsletterId = $context['newsletter_id'] ?? null;
     return $newsletterId ? $this->newslettersRepository->findOneById($newsletterId) : null;

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
@@ -16,6 +16,7 @@ class LinksToShortcodesConvertor {
     '[mailpoet/subscription-unsubscribe-url]' => '[link:subscription_unsubscribe_url]',
     '[mailpoet/subscription-manage-url]' => '[link:subscription_manage_url]',
     '[mailpoet/newsletter-view-in-browser-url]' => '[link:newsletter_view_in_browser_url]',
+    '[mailpoet/subscription-tracking-opt-out-url]' => '[link:subscription_tracking_opt_out_url]',
   ];
 
   private const PERSONALIZED_URL_TOKENS = [

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -86,6 +86,7 @@ class SubscriberEntity {
    * TrackingConsentController.
    *
    * @ORM\Column(type="string", length=20)
+   * @Assert\Choice({"unknown", "granted", "denied"})
    * @var string
    */
   private $trackingConsent = self::TRACKING_CONSENT_UNKNOWN;

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -98,7 +98,7 @@ class SubscriberEntity {
   private $trackingConsentUpdatedAt;
 
   /**
-   * @ORM\Column(type="string", nullable=true)
+   * @ORM\Column(type="string", length=40, nullable=true)
    * @var string|null
    */
   private $trackingConsentMethod;

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -38,6 +38,17 @@ class SubscriberEntity {
   const STATUS_UNCONFIRMED = 'unconfirmed';
   const STATUS_UNSUBSCRIBED = 'unsubscribed';
 
+  // tracking consent
+  const TRACKING_CONSENT_UNKNOWN = 'unknown';
+  const TRACKING_CONSENT_GRANTED = 'granted';
+  const TRACKING_CONSENT_DENIED = 'denied';
+
+  const TRACKING_CONSENT_METHOD_FOOTER_LINK = 'footer_link';
+  const TRACKING_CONSENT_METHOD_MANAGE_PAGE = 'manage_page';
+  const TRACKING_CONSENT_METHOD_FORM = 'form';
+  const TRACKING_CONSENT_METHOD_ADMIN = 'admin';
+  const TRACKING_CONSENT_METHOD_IMPORT = 'import';
+
   public const OBSOLETE_LINK_TOKEN_LENGTH = 6;
   public const LINK_TOKEN_LENGTH = 32;
   public const TIME_ZONE_FIELD_NAME = 'mailpoet_subscriber_timezone';
@@ -67,6 +78,39 @@ class SubscriberEntity {
    * @var bool
    */
   private $isWoocommerceUser = false;
+
+  /**
+   * CNIL/Garante: three states are legally distinct. `unknown` means we never
+   * asked — it is NOT consent, and under the opt-in regime it must not be
+   * treated as consent. How `unknown` is handled is a site setting; see
+   * TrackingConsentController.
+   *
+   * @ORM\Column(type="string", length=20)
+   * @var string
+   */
+  private $trackingConsent = self::TRACKING_CONSENT_UNKNOWN;
+
+  /**
+   * @ORM\Column(type="datetimetz", nullable=true)
+   * @var DateTimeInterface|null
+   */
+  private $trackingConsentUpdatedAt;
+
+  /**
+   * @ORM\Column(type="string", nullable=true)
+   * @var string|null
+   */
+  private $trackingConsentMethod;
+
+  /**
+   * The exact wording shown when the choice was made. Required for proof of
+   * consent (CNIL §6: a record of each person's consent "as well as the
+   * conditions under which that consent was obtained").
+   *
+   * @ORM\Column(type="text", nullable=true)
+   * @var string|null
+   */
+  private $trackingConsentCopy;
 
   /**
    * @ORM\Column(type="string")
@@ -308,6 +352,36 @@ class SubscriberEntity {
    */
   public function setIsWoocommerceUser($isWoocommerceUser) {
     $this->isWoocommerceUser = $isWoocommerceUser;
+  }
+
+  public function getTrackingConsent(): string {
+    return $this->trackingConsent;
+  }
+
+  /**
+   * Setting the state also stamps when, how, and against what wording it
+   * changed (CNIL/Garante record-keeping).
+   */
+  public function setTrackingConsent(string $consent, ?string $method = null, ?string $copy = null): void {
+    if ($this->trackingConsent === $consent) {
+      return;
+    }
+    $this->trackingConsent = $consent;
+    $this->trackingConsentUpdatedAt = new \DateTimeImmutable();
+    $this->trackingConsentMethod = $method;
+    $this->trackingConsentCopy = $copy;
+  }
+
+  public function getTrackingConsentUpdatedAt(): ?DateTimeInterface {
+    return $this->trackingConsentUpdatedAt;
+  }
+
+  public function getTrackingConsentMethod(): ?string {
+    return $this->trackingConsentMethod;
+  }
+
+  public function getTrackingConsentCopy(): ?string {
+    return $this->trackingConsentCopy;
   }
 
   /**

--- a/mailpoet/lib/Migrations/Db/Migration_20260715_100000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260715_100000_Db.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Migrator\DbMigration;
+
+/**
+ * Adds per-subscriber tracking consent columns (CNIL/Garante email tracking
+ * consent rules). Tri-state: existing subscribers land in 'unknown' — we have
+ * never asked them — which is deliberately distinct from 'granted'. The
+ * `tracking.consent.track_unknown` setting (default true) preserves today's
+ * behaviour for sites with no EU exposure.
+ *
+ * `tracking_consent_updated_at`, `_method` and `_copy` exist for compliance
+ * record-keeping (when, how, and against what wording the choice was made).
+ */
+class Migration_20260715_100000_Db extends DbMigration {
+  public function run(): void {
+    $subscribersTable = $this->getTableName(SubscriberEntity::class);
+    if (!$this->columnExists($subscribersTable, 'tracking_consent')) {
+      $this->connection->executeStatement("
+        ALTER TABLE `{$subscribersTable}`
+        ADD COLUMN `tracking_consent` varchar(20) NOT NULL DEFAULT 'unknown',
+        ADD COLUMN `tracking_consent_updated_at` timestamp NULL DEFAULT NULL,
+        ADD COLUMN `tracking_consent_method` varchar(40) NULL DEFAULT NULL,
+        ADD COLUMN `tracking_consent_copy` text NULL DEFAULT NULL
+      ");
+    }
+  }
+}

--- a/mailpoet/lib/Newsletter/NewsletterResendController.php
+++ b/mailpoet/lib/Newsletter/NewsletterResendController.php
@@ -254,17 +254,21 @@ class NewsletterResendController {
   private function getNonOpenerIds(NewsletterEntity $newsletter): array {
     $statisticsNewsletterTable = $this->entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName();
     $statisticsOpenTable = $this->entityManager->getClassMetadata(StatisticsOpenEntity::class)->getTableName();
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
 
     $connection = $this->entityManager->getConnection();
 
     $result = $connection->executeQuery(
       "SELECT DISTINCT sn.subscriber_id
        FROM $statisticsNewsletterTable sn
+       INNER JOIN $subscribersTable s
+         ON s.id = sn.subscriber_id
        LEFT JOIN $statisticsOpenTable so
          ON so.newsletter_id = sn.newsletter_id
          AND so.subscriber_id = sn.subscriber_id
        WHERE sn.newsletter_id = ?
-         AND so.id IS NULL",
+         AND so.id IS NULL
+         AND s.tracking_consent != 'denied'",
       [
         $newsletter->getId(),
       ],

--- a/mailpoet/lib/Newsletter/NewsletterResendController.php
+++ b/mailpoet/lib/Newsletter/NewsletterResendController.php
@@ -17,6 +17,7 @@ use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoet\UnexpectedValueException;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WP\Functions as WPFunctions;
@@ -65,6 +66,9 @@ class NewsletterResendController {
   /** @var TrackingConfig */
   private $trackingConfig;
 
+  /** @var TrackingConsentController */
+  private $trackingConsentController;
+
   public function __construct(
     NewsletterSaveController $newsletterSaveController,
     NewsletterDeleteController $newsletterDeleteController,
@@ -77,7 +81,8 @@ class NewsletterResendController {
     SettingsController $settings,
     SubscribersFeature $subscribersFeature,
     MailerFactory $mailerFactory,
-    TrackingConfig $trackingConfig
+    TrackingConfig $trackingConfig,
+    TrackingConsentController $trackingConsentController
   ) {
     $this->newsletterSaveController = $newsletterSaveController;
     $this->newsletterDeleteController = $newsletterDeleteController;
@@ -91,6 +96,7 @@ class NewsletterResendController {
     $this->subscribersFeature = $subscribersFeature;
     $this->mailerFactory = $mailerFactory;
     $this->trackingConfig = $trackingConfig;
+    $this->trackingConsentController = $trackingConsentController;
   }
 
   /**
@@ -268,11 +274,14 @@ class NewsletterResendController {
          AND so.subscriber_id = sn.subscriber_id
        WHERE sn.newsletter_id = ?
          AND so.id IS NULL
-         AND s.tracking_consent != 'denied'",
+         AND s.tracking_consent != 'denied'
+         AND (? = 1 OR s.tracking_consent != 'unknown')",
       [
         $newsletter->getId(),
+        $this->trackingConsentController->shouldTrackUnknownConsent() ? 1 : 0,
       ],
       [
+        ParameterType::INTEGER,
         ParameterType::INTEGER,
       ]
     );

--- a/mailpoet/lib/Newsletter/Renderer/PostProcess/OpenTracking.php
+++ b/mailpoet/lib/Newsletter/Renderer/PostProcess/OpenTracking.php
@@ -12,15 +12,37 @@ class OpenTracking {
     $DOM = new pQuery();
     $DOM = $DOM->parseStr($template);
     $template = $DOM->select('body');
+    self::appendToDomNodes($template, self::getTrackingImageHtml());
+    return $DOM->__toString();
+  }
+
+  public static function getTrackingImageHtml(): string {
     // url is a temporary data tag that will be further replaced with
     // the proper track API URL during sending
-    $url = Links::DATA_TAG_OPEN;
-    $openTrackingImage = sprintf(
-      '<img alt="" class="" src="%s"/>',
-      $url
-    );
-    self::appendToDomNodes($template, $openTrackingImage);
-    return $DOM->__toString();
+    return sprintf('<img alt="" class="" src="%s"/>', Links::DATA_TAG_OPEN);
+  }
+
+  /**
+   * Removes the whole open-tracking <img> element, not just the data tag —
+   * leaving an empty src would make email clients resolve the base URL or
+   * show a broken image.
+   *
+   * CNIL/Garante: for subscribers without tracking consent the read
+   * operation must not happen at all on future emails, so the pixel never
+   * ships. We first try an exact match on getTrackingImageHtml(); if pQuery
+   * re-serialised the tag (attribute order, self-closing style) we fall back
+   * to a regex that removes any <img> whose src is the open data tag.
+   */
+  public static function removeTrackingImage(string $template): string {
+    $exact = str_replace(self::getTrackingImageHtml(), '', $template);
+    if ($exact !== $template) {
+      return $exact;
+    }
+    // Fallback: remove the whole <img …> element that carries the open data
+    // tag as its src, regardless of attribute order/quoting/self-closing.
+    $pattern = '/<img\b[^>]*\bsrc=("|\')' . preg_quote(Links::DATA_TAG_OPEN, '/') . '\1[^>]*>/i';
+    $result = preg_replace($pattern, '', $template);
+    return is_string($result) ? $result : $template;
   }
 
   public static function addTrackingImage() {

--- a/mailpoet/lib/Newsletter/Scheduler/ReEngagementScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/ReEngagementScheduler.php
@@ -143,6 +143,7 @@ class ReEngagementScheduler {
         ns.subscriber_id = s.id
         AND s.deleted_at is NULL
         AND s.status = :subscribed
+        AND s.tracking_consent != 'denied'
         AND GREATEST(COALESCE(s.created_at, '0'), COALESCE(s.last_subscribed_at, '0'), COALESCE(s.last_engagement_at, '0')) < :thresholdDate
       JOIN $subscriberSegmentTable as ss ON ns.subscriber_id = ss.subscriber_id
         AND ss.segment_id = :segmentId

--- a/mailpoet/lib/Newsletter/Scheduler/ReEngagementScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/ReEngagementScheduler.php
@@ -13,6 +13,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\ParameterType;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -28,14 +29,19 @@ class ReEngagementScheduler {
   /** @var EntityManager */
   private $entityManager;
 
+  /** @var TrackingConsentController */
+  private $trackingConsentController;
+
   public function __construct(
     NewslettersRepository $newslettersRepository,
     ScheduledTasksRepository $scheduledTasksRepository,
-    EntityManager $entityManager
+    EntityManager $entityManager,
+    TrackingConsentController $trackingConsentController
   ) {
     $this->newslettersRepository = $newslettersRepository;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->entityManager = $entityManager;
+    $this->trackingConsentController = $trackingConsentController;
   }
 
   /**
@@ -144,6 +150,7 @@ class ReEngagementScheduler {
         AND s.deleted_at is NULL
         AND s.status = :subscribed
         AND s.tracking_consent != 'denied'
+        AND (:trackUnknown = 1 OR s.tracking_consent != 'unknown')
         AND GREATEST(COALESCE(s.created_at, '0'), COALESCE(s.last_subscribed_at, '0'), COALESCE(s.last_engagement_at, '0')) < :thresholdDate
       JOIN $subscriberSegmentTable as ss ON ns.subscriber_id = ss.subscriber_id
         AND ss.segment_id = :segmentId
@@ -163,6 +170,7 @@ class ReEngagementScheduler {
     $statement->bindValue('upperThresholdDate', $upperThresholdDate, ParameterType::STRING);
     $statement->bindValue('newsletterId', $newsletterId, ParameterType::INTEGER);
     $statement->bindValue('segmentId', $segmentId, ParameterType::INTEGER);
+    $statement->bindValue('trackUnknown', $this->trackingConsentController->shouldTrackUnknownConsent() ? 1 : 0, ParameterType::INTEGER);
 
     $result = $statement->executeQuery();
     return $result->rowCount();

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Link.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Link.php
@@ -73,6 +73,14 @@ class Link implements CategoryInterface {
           $wpUserPreview
         );
 
+      case 'subscription_tracking_opt_out_url':
+        return self::processUrl(
+          $shortcodeDetails['action'],
+          $subscriptionUrlFactory->getTrackingOptOutUrl($wpUserPreview ? null : $subscriber),
+          $queue,
+          $wpUserPreview
+        );
+
       case 'newsletter_view_in_browser_url':
         $url = $this->newsletterUrl->getViewInBrowserUrl(
           $newsletter,
@@ -139,6 +147,9 @@ class Link implements CategoryInterface {
         break;
       case 'subscription_manage_url':
         $url = $subscriptionUrlFactory->getManageUrl($subscriber);
+        break;
+      case 'subscription_tracking_opt_out_url':
+        $url = $subscriptionUrlFactory->getTrackingOptOutUrl($subscriber);
         break;
       case 'newsletter_view_in_browser_url':
         $url = $this->newsletterUrl->getViewInBrowserUrl(

--- a/mailpoet/lib/Newsletter/Shortcodes/ShortcodesHelper.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/ShortcodesHelper.php
@@ -110,6 +110,14 @@ class ShortcodesHelper {
             __('View in your browser', 'mailpoet')
           ),
         ],
+        [
+          'text' => __('Tracking opt-out link', 'mailpoet'),
+          'shortcode' => sprintf(
+            '<a target="_blank" href="%s">%s</a>',
+            '[link:subscription_tracking_opt_out_url]',
+            __('Opt out of tracking', 'mailpoet')
+          ),
+        ],
       ],
       __('Site', 'mailpoet') => [
         [

--- a/mailpoet/lib/Router/Endpoints/Subscription.php
+++ b/mailpoet/lib/Router/Endpoints/Subscription.php
@@ -126,6 +126,11 @@ class Subscription {
   public function trackingOptOut($data) {
     $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_TRACKING_OPT_OUT, $data);
     if ($this->isPostRequest()) {
+      $nonce = $this->request->getStringParam('_wpnonce');
+      if (!$this->wp->wpVerifyNonce($nonce, 'mailpoet_tracking_opt_out')) {
+        $this->wp->wpDie(__('Security check failed.', 'mailpoet'), '', ['response' => 403]);
+        exit;
+      }
       $subscription->trackingOptOut(
         SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK,
         UserSubscription\Pages::getTrackingOptOutConsentCopy()

--- a/mailpoet/lib/Router/Endpoints/Subscription.php
+++ b/mailpoet/lib/Router/Endpoints/Subscription.php
@@ -4,6 +4,7 @@ namespace MailPoet\Router\Endpoints;
 
 use MailPoet\Config\AccessControl;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
+use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscription as UserSubscription;
 use MailPoet\Util\Request;
 use MailPoet\WP\Functions as WPFunctions;
@@ -16,6 +17,7 @@ class Subscription {
   const ACTION_UNSUBSCRIBE_REASON = 'unsubscribeReason';
   const ACTION_CONFIRM_UNSUBSCRIBE = 'confirmUnsubscribe';
   const ACTION_RE_ENGAGEMENT = 'reEngagement';
+  const ACTION_TRACKING_OPT_OUT = 'trackingOptOut';
 
   public $allowedActions = [
     self::ACTION_CONFIRM,
@@ -24,6 +26,7 @@ class Subscription {
     self::ACTION_UNSUBSCRIBE_REASON,
     self::ACTION_CONFIRM_UNSUBSCRIBE,
     self::ACTION_RE_ENGAGEMENT,
+    self::ACTION_TRACKING_OPT_OUT,
   ];
 
   public $permissions = [
@@ -118,6 +121,18 @@ class Subscription {
 
   public function reEngagement($data) {
     $this->initSubscriptionPage(UserSubscription\Pages::ACTION_RE_ENGAGEMENT, $data);
+  }
+
+  public function trackingOptOut($data) {
+    $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_TRACKING_OPT_OUT, $data);
+    if ($this->isPostRequest()) {
+      $subscription->trackingOptOut(
+        SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK,
+        UserSubscription\Pages::getTrackingOptOutConsentCopy()
+      );
+    }
+    // GET renders the confirmation page; after POST the same page renders
+    // its "done" state via getTrackingOptOutContent().
   }
 
   private function initSubscriptionPage($action, $data) {

--- a/mailpoet/lib/Settings/SettingsController.php
+++ b/mailpoet/lib/Settings/SettingsController.php
@@ -79,6 +79,9 @@ class SettingsController {
         ],
         'tracking' => [
           'level' => TrackingConfig::LEVEL_FULL,
+          'consent' => [
+            'track_unknown' => true,
+          ],
         ],
         'subscription' => [
           'manage_subscription_page_style' => self::MANAGE_SUBSCRIPTION_PAGE_STYLE_MODERN,

--- a/mailpoet/lib/Statistics/Track/Clicks.php
+++ b/mailpoet/lib/Statistics/Track/Clicks.php
@@ -14,6 +14,7 @@ use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\StatisticsClicksRepository;
 use MailPoet\Statistics\UserAgentsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoet\Util\Cookies;
 use MailPoet\Util\Request;
 use MailPoet\WP\Functions as WPFunctions;
@@ -53,6 +54,9 @@ class Clicks {
   /** @var Request */
   private $request;
 
+  /** @var TrackingConsentController */
+  private $trackingConsentController;
+
   public function __construct(
     Cookies $cookies,
     SubscriberCookie $subscriberCookie,
@@ -63,7 +67,8 @@ class Clicks {
     LinkShortcodeCategory $linkShortcodeCategory,
     SubscribersRepository $subscribersRepository,
     TrackingConfig $trackingConfig,
-    Request $request
+    Request $request,
+    TrackingConsentController $trackingConsentController
   ) {
     $this->cookies = $cookies;
     $this->subscriberCookie = $subscriberCookie;
@@ -75,6 +80,7 @@ class Clicks {
     $this->subscribersRepository = $subscribersRepository;
     $this->trackingConfig = $trackingConfig;
     $this->request = $request;
+    $this->trackingConsentController = $trackingConsentController;
   }
 
   /**
@@ -93,9 +99,12 @@ class Clicks {
     /** @var NewsletterLinkEntity $link */
     $link = $data->link;
     $wpUserPreview = ($data->preview && ($subscriber->isWPUser()));
+    $trackingAllowed = $this->trackingConsentController->isTrackingAllowed($subscriber);
     // log statistics only if the action did not come from
     // a WP user previewing the newsletter
-    if (!$wpUserPreview) {
+    // No tracking consent (CNIL/Garante): skip all recording (stats, cookies,
+    // engagement) but keep the redirect below.
+    if (!$wpUserPreview && $trackingAllowed) {
       $userAgent = !empty($data->userAgent) ? $this->userAgentsRepository->findOrCreate($data->userAgent) : null;
       $statisticsClicks = $this->statisticsClicksRepository->createOrUpdateClickCount(
         $link,
@@ -126,7 +135,11 @@ class Clicks {
       $this->subscribersRepository->maybeUpdateLastClickAt($subscriber);
     }
     $url = $this->processUrl($link->getUrl(), $newsletter, $subscriber, $queue, $wpUserPreview);
-    do_action('mailpoet_link_clicked', $link, $subscriber, $wpUserPreview);
+    if ($trackingAllowed) {
+      // Consumers of this hook (e.g. automation "clicked link" triggers) use
+      // clicks for follow-up personalization — exactly what consent covers.
+      do_action('mailpoet_link_clicked', $link, $subscriber, $wpUserPreview);
+    }
     $this->redirectToUrl($url);
   }
 

--- a/mailpoet/lib/Statistics/Track/Opens.php
+++ b/mailpoet/lib/Statistics/Track/Opens.php
@@ -10,6 +10,7 @@ use MailPoet\Entities\UserAgentEntity;
 use MailPoet\Statistics\StatisticsOpensRepository;
 use MailPoet\Statistics\UserAgentsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Subscribers\TrackingConsentController;
 
 class Opens {
   /** @var StatisticsOpensRepository */
@@ -21,14 +22,19 @@ class Opens {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
+  /** @var TrackingConsentController */
+  private $trackingConsentController;
+
   public function __construct(
     StatisticsOpensRepository $statisticsOpensRepository,
     UserAgentsRepository $userAgentsRepository,
-    SubscribersRepository $subscribersRepository
+    SubscribersRepository $subscribersRepository,
+    TrackingConsentController $trackingConsentController
   ) {
     $this->statisticsOpensRepository = $statisticsOpensRepository;
     $this->userAgentsRepository = $userAgentsRepository;
     $this->subscribersRepository = $subscribersRepository;
+    $this->trackingConsentController = $trackingConsentController;
   }
 
   public function track($data, $displayImage = true) {
@@ -37,6 +43,13 @@ class Opens {
     }
     /** @var SubscriberEntity $subscriber */
     $subscriber = $data->subscriber;
+    // No tracking consent (CNIL/Garante): serve the image but record nothing —
+    // no statistics, no engagement update. This is the backstop for emails
+    // already sent; future sends have the pixel removed entirely (see
+    // Newsletter::prepareNewsletterForSending).
+    if (!$this->trackingConsentController->isTrackingAllowed($subscriber)) {
+      return $this->returnResponse($displayImage);
+    }
     /** @var SendingQueueEntity $queue */
     $queue = $data->queue;
     /** @var NewsletterEntity $newsletter */

--- a/mailpoet/lib/Statistics/Track/SubscriberActivityTracker.php
+++ b/mailpoet/lib/Statistics/Track/SubscriberActivityTracker.php
@@ -7,6 +7,8 @@ use MailPoet\Settings\TrackingConfig;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Doctrine\DBAL\Exception\InvalidFieldNameException;
+use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 
 class SubscriberActivityTracker {
 
@@ -111,6 +113,19 @@ class SubscriberActivityTracker {
   }
 
   private function getSubscriber(): ?SubscriberEntity {
+    try {
+      return $this->findSubscriber();
+    } catch (InvalidFieldNameException | TableNotFoundException $e) {
+      // The subscribers schema may be mid-migration during a plugin update (e.g. the
+      // tracking_consent column added in STOMAIL-8268). Skip activity tracking for this
+      // request rather than aborting Initializer::initialize(), which would take the whole
+      // mailpoet/v1 REST namespace down with it. Tracking resumes on the next request once
+      // the migration completes.
+      return null;
+    }
+  }
+
+  private function findSubscriber(): ?SubscriberEntity {
     $wpUser = $this->wp->wpGetCurrentUser();
     if ($wpUser->exists()) {
       return $this->subscribersRepository->findOneBy(['wpUserId' => $wpUser->ID]);

--- a/mailpoet/lib/Subscribers/InactiveSubscribersController.php
+++ b/mailpoet/lib/Subscribers/InactiveSubscribersController.php
@@ -21,10 +21,15 @@ class InactiveSubscribersController {
   /** @var EntityManager */
   private $entityManager;
 
+  /** @var TrackingConsentController */
+  private $trackingConsentController;
+
   public function __construct(
-    EntityManager $entityManager
+    EntityManager $entityManager,
+    TrackingConsentController $trackingConsentController
   ) {
     $this->entityManager = $entityManager;
+    $this->trackingConsentController = $trackingConsentController;
   }
 
   public function markInactiveSubscribers(int $daysToInactive, int $startId, int $endId, ?int $unopenedEmails = self::UNOPENED_EMAILS_THRESHOLD) {
@@ -98,6 +103,7 @@ class InactiveSubscribersController {
       WHERE s.last_subscribed_at < :thresholdDate
         AND s.status = :status
         AND s.tracking_consent != 'denied'
+        AND (:trackUnknown = 1 OR s.tracking_consent != 'unknown')
         AND s.id >= :startId
         AND s.id <= :endId
         AND s.email_count >= {$lifetimeEmailsThreshold}
@@ -107,6 +113,7 @@ class InactiveSubscribersController {
       [
         'thresholdDate' => $thresholdDateIso,
         'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+        'trackUnknown' => $this->trackingConsentController->shouldTrackUnknownConsent() ? 1 : 0,
         'startId' => $startId,
         'endId' => $endId,
         'unopenedEmailsThreshold' => $unopenedEmails,

--- a/mailpoet/lib/Subscribers/InactiveSubscribersController.php
+++ b/mailpoet/lib/Subscribers/InactiveSubscribersController.php
@@ -97,6 +97,7 @@ class InactiveSubscribersController {
         JOIN {$processedTaskIdsTable} task_ids ON task_ids.id = sts.task_id
       WHERE s.last_subscribed_at < :thresholdDate
         AND s.status = :status
+        AND s.tracking_consent != 'denied'
         AND s.id >= :startId
         AND s.id <= :endId
         AND s.email_count >= {$lifetimeEmailsThreshold}

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -113,6 +113,12 @@ class SubscriberSaveController {
       $data = $this->wp->stripslashesDeep($data);
     }
 
+    // Proof-of-consent fields are stamped server-side only. The manage page sets
+    // them by calling createOrUpdate() directly; this client-data path (admin/API)
+    // may change the consent state but must never forge the record of how or
+    // against what wording it was given.
+    unset($data['tracking_consent_method'], $data['tracking_consent_copy']);
+
     if (empty($data['segments'])) {
       $data['segments'] = [];
     }

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -230,6 +230,13 @@ class SubscriberSaveController {
     if (isset($data['first_name'])) $subscriber->setFirstName($data['first_name']);
     if (isset($data['last_name'])) $subscriber->setLastName($data['last_name']);
     if (isset($data['status'])) $subscriber->setStatus($data['status']);
+    if (isset($data['tracking_consent'])) {
+      $subscriber->setTrackingConsent(
+        (string)$data['tracking_consent'],
+        $data['tracking_consent_method'] ?? SubscriberEntity::TRACKING_CONSENT_METHOD_ADMIN,
+        $data['tracking_consent_copy'] ?? null
+      );
+    }
     if (isset($data['source'])) $subscriber->setSource($data['source']);
     if (isset($data['wp_user_id'])) $subscriber->setWpUserId($data['wp_user_id']);
     if (isset($data['subscribed_ip'])) $subscriber->setSubscribedIp($data['subscribed_ip']);

--- a/mailpoet/lib/Subscribers/TrackingConsentController.php
+++ b/mailpoet/lib/Subscribers/TrackingConsentController.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscribers;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\TrackingConfig;
+
+/**
+ * The single answer to "may we track this subscriber?" (CNIL/Garante).
+ *
+ * Used by BOTH enforcement points — send-time pixel removal and serve-time
+ * recording suppression — so they can never drift apart.
+ */
+class TrackingConsentController {
+  const SETTING_TRACK_UNKNOWN = 'tracking.consent.track_unknown';
+
+  private SettingsController $settings;
+
+  private TrackingConfig $trackingConfig;
+
+  public function __construct(
+    SettingsController $settings,
+    TrackingConfig $trackingConfig
+  ) {
+    $this->settings = $settings;
+    $this->trackingConfig = $trackingConfig;
+  }
+
+  public function isTrackingAllowed(SubscriberEntity $subscriber): bool {
+    // The existing global switch still wins. Settings > Advanced > basic
+    // already means "no engagement tracking at all" for the whole site.
+    if (!$this->trackingConfig->isEmailTrackingEnabled()) {
+      return false;
+    }
+
+    switch ($subscriber->getTrackingConsent()) {
+      case SubscriberEntity::TRACKING_CONSENT_GRANTED:
+        return true;
+      case SubscriberEntity::TRACKING_CONSENT_DENIED:
+        return false;
+      default:
+        // 'unknown' = we never asked. Sites under the opt-in regime (new FR
+        // and IT contacts) set this to false; everyone else keeps today's
+        // behaviour.
+        return (bool)$this->settings->get(self::SETTING_TRACK_UNKNOWN, true);
+    }
+  }
+}

--- a/mailpoet/lib/Subscribers/TrackingConsentController.php
+++ b/mailpoet/lib/Subscribers/TrackingConsentController.php
@@ -43,7 +43,21 @@ class TrackingConsentController {
         // 'unknown' = we never asked. Sites under the opt-in regime (new FR
         // and IT contacts) set this to false; everyone else keeps today's
         // behaviour.
-        return (bool)$this->settings->get(self::SETTING_TRACK_UNKNOWN, true);
+        return $this->shouldTrackUnknownConsent();
     }
+  }
+
+  /**
+   * Whether subscribers who have never been asked ('unknown' consent) may be
+   * treated as trackable. Default true (existing behaviour). When false (strict
+   * opt-in mode), only subscribers who explicitly granted consent are tracked.
+   *
+   * Background jobs that infer intent from missing engagement (inactive sweep,
+   * resend to non-openers, re-engagement) use this so that, in strict mode,
+   * untracked 'unknown' subscribers are excluded the same way 'denied' ones
+   * are — otherwise their frozen engagement would wrongly mark them disengaged.
+   */
+  public function shouldTrackUnknownConsent(): bool {
+    return (bool)$this->settings->get(self::SETTING_TRACK_UNKNOWN, true);
   }
 }

--- a/mailpoet/lib/Subscribers/TrackingConsentController.php
+++ b/mailpoet/lib/Subscribers/TrackingConsentController.php
@@ -37,13 +37,18 @@ class TrackingConsentController {
     switch ($subscriber->getTrackingConsent()) {
       case SubscriberEntity::TRACKING_CONSENT_GRANTED:
         return true;
-      case SubscriberEntity::TRACKING_CONSENT_DENIED:
-        return false;
-      default:
+      case SubscriberEntity::TRACKING_CONSENT_UNKNOWN:
         // 'unknown' = we never asked. Sites under the opt-in regime (new FR
         // and IT contacts) set this to false; everyone else keeps today's
         // behaviour.
         return $this->shouldTrackUnknownConsent();
+      case SubscriberEntity::TRACKING_CONSENT_DENIED:
+      default:
+        // Denied — and, defensively, any unrecognised value — is never tracked.
+        // Storage is constrained to the three states (Assert\Choice on the
+        // entity), so 'default' should be unreachable; deny rather than fall
+        // back to the permissive unknown path for a compliance-critical flag.
+        return false;
     }
   }
 

--- a/mailpoet/lib/Subscription/Manage.php
+++ b/mailpoet/lib/Subscription/Manage.php
@@ -95,6 +95,15 @@ class Manage {
     if (!is_array($subscriberData)) {
       $subscriberData = [];
     }
+    // Never trust posted method/copy: stamp them server-side from the actual checkbox state.
+    unset($subscriberData['tracking_consent_method'], $subscriberData['tracking_consent_copy']);
+    if (array_key_exists('tracking_consent', $subscriberData)) {
+      $subscriberData['tracking_consent'] = $subscriberData['tracking_consent']
+        ? SubscriberEntity::TRACKING_CONSENT_GRANTED
+        : SubscriberEntity::TRACKING_CONSENT_DENIED;
+      $subscriberData['tracking_consent_method'] = SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE;
+      $subscriberData['tracking_consent_copy'] = ManageSubscriptionFormRenderer::getTrackingConsentCopy();
+    }
     if ($this->hasInvalidStatus($subscriberData) || $this->hasMalformedLegacySegmentIds($subscriberData)) {
       $this->urlHelper->redirectBack(['error' => true]);
       return;
@@ -260,16 +269,17 @@ class Manage {
   }
 
   /**
-   * The manage-subscription form only edits the subscriber's name, email and
-   * global status. Subscription choices and custom fields are handled
-   * separately. Keep only those fields when saving the subscriber so any other
-   * submitted key is ignored. `status` is already validated by
-   * hasInvalidStatus().
+   * The manage-subscription form only edits the subscriber's name, email,
+   * global status, and tracking consent. Subscription choices and custom
+   * fields are handled separately. Keep only those fields when saving the
+   * subscriber so any other submitted key is ignored. `status` is already
+   * validated by hasInvalidStatus(); `tracking_consent`/`_method`/`_copy`
+   * are already stamped server-side in onSave().
    */
   private function filterToEditableFields(array $subscriberData): array {
     return array_intersect_key(
       $subscriberData,
-      array_flip(['email', 'first_name', 'last_name', 'status'])
+      array_flip(['email', 'first_name', 'last_name', 'status', 'tracking_consent', 'tracking_consent_method', 'tracking_consent_copy'])
     );
   }
 

--- a/mailpoet/lib/Subscription/Manage.php
+++ b/mailpoet/lib/Subscription/Manage.php
@@ -97,13 +97,6 @@ class Manage {
     }
     // Never trust posted method/copy: stamp them server-side from the actual checkbox state.
     unset($subscriberData['tracking_consent_method'], $subscriberData['tracking_consent_copy']);
-    if (array_key_exists('tracking_consent', $subscriberData)) {
-      $subscriberData['tracking_consent'] = $subscriberData['tracking_consent']
-        ? SubscriberEntity::TRACKING_CONSENT_GRANTED
-        : SubscriberEntity::TRACKING_CONSENT_DENIED;
-      $subscriberData['tracking_consent_method'] = SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE;
-      $subscriberData['tracking_consent_copy'] = ManageSubscriptionFormRenderer::getTrackingConsentCopy();
-    }
     if ($this->hasInvalidStatus($subscriberData) || $this->hasMalformedLegacySegmentIds($subscriberData)) {
       $this->urlHelper->redirectBack(['error' => true]);
       return;
@@ -121,6 +114,22 @@ class Manage {
             && $subscriber instanceof SubscriberEntity
             && $subscriber->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED
           );
+          if (array_key_exists('tracking_consent', $subscriberData)) {
+            $postedConsent = (bool)$subscriberData['tracking_consent'];
+            $currentlyGranted = $subscriber->getTrackingConsent() === SubscriberEntity::TRACKING_CONSENT_GRANTED;
+            if ($postedConsent === $currentlyGranted) {
+              // Checkbox state unchanged from what was rendered — don't rewrite consent.
+              // An untouched 'unknown' subscriber must stay 'unknown', not be flipped to
+              // 'denied' just because they saved the manage page for another reason.
+              unset($subscriberData['tracking_consent']);
+            } else {
+              $subscriberData['tracking_consent'] = $postedConsent
+                ? SubscriberEntity::TRACKING_CONSENT_GRANTED
+                : SubscriberEntity::TRACKING_CONSENT_DENIED;
+              $subscriberData['tracking_consent_method'] = SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE;
+              $subscriberData['tracking_consent_copy'] = ManageSubscriptionFormRenderer::getTrackingConsentCopy();
+            }
+          }
           $subscriber = $this->subscriberSaveController->createOrUpdate($this->filterToEditableFields($subscriberData), $subscriber);
           if ($shouldTrackUnsubscribe) {
             $this->unsubscribesTracker->track(

--- a/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
+++ b/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
@@ -222,6 +222,10 @@ class ManageSubscriptionFormRenderer {
     }, $this->customFieldsRepository->findAllActive());
   }
 
+  public static function getTrackingConsentCopy(): string {
+    return __('Allow us to track when I open emails and which links I click', 'mailpoet');
+  }
+
   private function getBasicFields(SubscriberEntity $subscriber, bool $isModernStyle): array {
     $statusParams = [
       'required' => true,
@@ -297,6 +301,19 @@ class ManageSubscriptionFormRenderer {
         'id' => 'status',
         'type' => 'select',
         'params' => $statusParams,
+      ],
+      [
+        'id' => 'tracking_consent',
+        'type' => 'checkbox',
+        'params' => [
+          'label' => __('Email activity tracking', 'mailpoet'),
+          'values' => [
+            [
+              'value' => self::getTrackingConsentCopy(),
+              'is_checked' => $subscriber->getTrackingConsent() === SubscriberEntity::TRACKING_CONSENT_GRANTED,
+            ],
+          ],
+        ],
       ],
     ];
   }

--- a/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
+++ b/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
@@ -223,7 +223,7 @@ class ManageSubscriptionFormRenderer {
   }
 
   public static function getTrackingConsentCopy(): string {
-    return __('Allow us to track when I open emails and which links I click', 'mailpoet');
+    return __('Allow tracking of email opens and link clicks', 'mailpoet');
   }
 
   private function getBasicFields(SubscriberEntity $subscriber, bool $isModernStyle): array {

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -627,6 +627,7 @@ class Pages {
     $optOutUrl = $this->subscriptionUrlFactory->getTrackingOptOutUrl($this->subscriber);
     return '<p>' . self::getTrackingOptOutConsentCopy() . '</p>'
       . '<form method="post" action="' . esc_attr((string)$optOutUrl) . '" class="mailpoet_tracking_opt_out_form">'
+      . '<input type="hidden" name="_wpnonce" value="' . esc_attr($this->wp->wpCreateNonce('mailpoet_tracking_opt_out')) . '" />'
       . '<input type="submit" value="' . esc_attr__('Stop tracking my activity', 'mailpoet') . '" />'
       . '</form>';
   }

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -36,6 +36,7 @@ class Pages {
   const ACTION_MANAGE = 'manage';
   const ACTION_UNSUBSCRIBE = 'unsubscribe';
   const ACTION_RE_ENGAGEMENT = 're_engagement';
+  const ACTION_TRACKING_OPT_OUT = 'tracking_opt_out';
 
   private $action;
   private $data;
@@ -306,6 +307,26 @@ class Pages {
     }
   }
 
+  public function trackingOptOut(string $method, string $copy): void {
+    if (
+      !$this->isPreview()
+      && (!is_null($this->subscriber))
+      && ($this->subscriber->getTrackingConsent() !== SubscriberEntity::TRACKING_CONSENT_DENIED)
+    ) {
+      $this->subscriber->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_DENIED, $method, $copy);
+      $this->subscribersRepository->persist($this->subscriber);
+      $this->subscribersRepository->flush();
+    }
+  }
+
+  /**
+   * The wording the subscriber is shown before choosing. Kept in one place so
+   * the copy we store as proof is exactly the copy we rendered.
+   */
+  public static function getTrackingOptOutConsentCopy(): string {
+    return __('If you confirm, we will stop tracking when you open our emails and which links you click. This is separate from unsubscribing: you will keep receiving our emails.', 'mailpoet');
+  }
+
   public function isSubscriberUnsubscribed(): bool {
     return $this->subscriber instanceof SubscriberEntity
       && $this->subscriber->getStatus() === SubscriberEntity::STATUS_UNSUBSCRIBED;
@@ -346,6 +367,9 @@ class Pages {
 
         case self::ACTION_RE_ENGAGEMENT:
           return $this->getReEngagementTitle();
+
+        case self::ACTION_TRACKING_OPT_OUT:
+          return $this->getTrackingOptOutTitle();
       }
     }
   }
@@ -375,6 +399,9 @@ class Pages {
           break;
         case self::ACTION_RE_ENGAGEMENT:
           $content = $this->getReEngagementContent();
+          break;
+        case self::ACTION_TRACKING_OPT_OUT:
+          $content = $this->getTrackingOptOutContent();
           break;
       }
       return str_replace('[mailpoet_page]', trim($content), $pageContent);
@@ -439,6 +466,15 @@ class Pages {
   private function getReEngagementTitle() {
     if ($this->isPreview() || $this->subscriber !== null) {
       return __('Thank you for letting us know!', 'mailpoet');
+    }
+  }
+
+  private function getTrackingOptOutTitle() {
+    if ($this->isPreview() || $this->subscriber !== null) {
+      if ($this->subscriber !== null && $this->subscriber->getTrackingConsent() === SubscriberEntity::TRACKING_CONSENT_DENIED) {
+        return __('You have opted out of email activity tracking.', 'mailpoet');
+      }
+      return __('Opt out of email activity tracking', 'mailpoet');
     }
   }
 
@@ -577,6 +613,22 @@ class Pages {
       $content .= '<p>' . __('We appreciate your continued interest in our updates. Expect to hear from us again soon!', 'mailpoet') . '</p>';
     }
     return $content;
+  }
+
+  private function getTrackingOptOutContent() {
+    if (!$this->isPreview() && $this->subscriber === null) {
+      return '';
+    }
+    if ($this->subscriber !== null && $this->subscriber->getTrackingConsent() === SubscriberEntity::TRACKING_CONSENT_DENIED) {
+      return '<p class="mailpoet_tracking_opt_out_content">'
+        . __('We will no longer track when you open our emails or which links you click. You will keep receiving our emails as usual.', 'mailpoet')
+        . ' <strong>[mailpoet_manage]</strong></p>';
+    }
+    $optOutUrl = $this->subscriptionUrlFactory->getTrackingOptOutUrl($this->subscriber);
+    return '<p>' . self::getTrackingOptOutConsentCopy() . '</p>'
+      . '<form method="post" action="' . esc_attr((string)$optOutUrl) . '" class="mailpoet_tracking_opt_out_form">'
+      . '<input type="submit" value="' . esc_attr__('Stop tracking my activity', 'mailpoet') . '" />'
+      . '</form>';
   }
 
   private function getConfirmUnsubscribeContent() {

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -324,7 +324,7 @@ class Pages {
    * the copy we store as proof is exactly the copy we rendered.
    */
   public static function getTrackingOptOutConsentCopy(): string {
-    return __('If you confirm, we will stop tracking when you open our emails and which links you click. This is separate from unsubscribing: you will keep receiving our emails.', 'mailpoet');
+    return __('If you confirm, tracking of email opens and link clicks will stop. This is separate from unsubscribing: you will keep receiving emails.', 'mailpoet');
   }
 
   public function isSubscriberUnsubscribed(): bool {
@@ -621,7 +621,7 @@ class Pages {
     }
     if ($this->subscriber !== null && $this->subscriber->getTrackingConsent() === SubscriberEntity::TRACKING_CONSENT_DENIED) {
       return '<p class="mailpoet_tracking_opt_out_content">'
-        . __('We will no longer track when you open our emails or which links you click. You will keep receiving our emails as usual.', 'mailpoet')
+        . __('Tracking of email opens and link clicks is now off. You will keep receiving emails as usual.', 'mailpoet')
         . ' <strong>[mailpoet_manage]</strong></p>';
     }
     $optOutUrl = $this->subscriptionUrlFactory->getTrackingOptOutUrl($this->subscriber);

--- a/mailpoet/lib/Subscription/SubscriptionUrlFactory.php
+++ b/mailpoet/lib/Subscription/SubscriptionUrlFactory.php
@@ -64,6 +64,11 @@ class SubscriptionUrlFactory {
     return $this->getSubscriptionUrl($post, 'unsubscribe_reason', $subscriber, $data);
   }
 
+  public function getTrackingOptOutUrl(?SubscriberEntity $subscriber = null) {
+    $post = $this->getPost($this->settings->get('subscription.pages.manage'));
+    return $this->getSubscriptionUrl($post, 'tracking_opt_out', $subscriber);
+  }
+
   public function getReEngagementUrl(?SubscriberEntity $subscriber = null) {
     $reEngagementSetting = $this->settings->get('reEngagement');
     $postId = $reEngagementSetting['page'] ?? null;

--- a/mailpoet/tests/acceptance/Subscribers/TrackingConsentCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/TrackingConsentCest.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Subscription\SubscriptionUrlFactory;
+use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Settings;
+use MailPoet\Test\DataFactories\Subscriber;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @group frontend
+ */
+class TrackingConsentCest {
+
+  /** @var Settings */
+  private $settings;
+
+  public function _before() {
+    $this->settings = new Settings();
+    $this->settings->withTrackingEnabled();
+  }
+
+  public function footerTrackingOptOutLinkOptsSubscriberOut(\AcceptanceTester $i) {
+    $i->wantTo('Verify a subscriber can opt out of activity tracking via the footer opt-out link');
+
+    $segment = (new Segment())
+      ->withName('Tracking consent list')
+      ->create();
+    $subscriber = (new Subscriber())
+      ->withEmail('tracking-optout@example.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->withSegments([$segment])
+      ->create();
+    $subscriberId = (int)$subscriber->getId();
+
+    $optOutUrl = SubscriptionUrlFactory::getInstance()->getTrackingOptOutUrl($subscriber);
+    Assert::assertIsString($optOutUrl);
+
+    $i->wantTo('Open the opt-out confirmation page from the footer link');
+    $i->amOnUrl($optOutUrl);
+    $i->waitForText('Opt out of email activity tracking');
+    $i->see('you will keep receiving our emails');
+
+    $i->wantTo('Confirm the opt-out and see the done state');
+    $i->click('Stop tracking my activity');
+    $i->waitForText('You have opted out of email activity tracking.');
+    $i->see('We will no longer track when you open our emails');
+    $i->seeNoJSErrors();
+
+    $i->wantTo('Verify the subscriber consent is recorded as denied via the footer link');
+    $reloaded = $this->reloadSubscriber($subscriberId);
+    Assert::assertSame(SubscriberEntity::TRACKING_CONSENT_DENIED, $reloaded->getTrackingConsent());
+    Assert::assertSame(SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK, $reloaded->getTrackingConsentMethod());
+  }
+
+  public function managePageCheckboxControlsTrackingConsent(\AcceptanceTester $i) {
+    $i->wantTo('Verify the manage-subscription checkbox grants tracking consent, while an untouched save leaves an unknown subscriber unchanged');
+
+    $segment = (new Segment())
+      ->withName('Tracking consent list')
+      ->create();
+    $subscriber = (new Subscriber())
+      ->withEmail('tracking-manage@example.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->withSegments([$segment])
+      ->create();
+    $subscriberId = (int)$subscriber->getId();
+    // A freshly created subscriber has never been asked, so consent is unknown.
+    Assert::assertSame(SubscriberEntity::TRACKING_CONSENT_UNKNOWN, $subscriber->getTrackingConsent());
+
+    $manageUrl = SubscriptionUrlFactory::getInstance()->getManageUrl($subscriber);
+    Assert::assertIsString($manageUrl);
+    $checkbox = 'input[data-parsley-group="custom_field_tracking_consent"]';
+    $saveButton = '[data-automation-id="subscribe-submit-button"]';
+    $successMessage = 'Your subscription settings have been saved.';
+    $approximateSaveButtonHeight = 50; // scroll offset so the button is not hidden above the top fold
+
+    $i->wantTo('See the tracking-consent checkbox rendered unchecked for an unknown subscriber');
+    $i->amOnUrl($manageUrl);
+    $i->waitForText('Email activity tracking');
+    $i->see('Allow us to track when I open emails and which links I click');
+    $i->dontSeeCheckboxIsChecked($checkbox);
+
+    $i->wantTo('Save without touching the checkbox and verify consent stays unknown (not silently denied)');
+    $i->scrollTo($saveButton, 0, -$approximateSaveButtonHeight);
+    $i->click('Save changes');
+    $i->waitForText($successMessage);
+    $reloaded = $this->reloadSubscriber($subscriberId);
+    Assert::assertSame(SubscriberEntity::TRACKING_CONSENT_UNKNOWN, $reloaded->getTrackingConsent());
+
+    $i->wantTo('Tick the checkbox and save to grant tracking consent');
+    $i->checkOption($checkbox);
+    $i->scrollTo($saveButton, 0, -$approximateSaveButtonHeight);
+    $i->click('Save changes');
+    $i->waitForText($successMessage);
+    $i->seeCheckboxIsChecked($checkbox);
+    $i->seeNoJSErrors();
+    $reloaded = $this->reloadSubscriber($subscriberId);
+    Assert::assertSame(SubscriberEntity::TRACKING_CONSENT_GRANTED, $reloaded->getTrackingConsent());
+    Assert::assertSame(SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE, $reloaded->getTrackingConsentMethod());
+  }
+
+  private function reloadSubscriber(int $id): SubscriberEntity {
+    $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
+    // Drop the identity map so we read the row the browser just wrote, not a cached copy.
+    $entityManager->clear();
+    $subscriber = $entityManager->find(SubscriberEntity::class, $id);
+    Assert::assertInstanceOf(SubscriberEntity::class, $subscriber);
+    return $subscriber;
+  }
+}

--- a/mailpoet/tests/acceptance/Subscribers/TrackingConsentCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/TrackingConsentCest.php
@@ -43,12 +43,12 @@ class TrackingConsentCest {
     $i->wantTo('Open the opt-out confirmation page from the footer link');
     $i->amOnUrl($optOutUrl);
     $i->waitForText('Opt out of email activity tracking');
-    $i->see('you will keep receiving our emails');
+    $i->see('you will keep receiving emails');
 
     $i->wantTo('Confirm the opt-out and see the done state');
     $i->click('Stop tracking my activity');
     $i->waitForText('You have opted out of email activity tracking.');
-    $i->see('We will no longer track when you open our emails');
+    $i->see('Tracking of email opens and link clicks is now off');
     $i->seeNoJSErrors();
 
     $i->wantTo('Verify the subscriber consent is recorded as denied via the footer link');
@@ -82,7 +82,7 @@ class TrackingConsentCest {
     $i->wantTo('See the tracking-consent checkbox rendered unchecked for an unknown subscriber');
     $i->amOnUrl($manageUrl);
     $i->waitForText('Email activity tracking');
-    $i->see('Allow us to track when I open emails and which links I click');
+    $i->see('Allow tracking of email opens and link clicks');
     $i->dontSeeCheckboxIsChecked($checkbox);
 
     $i->wantTo('Save without touching the checkbox and verify consent stays unknown (not silently denied)');

--- a/mailpoet/tests/acceptance/WelcomeWizard/WelcomeWizardCest.php
+++ b/mailpoet/tests/acceptance/WelcomeWizard/WelcomeWizardCest.php
@@ -77,7 +77,7 @@ class WelcomeWizardCest {
     Assert::assertSame($senderAddress, $this->findSetting('sender')->getValue()['address']);
     Assert::assertSame(['enabled' => '1'], $this->findSetting('3rd_party_libs')->getValue());
     Assert::assertSame(['enabled' => '1'], $this->findSetting('analytics')->getValue());
-    Assert::assertSame(['level' => 'full', 'opens' => 'merged'], $this->findSetting('tracking')->getValue());
+    Assert::assertSame(['level' => 'full', 'opens' => 'merged', 'consent' => ['track_unknown' => '1']], $this->findSetting('tracking')->getValue());
     Assert::assertSame($mailPoetSendingKey, $this->findSetting('mta')->getValue()['mailpoet_api_key']);
   }
 
@@ -118,7 +118,7 @@ class WelcomeWizardCest {
     Assert::assertSame($senderAddress, $this->findSetting('sender')->getValue()['address']);
     Assert::assertSame(['enabled' => '1'], $this->findSetting('3rd_party_libs')->getValue());
     Assert::assertSame(['enabled' => '1'], $this->findSetting('analytics')->getValue());
-    Assert::assertSame(['level' => 'full', 'opens' => 'merged'], $this->findSetting('tracking')->getValue());
+    Assert::assertSame(['level' => 'full', 'opens' => 'merged', 'consent' => ['track_unknown' => '1']], $this->findSetting('tracking')->getValue());
     Assert::assertSame($mailPoetSendingKey, $this->findSetting('mta')->getValue()['mailpoet_api_key']);
   }
 

--- a/mailpoet/tests/acceptance/WelcomeWizard/WelcomeWizardCest.php
+++ b/mailpoet/tests/acceptance/WelcomeWizard/WelcomeWizardCest.php
@@ -77,7 +77,7 @@ class WelcomeWizardCest {
     Assert::assertSame($senderAddress, $this->findSetting('sender')->getValue()['address']);
     Assert::assertSame(['enabled' => '1'], $this->findSetting('3rd_party_libs')->getValue());
     Assert::assertSame(['enabled' => '1'], $this->findSetting('analytics')->getValue());
-    Assert::assertSame(['level' => 'full', 'opens' => 'merged', 'consent' => ['track_unknown' => '1']], $this->findSetting('tracking')->getValue());
+    Assert::assertSame(['level' => 'full', 'opens' => 'merged'], $this->findSetting('tracking')->getValue());
     Assert::assertSame($mailPoetSendingKey, $this->findSetting('mta')->getValue()['mailpoet_api_key']);
   }
 
@@ -118,7 +118,7 @@ class WelcomeWizardCest {
     Assert::assertSame($senderAddress, $this->findSetting('sender')->getValue()['address']);
     Assert::assertSame(['enabled' => '1'], $this->findSetting('3rd_party_libs')->getValue());
     Assert::assertSame(['enabled' => '1'], $this->findSetting('analytics')->getValue());
-    Assert::assertSame(['level' => 'full', 'opens' => 'merged', 'consent' => ['track_unknown' => '1']], $this->findSetting('tracking')->getValue());
+    Assert::assertSame(['level' => 'full', 'opens' => 'merged'], $this->findSetting('tracking')->getValue());
     Assert::assertSame($mailPoetSendingKey, $this->findSetting('mta')->getValue()['mailpoet_api_key']);
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -20,6 +20,7 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Mailer\MailerLog;
+use MailPoet\Newsletter\Links\Links;
 use MailPoet\Newsletter\NewsletterPostsRepository;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\Coupon;
@@ -391,6 +392,46 @@ class NewsletterTest extends \MailPoetTest {
       ->stringNotContainsString(Router::NAME . '&endpoint=track&action=click&data=');
     verify($result['body']['text'])
       ->stringNotContainsString(Router::NAME . '&endpoint=track&action=click&data=');
+  }
+
+  public function testItRemovesOpenTrackingPixelForSubscriberWithoutConsent() {
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK
+    );
+    $this->entityManager->flush();
+
+    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
+    $result = $this->newsletterTask->prepareNewsletterForSending(
+      $newsletterEntity,
+      $this->subscriber,
+      $this->sendingQueueEntity
+    );
+
+    // The pixel must not ship: neither the placeholder data tag, a
+    // stripped-to-empty-src <img>, nor a resolved open-tracking URL (which
+    // is what the client would actually request on open) may remain.
+    $this->assertStringNotContainsString(Links::DATA_TAG_OPEN, $result['body']['html']);
+    $this->assertStringNotContainsString('<img alt="" class="" src=""', $result['body']['html']);
+    $this->assertStringNotContainsString('endpoint=track&action=open', $result['body']['html']);
+  }
+
+  public function testItKeepsOpenTrackingPixelForConsentingSubscriber() {
+    $this->subscriber->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    $this->entityManager->flush();
+
+    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
+    $result = $this->newsletterTask->prepareNewsletterForSending(
+      $newsletterEntity,
+      $this->subscriber,
+      $this->sendingQueueEntity
+    );
+
+    // Placeholder is gone because it was replaced with a real tracked URL.
+    $this->assertStringNotContainsString(Links::DATA_TAG_OPEN, $result['body']['html']);
+    $this->assertStringContainsString('endpoint=track&action=open', $result['body']['html']);
   }
 
   public function testItPausesSendingWhenOrderReviewUrlCannotBeResolved(): void {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
@@ -302,6 +302,13 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
     $this->assertStringNotContainsString('data-link-href=', $html);
   }
 
+  public function testItConvertsTrackingOptOutTagToShortcode(): void {
+    $convertor = new LinksToShortcodesConvertor();
+    $html = '<a data-link-href="[mailpoet/subscription-tracking-opt-out-url]" href="#">Stop tracking me</a>';
+    $result = $convertor->convertLinkTagsToShortcodes($html);
+    $this->assertStringContainsString('[link:subscription_tracking_opt_out_url]', $result);
+  }
+
   public function testItResolvesOrderReviewUrlDataAttributeAfterPersonalization(): void {
     $convertor = new LinksToShortcodesConvertor();
 

--- a/mailpoet/tests/integration/Newsletter/NewsletterResendControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterResendControllerTest.php
@@ -62,6 +62,22 @@ class NewsletterResendControllerTest extends \MailPoetTest {
     verify($taskSubscribers)->equals(6);
   }
 
+  public function testItDoesNotResendToSubscribersWhoDeniedTrackingConsent() {
+    [$newsletter, $subscriber] = $this->arrangeSentButNotOpened();
+    $subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK
+    );
+    $this->entityManager->flush();
+
+    $resent = $this->controller->resendToNonOpeners($newsletter, 'Second try');
+    verify($resent->getSubject())->equals('Second try');
+
+    $taskSubscribers = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)
+      ->findBy(['subscriber' => $subscriber]);
+    $this->assertCount(0, $taskSubscribers);
+  }
+
   public function testMachineOpensCountAsOpens() {
     $newsletter = $this->createSentNewsletter('Test Subject');
     $subscribers = $this->createSubscribers(10);
@@ -291,6 +307,14 @@ class NewsletterResendControllerTest extends \MailPoetTest {
     $newsletter->setSentAt($sentAt ?? Carbon::now()->subHours(36));
     $this->entityManager->flush();
     return $newsletter;
+  }
+
+  /** @return array{0: NewsletterEntity, 1: SubscriberEntity} */
+  private function arrangeSentButNotOpened(): array {
+    $newsletter = $this->createSentNewsletter('Test Subject');
+    $subscribers = $this->createSubscribers(2);
+    $this->createStatisticsNewsletters($newsletter, $subscribers);
+    return [$newsletter, $subscribers[0]];
   }
 
   /** @return SubscriberEntity[] */

--- a/mailpoet/tests/integration/Newsletter/NewsletterResendControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterResendControllerTest.php
@@ -8,6 +8,7 @@ use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\StatisticsNewsletters as StatisticsNewslettersFactory;
 use MailPoet\Test\DataFactories\StatisticsOpens as StatisticsOpensFactory;
@@ -76,6 +77,31 @@ class NewsletterResendControllerTest extends \MailPoetTest {
     $taskSubscribers = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)
       ->findBy(['subscriber' => $subscriber]);
     $this->assertCount(0, $taskSubscribers);
+  }
+
+  public function testItDoesNotResendToUnknownConsentSubscribersInStrictMode() {
+    // Strict opt-in mode: unknown-consent subscribers are not tracked, so they
+    // must not be treated as non-openers. A second, consenting subscriber keeps
+    // the resend non-empty.
+    $this->diContainer->get(SettingsController::class)->set(TrackingConsentController::SETTING_TRACK_UNKNOWN, false);
+    $newsletter = $this->createSentNewsletter('Test Subject');
+    $subscribers = $this->createSubscribers(2); // both unknown consent by default
+    $subscribers[1]->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE
+    );
+    $this->entityManager->flush();
+    $this->createStatisticsNewsletters($newsletter, $subscribers);
+
+    $resent = $this->controller->resendToNonOpeners($newsletter, 'Second try');
+    verify($resent->getSubject())->equals('Second try');
+
+    $unknownTaskSubscribers = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)
+      ->findBy(['subscriber' => $subscribers[0]]);
+    $this->assertCount(0, $unknownTaskSubscribers);
+    $grantedTaskSubscribers = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)
+      ->findBy(['subscriber' => $subscribers[1]]);
+    $this->assertCount(1, $grantedTaskSubscribers);
   }
 
   public function testMachineOpensCountAsOpens() {

--- a/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
@@ -13,6 +13,8 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterOptionField;
 use MailPoet\Test\DataFactories\Segment;
@@ -147,6 +149,25 @@ class ReEngagementSchedulerTest extends \MailPoetTest {
       SubscriberEntity::TRACKING_CONSENT_DENIED,
       SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK
     );
+    $this->entityManager->flush();
+
+    $scheduled = $this->scheduler->scheduleAll();
+    verify($scheduled)->arrayCount(0);
+  }
+
+  public function testItDoesNotScheduleUnknownConsentSubscriberInStrictMode() {
+    // Strict opt-in mode: an unknown-consent subscriber is not tracked, so their
+    // frozen engagement must not make them eligible for re-engagement.
+    $this->diContainer->get(SettingsController::class)->set(TrackingConsentController::SETTING_TRACK_UNKNOWN, false);
+    $beforeCheckInterval = Carbon::now();
+    $beforeCheckInterval->subMonths(10);
+    $withinCheckInterval = Carbon::now();
+    $withinCheckInterval->subMonth();
+    $this->createReEngagementEmail(5);
+
+    $subscriber = $this->createSubscriber('unknown_tracking@example.com', $beforeCheckInterval, $this->segment);
+    verify($subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    $this->addSentEmailToSubscriber($this->sentStandardNewsletter, $subscriber, $withinCheckInterval);
     $this->entityManager->flush();
 
     $scheduled = $this->scheduler->scheduleAll();

--- a/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
@@ -133,6 +133,26 @@ class ReEngagementSchedulerTest extends \MailPoetTest {
     verify($sendingQueue->getCountProcessed())->equals(0);
   }
 
+  public function testItDoesNotScheduleSubscriberWhoDeniedTrackingConsent() {
+    $beforeCheckInterval = Carbon::now();
+    $beforeCheckInterval->subMonths(10);
+    $withinCheckInterval = Carbon::now();
+    $withinCheckInterval->subMonth();
+    $this->createReEngagementEmail(5);
+
+    // Disengaged subscriber who would normally be scheduled, but denied tracking consent
+    $subscriberWhoDeniedTracking = $this->createSubscriber('denied_tracking@example.com', $beforeCheckInterval, $this->segment);
+    $this->addSentEmailToSubscriber($this->sentStandardNewsletter, $subscriberWhoDeniedTracking, $withinCheckInterval);
+    $subscriberWhoDeniedTracking->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK
+    );
+    $this->entityManager->flush();
+
+    $scheduled = $this->scheduler->scheduleAll();
+    verify($scheduled)->arrayCount(0);
+  }
+
   public function testItSchedulesOneSubscriberInTwoSegmentsOnlyOnce() {
     $beforeCheckInterval = Carbon::now();
     $beforeCheckInterval->subMonths(10);

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -418,6 +418,12 @@ class ShortcodesTest extends \MailPoetTest {
     verify($linkData['token'])->equals($this->subscriber->getLinkToken());
   }
 
+  public function testItReplacesTrackingOptOutLinkShortcode() {
+    $result = $this->shortcodesObject->replace('[link:subscription_tracking_opt_out_url]');
+    $this->assertStringContainsString('action=tracking_opt_out', (string)$result);
+    $this->assertStringContainsString('endpoint=subscription', (string)$result);
+  }
+
   private function getLinkData(string $link): array {
     $parsedUrlQuery = parse_url($link, PHP_URL_QUERY);
     $queryData = [];

--- a/mailpoet/tests/integration/Router/Endpoints/SubscriptionTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/SubscriptionTest.php
@@ -172,6 +172,56 @@ class SubscriptionTest extends \MailPoetTest {
     }
   }
 
+  public function testItOptsOutOfTrackingWithValidNonce() {
+    $wp = $this->createMock(WPFunctions::class);
+    $optedOut = false;
+    $pages = Stub::make(Pages::class, [
+      'wp' => $wp,
+      'trackingOptOut' => Expected::once(function($method, $copy) use (&$optedOut) {
+        $optedOut = true;
+      }),
+    ], $this);
+
+    $request = $this->createMock(Request::class);
+    $request->method('isPost')->willReturn(true);
+    $request->method('getStringParam')->willReturnMap([
+      ['_wpnonce', 'valid_nonce'],
+    ]);
+    $wp->method('wpVerifyNonce')->with('valid_nonce', 'mailpoet_tracking_opt_out')->willReturn(true);
+
+    $subscription = new Subscription($pages, $wp, $request);
+    $subscription->trackingOptOut($this->data);
+
+    verify($optedOut)->true();
+  }
+
+  public function testItRejectsTrackingOptOutWithInvalidNonce() {
+    $wp = $this->createMock(WPFunctions::class);
+    $pages = Stub::make(Pages::class, [
+      'wp' => $wp,
+      'trackingOptOut' => Expected::never(),
+    ], $this);
+
+    $request = $this->createMock(Request::class);
+    $request->method('isPost')->willReturn(true);
+    $request->method('getStringParam')->willReturnMap([
+      ['_wpnonce', 'invalid_nonce'],
+    ]);
+    $wp->method('wpVerifyNonce')->with('invalid_nonce', 'mailpoet_tracking_opt_out')->willReturn(false);
+    $wp->expects($this->once())
+      ->method('wpDie')
+      ->with($this->anything(), '', ['response' => 403])
+      ->willThrowException(new \RuntimeException('exit_die'));
+
+    $subscription = new Subscription($pages, $wp, $request);
+    try {
+      $subscription->trackingOptOut($this->data);
+      $this->fail('Expected wpDie to interrupt execution');
+    } catch (\RuntimeException $e) {
+      verify($e->getMessage())->equals('exit_die');
+    }
+  }
+
   public function testItRedirectsGetRequestToHomeUrl() {
     $wp = $this->createMock(WPFunctions::class);
     $pages = Stub::make(Pages::class, [

--- a/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
@@ -9,6 +9,8 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterLinkEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\UserAgentEntity;
 use MailPoet\Newsletter\Shortcodes\Categories\Link as LinkShortcodeCategory;
@@ -22,6 +24,7 @@ use MailPoet\Statistics\Track\SubscriberCookie;
 use MailPoet\Statistics\UserAgentsRepository;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoet\Util\Cookies;
 use MailPoet\Util\Request;
 use MailPoet\WP\Functions as WPFunctions;
@@ -103,7 +106,8 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
-      $this->diContainer->get(Request::class)
+      $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class)
     );
 
     $this->statisticsClicksRepository = $this->diContainer->get(StatisticsClicksRepository::class);
@@ -123,6 +127,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'abort' => Expected::exactly(2),
     ], $this);
@@ -150,6 +155,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -172,6 +178,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -196,6 +203,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -223,6 +231,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -256,6 +265,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -299,6 +309,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -342,6 +353,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -378,6 +390,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -416,10 +429,38 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => Expected::exactly(1),
     ], $this);
     $clicks->track($this->trackData);
+  }
+
+  public function testItDoesNotTrackClickWithoutConsentButStillRedirects() {
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK
+    );
+    $this->entityManager->flush();
+    $clicks = Stub::construct($this->clicks, [
+      $this->diContainer->get(Cookies::class),
+      $this->diContainer->get(SubscriberCookie::class),
+      $this->diContainer->get(Shortcodes::class),
+      $this->diContainer->get(Opens::class),
+      $this->diContainer->get(StatisticsClicksRepository::class),
+      $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(LinkShortcodeCategory::class),
+      $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
+    ], [
+      'redirectToUrl' => Expected::exactly(1),
+    ], $this);
+    $clicks->track($this->trackData);
+    $this->assertCount(0, $this->entityManager->getRepository(StatisticsClickEntity::class)->findAll());
+    $this->assertCount(0, $this->entityManager->getRepository(StatisticsOpenEntity::class)->findAll());
+    $this->assertNull($this->subscriber->getLastClickAt());
   }
 
   public function testItIncrementsClickEventCount() {
@@ -434,6 +475,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -481,6 +523,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'abort' => Expected::exactly(1),
     ], $this);
@@ -582,7 +625,8 @@ class ClicksTest extends \MailPoetTest {
     $opens = new Opens(
       $statisticsOpensRepository,
       $this->diContainer->get(UserAgentsRepository::class),
-      $subscribersRepository
+      $subscribersRepository,
+      $this->diContainer->get(TrackingConsentController::class)
     );
     $clicks = Stub::construct($this->clicks, [
       $this->diContainer->get(Cookies::class),
@@ -595,6 +639,7 @@ class ClicksTest extends \MailPoetTest {
       $subscribersRepository,
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -627,7 +672,8 @@ class ClicksTest extends \MailPoetTest {
     $opens = new Opens(
       $statisticsOpensRepository,
       $this->diContainer->get(UserAgentsRepository::class),
-      $subscribersRepository
+      $subscribersRepository,
+      $this->diContainer->get(TrackingConsentController::class)
     );
     $clicks = Stub::construct($this->clicks, [
       $this->diContainer->get(Cookies::class),
@@ -640,6 +686,7 @@ class ClicksTest extends \MailPoetTest {
       $subscribersRepository,
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -672,7 +719,8 @@ class ClicksTest extends \MailPoetTest {
     $opens = new Opens(
       $statisticsOpensRepository,
       $this->diContainer->get(UserAgentsRepository::class),
-      $subscribersRepository
+      $subscribersRepository,
+      $this->diContainer->get(TrackingConsentController::class)
     );
     $clicks = Stub::construct($this->clicks, [
       $this->diContainer->get(Cookies::class),
@@ -685,6 +733,7 @@ class ClicksTest extends \MailPoetTest {
       $subscribersRepository,
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -714,6 +763,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'redirectToUrl' => null,
     ], $this);

--- a/mailpoet/tests/integration/Statistics/Track/OpensTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/OpensTest.php
@@ -435,4 +435,26 @@ class OpensTest extends \MailPoetTest {
     verify($savedOpenTime->getTimestamp())->equals($now->getTimestamp());
     Carbon::setTestNow();
   }
+
+  public function testTrackingConsentIsPersistedWithMethodTimestampAndCopy() {
+    $copy = 'Do not track my email activity';
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK,
+      $copy
+    );
+    $this->entityManager->flush();
+    $this->entityManager->clear();
+    $subscriber = $this->entityManager->find(SubscriberEntity::class, $this->subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_DENIED, $subscriber->getTrackingConsent());
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK, $subscriber->getTrackingConsentMethod());
+    $this->assertSame($copy, $subscriber->getTrackingConsentCopy());
+    $this->assertNotNull($subscriber->getTrackingConsentUpdatedAt());
+  }
+
+  public function testTrackingConsentDefaultsToUnknown() {
+    $subscriber = new SubscriberEntity();
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_UNKNOWN, $subscriber->getTrackingConsent());
+  }
 }

--- a/mailpoet/tests/integration/Statistics/Track/OpensTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/OpensTest.php
@@ -16,6 +16,7 @@ use MailPoet\Statistics\Track\Opens;
 use MailPoet\Statistics\UserAgentsRepository;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoetVendor\Carbon\Carbon;
 
 class OpensTest extends \MailPoetTest {
@@ -81,7 +82,8 @@ class OpensTest extends \MailPoetTest {
     $this->opens = new Opens(
       $this->statisticsOpensRepository,
       $this->diContainer->get(UserAgentsRepository::class),
-      $this->diContainer->get(SubscribersRepository::class)
+      $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class)
     );
   }
 
@@ -90,6 +92,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => Expected::exactly(1),
     ], $this);
@@ -105,6 +108,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -121,6 +125,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -133,6 +138,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -147,6 +153,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => Expected::exactly(1),
     ], $this);
@@ -159,6 +166,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -178,6 +186,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -197,6 +206,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -218,6 +228,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -256,6 +267,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -294,6 +306,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -325,6 +338,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -361,6 +375,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -378,6 +393,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -400,6 +416,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -422,6 +439,7 @@ class OpensTest extends \MailPoetTest {
       $this->diContainer->get(StatisticsOpensRepository::class),
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
     ], [
       'returnResponse' => null,
     ], $this);
@@ -456,5 +474,24 @@ class OpensTest extends \MailPoetTest {
   public function testTrackingConsentDefaultsToUnknown() {
     $subscriber = new SubscriberEntity();
     $this->assertSame(SubscriberEntity::TRACKING_CONSENT_UNKNOWN, $subscriber->getTrackingConsent());
+  }
+
+  public function testItDoesNotTrackOpenForSubscriberWhoDeniedConsent() {
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK
+    );
+    $this->entityManager->flush();
+    $opens = Stub::construct($this->opens, [
+      $this->diContainer->get(StatisticsOpensRepository::class),
+      $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConsentController::class),
+    ], [
+      'returnResponse' => Expected::exactly(1),
+    ], $this);
+    $opens->track($this->trackData);
+    $this->assertCount(0, $this->statisticsOpensRepository->findAll());
+    $this->assertNull($this->subscriber->getLastOpenAt());
   }
 }

--- a/mailpoet/tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/SubscriberActivityTrackerTest.php
@@ -149,6 +149,36 @@ class SubscriberActivityTrackerTest extends \MailPoetTest {
     verify($subscriber->getLastEngagementAt())->lessThan(Carbon::now()->addMinute());
   }
 
+  public function testItSkipsTrackingWhenTrackingConsentColumnIsMissing() {
+    // Reproduce the plugin-update window: SubscriberEntity maps tracking_consent, but the
+    // migration that adds it has not run yet on this request. The read in getSubscriber()
+    // must degrade to "skip tracking" rather than throw, which would abort
+    // Initializer::initialize() and take the whole mailpoet/v1 REST namespace down.
+    $this->diContainer->get(SettingsController::class)->set('tracking.level', TrackingConfig::LEVEL_PARTIAL);
+    $wpUserEmail = 'tracking_consent_missing@test.com';
+    $this->tester->deleteWordPressUser($wpUserEmail);
+    $user = (new User())->createUser('consent_missing', 'editor', $wpUserEmail);
+    wp_set_current_user($user->ID);
+    $this->setPageViewCookieTimestamp(null);
+    $this->setSubscriberCookieSubscriber(null);
+
+    $table = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $connection = $this->entityManager->getConnection();
+    $dropped = false;
+    try {
+      $connection->executeStatement("ALTER TABLE `{$table}` DROP COLUMN `tracking_consent`");
+      $dropped = true;
+
+      // Must not throw an uncaught QueryException; the guard returns null and trackActivity bails.
+      $result = $this->tracker->trackActivity();
+      verify($result)->false();
+    } finally {
+      if ($dropped) {
+        $connection->executeStatement("ALTER TABLE `{$table}` ADD COLUMN `tracking_consent` VARCHAR(20) NOT NULL DEFAULT 'unknown'");
+      }
+    }
+  }
+
   public function testItUpdatesSubscriberEngagementForWpUserEvenWithDisabledCookieTracking() {
     $this->diContainer->get(SettingsController::class)->set('tracking.level', TrackingConfig::LEVEL_PARTIAL);
     $wpUserEmail = 'pageview_track_user@test.com';

--- a/mailpoet/tests/integration/Subscribers/InactiveSubscribersControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/InactiveSubscribersControllerTest.php
@@ -44,8 +44,7 @@ class InactiveSubscribersControllerTest extends \MailPoetTest {
   }
 
   public function testItDeactivatesOldSubscribersOnlyWhenUnopenedEmailsReachThreshold(): void {
-    $subscriber1 = $this->createSubscriber('s1@email.com', 10);
-    $this->createCompletedSendingTasksForSubscriber($subscriber1, self::UNOPENED_EMAILS_THRESHOLD, 3);
+    [, $subscriber1] = $this->arrangeInactiveScenario();
 
     $subscriber2 = $this->createSubscriber('s2@email.com', 10);
     $this->createCompletedSendingTasksForSubscriber($subscriber2, self::UNOPENED_EMAILS_THRESHOLD - 1, 3);
@@ -59,6 +58,22 @@ class InactiveSubscribersControllerTest extends \MailPoetTest {
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber2);
     verify($subscriber1->getStatus())->equals(SubscriberEntity::STATUS_INACTIVE);
     verify($subscriber2->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+  }
+
+  public function testItDoesNotDeactivateSubscribersWhoDeniedTrackingConsent(): void {
+    [$controller, $subscriber] = $this->arrangeInactiveScenario();
+    $subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE
+    );
+    $this->entityManager->flush();
+
+    $controller->markInactiveSubscribers(self::INACTIVITY_DAYS_THRESHOLD, 0, self::PROCESS_END_ID);
+
+    $this->entityManager->clear();
+    $reloaded = $this->subscribersRepository->findOneById($subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $reloaded);
+    verify($reloaded->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
   }
 
   public function testItDeactivatesLimitedAmountOfSubscribers(): void {
@@ -225,6 +240,15 @@ class InactiveSubscribersControllerTest extends \MailPoetTest {
     $subscriber = $this->subscribersRepository->findOneById($subscriber->getId());
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     verify($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+  }
+
+  /**
+   * @return array{0: InactiveSubscribersController, 1: SubscriberEntity}
+   */
+  private function arrangeInactiveScenario(): array {
+    $subscriber = $this->createSubscriber('s1@email.com', 10);
+    $this->createCompletedSendingTasksForSubscriber($subscriber, self::UNOPENED_EMAILS_THRESHOLD, 3);
+    return [$this->controller, $subscriber];
   }
 
   private function createSubscriber(

--- a/mailpoet/tests/integration/Subscribers/InactiveSubscribersControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/InactiveSubscribersControllerTest.php
@@ -9,6 +9,7 @@ use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Settings\SettingsController;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -30,7 +31,8 @@ class InactiveSubscribersControllerTest extends \MailPoetTest {
 
   public function _before() {
     $this->controller = new InactiveSubscribersController(
-      $this->diContainer->get(EntityManager::class)
+      $this->diContainer->get(EntityManager::class),
+      $this->diContainer->get(TrackingConsentController::class)
     );
     $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $this->entityManager->getConnection()->executeQuery('DROP TABLE IF EXISTS inactive_task_ids');
@@ -67,6 +69,21 @@ class InactiveSubscribersControllerTest extends \MailPoetTest {
       SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE
     );
     $this->entityManager->flush();
+
+    $controller->markInactiveSubscribers(self::INACTIVITY_DAYS_THRESHOLD, 0, self::PROCESS_END_ID);
+
+    $this->entityManager->clear();
+    $reloaded = $this->subscribersRepository->findOneById($subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $reloaded);
+    verify($reloaded->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+  }
+
+  public function testItDoesNotDeactivateUnknownConsentSubscribersInStrictMode(): void {
+    // Strict opt-in mode: unknown-consent subscribers are not tracked, so their
+    // frozen engagement must not get them deactivated.
+    $this->diContainer->get(SettingsController::class)->set(TrackingConsentController::SETTING_TRACK_UNKNOWN, false);
+    [$controller, $subscriber] = $this->arrangeInactiveScenario();
+    verify($subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
 
     $controller->markInactiveSubscribers(self::INACTIVITY_DAYS_THRESHOLD, 0, self::PROCESS_END_ID);
 

--- a/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Subscribers;
 
 use MailPoet\ConflictException;
+use MailPoet\Doctrine\Validator\ValidationException;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
@@ -74,6 +75,31 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
     verify($subscriber->getSegments())->arrayCount(2);
     verify($subscriber->getSubscriberSegments())->arrayCount(2);
     verify($subscriber->getSubscriberTags())->arrayCount(2);
+  }
+
+  public function testItStripsClientSuppliedTrackingConsentProofFields(): void {
+    // A client (admin/API) can change the consent state but must not be able to
+    // forge the proof-of-consent method/copy; those are stamped server-side only.
+    $subscriber = $this->saveController->save([
+      'email' => 'consent-forge@test.com',
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      'tracking_consent' => SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      'tracking_consent_method' => SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE,
+      'tracking_consent_copy' => 'Forged copy the subscriber never saw',
+    ]);
+    verify($subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    // Forged method/copy dropped: method falls back to the server-side ADMIN default, copy stays null.
+    verify($subscriber->getTrackingConsentMethod())->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_ADMIN);
+    verify($subscriber->getTrackingConsentCopy())->null();
+  }
+
+  public function testItRejectsInvalidTrackingConsentValue(): void {
+    $this->expectException(ValidationException::class);
+    $this->saveController->save([
+      'email' => 'consent-bogus@test.com',
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      'tracking_consent' => 'bogus',
+    ]);
   }
 
   public function testItSavesSubscriberTimeZoneWhenCollectionIsEnabled(): void {

--- a/mailpoet/tests/integration/Subscribers/TrackingConsentControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/TrackingConsentControllerTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscribers;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\TrackingConfig;
+
+class TrackingConsentControllerTest extends \MailPoetTest {
+  public function testItAllowsGrantedAndBlocksDenied() {
+    $controller = $this->diContainer->get(TrackingConsentController::class);
+    $subscriber = new SubscriberEntity();
+
+    $subscriber->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    $this->assertTrue($controller->isTrackingAllowed($subscriber));
+
+    $subscriber->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_DENIED);
+    $this->assertFalse($controller->isTrackingAllowed($subscriber));
+  }
+
+  public function testUnknownFollowsTheSiteSetting() {
+    $settings = $this->diContainer->get(SettingsController::class);
+    $controller = $this->diContainer->get(TrackingConsentController::class);
+    $subscriber = new SubscriberEntity(); // defaults to unknown
+
+    // Default: existing sites keep tracking exactly as they do today.
+    $this->assertTrue($controller->isTrackingAllowed($subscriber));
+
+    $settings->set('tracking.consent.track_unknown', false);
+    $this->assertFalse($controller->isTrackingAllowed($subscriber));
+  }
+
+  public function testGlobalTrackingOffWinsOverIndividualConsent() {
+    $settings = $this->diContainer->get(SettingsController::class);
+    $settings->set('tracking.level', TrackingConfig::LEVEL_BASIC);
+    $controller = $this->diContainer->get(TrackingConsentController::class);
+    $subscriber = new SubscriberEntity();
+    $subscriber->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+
+    $this->assertFalse($controller->isTrackingAllowed($subscriber));
+  }
+}

--- a/mailpoet/tests/integration/Subscription/ManageTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageTest.php
@@ -33,6 +33,9 @@ class ManageTest extends \MailPoetTest {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
+  /** @var Manage */
+  private $manage;
+
   public function _before() {
     parent::_before();
     $this->_after();
@@ -560,6 +563,28 @@ class ManageTest extends \MailPoetTest {
     verify($createdAt->format('Y-m-d'))->notEquals('2004-05-06');
   }
 
+  public function testOnSaveGrantsTrackingConsentWhenChecked() {
+    $this->setUpSavePost(['tracking_consent' => '1']);
+    $this->manage->onSave();
+
+    $this->entityManager->clear();
+    $subscriber = $this->entityManager->find(SubscriberEntity::class, $this->subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_GRANTED, $subscriber->getTrackingConsent());
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE, $subscriber->getTrackingConsentMethod());
+    $this->assertNotNull($subscriber->getTrackingConsentCopy());
+  }
+
+  public function testOnSaveDeniesTrackingConsentWhenUnchecked() {
+    $this->setUpSavePost(['tracking_consent' => '0']);
+    $this->manage->onSave();
+
+    $this->entityManager->clear();
+    $subscriber = $this->entityManager->find(SubscriberEntity::class, $this->subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_DENIED, $subscriber->getTrackingConsent());
+  }
+
   public function testItRedirectsWithErrorAndDoesNotSaveWhenTokenVerificationFails(): void {
     $redirectParams = null;
     $manage = $this->getManageService([
@@ -625,6 +650,18 @@ class ManageTest extends \MailPoetTest {
 
     verify($redirectParams)->equals(['error' => true]);
     verify($this->subscribersRepository->findOneBy(['email' => 'unknown@example.com']))->null();
+  }
+
+  private function setUpSavePost(array $data = [], array $overrides = []): void {
+    $this->manage = $this->getManageService($overrides);
+    $_POST['action'] = 'mailpoet_subscription_update';
+    $_POST['token'] = 'token';
+    $_POST['data'] = array_merge([
+      'first_name' => 'John',
+      'last_name' => 'John',
+      'email' => 'john.doe@example.com',
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+    ], $data);
   }
 
   private function getManageService(array $overrides = []): Manage {

--- a/mailpoet/tests/integration/Subscription/ManageTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageTest.php
@@ -576,6 +576,13 @@ class ManageTest extends \MailPoetTest {
   }
 
   public function testOnSaveDeniesTrackingConsentWhenUnchecked() {
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE,
+      'copy'
+    );
+    $this->entityManager->flush();
+
     $this->setUpSavePost(['tracking_consent' => '0']);
     $this->manage->onSave();
 
@@ -583,6 +590,36 @@ class ManageTest extends \MailPoetTest {
     $subscriber = $this->entityManager->find(SubscriberEntity::class, $this->subscriber->getId());
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     $this->assertSame(SubscriberEntity::TRACKING_CONSENT_DENIED, $subscriber->getTrackingConsent());
+  }
+
+  public function testOnSaveLeavesUnknownConsentUntouchedWhenBoxUnticked() {
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_UNKNOWN, $this->subscriber->getTrackingConsent());
+
+    $this->setUpSavePost(['tracking_consent' => '0']);
+    $this->manage->onSave();
+
+    $this->entityManager->clear();
+    $subscriber = $this->entityManager->find(SubscriberEntity::class, $this->subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_UNKNOWN, $subscriber->getTrackingConsent());
+    $this->assertNull($subscriber->getTrackingConsentMethod());
+  }
+
+  public function testOnSaveLeavesGrantedConsentUntouchedWhenBoxStaysChecked() {
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE,
+      'copy'
+    );
+    $this->entityManager->flush();
+
+    $this->setUpSavePost(['tracking_consent' => '1']);
+    $this->manage->onSave();
+
+    $this->entityManager->clear();
+    $subscriber = $this->entityManager->find(SubscriberEntity::class, $this->subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_GRANTED, $subscriber->getTrackingConsent());
   }
 
   public function testItRedirectsWithErrorAndDoesNotSaveWhenTokenVerificationFails(): void {

--- a/mailpoet/tests/integration/Subscription/PagesTest.php
+++ b/mailpoet/tests/integration/Subscription/PagesTest.php
@@ -442,6 +442,19 @@ class PagesTest extends \MailPoetTest {
     verify($this->statisticsUnsubscribesRepository->findAll())->arrayCount(0);
   }
 
+  public function testTrackingOptOutActionDeniesConsentAndRecordsCopy() {
+    $copy = 'We will no longer track when you open our emails.';
+    $pages = $this->getPages()->init(Pages::ACTION_TRACKING_OPT_OUT, $this->testData, false, false);
+    $pages->trackingOptOut(SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK, $copy);
+
+    $this->entityManager->clear();
+    $subscriber = $this->entityManager->find(SubscriberEntity::class, $this->subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_DENIED, $subscriber->getTrackingConsent());
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK, $subscriber->getTrackingConsentMethod());
+    $this->assertSame($copy, $subscriber->getTrackingConsentCopy());
+  }
+
   public function testWindowTitleCanBeCalledWithSingleArgument() {
     $pages = $this->getPages();
 

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -255,4 +255,6 @@
   'engagementTrackingFull': __('Full – additionally use browser cookies to improve the site and email engagement tracking and abandoned cart email accuracy.'),
   'engagementTrackingPartial': __('Partial – additionally track email engagement (opens, clicks). Disable cookie-based tracking.'),
   'engagementTrackingBasic': __('Basic / None – only use data your site already has about your subscribers. Disable email engagement and cookie-based tracking, and re-engagement emails.'),
+  'trackUnknownConsentTitle': __('Tracking consent for unknown subscribers'),
+  'trackUnknownConsentDescription': __('Some subscribers have never been asked whether they allow open and click tracking. Choose whether to track them by default. Select No for a strict opt-in approach, where only subscribers who explicitly allow tracking are tracked. This helps with the consent rules in France and Italy. It has no effect when engagement tracking above is set to Basic / None.'),
 }) %>

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -254,5 +254,5 @@
   'engagementTrackingDescription': __('Choose the balance between subscriber privacy and deeper engagement insights that is right for your business.'),
   'engagementTrackingFull': __('Full – additionally use browser cookies to improve the site and email engagement tracking and abandoned cart email accuracy.'),
   'engagementTrackingPartial': __('Partial – additionally track email engagement (opens, clicks). Disable cookie-based tracking.'),
-  'engagementTrackingBasic': __('Basic – only use data your site already has about your subscribers. Disable email engagement and cookie-based tracking, and re-engagement emails.'),
+  'engagementTrackingBasic': __('Basic / None – only use data your site already has about your subscribers. Disable email engagement and cookie-based tracking, and re-engagement emails.'),
 }) %>


### PR DESCRIPTION
## What this does

Adds a per-subscriber way to turn off email open and click tracking, so site owners can honour individual opt-out choices for recipients in France and Italy.

## Why

The French (CNIL) and Italian (Garante) data protection authorities both ruled that tracking whether someone opened an email or clicked a link is the same legal category as a website cookie. That means it needs the recipient's consent separate from their consent to receive the email, plus a way to opt out of the tracking that is separate from unsubscribing.

MailPoet today only has a global tracking level (Basic / Partial / Full). There is no way to honour one subscriber's choice while still tracking others. This adds that per-subscriber layer on top of the existing global setting.

## What is in it

- A tri-state `tracking_consent` on subscribers (`unknown` / `granted` / `denied`), plus timestamp, method and shown-copy columns for record keeping. New subscribers are `unknown` (we have never asked them).
- One decision service, `TrackingConsentController`, that both enforcement points use so they can never disagree. It checks the global tracking setting first (global off still wins), then the subscriber's consent, then a `tracking.consent.track_unknown` site setting for how to treat `unknown` (default: track, so existing sites behave exactly as before).
- Two enforcement points:
  - Send time (`Newsletter::prepareNewsletterForSending`): the open pixel is removed from the email body for non-consenting subscribers, so the read never happens on future emails.
  - Serve time (`Opens`/`Clicks::track`): recording is suppressed as a backstop for emails already sent. The click redirect and the open-pixel response always still happen.
- A footer opt-out link, separate from unsubscribe, in both editors: the legacy `[link:subscription_tracking_opt_out_url]` shortcode and a `mailpoet/subscription-tracking-opt-out-url` block-editor personalization tag. Both lead to a confirmation page that records the choice.
- A tracking-consent checkbox on the manage-subscription page. It uses positive framing ("Allow us to track...") and only writes consent when the checkbox state actually changes, so saving the page for another reason does not silently change an untouched subscriber.
- Denied subscribers are kept out of the inactive-subscribers sweep, resend-to-non-openers, and re-engagement emails, so opting out of tracking never silently reduces the emails a subscriber receives.
- The global "Basic" tracking level is relabelled "Basic / None" so the site-wide off switch is easier to find.

## Behavioural invariants

- Default behaviour is unchanged for existing sites: consent defaults to `unknown`, which is treated as tracked.
- Global tracking off still wins over any individual consent.
- The click redirect and the open-pixel HTTP response are never suppressed. Only the recording is.
- Consent proof (method and the exact wording shown) is stamped server-side and never trusts client-posted values.

## Testing

- Integration tests for every part: the consent decision, open and click suppression, send-time pixel removal (including the pixel's on-wire serialization), the three sweep exclusions, shortcode and personalization-tag resolution, and the manage-page save.
- Acceptance tests for the footer opt-out flow and the manage-page checkbox.
- Verified end to end on a local site: sent emails to consenting and non-consenting subscribers and confirmed in the received messages that the open pixel and tracked links are present or absent as expected, that the open and click endpoints still serve the gif and redirect while recording nothing for non-consenting subscribers, and that the footer link and manage-page checkbox both opt subscribers out.

## Out of scope (follow-ups)

- Un-tracking click links at send time. This PR removes the open pixel only. Click links are still rewritten, and their recording is suppressed at serve time.
- A settings toggle and strict opt-in mode for treating `unknown` subscribers as not-consented (and excluding them from the sweeps).
- A tracking-consent block in the form editor to capture consent at signup.
- Exportable proof-of-consent and an admin subscriber-list column.


## Screenshots

Form
<img width="987" height="662" alt="Screenshot 2026-07-17 at 12 11 55 AM" src="https://github.com/user-attachments/assets/8dfe9e83-26fa-42a0-a185-d7b558e62bff" />

The subscriber clicked the opt-out link from email:
<img width="957" height="510" alt="Screenshot 2026-07-17 at 12 14 00 AM" src="https://github.com/user-attachments/assets/56f9f250-5bf1-441f-a417-c935104265aa" />

<img width="986" height="473" alt="Screenshot 2026-07-17 at 12 12 55 AM" src="https://github.com/user-attachments/assets/3ead4119-4967-467b-891e-5ad3367f320a" />


Settings field to handle unknown status for subscribers. By default, true. Can be set to false.
<img width="1550" height="325" alt="Screenshot 2026-07-17 at 12 14 48 AM" src="https://github.com/user-attachments/assets/7549a155-6a3f-4bd7-b75c-db2e34e4d274" />



Email Editor Personalization tag
<img width="522" height="664" alt="Screenshot 2026-07-17 at 12 15 56 AM" src="https://github.com/user-attachments/assets/efd34e25-9681-48ca-beb3-f2de3b77e62d" />
<img width="390" height="289" alt="Screenshot 2026-07-17 at 12 17 18 AM" src="https://github.com/user-attachments/assets/2564f241-5c8b-437d-8b82-131a87bf35cf" />



Legacy newsletter editor shortcode window
<img width="675" height="386" alt="Screenshot 2026-07-17 at 12 28 02 AM" src="https://github.com/user-attachments/assets/3301a2ea-4595-4758-a439-0fb7ba598b4d" />


## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8268-assess-cnil-compliance-per-subscriber-tracking-pixel-opt-out)

_The latest successful build from `stomail-8268-assess-cnil-compliance-per-subscriber-tracking-pixel-opt-out` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->