### PR TITLE
Show which trashed subscribers cannot be deleted

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_listing.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing.scss
@@ -36,6 +36,17 @@
   }
 }
 
+.mailpoet-listing-title-row {
+  align-items: center;
+  display: inline-flex;
+  gap: 8px;
+
+  .mailpoet-tooltip {
+    overflow-wrap: break-word;
+    white-space: normal;
+  }
+}
+
 .mailpoet-listing-title {
   color: $color-text;
   font-size: $font-size;

--- a/mailpoet/assets/js/src/subscribers/api.ts
+++ b/mailpoet/assets/js/src/subscribers/api.ts
@@ -81,6 +81,7 @@ export type { SubscriberBulkActionScope } from './bulk-action-payload';
 export type SubscriberBulkActionResult = {
   action: SubscriberBulkAction;
   count: number;
+  kept?: number;
   segment: { id: number; name: string } | null;
   tag: { id: number; name: string } | null;
   queue?: {

--- a/mailpoet/assets/js/src/subscribers/fields.tsx
+++ b/mailpoet/assets/js/src/subscribers/fields.tsx
@@ -3,10 +3,20 @@ import { __ } from '@wordpress/i18n';
 import type { Field } from '@wordpress/dataviews';
 import { MailPoet } from 'mailpoet';
 import { SegmentTags, SubscriberTags } from 'common';
+import { Badge } from 'common/listings/newsletter-stats/badge';
 import { ListingsEngagementScore } from './listings-engagement-score';
 import type { Segment, Subscriber } from './api';
 
 const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
+
+// Mirrors SubscribersRepository::bulkDelete: subscribers linked to a WordPress
+// user or WooCommerce customer are never permanently deleted.
+function isDeletable(subscriber: Subscriber): boolean {
+  return (
+    Number(subscriber.wp_user_id) === 0 &&
+    Number(subscriber.is_woocommerce_user) === 0
+  );
+}
 
 function statusLabel(status: string): string {
   switch (status) {
@@ -60,6 +70,7 @@ function dateTime(value: string | null): JSX.Element | null {
 
 export function getSubscriberFields(
   getBackUrl: () => string,
+  group?: string,
 ): Field<Subscriber>[] {
   const statisticsFields: Field<Subscriber>[] = mailpoetTrackingEnabled
     ? [
@@ -95,14 +106,28 @@ export function getSubscriberFields(
       enableGlobalSearch: true,
       render: ({ item }) => (
         <div>
-          <Link
-            className="mailpoet-listing-title"
-            data-automation-id={`listing_item_${item.id}`}
-            to={`/edit/${item.id}`}
-            state={{ backUrl: getBackUrl() }}
-          >
-            {item.email}
-          </Link>
+          <span className="mailpoet-listing-title-row">
+            <Link
+              className="mailpoet-listing-title"
+              data-automation-id={`listing_item_${item.id}`}
+              to={`/edit/${item.id}`}
+              state={{ backUrl: getBackUrl() }}
+            >
+              {item.email}
+            </Link>
+            {group === 'trash' && !isDeletable(item) && (
+              <Badge
+                type="unknown"
+                isInverted={false}
+                name={__('Not deletable', 'mailpoet')}
+                tooltipId={`not-deletable-${item.id}`}
+                tooltip={__(
+                  'This subscriber is linked to a WordPress user or WooCommerce customer, so it is kept and will not be permanently deleted.',
+                  'mailpoet',
+                )}
+              />
+            )}
+          </span>
           <div className="mailpoet-listing-subtitle">
             {item.first_name} {item.last_name}
           </div>

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -314,14 +314,30 @@ function actionSuccessMessage(
           ),
     );
   } else if (action === 'delete') {
-    MailPoet.Notice.success(
-      count === 1
-        ? __('1 subscriber was permanently deleted.', 'mailpoet')
-        : __('%1$d subscribers were permanently deleted.', 'mailpoet').replace(
-            '%1$d',
-            formatCount(count),
-          ),
+    const kept = Number(result.kept ?? 0);
+    const deletedMessage = sprintf(
+      _n(
+        '%s subscriber was permanently deleted.',
+        '%s subscribers were permanently deleted.',
+        count,
+        'mailpoet',
+      ),
+      formatCount(count),
     );
+    if (kept > 0) {
+      const keptMessage = sprintf(
+        _n(
+          '%s subscriber was kept because it is linked to a WordPress user or WooCommerce customer.',
+          '%s subscribers were kept because they are linked to a WordPress user or WooCommerce customer.',
+          kept,
+          'mailpoet',
+        ),
+        formatCount(kept),
+      );
+      MailPoet.Notice.success(`${deletedMessage} ${keptMessage}`);
+    } else {
+      MailPoet.Notice.success(deletedMessage);
+    }
   } else if (action === 'restore') {
     MailPoet.Notice.success(
       count === 1
@@ -1324,7 +1340,10 @@ function SubscriberList() {
     [group, groupCounts, groups],
   );
 
-  const fields = useMemo(() => getSubscriberFields(getBackUrl), [getBackUrl]);
+  const fields = useMemo(
+    () => getSubscriberFields(getBackUrl, group),
+    [getBackUrl, group],
+  );
 
   const paginationInfo = useMemo(
     () => ({ totalItems: meta.count, totalPages: meta.pages }),

--- a/mailpoet/changelog/2026-07-17-11-51-10-fixed-show-how-many-trashed-subscribers-were-kept-when-e.md
+++ b/mailpoet/changelog/2026-07-17-11-51-10-fixed-show-how-many-trashed-subscribers-were-kept-when-e.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Show how many trashed subscribers were kept when emptying the trash, since subscribers linked to WordPress or WooCommerce accounts are not permanently deleted

--- a/mailpoet/lib/Subscribers/BulkActionController.php
+++ b/mailpoet/lib/Subscribers/BulkActionController.php
@@ -84,7 +84,7 @@ class BulkActionController {
 
   /**
    * @param array{segment_id?: int|string, tag_id?: int|string, trigger_automations?: bool} $data
-   * @return array{count: int, segment?: array{id: int, name: string}, tag?: array{id: int, name: string}}
+   * @return array{count: int, kept?: int, segment?: array{id: int, name: string}, tag?: array{id: int, name: string}}
    * @throws BulkActionException
    */
   public function execute(string $action, ListingDefinition $definition, array $data = []): array {
@@ -109,6 +109,11 @@ class BulkActionController {
     $count = $this->dispatch($action, $ids, $segment, $tag, $skipHooks);
 
     $result = ['count' => $count];
+    if ($action === self::ACTION_DELETE) {
+      // bulkDelete keeps subscribers linked to a WordPress user or WooCommerce
+      // customer, so the remainder of the actionable set is what was kept.
+      $result['kept'] = max(0, count($ids) - $count);
+    }
     if ($segment instanceof SegmentEntity) {
       $result['segment'] = ['id' => (int)$segment->getId(), 'name' => (string)$segment->getName()];
     }

--- a/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
+++ b/mailpoet/lib/Subscribers/RestApi/Endpoints/SubscribersBulkActionEndpoint.php
@@ -121,6 +121,7 @@ class SubscribersBulkActionEndpoint extends Endpoint {
     return new Response([
       'action' => $action,
       'count' => $result['count'],
+      'kept' => $result['kept'] ?? 0,
       'segment' => $result['segment'] ?? null,
       'tag' => $result['tag'] ?? null,
     ]);

--- a/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Subscribers/SubscribersEndpointsTest.php
@@ -276,6 +276,42 @@ class SubscribersEndpointsTest extends Test {
     $this->assertNull($this->subscribersRepository->findOneById($trashedId));
   }
 
+  public function testBulkDeleteReturnsKeptCountForLinkedSubscribers(): void {
+    $deletable = (new SubscriberFactory())
+      ->withEmail('rest-empty-trash-plain-' . uniqid() . '@example.com')
+      ->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)
+      ->withDeletedAt(new \DateTimeImmutable())
+      ->create();
+    $wpUser = (new SubscriberFactory())
+      ->withEmail('rest-empty-trash-wp-' . uniqid() . '@example.com')
+      ->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)
+      ->withWpUserId(1)
+      ->withDeletedAt(new \DateTimeImmutable())
+      ->create();
+    $deletableId = (int)$deletable->getId();
+    $wpUserId = (int)$wpUser->getId();
+
+    $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
+      'action' => 'delete',
+      'group' => 'trash',
+      'selection' => [],
+      'select_all' => true,
+    ]]);
+
+    $this->assertIsArray($response);
+    $payload = $response['data'];
+    $this->assertIsArray($payload);
+    $this->assertArrayHasKey('kept', $payload);
+    $this->assertGreaterThanOrEqual(1, $payload['count']);
+    $this->assertGreaterThanOrEqual(1, $payload['kept']);
+    $this->entityManager->clear();
+    $this->assertNull($this->subscribersRepository->findOneById($deletableId));
+    $this->assertInstanceOf(
+      SubscriberEntity::class,
+      $this->subscribersRepository->findOneById($wpUserId)
+    );
+  }
+
   public function testBulkTrashWithSelectAllIsRejectedFromTrash(): void {
     $response = $this->post(self::BULK_ACTION_PATH, ['json' => [
       'action' => 'trash',

--- a/mailpoet/tests/integration/Subscribers/BulkActionControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/BulkActionControllerTest.php
@@ -69,6 +69,36 @@ class BulkActionControllerTest extends \MailPoetTest {
     verify($this->subscribersRepository->findOneById($subscriberId))->null();
   }
 
+  public function testItReportsKeptSubscribersOnEmptyTrashDelete(): void {
+    $deletable = (new SubscriberFactory())
+      ->withEmail('plain@example.com')
+      ->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)
+      ->withDeletedAt(new \DateTimeImmutable())
+      ->create();
+    $wpUser = (new SubscriberFactory())
+      ->withEmail('wpuser@example.com')
+      ->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)
+      ->withWpUserId(1)
+      ->withDeletedAt(new \DateTimeImmutable())
+      ->create();
+    $wooUser = (new SubscriberFactory())
+      ->withEmail('woo@example.com')
+      ->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)
+      ->withIsWooCommerceUser()
+      ->withDeletedAt(new \DateTimeImmutable())
+      ->create();
+
+    // Empty Trash targets the whole trash group (no explicit selection).
+    $result = $this->controller->execute(BulkActionController::ACTION_DELETE, $this->definition([], 'trash'));
+
+    verify($result['count'])->equals(1);
+    verify($result['kept'] ?? null)->equals(2);
+    $this->entityManager->clear();
+    verify($this->subscribersRepository->findOneById((int)$deletable->getId()))->null();
+    verify($this->subscribersRepository->findOneById((int)$wpUser->getId()))->notNull();
+    verify($this->subscribersRepository->findOneById((int)$wooUser->getId()))->notNull();
+  }
+
   public function testItUnsubscribesAndTracksAdministrativeSourceOnce(): void {
     $segment = (new SegmentFactory())->withName('Segment')->create();
     $active = $this->createSubscriber('active@example.com', SubscriberEntity::STATUS_SUBSCRIBED, [$segment]);


### PR DESCRIPTION
## Description

The "Empty Trash" button in Subscribers could delete 0 rows and give no reason. Subscribers linked to a WordPress user or WooCommerce customer are never permanently deleted, so they stay in the trash.

This PR adds a few UI improvements to make it clear:

- The success notice shows how many were deleted and how many were kept, and why.
- Trashed subscribers that can't be deleted show a "Not deletable" badge with a tooltip that explains why.

## Code review notes

_N/A_

## QA notes

1. Add a subscriber that is a WordPress user or WooCommerce customer.
2. Move it to the trash and open the Trash tab.
3. It shows a "Not deletable" badge.
4. Click "Empty Trash". The notice shows how many were deleted and how many were kept.

## Linked PRs

[STOMAIL-8273: "Empty Trash" button does not work in subscribers list](https://linear.app/a8c/issue/STOMAIL-8273/empty-trash-button-does-not-work-in-subscribers-list)

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          | Success notice                          |
| ------------------------------- | ------------------------------ | ------------------------------ |
| <img width="3254" height="1860" alt="r3yPLvCRkGuZR81S@2x" src="https://github.com/user-attachments/assets/6c68bccb-1183-45c0-abe8-cad5a79421ca" /> | <img width="3284" height="1876" alt="PPOyvnLI6bacqCMB@2x" src="https://github.com/user-attachments/assets/c51dbcf6-9975-4913-8618-bd20304166a1" /> | <img width="3284" height="1875" alt="6ImJC9NNDsLThxur@2x" src="https://github.com/user-attachments/assets/0b7a1d9a-2efb-4244-bb1e-d3d6fa611db9" /> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8273-empty-trash-button-does-not-work-in-subscribers-list)

_The latest successful build from `stomail-8273-empty-trash-button-does-not-work-in-subscribers-list` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->