### PR TITLE
Fix acceptance tests for WordPress 7.1

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -118,9 +118,9 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('Save draft', '.edit-post-header');
     $i->waitForText('Saved');
     $i->click('.editor-preview-dropdown__toggle');
-    $i->waitForElementVisible('//a[text()="Preview in new tab"]');
-    $i->waitForElementClickable('//a[text()="Preview in new tab"]');
-    $i->click('//a[text()="Preview in new tab"]');
+    $i->waitForElementVisible('//a[contains(., "Preview in new tab")]');
+    $i->waitForElementClickable('//a[contains(., "Preview in new tab")]');
+    $i->click('//a[contains(., "Preview in new tab")]');
     $i->switchToNextTab();
     $i->canSeeInCurrentUrl('post_type=mailpoet_email');
     $i->canSee('Sample text');

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -121,8 +121,9 @@ class GutenbergFormBlockCest {
     $i->wantTo('Add Gutenberg form block to the post manually');
     $i->login();
     $i->amEditingPostWithId($postId);
-    $this->closeDialog($i);
     $i->waitForText('My Gutenberg form');
+    $this->closeDialog($i);
+    $i->waitForElement('iframe[name="editor-canvas"]', 30);
     $i->switchToIframe('iframe[name="editor-canvas"]');
     $i->click('[aria-label="Add title"]');
     $i->click('[aria-label="Add block"]');

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -68,6 +68,7 @@ class WooCheckoutBlocksCest {
     $i->wantTo('Check a message when opt-in is disabled');
     $i->login();
     $i->amOnAdminPage("post.php?post={$this->checkoutPostId}&action=edit");
+    $i->waitForElement('iframe[name="editor-canvas"]', 30);
     $i->switchToIframe('iframe[name="editor-canvas"]');
     $i->canSee('MailPoet marketing opt-in would be shown here if enabled. You can enable from the settings page.');
     $i->switchToIframe();
@@ -230,6 +231,7 @@ class WooCheckoutBlocksCest {
       $i->wantTo('Choose a pattern was not present, skipping action.');
     }
     $this->closeDialog($i);
+    $i->waitForElement('iframe[name="editor-canvas"]', 30);
     $i->switchToIframe('iframe[name="editor-canvas"]');
     $i->click('[aria-label="Add title"]'); // For block inserter to show up
     $i->click('[aria-label="Add block"]');


### PR DESCRIPTION
## Description

Fix [three acceptance tests that started failing](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/24350/workflows/17ce8422-fbed-41d2-89ec-abd2b29f2d87/jobs/429164/tests) on the WordPress 7.1 beta1 nightly build.

WordPress 7.1 changed the block editor markup. This broke test selectors and timing, not the plugin itself.

This PR updates the failing tests to be compatible with WordPress 7.1.

## Code review notes

Test-only changes. No plugin code was touched.

## QA notes

Ran [all three tests](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/24350/workflows/17ce8422-fbed-41d2-89ec-abd2b29f2d87/jobs/429164/tests) locally against WordPress 7.1 beta1.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/acceptance-tests-wp-7-1-beta1)

_The latest successful build from `fix/acceptance-tests-wp-7-1-beta1` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->