### PR TITLE
Fix CircleCI auth null password deprecation in release tooling

### DIFF
--- a/mailpoet/tasks/release/CircleCiController.php
+++ b/mailpoet/tasks/release/CircleCiController.php
@@ -49,7 +49,7 @@ class CircleCiController {
     $circleCiProject = $this->getCircleCiProject($project);
     $this->zipFilename = $project === self::PROJECT_MAILPOET ? self::FREE_ZIP_FILENAME : self::PREMIUM_ZIP_FILENAME;
     $this->httpClient = $httpClient ?? new Client([
-      'auth' => [$token, null],
+      'auth' => [$token, ''],
       'headers' => [
         'Accept' => 'application/json',
       ],


### PR DESCRIPTION
## Description

Running `./do release:publish` prints a `guzzle` deprecation at the end.

```
ERROR: Since guzzlehttp/guzzle 7.11: Passing null to request option "auth.1" is deprecated; guzzlehttp/guzzle 8.0 requires string. 
in mailpoet/mailpoet/vendor/symfony/deprecation-contracts/function.php:25
```

The source is `tasks/release/CircleCiController.php`, which builds its `guzzle` client with `auth => [$token, null]`. The CircleCI API v2 authenticates with the API token as the basic-auth username and an empty password, so the password element was set to `null`. Guzzle started flagging a null password in 7.11 and will reject it in 8.0, requiring a string.

This fix passes an empty string, which is the correct value for token-as-username basic auth and is forward-compatible with `guzzle` 8.0.

This only affects the local release tooling, so no changelog entry is added.

## Code review notes

The change is a single value: `[$token, null]` to `[$token, '']`.

The fix is behavior-neutral. Guzzle applies basic auth for any non-empty `auth` array and builds the header as `'Basic ' . base64_encode("$value[0]:$value[1]")`, so a `null` and an empty-string password both interpolate to the same empty value and produce an identical `Authorization` header.

Ref: https://github.com/guzzle/guzzle/blob/7.15.1/src/Client.php#L1161-L1169

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/circleci-auth-deprecation)

_The latest successful build from `fix/circleci-auth-deprecation` will be used. If none is available, the link won't work._