### PR TITLE
Speed up recipient count and keep send unblocked

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/send-panel/send-panel.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/send-panel/send-panel.tsx
@@ -12,6 +12,7 @@ import { useRecipients } from '../shared/use-recipients';
 import { ScheduledDatePicker } from '../shared/scheduled-date-picker';
 import { ScheduleModeControls } from '../shared/schedule-mode-controls';
 import { RecipientsSelector } from '../shared/recipients-selector';
+import { hasNoRecipients } from '../shared/recipients-gating';
 import { store as emailEditorIntegrationStore } from '../store';
 import { useSendEmail } from './use-send-email';
 import { MAILPOET_EMAIL_POST_TYPE } from '../constants';
@@ -40,13 +41,18 @@ export function SendPanel() {
     totalRecipientCount,
     isLoadingSegments,
     isLoadingRecipientCount,
+    recipientCountFailed,
   } = recipients;
   const { sendEmail, isSending, error, clearError } = useSendEmail();
   const senderFields = useSenderFields();
   const { hasValidationErrors, validateSenderFields } = senderFields;
 
-  const hasNoRecipients =
-    !isLoadingSegments && !isLoadingRecipientCount && totalRecipientCount === 0;
+  const noRecipients = hasNoRecipients({
+    isLoadingSegments,
+    isLoadingRecipientCount,
+    recipientCountFailed,
+    totalRecipientCount,
+  });
 
   const handleSendTestEmail = useCallback(() => {
     if (postId) {
@@ -102,7 +108,7 @@ export function SendPanel() {
             variant="primary"
             size="compact"
             isBusy={isSending}
-            disabled={isSending || hasNoRecipients || hasValidationErrors}
+            disabled={isSending || noRecipients || hasValidationErrors}
             onClick={() => void handleSend()}
             data-automation-id="email_send_panel_send_button"
           >
@@ -171,7 +177,7 @@ export function SendPanel() {
             >
               {__('Send a test email', 'mailpoet')}
             </UiButton>
-            {hasNoRecipients && (
+            {noRecipients && (
               <Text
                 variant="body-sm"
                 className="mailpoet-send-panel__no-recipients"

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/recipients-gating.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/recipients-gating.ts
@@ -1,0 +1,23 @@
+export type RecipientsGatingState = {
+  isLoadingSegments: boolean;
+  isLoadingRecipientCount: boolean;
+  recipientCountFailed: boolean;
+  totalRecipientCount: number;
+};
+
+/**
+ * Whether the send flow should treat the selection as having no recipients.
+ *
+ * A failed or timed-out exact count must NOT gate sending — only a successful
+ * count of 0 means there are genuinely no recipients. While the count (or the
+ * segments) is still loading we also don't gate, to avoid a flash of the
+ * no-recipient state.
+ */
+export function hasNoRecipients(state: RecipientsGatingState): boolean {
+  return (
+    !state.isLoadingSegments &&
+    !state.isLoadingRecipientCount &&
+    !state.recipientCountFailed &&
+    state.totalRecipientCount === 0
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/recipients-selector.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/recipients-selector.tsx
@@ -1,4 +1,9 @@
-import { FormTokenField, RadioControl, Spinner } from '@wordpress/components';
+import {
+  FormTokenField,
+  RadioControl,
+  Spinner,
+  Tooltip,
+} from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import type { RecipientType, UseRecipients } from './use-recipients';
 
@@ -17,6 +22,7 @@ export function RecipientsSelector({
     setSelectedSegments,
     recipientCount,
     isLoadingRecipientCount,
+    recipientCountFailed,
     allCustomersSegmentCount,
   } = recipients;
 
@@ -25,6 +31,26 @@ export function RecipientsSelector({
   }
 
   const showSegmentField = !isWooActive || recipientType === 'segment';
+
+  let recipientCountContent: JSX.Element | string;
+  if (isLoadingRecipientCount) {
+    recipientCountContent = (
+      <Spinner className="mailpoet-status-panel__recipients-loader" />
+    );
+  } else if (recipientCountFailed) {
+    recipientCountContent = (
+      <Tooltip
+        text={__(
+          "We couldn't calculate the number of recipients. You can still send this email.",
+          'mailpoet',
+        )}
+      >
+        <span>{__('Unavailable', 'mailpoet')}</span>
+      </Tooltip>
+    );
+  } else {
+    recipientCountContent = (recipientCount ?? 0).toLocaleString();
+  }
 
   return (
     <>
@@ -72,12 +98,7 @@ export function RecipientsSelector({
             __experimentalShowHowTo={false}
           />
           <div className="mailpoet-status-panel__recipients-total-count">
-            {__('Total recipients: ', 'mailpoet')}{' '}
-            {isLoadingRecipientCount ? (
-              <Spinner className="mailpoet-status-panel__recipients-loader" />
-            ) : (
-              (recipientCount ?? 0).toLocaleString()
-            )}
+            {__('Total recipients: ', 'mailpoet')} {recipientCountContent}
           </div>
         </div>
       )}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/use-recipients.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/shared/use-recipients.ts
@@ -87,6 +87,7 @@ export type UseRecipients = {
   setSelectedSegments: (segmentNames: string[]) => void;
   recipientCount: number | null;
   isLoadingRecipientCount: boolean;
+  recipientCountFailed: boolean;
   allCustomersSegmentCount: number;
   recipientLabel: string;
   totalRecipientCount: number;
@@ -113,6 +114,7 @@ export function useRecipients(): UseRecipients {
   const [recipientType, setRecipientType] = useState<RecipientType>('segment');
   const [recipientCount, setRecipientCount] = useState<number | null>(null);
   const [isLoadingRecipientCount, setIsLoadingRecipientCount] = useState(false);
+  const [recipientCountFailed, setRecipientCountFailed] = useState(false);
 
   // Fetch segments on mount.
   useEffect(() => {
@@ -189,12 +191,14 @@ export function useRecipients(): UseRecipients {
   useEffect(() => {
     if (recipientType !== 'segment' || selectedSegmentIds.length === 0) {
       setRecipientCount(null);
+      setRecipientCountFailed(false);
       setIsLoadingRecipientCount(false);
       return undefined;
     }
 
     let mounted = true;
     setIsLoadingRecipientCount(true);
+    setRecipientCountFailed(false);
 
     void MailPoet.Ajax.post({
       api_version: window.mailpoet_api_version,
@@ -211,7 +215,10 @@ export function useRecipients(): UseRecipients {
       })
       .catch(() => {
         if (mounted) {
+          // Keep the send flow usable: a failed/timed-out exact count must not
+          // read as "zero recipients".
           setRecipientCount(null);
+          setRecipientCountFailed(true);
         }
       })
       .always(() => {
@@ -317,6 +324,7 @@ export function useRecipients(): UseRecipients {
     setSelectedSegments,
     recipientCount,
     isLoadingRecipientCount,
+    recipientCountFailed,
     allCustomersSegmentCount,
     recipientLabel,
     totalRecipientCount,

--- a/mailpoet/assets/js/src/newsletters/send/recipient-count.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/recipient-count.tsx
@@ -16,6 +16,7 @@ function configString(segmentIds: string[], filterSegmentId?: string) {
 export function RecipientCount(props: RecipientCountProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [recipientCount, setRecipientCount] = useState(0);
+  const [hasError, setHasError] = useState(false);
 
   const segmentIds = useMemo(
     () => (props.item.segments || []).map((segment) => segment.id),
@@ -36,6 +37,7 @@ export function RecipientCount(props: RecipientCountProps) {
 
     if (segmentIds.length < 1) {
       setRecipientCount(0);
+      setHasError(false);
       setIsLoading(false);
       return;
     }
@@ -44,11 +46,13 @@ export function RecipientCount(props: RecipientCountProps) {
       setRecipientCount(
         apiResponseCache.current[currentConfigString] as number,
       );
+      setHasError(false);
       setIsLoading(false);
       return;
     }
 
     setIsLoading(true);
+    setHasError(false);
     void MailPoet.Ajax.post({
       api_version: window.mailpoet_api_version,
       endpoint: 'segments',
@@ -67,6 +71,14 @@ export function RecipientCount(props: RecipientCountProps) {
           setRecipientCount(calculatedCount as number);
         }
       })
+      .fail(() => {
+        // Show an "Unavailable" label instead of dropping to zero, and don't
+        // cache the failure so a later selection change retries.
+        const configAfter = configString(segmentIds, filterSegmentId);
+        if (configBeforeRef.current === configAfter) {
+          setHasError(true);
+        }
+      })
       .always(() => setIsLoading(false));
   }, [segmentIds, filterSegmentId]);
 
@@ -80,7 +92,7 @@ export function RecipientCount(props: RecipientCountProps) {
           className="mailpoet-recipient-count-spinner"
         />
       )}
-      {!isLoading && (
+      {!isLoading && !hasError && (
         <>
           <Tooltip place="right" id="estimated-count-tooltip">
             {__('This count may change at the time of sending.', 'mailpoet')}
@@ -91,6 +103,23 @@ export function RecipientCount(props: RecipientCountProps) {
             className="estimated-recipient-count"
           >
             {recipientCount.toLocaleString()}
+          </span>
+        </>
+      )}
+      {!isLoading && hasError && (
+        <>
+          <Tooltip place="right" id="estimated-count-tooltip">
+            {__(
+              "We couldn't calculate the number of recipients. You can still send this email.",
+              'mailpoet',
+            )}
+          </Tooltip>
+          <span
+            data-tip
+            data-tooltip-id="estimated-count-tooltip"
+            className="estimated-recipient-count"
+          >
+            {__('Unavailable', 'mailpoet')}
           </span>
         </>
       )}

--- a/mailpoet/changelog/2026-07-03-14-23-39-improved-speed-up-the-recipient-count-on-the-send-screens-a.md
+++ b/mailpoet/changelog/2026-07-03-14-23-39-improved-speed-up-the-recipient-count-on-the-send-screens-a.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Speed up the recipient count on the send screens and keep sending available when the exact count can't be calculated

--- a/mailpoet/lib/API/JSON/v1/Segments.php
+++ b/mailpoet/lib/API/JSON/v1/Segments.php
@@ -21,6 +21,7 @@ use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SegmentSubscribersRepository;
 use MailPoet\Segments\WP;
 use MailPoet\Subscribers\SubscribersRepository;
+use Throwable;
 
 class Segments extends APIEndpoint {
   public $permissions = [
@@ -258,9 +259,26 @@ class Segments extends APIEndpoint {
         APIError::BAD_REQUEST => __('No segment IDs provided.', 'mailpoet'),
       ]);
     }
-    $filterSegmentId = $data['filterSegmentId'] ?? null;
+    // filterSegmentId arrives as a string (it can come straight from a URL query
+    // param). Empty and 0 mean "no filter segment"; anything else must be a valid
+    // positive segment id, otherwise the count would be silently wrong.
+    $filterSegmentId = null;
+    if (!empty($data['filterSegmentId'])) {
+      $filterSegmentId = filter_var($data['filterSegmentId'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+      if ($filterSegmentId === false) {
+        return $this->badRequest([
+          APIError::BAD_REQUEST => __('Invalid filter segment.', 'mailpoet'),
+        ]);
+      }
+    }
     $status = $data['status'] ?? SubscriberEntity::STATUS_SUBSCRIBED;
-    $response['count'] = $this->segmentSubscribersRepository->getSubscribersCountBySegmentIds($segmentIds, $status, $filterSegmentId);
+    try {
+      $response['count'] = $this->segmentSubscribersRepository->getSubscribersCountBySegmentIds($segmentIds, $status, $filterSegmentId);
+    } catch (Throwable $e) {
+      return $this->errorResponse([
+        APIError::UNKNOWN => __('The recipient count could not be calculated.', 'mailpoet'),
+      ], [], Response::STATUS_UNKNOWN);
+    }
 
     return $this->successResponse($response);
   }

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -21,6 +21,7 @@ use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscription\Pages;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\CarbonImmutable;
+use Throwable;
 
 class Shortcodes {
   const DEFAULT_ARCHIVE_LIMIT = 100;
@@ -168,9 +169,13 @@ class Shortcodes {
         $this->subscribersRepository->countBy(['status' => SubscriberEntity::STATUS_SUBSCRIBED, 'deletedAt' => null])
       );
     } else {
-      return $this->wp->numberFormatI18n(
-        $this->segmentSubscribersRepository->getSubscribersCountBySegmentIds($segmentIds, SubscriberEntity::STATUS_SUBSCRIBED)
-      );
+      // A failed count must not break rendering of the email/shortcode.
+      try {
+        $count = $this->segmentSubscribersRepository->getSubscribersCountBySegmentIds($segmentIds, SubscriberEntity::STATUS_SUBSCRIBED);
+      } catch (Throwable $e) {
+        $count = 0;
+      }
+      return $this->wp->numberFormatI18n($count);
     }
   }
 

--- a/mailpoet/lib/Segments/SegmentSubscribersRepository.php
+++ b/mailpoet/lib/Segments/SegmentSubscribersRepository.php
@@ -65,7 +65,7 @@ class SegmentSubscribersRepository {
   public function getSubscribersCountBySegmentIds(array $segmentIds, ?string $status = null, ?int $filterSegmentId = null): int {
     $segments = $this->segmentsRepository->findByIds($segmentIds);
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    $queryBuilder = $this->createCountQueryBuilder();
+    $queryBuilder = $this->entityManager->getConnection()->createQueryBuilder();
 
     $subQueries = [];
     foreach ($segments as $segment) {
@@ -89,12 +89,13 @@ class SegmentSubscribersRepository {
       $subQueries[] = $segmentQb->getSQL();
     }
 
-    $queryBuilder->innerJoin(
-      $subscribersTable,
-      sprintf('(%s)', join(' UNION ', $subQueries)),
-      'inner_subscribers',
-      "inner_subscribers.inner_id = {$subscribersTable}.id"
-    );
+    // No resolvable segments (e.g. all ids stale/deleted) means no recipients;
+    // bail before building an empty `FROM ()` that would be invalid SQL.
+    if (empty($subQueries)) {
+      return 0;
+    }
+
+    $unionSubquery = sprintf('(%s)', join(' UNION ', $subQueries));
 
     try {
       if (is_int($filterSegmentId)) {
@@ -103,12 +104,21 @@ class SegmentSubscribersRepository {
         $filterSegmentQb->select("{$subscribersTable}.id AS filter_segment_subscriber_id");
         $filterSegmentQb = $this->filterSubscribersInDynamicSegment($filterSegmentQb, $filterSegment, $status);
         $queryBuilder->setParameters(array_merge($filterSegmentQb->getParameters(), $queryBuilder->getParameters()), array_merge($filterSegmentQb->getParameterTypes(), $queryBuilder->getParameterTypes()));
-        $queryBuilder->innerJoin(
-          $subscribersTable,
-          sprintf('(%s)', $filterSegmentQb->getSQL()),
-          'filter_segment',
-          "filter_segment.filter_segment_subscriber_id = {$subscribersTable}.id"
-        );
+        // COUNT(DISTINCT) to stay correct even if the filter-segment subquery
+        // ever yields the same subscriber id more than once.
+        $queryBuilder
+          ->select('COUNT(DISTINCT inner_subscribers.inner_id)')
+          ->from($unionSubquery, 'inner_subscribers')
+          ->innerJoin(
+            'inner_subscribers',
+            sprintf('(%s)', $filterSegmentQb->getSQL()),
+            'filter_segment',
+            'filter_segment.filter_segment_subscriber_id = inner_subscribers.inner_id'
+          );
+      } else {
+        $queryBuilder
+          ->select('COUNT(*)')
+          ->from($unionSubquery, 'inner_subscribers');
       }
     } catch (InvalidStateException $exception) {
       return 0;
@@ -121,7 +131,7 @@ class SegmentSubscribersRepository {
       return (int)$result;
     } catch (Throwable $e) {
       $this->logQueryException(null, $e);
-      return 0;
+      throw $e;
     }
   }
 

--- a/mailpoet/tests/integration/API/JSON/v1/SegmentsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SegmentsTest.php
@@ -12,6 +12,10 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Segments\SegmentSubscribersRepository;
+use MailPoet\Test\DataFactories\DynamicSegment;
+use MailPoet\Test\DataFactories\Segment as SegmentFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 
 class SegmentsTest extends \MailPoetTest {
   /** @var SegmentEntity */
@@ -249,6 +253,56 @@ class SegmentsTest extends \MailPoetTest {
       $this->responseBuilder->build($segment)
     );
     verify($response->meta['count'])->equals(1);
+  }
+
+  public function testSubscriberCountReturnsErrorWhenTheCountFails(): void {
+    $throwingRepository = $this->createMock(SegmentSubscribersRepository::class);
+    $throwingRepository
+      ->method('getSubscribersCountBySegmentIds')
+      ->willThrowException(new \RuntimeException('Query failed'));
+    $endpoint = $this->getServiceWithOverrides(Segments::class, [
+      'segmentSubscribersRepository' => $throwingRepository,
+    ]);
+
+    $response = $endpoint->subscriberCount(['segmentIds' => [$this->segment1->getId()]]);
+
+    // The frontend relies on this 500 to show "Unavailable" instead of gating
+    // the send on a misleading zero.
+    verify($response->status)->equals(APIResponse::STATUS_UNKNOWN);
+  }
+
+  public function testSubscriberCountAppliesFilterSegmentPassedAsString(): void {
+    $segment = (new SegmentFactory())->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    (new SubscriberFactory())->withEngagementScore(50)->withSegments([$segment])->create();
+    (new SubscriberFactory())->withEngagementScore(30)->withSegments([$segment])->create();
+    $filterSegment = (new DynamicSegment())->withEngagementScoreFilter(40, 'higherThan')->create();
+    $this->assertIsInt($segment->getId());
+    $this->assertIsInt($filterSegment->getId());
+
+    // The frontend sends ids as strings (filterSegmentId can come from a URL
+    // param); the endpoint must still apply the filter, not silently ignore it.
+    $response = $this->endpoint->subscriberCount([
+      'segmentIds' => [(string)$segment->getId()],
+      'filterSegmentId' => (string)$filterSegment->getId(),
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    // Only the engagement-50 subscriber is in the list AND the filter segment.
+    verify($response->data['count'])->equals(1);
+  }
+
+  public function testSubscriberCountRejectsInvalidFilterSegmentId(): void {
+    $segment = (new SegmentFactory())->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $this->assertIsInt($segment->getId());
+
+    // A non-integer filter segment must be rejected, not silently coerced to a
+    // wrong count.
+    $response = $this->endpoint->subscriberCount([
+      'segmentIds' => [(string)$segment->getId()],
+      'filterSegmentId' => 'not-a-number',
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
   }
 
   private function createForm(string $formName, array $settings) {

--- a/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
@@ -152,8 +152,8 @@ class SegmentSubscribersRepositoryTest extends \MailPoetTest {
   }
 
   public function testGetSubscribersCountBySegmentIds(): void {
-    $segmentOne = $this->segmentRepository->createOrUpdate('Segment' . rand(0, 10000));
-    $segmentTwo = $this->segmentRepository->createOrUpdate('Segment' . rand(0, 10000));
+    $segmentOne = $this->segmentRepository->createOrUpdate('Segment' . bin2hex(random_bytes(7)));
+    $segmentTwo = $this->segmentRepository->createOrUpdate('Segment' . bin2hex(random_bytes(7)));
 
     $subscriberOne = $this->createSubscriberEntity();
     $subscriberTwo = $this->createSubscriberEntity();
@@ -209,6 +209,50 @@ class SegmentSubscribersRepositoryTest extends \MailPoetTest {
       $dynamicSegmentTwo->getId(),
     ]);
     verify($count)->equals(6);
+  }
+
+  public function testGetSubscribersCountDeduplicatesSubscribersInMultipleSegments(): void {
+    $segmentOne = $this->segmentRepository->createOrUpdate('Segment' . bin2hex(random_bytes(7)));
+    $segmentTwo = $this->segmentRepository->createOrUpdate('Segment' . bin2hex(random_bytes(7)));
+
+    $sharedSubscriber = $this->createSubscriberEntity();
+    $onlyInSegmentOne = $this->createSubscriberEntity();
+
+    // The shared subscriber belongs to both selected lists.
+    $this->createSubscriberSegmentEntity($segmentOne, $sharedSubscriber);
+    $this->createSubscriberSegmentEntity($segmentTwo, $sharedSubscriber);
+    $this->createSubscriberSegmentEntity($segmentOne, $onlyInSegmentOne);
+    $this->entityManager->flush();
+
+    // The shared subscriber must be counted once, not once per list.
+    $count = $this->repository->getSubscribersCountBySegmentIds([$segmentOne->getId(), $segmentTwo->getId()]);
+    verify($count)->equals(2);
+  }
+
+  public function testGetSubscribersCountReturnsZeroForNonexistentSegments(): void {
+    // No resolvable segments must yield 0, not an invalid empty-UNION query.
+    $count = $this->repository->getSubscribersCountBySegmentIds([999999]);
+    verify($count)->equals(0);
+  }
+
+  public function testGetSubscribersCountDeduplicatesAcrossStaticAndDynamicSegments(): void {
+    $staticSegment = (new SegmentFactory())->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $dynamicSegment = (new DynamicSegment())->withEngagementScoreFilter(40, 'higherThan')->create();
+    $this->assertIsInt($staticSegment->getId());
+    $this->assertIsInt($dynamicSegment->getId());
+
+    // Shared subscriber: matches the dynamic segment (engagement > 40) and is a
+    // member of the static list.
+    (new SubscriberFactory())->withEngagementScore(50)->withSegments([$staticSegment])->create();
+    // Only matches the dynamic segment.
+    (new SubscriberFactory())->withEngagementScore(60)->create();
+
+    // The static list's only member already matches the dynamic segment, so
+    // selecting both must count it once, not twice.
+    $dynamicOnly = $this->repository->getSubscribersCountBySegmentIds([$dynamicSegment->getId()]);
+    $combined = $this->repository->getSubscribersCountBySegmentIds([$staticSegment->getId(), $dynamicSegment->getId()]);
+    verify($dynamicOnly)->equals(2);
+    verify($combined)->equals(2);
   }
 
   public function testSubscriberCountCanBeFilteredByDynamicSegment(): void {

--- a/mailpoet/tests/javascript/mailpoet-email-editor-integration/recipients-gating.spec.ts
+++ b/mailpoet/tests/javascript/mailpoet-email-editor-integration/recipients-gating.spec.ts
@@ -1,0 +1,55 @@
+import {
+  hasNoRecipients,
+  RecipientsGatingState,
+} from '../../../assets/js/src/mailpoet-email-editor-integration/shared/recipients-gating';
+
+const baseState: RecipientsGatingState = {
+  isLoadingSegments: false,
+  isLoadingRecipientCount: false,
+  recipientCountFailed: false,
+  totalRecipientCount: 5,
+};
+
+describe('send-panel recipient gating', () => {
+  it('does not gate sending when there are recipients', () => {
+    expect(hasNoRecipients({ ...baseState, totalRecipientCount: 5 })).to.equal(
+      false,
+    );
+  });
+
+  it('gates sending on a successful count of zero', () => {
+    expect(hasNoRecipients({ ...baseState, totalRecipientCount: 0 })).to.equal(
+      true,
+    );
+  });
+
+  it('does not gate sending when the count request failed, even at zero', () => {
+    expect(
+      hasNoRecipients({
+        ...baseState,
+        totalRecipientCount: 0,
+        recipientCountFailed: true,
+      }),
+    ).to.equal(false);
+  });
+
+  it('does not gate sending while the recipient count is loading', () => {
+    expect(
+      hasNoRecipients({
+        ...baseState,
+        totalRecipientCount: 0,
+        isLoadingRecipientCount: true,
+      }),
+    ).to.equal(false);
+  });
+
+  it('does not gate sending while segments are loading', () => {
+    expect(
+      hasNoRecipients({
+        ...baseState,
+        totalRecipientCount: 0,
+        isLoadingSegments: true,
+      }),
+    ).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Description

This PR improves fetching the live subscribers count on sites with a large number of subscribers. These numbers are shown when the user selects lists for sending.

The issue was that on large sites, the request timed out and the count was resolved as 0, and sending was blocked even though sending was possible.

This PR addresses it by:

1) Improving SQL for fetching subscriber count
2) In case of a timeout, we now render that count as `Unavailable` but still allow it to trigger sending.

It is addressed on the Send page and also in the send sidebar of the block editor.

Scope note: `STOMAIL-8216` was originally an approximate cached-count fallback. After benchmarking (the recent `segment_id_status` index makes the exact static-list count index-only, and an approximate per-segment count overcounts on overlapping lists), we shipped the perf + resilience subset instead of the fallback.

## Code review notes

- **Why the outer join is safe to drop:** each per-segment subquery already `INNER JOIN`s `subscribers` and filters `deleted_at IS NULL`, so every `inner_id` in the `UNION` is a valid subscriber. The old outer `COUNT(DISTINCT subscribers.id)` join added nothing but the scan. `UNION` (not `UNION ALL`) dedups across segments, so `COUNT(*)` is exact; the filter-segment path keeps `COUNT(DISTINCT)` in case that subquery ever yields a subscriber twice.
- **Error-contract change is intentional and split.** The repository now logs and **rethrows** instead of returning `0`; `Segments::subscriberCount()` maps that to a 500, while `Shortcodes::getSubscribersCount()` keeps `0`-on-failure. The frontend's "Unavailable / don't gate" behavior depends on the API actually 500-ing — there's a test locking that contract in.
- **No `FORCE INDEX`.** Benchmarks showed MariaDB mis-picks the non-covering unique key on `subscriber_segment` at scale, but a hint is engine-specific and fragile, so it's deliberately omitted.
- `hasNoRecipients()` is extracted into `shared/recipients-gating.ts` so the send-gating decision is unit-testable without mounting the whole `SendPanel`.

## QA notes

- On either surface, pick one or more lists → the exact count appears.
- **Block editor:** with recipients selected the Send button is enabled; pick a genuinely empty list → count shows `0` and Send is disabled.
- **Failure path:** simulate a failed/timed-out count (e.g. block the `subscriberCount` request in devtools) → the count shows **"Unavailable"**, and in the block editor **Send stays enabled**.

## Linked PRs

_N/A_

## Linked tickets

- [STOMAIL-8216](https://linear.app/a8c/issue/STOMAIL-8216/fallback-to-approximate-recipient-counts-when-exact-send-count-times)

## After-merge notes

Update STOMAIL-8216 to reflect the descope (perf + resilience shipped; approximate-count fallback intentionally not implemented).

## Screenshots or screencast

Cropped to the recipients input + count for each state.

| State | Block editor (send panel) | Legacy send page |
| --- | --- | --- |
| **Recipients loading** | <img width="565" height="480" alt="block-editor-3-loading" src="https://github.com/user-attachments/assets/db40ebe3-03f1-4c99-b131-1e09eb4cd4b0" /> | <img width="800" height="520" alt="legacy-3-loading" src="https://github.com/user-attachments/assets/3f184aeb-0b39-485c-b951-506ee54a71f8" />|
| **Exact count** |<img width="565" height="480" alt="block-editor-1-correct" src="https://github.com/user-attachments/assets/0a38c4d6-aea7-43fa-8406-84bb29324e18" /> |<img width="800" height="420" alt="legacy-1-correct" src="https://github.com/user-attachments/assets/9a81eb5a-c3f8-461f-aadb-c45bfefece1a" /> |
| **Count unavailable** (request failed / timed out) | <img width="565" height="480" alt="block-editor-2-failed" src="https://github.com/user-attachments/assets/f9476178-d2d0-42fe-b91e-8f95cc9f3c05" /> |<img width="800" height="420" alt="legacy-2-failed" src="https://github.com/user-attachments/assets/ad14973a-791f-4845-bee8-08dbab61d061" /> |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:improve/live-list-count)

_The latest successful build from `improve/live-list-count` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->