### PR TITLE
Encode subscriber name and email in personalization tags and shortcodes

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Subscriber.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Subscriber.php
@@ -32,18 +32,20 @@ class Subscriber {
 
   public function getFirstName(array $context, array $args = []): string {
     $subscriber = $this->getSubscriber($context);
+    $value = ($subscriber && $subscriber->getFirstName()) ? $subscriber->getFirstName() : ($args['default'] ?? '');
 
-    return ($subscriber && $subscriber->getFirstName()) ? $subscriber->getFirstName() : $args['default'] ?? '';
+    return htmlspecialchars($value, self::HTML_ENTITY_FLAGS);
   }
 
   public function getLastName(array $context, array $args = []): string {
     $subscriber = $this->getSubscriber($context);
+    $value = ($subscriber && $subscriber->getLastName()) ? $subscriber->getLastName() : ($args['default'] ?? '');
 
-    return ($subscriber && $subscriber->getLastName()) ? $subscriber->getLastName() : $args['default'] ?? '';
+    return htmlspecialchars($value, self::HTML_ENTITY_FLAGS);
   }
 
   public function getEmail(array $context, array $args = []): string {
-    return $context['recipient_email'] ?? '';
+    return htmlspecialchars($context['recipient_email'] ?? '', self::HTML_ENTITY_FLAGS);
   }
 
   public function getActivationLink(array $context, array $args = []): string {
@@ -60,12 +62,12 @@ class Subscriber {
     $default = $args['default'] ?? '';
     $subscriber = $this->getSubscriber($context);
     if (!$subscriber || !$subscriber->getWpUserId()) {
-      return $default;
+      return htmlspecialchars($default, self::HTML_ENTITY_FLAGS);
     }
 
     $wpUser = $this->wp->getUserdata($subscriber->getWpUserId());
 
-    return ($wpUser instanceof \WP_User) ? $wpUser->display_name : $default; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    return ($wpUser instanceof \WP_User) ? (string)$wpUser->display_name : htmlspecialchars($default, self::HTML_ENTITY_FLAGS); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
   public function getCount(array $context, array $args = []): string {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Subscriber.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Subscriber.php
@@ -59,15 +59,16 @@ class Subscriber {
   }
 
   public function getDisplayName(array $context, array $args = []): string {
-    $default = $args['default'] ?? '';
+    $value = $args['default'] ?? '';
     $subscriber = $this->getSubscriber($context);
-    if (!$subscriber || !$subscriber->getWpUserId()) {
-      return htmlspecialchars($default, self::HTML_ENTITY_FLAGS);
+    if ($subscriber && $subscriber->getWpUserId()) {
+      $wpUser = $this->wp->getUserdata($subscriber->getWpUserId());
+      if ($wpUser instanceof \WP_User) {
+        $value = (string)$wpUser->display_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      }
     }
 
-    $wpUser = $this->wp->getUserdata($subscriber->getWpUserId());
-
-    return ($wpUser instanceof \WP_User) ? (string)$wpUser->display_name : htmlspecialchars($default, self::HTML_ENTITY_FLAGS); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    return htmlspecialchars($value, self::HTML_ENTITY_FLAGS, 'UTF-8', false);
   }
 
   public function getCount(array $context, array $args = []): string {

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
@@ -48,17 +48,17 @@ class Subscriber implements CategoryInterface {
       '';
     switch ($shortcodeDetails['action']) {
       case 'firstname':
-        return (!empty($subscriber->getFirstName())) ? htmlspecialchars($subscriber->getFirstName(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401) : $defaultValue;
+        return htmlspecialchars((!empty($subscriber->getFirstName())) ? $subscriber->getFirstName() : $defaultValue, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
       case 'lastname':
-        return !empty($subscriber->getLastName()) ? htmlspecialchars($subscriber->getLastName(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401) : $defaultValue;
+        return htmlspecialchars(!empty($subscriber->getLastName()) ? $subscriber->getLastName() : $defaultValue, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
       case 'email':
-        return $subscriber->getEmail();
+        return htmlspecialchars((string)$subscriber->getEmail(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
       case 'displayname':
         if ($subscriber->getWpUserId()) {
           $wpUser = WPFunctions::get()->getUserdata($subscriber->getWpUserId());
-          return $wpUser->display_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+          return (string)$wpUser->display_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
         }
-        return $defaultValue;
+        return htmlspecialchars($defaultValue, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
       case 'count':
         return (string)$this->getSubscribersCountWithSubscribedStatus();
       default:

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
@@ -56,7 +56,9 @@ class Subscriber implements CategoryInterface {
       case 'displayname':
         if ($subscriber->getWpUserId()) {
           $wpUser = WPFunctions::get()->getUserdata($subscriber->getWpUserId());
-          return (string)$wpUser->display_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+          if ($wpUser instanceof \WP_User) {
+            return htmlspecialchars((string)$wpUser->display_name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8', false); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+          }
         }
         return htmlspecialchars($defaultValue, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
       case 'count':

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -233,8 +233,8 @@ class SubscriberSaveController {
     }
 
     if (isset($data['email'])) $subscriber->setEmail($data['email']);
-    if (isset($data['first_name'])) $subscriber->setFirstName($data['first_name']);
-    if (isset($data['last_name'])) $subscriber->setLastName($data['last_name']);
+    if (isset($data['first_name'])) $subscriber->setFirstName(sanitize_text_field($data['first_name']));
+    if (isset($data['last_name'])) $subscriber->setLastName(sanitize_text_field($data['last_name']));
     if (isset($data['status'])) $subscriber->setStatus($data['status']);
     if (isset($data['tracking_consent'])) {
       $subscriber->setTrackingConsent(

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/SubscriberTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/SubscriberTest.php
@@ -118,4 +118,69 @@ class SubscriberTest extends \MailPoetTest {
     $expected = $this->wp->dateI18n('F j', (int)strtotime('2010-04-20 00:00:00'));
     $this->assertSame($expected, $result);
   }
+
+  public function testItEncodesFirstNameSpecialCharacters(): void {
+    $subscriber = (new SubscriberFactory())
+      ->withEmail('encode-first@example.com')
+      ->withFirstName('<script>alert(1)</script>')
+      ->create();
+
+    $result = $this->subscriber->getFirstName(
+      ['recipient_email' => $subscriber->getEmail()],
+      ['default' => 'member']
+    );
+
+    $this->assertSame('&lt;script&gt;alert(1)&lt;/script&gt;', $result);
+  }
+
+  public function testItEncodesLastNameSpecialCharacters(): void {
+    $subscriber = (new SubscriberFactory())
+      ->withEmail('encode-last@example.com')
+      ->withLastName('"><b>x</b>')
+      ->create();
+
+    $result = $this->subscriber->getLastName(
+      ['recipient_email' => $subscriber->getEmail()],
+      ['default' => 'member']
+    );
+
+    $this->assertSame('&quot;&gt;&lt;b&gt;x&lt;/b&gt;', $result);
+  }
+
+  public function testItEncodesEmailSpecialCharacters(): void {
+    $result = $this->subscriber->getEmail(
+      ['recipient_email' => '"><b>@example.com'],
+      []
+    );
+
+    $this->assertSame('&quot;&gt;&lt;b&gt;@example.com', $result);
+  }
+
+  public function testItEncodesDisplayNameSpecialCharacters(): void {
+    wp_create_user('mailpoet_encode_display', 'pass', 'encode-display@example.com');
+    $wpUser = get_user_by('login', 'mailpoet_encode_display');
+    $this->assertInstanceOf(\WP_User::class, $wpUser);
+    wp_update_user(['ID' => $wpUser->ID, 'display_name' => 'Boss & Co']);
+
+    $subscriber = (new SubscriberFactory())
+      ->withEmail('sub-encode-display@example.com')
+      ->withWpUserId((int)$wpUser->ID)
+      ->create();
+
+    $result = $this->subscriber->getDisplayName(
+      ['recipient_email' => $subscriber->getEmail()],
+      ['default' => 'member']
+    );
+
+    $this->assertSame('Boss &amp; Co', $result);
+  }
+
+  public function testItEncodesTheDefaultFallbackValue(): void {
+    $result = $this->subscriber->getFirstName(
+      ['recipient_email' => 'no-such-subscriber@example.com'],
+      ['default' => 'Tom & Jerry']
+    );
+
+    $this->assertSame('Tom &amp; Jerry', $result);
+  }
 }

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -229,6 +229,18 @@ class ShortcodesTest extends \MailPoetTest {
     verify($result[0])->equals(' &quot;&gt;&lt;img src=x onError=prompt(2)&gt;');
   }
 
+  public function testSanitizeEmailAndDisplayName() {
+    $subscriber = $this->subscriber;
+    $subscriber->setEmail('"><img src=x>@example.com');
+    $result = $this->shortcodesObject->process(['[subscriber:email]']);
+    verify($result[0])->equals('&quot;&gt;&lt;img src=x&gt;@example.com');
+
+    wp_update_user(['ID' => $this->wPUser->ID, 'display_name' => 'x & y']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $subscriber->setWpUserId((int)$this->wPUser->ID); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $result = $this->shortcodesObject->process(['[subscriber:displayname | default:test]']);
+    verify($result[0])->equals('x &amp; y');
+  }
+
   public function testItCanProcessSubscriberShortcodes() {
     $shortcodesObject = $this->shortcodesObject;
     $result =

--- a/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
@@ -334,6 +334,28 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
     $this->assertSame(2, $count); // @phpstan-ignore-line -- PHPStan doesn't get the $count side effect
   }
 
+  public function testItSanitizesFirstAndLastNameOnCreate(): void {
+    $subscriber = $this->saveController->createOrUpdate([
+      'email' => 'sanitize-name@example.com',
+      'first_name' => '<script>alert(1)</script>John',
+      'last_name' => '  Doe<img src=x>  ',
+    ], null);
+
+    verify($subscriber->getFirstName())->equals('John');
+    verify($subscriber->getLastName())->equals('Doe');
+  }
+
+  public function testItPreservesLegitimateNameCharacters(): void {
+    $subscriber = $this->saveController->createOrUpdate([
+      'email' => 'legit-name@example.com',
+      'first_name' => 'Tom & Jerry',
+      'last_name' => "O'Brien-José",
+    ], null);
+
+    verify($subscriber->getFirstName())->equals('Tom & Jerry');
+    verify($subscriber->getLastName())->equals("O'Brien-José");
+  }
+
   private function createSubscriber(string $email, string $status): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($email);


### PR DESCRIPTION
### What

Subscriber first name, last name, email, and WP user display names are now HTML-encoded when they are rendered through the email editor personalization tags and the classic newsletter shortcodes. Values that contain characters like `<`, `>`, `&` or `"` now display correctly instead of being interpreted as markup. The fallback default values are encoded the same way.

On the input side, subscriber first and last names are run through `sanitize_text_field` in the shared save path, so submitted names are cleaned regardless of the front-end. Legitimate characters (ampersands, apostrophes, accents, hyphens) are preserved.

### Testing

- Added integration tests for the encoded tag/shortcode output, the encoded default fallback, and the name sanitization on save (including a check that legitimate characters are kept intact).
- `./do test:integration` for the touched files, `phpcs`, and `phpstan` all pass.

Ref: STOMAIL-8309

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:encode-subscriber-personalization-output)

_The latest successful build from `encode-subscriber-personalization-output` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->