### PR TITLE
Avoid reading user locale before plugins_loaded

### DIFF
--- a/mailpoet/changelog/2026-07-23-04-34-10-fixed-fatal-error-that-could-occur-on-php-8-when-mailpoe.md
+++ b/mailpoet/changelog/2026-07-23-04-34-10-fixed-fatal-error-that-could-occur-on-php-8-when-mailpoe.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fatal error that could occur on PHP 8 when MailPoet is network activated on a WordPress multisite

--- a/mailpoet/lib/Config/Localizer.php
+++ b/mailpoet/lib/Config/Localizer.php
@@ -26,9 +26,18 @@ class Localizer {
   }
 
   public function locale() {
+    // Reading the user locale resolves the current user. Before 'plugins_loaded'
+    // (e.g. when network activated on multisite) the auth cookie constants may
+    // not be defined yet, and resolving the user fatals on PHP 8 if pluggable.php
+    // was already loaded by another early component. Fall back to the site
+    // locale; Initializer::setupUserLocale() switches to the user locale on
+    // 'wp_loaded'.
+    $defaultLocale = WPFunctions::get()->didAction('plugins_loaded')
+      ? WPFunctions::get()->getUserLocale()
+      : WPFunctions::get()->getLocale();
     $locale = WPFunctions::get()->applyFilters(
       'plugin_locale',
-      WPFunctions::get()->getUserLocale(),
+      $defaultLocale,
       Env::$pluginName
     );
     return $locale;

--- a/mailpoet/tests/unit/Config/LocalizerTest.php
+++ b/mailpoet/tests/unit/Config/LocalizerTest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Config;
+
+use MailPoet\WP\Functions as WPFunctions;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class LocalizerTest extends \MailPoetUnitTest {
+  /** @var WPFunctions & MockObject */
+  private $wpFunctions;
+
+  public function _before() {
+    parent::_before();
+    $this->wpFunctions = $this->createMock(WPFunctions::class);
+    WPFunctions::set($this->wpFunctions);
+  }
+
+  public function _after() {
+    WPFunctions::set(new WPFunctions());
+    parent::_after();
+  }
+
+  public function testItUsesSiteLocaleBeforePluginsLoaded(): void {
+    $this->wpFunctions->expects($this->once())
+      ->method('didAction')
+      ->with('plugins_loaded')
+      ->willReturn(0);
+    $this->wpFunctions->expects($this->once())
+      ->method('getLocale')
+      ->willReturn('fr_FR');
+    // Reading the user locale before 'plugins_loaded' can fatal when the
+    // plugin is network activated on multisite (see Localizer::locale()).
+    $this->wpFunctions->expects($this->never())
+      ->method('getUserLocale');
+    $this->wpFunctions->expects($this->once())
+      ->method('applyFilters')
+      ->with('plugin_locale', 'fr_FR', $this->anything())
+      ->willReturnArgument(1);
+
+    $this->assertSame('fr_FR', (new Localizer())->locale());
+  }
+
+  public function testItUsesUserLocaleAfterPluginsLoaded(): void {
+    $this->wpFunctions->expects($this->once())
+      ->method('didAction')
+      ->with('plugins_loaded')
+      ->willReturn(1);
+    $this->wpFunctions->expects($this->once())
+      ->method('getUserLocale')
+      ->willReturn('de_DE');
+    $this->wpFunctions->expects($this->never())
+      ->method('getLocale');
+    $this->wpFunctions->expects($this->once())
+      ->method('applyFilters')
+      ->with('plugin_locale', 'de_DE', $this->anything())
+      ->willReturnArgument(1);
+
+    $this->assertSame('de_DE', (new Localizer())->locale());
+  }
+
+  public function testItAppliesThePluginLocaleFilter(): void {
+    $this->wpFunctions->method('didAction')->willReturn(1);
+    $this->wpFunctions->method('getUserLocale')->willReturn('de_DE');
+    $this->wpFunctions->expects($this->once())
+      ->method('applyFilters')
+      ->with('plugin_locale', 'de_DE', $this->anything())
+      ->willReturn('ja');
+
+    $this->assertSame('ja', (new Localizer())->locale());
+  }
+}


### PR DESCRIPTION
## Description

When MailPoet is network activated on a multisite, the plugin file is included during the network plugins phase of `wp-settings.php`, before WordPress defines the auth cookie constants. MailPoet loads its translations at include time, and `Localizer::locale()` calls `get_user_locale()`, which resolves the current user.

On a stock install, this is harmless because `pluggable.php` (which defines `wp_get_current_user()`) only loads after all plugins, and core's `get_user_locale()` falls back to the site locale when that function does not exist. However, when another early component (a mu-plugin, a drop-in, or another network plugin) has already loaded `pluggable.php`, resolving the current user validates the auth cookie and reads a cookie constant that is not defined yet. On PHP 7, this was a silent warning; on PHP 8, it is a fatal `Error` on every request. This is exactly the setup reported in the linked ticket.

The fix makes `Localizer::locale()` use the user locale only after `plugins_loaded` has fired, and the site locale before that. This is effectively a no-op on standard installs: at include time, core's own `function_exists` guard already made `get_user_locale()` return the site locale anyway, and the existing `Initializer::setupUserLocale()` callback on `wp_loaded` still reloads translations with the user locale when it differs.

## Code review notes

The alternative of moving the whole `setupLocalizer()` call to the `init` hook (which is the WordPress 6.7+ guidance for translation loading) was considered but rejected for this fix, as it has a much larger blast radius for strings rendered between plugin load and `init`. The guard closes the fatal with no practical behavior change.

The root cause analysis, a scan of all other include-time code paths (this call site is the only unconditional current-user read during include), and the verification experiments are documented in the linked ticket.

## QA notes

The fatal needs an unusual environment: multisite, network activation, PHP 8, and a component that loads `pluggable.php` before network plugins. It was reproduced and the fix verified in an isolated environment (PHP 8.3.32, latest WordPress) as follows.

1. Install a multisite: `wp core multisite-install`.
2. Network activate MailPoet: `wp plugin activate mailpoet --network`.
3. Add an mu-plugin that simulates the early `pluggable.php` load:
   ```php
   require ABSPATH . WPINC . '/pluggable.php';
   ```
4. Load any page of the site (front end or wp-admin). The fatal error happens while WordPress is still loading network plugins, before any page logic runs, so every request that executes PHP hits it.

Before this fix, step 4 produces the fatal below (over HTTPS the constant is `SECURE_AUTH_COOKIE`, matching the merchant's trace):

```
PHP Fatal error: Uncaught Error: Undefined constant "AUTH_COOKIE" in wp-includes/pluggable.php:1030
...
#6 plugins/mailpoet/lib/WP/Functions.php(393): get_user_locale(0)
#7 plugins/mailpoet/lib/Config/Localizer.php(31): MailPoet\WP\Functions->getUserLocale()
...
#14 wp-settings.php(520): include_once(...)
```

With this fix, step 4 completes normally. Removing the mu-plugin or switching to per-site activation also avoids the fatal on the unpatched code, confirming the mechanism.

Regression coverage on a normal single-site setup was verified manually with this branch: with the site language set to French, MailPoet admin pages render with French strings; with an admin user whose profile language differs from the site language (tested in both directions: French site with an English profile, and English site with a French profile), the MailPoet admin pages follow the profile language, confirming the `wp_loaded` reload path still works.

## Linked tickets

STOMAIL-8314

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8314-early-user-locale-read)

_The latest successful build from `fix/stomail-8314-early-user-locale-read` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->