### PR TITLE
Bump minimum WooCommerce to 10.9, tested up to 11.0

### DIFF
--- a/mailpoet/changelog/2026-07-23-06-17-40-updated-bump-the-minimum-required-woocommerce-version-to-1.md
+++ b/mailpoet/changelog/2026-07-23-06-17-40-updated-bump-the-minimum-required-woocommerce-version-to-1.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Bump the minimum required WooCommerce version to 10.9 and tested up to version to 11.0

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,8 +11,8 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 10.8
- * WC tested up to: 10.9
+ * WC requires at least: 10.9
+ * WC tested up to: 11.0
  *
  * @package WordPress
  * @author MailPoet
@@ -28,7 +28,7 @@ $mailpoetPlugin = [
 ];
 
 const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.9'; // L-1 version, not the latest
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.8'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.9'; // L-1 version, not the latest
 
 
 // Display WP version error notice


### PR DESCRIPTION
## Description

This PR bumps the minimum required WooCommerce to 10.9 and tested up to 11.0.

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/wc-compatibility)

_The latest successful build from `update/wc-compatibility` will be used. If none is available, the link won't work._