### PR TITLE
Reject out-of-range page in tags REST listing

### DIFF
--- a/mailpoet/lib/Tags/RestApi/Endpoints/TagsGetEndpoint.php
+++ b/mailpoet/lib/Tags/RestApi/Endpoints/TagsGetEndpoint.php
@@ -27,6 +27,10 @@ class TagsGetEndpoint extends TagsEndpoint {
   }
 
   public function handle(Request $request): Response {
+    // Reject out-of-range pagination up front (e.g. a page beyond MAX_PAGE),
+    // otherwise a huge page overflows the SQL offset and surfaces as a 500.
+    $this->validatePagination($request);
+
     $search = is_string($request->getParam('search')) ? (string)$request->getParam('search') : '';
     $orderby = is_string($request->getParam('orderby')) ? (string)$request->getParam('orderby') : 'name';
     $order = is_string($request->getParam('order')) ? (string)$request->getParam('order') : 'asc';

--- a/mailpoet/tests/integration/REST/Tags/TagsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Tags/TagsEndpointsTest.php
@@ -147,6 +147,14 @@ class TagsEndpointsTest extends Test {
     $this->assertSame(400, $data['data']['status']);
   }
 
+  public function testGetRejectsOutOfRangePage(): void {
+    // A page far beyond MAX_PAGE must be rejected with a 400, not overflow the
+    // SQL offset into a negative value and surface as an uncaught 500.
+    $data = $this->get(self::BASE_PATH, ['query' => ['page' => '232017383506012688140070609349509120']]);
+    $this->assertSame('mailpoet_tags_invalid_page', $data['code']);
+    $this->assertSame(400, $data['data']['status']);
+  }
+
   public function testGetRejectsGuest(): void {
     wp_set_current_user(0);
     $data = $this->get(self::BASE_PATH);


### PR DESCRIPTION
### What

`GET /mailpoet/v1/tags` returns a 500 when the `page` query param is a very large number.

### Why

`TagsGetEndpoint` uses `ListingRequestValidationTrait` and defines `MAX_PAGE`, but `handle()` never called `validatePagination()`. A huge `page` value casts to `PHP_INT_MAX`, and `($page - 1) * $perPage` overflows into a negative SQL offset. Doctrine then rejects it with an uncaught `DBALxception: Offset must be a positive integer or zero, -9223372036854775808 given`, which surfaces as a 500 (`mailpoet_automation_unknown_error`).

### Fix

Call `validatePagination()` at the top of `handle()`. An out-of-range or unparseable `page` now returns a clean `400 mailpoet_tags_invalid_page` instead of a 500. This matches how the other listing endpoints validate pagination, and the endpoint already declared the bounds it just wasn't enforcing them.

### Testing

- Added `testGetRejectsOutOfRangePage` (RED first: it returned the 500, then GREEN after the fix).
- Full Tags REST suite passes: 19 tests, 72 assertions.
- Verified on a local env: huge `page` -> 400, normal `page` -> 200.

Found by QIT API fuzz testing against the plugin's REST surface.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/tags-rest-page-overflow)

_The latest successful build from `fix/tags-rest-page-overflow` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

1 issue found:
- **Bug (1):** Excessively large or invalid `page` values could cause SQL offset overflow and a 500 response. Pagination validation now returns a 400 error, with regression coverage added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->