### PR TITLE
Stop HTML-encoding personalization tags in subject and plain-text emails

### DIFF
--- a/mailpoet/changelog/2026-07-23-13-40-06-fixed-personalization-tags-showing-html-encoded-characte.md
+++ b/mailpoet/changelog/2026-07-23-13-40-06-fixed-personalization-tags-showing-html-encoded-characte.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Personalization tags showing HTML-encoded characters in email subjects and plain-text emails

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplateEmailPreviewRenderer.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplateEmailPreviewRenderer.php
@@ -109,7 +109,7 @@ class TemplateEmailPreviewRenderer {
       'newsletter_id' => 0,
       'queue_id' => null,
     ]);
-    return $personalizer->personalize_content($html);
+    return $personalizer->personalize_content($html, Personalizer::RENDERING_CONTEXT_HTML);
   }
 
   private function getRenderer(): GutenbergRenderer {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -483,31 +483,31 @@ class Newsletter {
         $preparedNewsletter = OpenTracking::removeTrackingImage($preparedNewsletter);
       }
     }
-    $preparedNewsletter = Helpers::splitObject($preparedNewsletter);
+    [$subject, $html, $text] = Helpers::splitObject($preparedNewsletter);
     if ($context !== null) {
-      $this->guardOrderReviewUrlPersonalization($newsletter, $queue, $preparedNewsletter, $context);
+      $this->guardOrderReviewUrlPersonalization($newsletter, $queue, [$subject, $html, $text], $context);
 
       $this->personalizer->set_context($context);
-      $preparedNewsletter[0] = $this->personalizer->personalize_content($preparedNewsletter[0], Personalizer::RENDERING_CONTEXT_TEXT);
-      $preparedNewsletter[1] = $this->personalizer->personalize_content($preparedNewsletter[1], Personalizer::RENDERING_CONTEXT_HTML);
-      $preparedNewsletter[2] = $this->personalizer->personalize_content($preparedNewsletter[2], Personalizer::RENDERING_CONTEXT_TEXT);
+      $subject = $this->personalizer->personalize_content($subject, Personalizer::RENDERING_CONTEXT_TEXT);
+      $html = $this->personalizer->personalize_content($html, Personalizer::RENDERING_CONTEXT_HTML);
+      $text = $this->personalizer->personalize_content($text, Personalizer::RENDERING_CONTEXT_TEXT);
       // Token links that were not hashed (tracking disabled) are still literal in the text body.
-      $preparedNewsletter[2] = $this->personalizationTagLinkResolver->resolveMarkdownLinks($preparedNewsletter[2], $context);
-      $personalizedHtml = $this->wp->applyFilters('mailpoet_automation_email_personalize_html_after', $preparedNewsletter[1], $context);
+      $text = $this->personalizationTagLinkResolver->resolveMarkdownLinks($text, $context);
+      $personalizedHtml = $this->wp->applyFilters('mailpoet_automation_email_personalize_html_after', $html, $context);
       if (is_string($personalizedHtml)) {
-        $preparedNewsletter[1] = $personalizedHtml;
+        $html = $personalizedHtml;
       }
-      $personalizedText = $this->wp->applyFilters('mailpoet_automation_email_personalize_text_after', $preparedNewsletter[2], $context);
+      $personalizedText = $this->wp->applyFilters('mailpoet_automation_email_personalize_text_after', $text, $context);
       if (is_string($personalizedText)) {
-        $preparedNewsletter[2] = $personalizedText;
+        $text = $personalizedText;
       }
     }
     return [
       'id' => $newsletter->getId(),
-      'subject' => $preparedNewsletter[0],
+      'subject' => $subject,
       'body' => [
-        'html' => $preparedNewsletter[1],
-        'text' => $preparedNewsletter[2],
+        'html' => $html,
+        'text' => $text,
       ],
     ];
   }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -488,9 +488,9 @@ class Newsletter {
       $this->guardOrderReviewUrlPersonalization($newsletter, $queue, $preparedNewsletter, $context);
 
       $this->personalizer->set_context($context);
-      foreach ($preparedNewsletter as $key => $content) {
-        $preparedNewsletter[$key] = $this->personalizer->personalize_content($content);
-      }
+      $preparedNewsletter[0] = $this->personalizer->personalize_content($preparedNewsletter[0], Personalizer::RENDERING_CONTEXT_TEXT);
+      $preparedNewsletter[1] = $this->personalizer->personalize_content($preparedNewsletter[1], Personalizer::RENDERING_CONTEXT_HTML);
+      $preparedNewsletter[2] = $this->personalizer->personalize_content($preparedNewsletter[2], Personalizer::RENDERING_CONTEXT_TEXT);
       // Token links that were not hashed (tracking disabled) are still literal in the text body.
       $preparedNewsletter[2] = $this->personalizationTagLinkResolver->resolveMarkdownLinks($preparedNewsletter[2], $context);
       $personalizedHtml = $this->wp->applyFilters('mailpoet_automation_email_personalize_html_after', $preparedNewsletter[1], $context);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -137,7 +137,8 @@ class PersonalizationTagManager {
         [$this->subscriber, 'getFirstName'],
         ['default' => __('subscriber', 'mailpoet')],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
       $registry->register(new Personalization_Tag(
         __('Last Name', 'mailpoet'),
@@ -146,7 +147,8 @@ class PersonalizationTagManager {
         [$this->subscriber, 'getLastName'],
         ['default' => __('subscriber', 'mailpoet')],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
       $registry->register(new Personalization_Tag(
         __('Email', 'mailpoet'),
@@ -155,7 +157,8 @@ class PersonalizationTagManager {
         [$this->subscriber, 'getEmail'],
         [],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
       $registry->register(new Personalization_Tag(
         __('Activation Link', 'mailpoet'),
@@ -173,7 +176,8 @@ class PersonalizationTagManager {
         [$this->subscriber, 'getDisplayName'],
         ['default' => __('member', 'mailpoet')],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
       $registry->register(new Personalization_Tag(
         __('Total Number of Subscribers', 'mailpoet'),
@@ -182,7 +186,8 @@ class PersonalizationTagManager {
         [$this->subscriber, 'getCount'],
         [],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
       $this->registerSubscriberCustomFieldTags($registry);
 
@@ -194,7 +199,8 @@ class PersonalizationTagManager {
         [$this->newsletter, 'getSubject'],
         [],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
 
       // Date Personalization Tags
@@ -205,7 +211,8 @@ class PersonalizationTagManager {
         [$this->date, 'getDay'],
         [],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
       $registry->register(new Personalization_Tag(
         __('Current day of the month in ordinal form, i.e. 2nd, 3rd, 4th, etc.', 'mailpoet'),
@@ -214,7 +221,8 @@ class PersonalizationTagManager {
         [$this->date, 'getDayOrdinal'],
         [],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
       $registry->register(new Personalization_Tag(
         __('Full name of current day', 'mailpoet'),
@@ -223,7 +231,8 @@ class PersonalizationTagManager {
         [$this->date, 'getDayName'],
         [],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
       $registry->register(new Personalization_Tag(
         __('Current month number', 'mailpoet'),
@@ -232,7 +241,8 @@ class PersonalizationTagManager {
         [$this->date, 'getMonth'],
         [],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
       $registry->register(new Personalization_Tag(
         __('Full name of current month', 'mailpoet'),
@@ -241,7 +251,8 @@ class PersonalizationTagManager {
         [$this->date, 'getMonthName'],
         [],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
       $registry->register(new Personalization_Tag(
         __('Year', 'mailpoet'),
@@ -250,7 +261,8 @@ class PersonalizationTagManager {
         [$this->date, 'getYear'],
         [],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
 
       // Site Personalization Tags
@@ -261,7 +273,8 @@ class PersonalizationTagManager {
         [$this->site, 'getTitle'],
         [],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
       $registry->register(new Personalization_Tag(
         __('Site Description', 'mailpoet'),
@@ -270,7 +283,8 @@ class PersonalizationTagManager {
         [$this->site, 'getDescription'],
         [],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
       $registry->register(new Personalization_Tag(
         __('Homepage URL', 'mailpoet'),
@@ -349,7 +363,8 @@ class PersonalizationTagManager {
         },
         [],
         null,
-        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
+        Personalization_Tag::VALUE_TYPE_TEXT
       ));
     }
   }
@@ -440,7 +455,8 @@ class PersonalizationTagManager {
             $tag->get_callback(),
             $tag->get_attributes(),
             $tag->get_value_to_insert(),
-            $postTypes
+            $postTypes,
+            $tag->get_value_type()
           ));
         }
       }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Subscriber.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Subscriber.php
@@ -12,8 +12,6 @@ use MailPoet\WP\Functions as WPFunctions;
 
 class Subscriber {
 
-  private const HTML_ENTITY_FLAGS = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401;
-
   private SubscribersRepository $subscribersRepository;
   private SubscriberCustomFieldRepository $subscriberCustomFieldRepository;
   private WPFunctions $wp;
@@ -32,20 +30,18 @@ class Subscriber {
 
   public function getFirstName(array $context, array $args = []): string {
     $subscriber = $this->getSubscriber($context);
-    $value = ($subscriber && $subscriber->getFirstName()) ? $subscriber->getFirstName() : ($args['default'] ?? '');
 
-    return htmlspecialchars($value, self::HTML_ENTITY_FLAGS);
+    return ($subscriber && $subscriber->getFirstName()) ? $subscriber->getFirstName() : ($args['default'] ?? '');
   }
 
   public function getLastName(array $context, array $args = []): string {
     $subscriber = $this->getSubscriber($context);
-    $value = ($subscriber && $subscriber->getLastName()) ? $subscriber->getLastName() : ($args['default'] ?? '');
 
-    return htmlspecialchars($value, self::HTML_ENTITY_FLAGS);
+    return ($subscriber && $subscriber->getLastName()) ? $subscriber->getLastName() : ($args['default'] ?? '');
   }
 
   public function getEmail(array $context, array $args = []): string {
-    return htmlspecialchars($context['recipient_email'] ?? '', self::HTML_ENTITY_FLAGS);
+    return $context['recipient_email'] ?? '';
   }
 
   public function getActivationLink(array $context, array $args = []): string {
@@ -64,11 +60,15 @@ class Subscriber {
     if ($subscriber && $subscriber->getWpUserId()) {
       $wpUser = $this->wp->getUserdata($subscriber->getWpUserId());
       if ($wpUser instanceof \WP_User) {
-        $value = (string)$wpUser->display_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        // WordPress stores display_name HTML-entity-encoded; decode to return plain text.
+        $value = htmlspecialchars_decode(
+          (string)$wpUser->display_name, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+          ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
+        );
       }
     }
 
-    return htmlspecialchars($value, self::HTML_ENTITY_FLAGS, 'UTF-8', false);
+    return $value;
   }
 
   public function getCount(array $context, array $args = []): string {
@@ -107,10 +107,10 @@ class Subscriber {
       $params = $definition->getParams();
       $label = (is_array($params) && isset($params['values'][0]['value'])) ? (string)$params['values'][0]['value'] : '';
 
-      return $label !== '' ? htmlspecialchars($label, self::HTML_ENTITY_FLAGS) : $default;
+      return $label !== '' ? $label : $default;
     }
 
-    return htmlspecialchars($value, self::HTML_ENTITY_FLAGS);
+    return $value;
   }
 
   private function getSubscriber(array $context): ?SubscriberEntity {

--- a/mailpoet/lib/Newsletter/Preview/SendPreviewController.php
+++ b/mailpoet/lib/Newsletter/Preview/SendPreviewController.php
@@ -109,9 +109,9 @@ class SendPreviewController {
       }
 
       $this->personalizer->set_context($context);
-      $renderedNewsletter['subject'] = $this->personalizer->personalize_content($renderedNewsletter['subject']);
-      $renderedNewsletter['body']['html'] = $this->personalizer->personalize_content($renderedNewsletter['body']['html']);
-      $renderedNewsletter['body']['text'] = $this->personalizer->personalize_content($renderedNewsletter['body']['text']);
+      $renderedNewsletter['subject'] = $this->personalizer->personalize_content($renderedNewsletter['subject'], Personalizer::RENDERING_CONTEXT_TEXT);
+      $renderedNewsletter['body']['html'] = $this->personalizer->personalize_content($renderedNewsletter['body']['html'], Personalizer::RENDERING_CONTEXT_HTML);
+      $renderedNewsletter['body']['text'] = $this->personalizer->personalize_content($renderedNewsletter['body']['text'], Personalizer::RENDERING_CONTEXT_TEXT);
       $renderedNewsletter['body']['text'] = $this->personalizationTagLinkResolver->resolveMarkdownLinks($renderedNewsletter['body']['text'], $context);
     }
 

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
@@ -169,7 +169,7 @@ class ViewInBrowserRenderer {
         'newsletter_id' => $newsletter->getId(),
         'queue_id' => $queue ? $queue->getId() : null,
       ]);
-      $renderedNewsletter = $this->personalizer->personalize_content($renderedNewsletter);
+      $renderedNewsletter = $this->personalizer->personalize_content($renderedNewsletter, Personalizer::RENDERING_CONTEXT_HTML);
     }
     return $renderedNewsletter;
   }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplateEmailPreviewRendererTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/TemplateEmailPreviewRendererTest.php
@@ -33,6 +33,21 @@ class TemplateEmailPreviewRendererTest extends MailPoetTest {
     verify($html)->stringNotContainsString('<!--[mailpoet/');
   }
 
+  public function testItEscapesTextTagValuesInHtmlOutput(): void {
+    $previousBlogname = get_option('blogname');
+    $this->assertIsString($previousBlogname);
+    update_option('blogname', 'Tom & <b>Jerry</b>');
+    try {
+      $html = (string)$this->renderer->render('welcome-email-content', 'Welcome subject', 'Preheader');
+    } finally {
+      update_option('blogname', $previousBlogname);
+    }
+    // The site title tag is text-valued; the preview renders in the HTML context,
+    // so the Personalizer must escape the value exactly once.
+    verify($html)->stringContainsString('Tom &amp; &lt;b&gt;Jerry&lt;/b&gt;');
+    verify($html)->stringNotContainsString('<b>Jerry</b>');
+  }
+
   public function testItDoesNotPersistAnyPost(): void {
     $countBefore = $this->countPreviewPosts();
     $this->renderer->render('welcome-email-content', 'Welcome subject', 'Preheader');

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -803,6 +803,96 @@ class NewsletterTest extends \MailPoetTest {
     return [$newsletter, $scheduledTask, $sendingQueue];
   }
 
+  public function testItPersonalizesSubjectHtmlAndTextWithProperEncoding(): void {
+    $postId = WPFunctions::get()->wpInsertPost([
+      'post_type' => 'mailpoet_email',
+      'post_status' => 'private',
+      'post_title' => 'Personalized email',
+      'post_content' => '',
+    ]);
+    $this->assertIsInt($postId);
+    $this->assertGreaterThan(0, $postId);
+
+    $subscriber = (new SubscriberFactory())
+      ->withEmail('personalized-encoding@example.com')
+      ->withFirstName('Tom & <b>Jerry</b>')
+      ->create();
+
+    $newsletter = (new NewsletterFactory())
+      ->withWpPostId($postId)
+      ->create();
+    $scheduledTask = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $sendingQueue = (new SendingQueueFactory())->create($scheduledTask, $newsletter);
+    $sendingQueue->setNewsletterRenderedSubject('Hello <!--[mailpoet/subscriber-firstname default="subscriber"]-->');
+    $sendingQueue->setNewsletterRenderedBody([
+      'html' => '<p>Hi <!--[mailpoet/subscriber-firstname default="subscriber"]--></p>',
+      'text' => 'Hi <!--[mailpoet/subscriber-firstname default="subscriber"]-->',
+    ]);
+    $this->sendingQueuesRepository->persist($sendingQueue);
+    $this->sendingQueuesRepository->flush();
+
+    $result = $this->newsletterTask->prepareNewsletterForSending(
+      $newsletter,
+      $subscriber,
+      $sendingQueue
+    );
+
+    // Subject and plain-text body are text contexts: the raw value must not be HTML-escaped.
+    $this->assertSame('Hello Tom & <b>Jerry</b>', $result['subject']);
+    $this->assertSame('Hi Tom & <b>Jerry</b>', $result['body']['text']);
+    // The HTML body is an HTML context: text-only tag values must be escaped by the Personalizer.
+    $this->assertSame('<p>Hi Tom &amp; &lt;b&gt;Jerry&lt;/b&gt;</p>', $result['body']['html']);
+  }
+
+  public function testItNeutralizesMaliciousTagValuesInHtmlOutput(): void {
+    $postId = WPFunctions::get()->wpInsertPost([
+      'post_type' => 'mailpoet_email',
+      'post_status' => 'private',
+      'post_title' => 'Malicious values email',
+      'post_content' => '',
+    ]);
+    $this->assertIsInt($postId);
+    $this->assertGreaterThan(0, $postId);
+
+    $subscriber = (new SubscriberFactory())
+      ->withEmail('malicious-encoding@example.com')
+      ->withFirstName('<script>alert(1);</script>')
+      ->withLastName('</title><script>alert(2);</script>')
+      ->create();
+
+    $newsletter = (new NewsletterFactory())
+      ->withWpPostId($postId)
+      ->create();
+    $scheduledTask = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $sendingQueue = (new SendingQueueFactory())->create($scheduledTask, $newsletter);
+    $sendingQueue->setNewsletterRenderedSubject('Hello <!--[mailpoet/subscriber-firstname default="subscriber"]-->');
+    $sendingQueue->setNewsletterRenderedBody([
+      'html' => '<html><head><title>Hi <!--[mailpoet/subscriber-firstname default="subscriber"]--> <!--[mailpoet/subscriber-lastname default="subscriber"]--></title></head>'
+        . '<body><p>Hi <!--[mailpoet/subscriber-firstname default="subscriber"]--> <!--[mailpoet/subscriber-lastname default="subscriber"]--></p></body></html>',
+      'text' => 'Hi <!--[mailpoet/subscriber-firstname default="subscriber"]--> <!--[mailpoet/subscriber-lastname default="subscriber"]-->',
+    ]);
+    $this->sendingQueuesRepository->persist($sendingQueue);
+    $this->sendingQueuesRepository->flush();
+
+    $result = $this->newsletterTask->prepareNewsletterForSending(
+      $newsletter,
+      $subscriber,
+      $sendingQueue
+    );
+
+    // Subject and plain-text body are never parsed as HTML by mail clients; values stay raw.
+    $this->assertSame('Hello <script>alert(1);</script>', $result['subject']);
+    $this->assertSame('Hi <script>alert(1);</script> </title><script>alert(2);</script>', $result['body']['text']);
+
+    $html = $result['body']['html'];
+    // In the HTML body the values must be fully escaped — no executable script element.
+    $this->assertStringContainsString('<p>Hi &lt;script&gt;alert(1);&lt;/script&gt; &lt;/title&gt;&lt;script&gt;alert(2);&lt;/script&gt;</p>', $html);
+    // The title must not be closed early by the value; a "</title><script>" sequence would
+    // escape the RCDATA context and make the script element executable (e.g. in view in browser).
+    $this->assertStringNotContainsString('</title><script>', $html);
+    $this->assertSame(1, substr_count($html, '</title>'));
+  }
+
   public function testItLogsErrorWhenQueueWithCannotBeSaved() {
     $sendingQueuesRepositoryStub = $this->createStub(SendingQueuesRepository::class);
     $sendingQueuesRepositoryStub->method('flush')

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
@@ -114,6 +114,76 @@ class PersonalizationTagManagerTest extends \MailPoetTest {
     }
   }
 
+  public function testItDeclaresTextTagsAsTextAndUrlTagsAsHtml(): void {
+    $customField = (new CustomFieldFactory())->create();
+
+    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+    $personalizationManager->initialize();
+
+    $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
+    WPFunctions::get()->applyFilters('woocommerce_email_editor_register_personalization_tags', $registry);
+
+    $expectedValueTypes = [
+      '[mailpoet/subscriber-firstname]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/subscriber-lastname]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/subscriber-email]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/subscriber-displayname]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/subscriber-count]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/subscriber-cf-' . $customField->getId() . ']' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/newsletter-subject]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/date-day]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/date-day-ordinal]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/date-day-name]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/date-month]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/date-month-name]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/date-year]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/site-title]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      '[mailpoet/site-description]' => Personalization_Tag::VALUE_TYPE_TEXT,
+      // URL tags are inserted unescaped into hrefs and plain text
+      '[mailpoet/subscriber-activation-link]' => Personalization_Tag::VALUE_TYPE_HTML,
+      '[mailpoet/site-homepage-url]' => Personalization_Tag::VALUE_TYPE_HTML,
+      '[mailpoet/subscription-unsubscribe-url]' => Personalization_Tag::VALUE_TYPE_HTML,
+      '[mailpoet/subscription-manage-url]' => Personalization_Tag::VALUE_TYPE_HTML,
+      '[mailpoet/newsletter-view-in-browser-url]' => Personalization_Tag::VALUE_TYPE_HTML,
+    ];
+
+    foreach ($expectedValueTypes as $token => $valueType) {
+      $tag = $registry->get_by_token($token);
+      $this->assertNotNull($tag, "Expected personalization tag {$token} to be registered.");
+      $this->assertSame($valueType, $tag->get_value_type(), "Unexpected value type for {$token}.");
+    }
+  }
+
+  public function testItKeepsValueTypeWhenExtendingWooCommerceTags(): void {
+    $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
+    $token = '[test/order-text-tag]';
+    $registry->unregister($token);
+    $registry->register(new Personalization_Tag(
+      'Order text tag',
+      $token,
+      'Order',
+      function (): string {
+        return 'value';
+      },
+      [],
+      null,
+      ['woo_email'],
+      Personalization_Tag::VALUE_TYPE_TEXT
+    ));
+
+    try {
+      $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+      $personalizationManager->extendWooCommerceTagsForMailPoet($registry, [OrderSubject::KEY]);
+
+      $tag = $registry->get_by_token($token);
+      $this->assertNotNull($tag);
+      $this->assertContains(EmailEditor::MAILPOET_EMAIL_POST_TYPE, $tag->get_post_types());
+      $this->assertSame(Personalization_Tag::VALUE_TYPE_TEXT, $tag->get_value_type());
+    } finally {
+      $registry->unregister($token);
+    }
+  }
+
   public function testItRegistersOrderReviewUrlTagForOrderAutomations(): void {
     $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
     $registry->unregister('[woocommerce/order-review-url]');

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/SubscriberTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTags/SubscriberTest.php
@@ -119,7 +119,7 @@ class SubscriberTest extends \MailPoetTest {
     $this->assertSame($expected, $result);
   }
 
-  public function testItEncodesFirstNameSpecialCharacters(): void {
+  public function testItReturnsRawFirstNameSpecialCharacters(): void {
     $subscriber = (new SubscriberFactory())
       ->withEmail('encode-first@example.com')
       ->withFirstName('<script>alert(1)</script>')
@@ -130,10 +130,11 @@ class SubscriberTest extends \MailPoetTest {
       ['default' => 'member']
     );
 
-    $this->assertSame('&lt;script&gt;alert(1)&lt;/script&gt;', $result);
+    // The tag is registered as text-only; HTML escaping is applied by the Personalizer.
+    $this->assertSame('<script>alert(1)</script>', $result);
   }
 
-  public function testItEncodesLastNameSpecialCharacters(): void {
+  public function testItReturnsRawLastNameSpecialCharacters(): void {
     $subscriber = (new SubscriberFactory())
       ->withEmail('encode-last@example.com')
       ->withLastName('"><b>x</b>')
@@ -144,23 +145,26 @@ class SubscriberTest extends \MailPoetTest {
       ['default' => 'member']
     );
 
-    $this->assertSame('&quot;&gt;&lt;b&gt;x&lt;/b&gt;', $result);
+    $this->assertSame('"><b>x</b>', $result);
   }
 
-  public function testItEncodesEmailSpecialCharacters(): void {
+  public function testItReturnsRawEmailSpecialCharacters(): void {
     $result = $this->subscriber->getEmail(
       ['recipient_email' => '"><b>@example.com'],
       []
     );
 
-    $this->assertSame('&quot;&gt;&lt;b&gt;@example.com', $result);
+    $this->assertSame('"><b>@example.com', $result);
   }
 
-  public function testItEncodesDisplayNameSpecialCharacters(): void {
+  public function testItDecodesEntityEncodedDisplayName(): void {
     wp_create_user('mailpoet_encode_display', 'pass', 'encode-display@example.com');
     $wpUser = get_user_by('login', 'mailpoet_encode_display');
     $this->assertInstanceOf(\WP_User::class, $wpUser);
     wp_update_user(['ID' => $wpUser->ID, 'display_name' => 'Boss & Co']);
+    $storedUser = get_userdata($wpUser->ID);
+    $this->assertInstanceOf(\WP_User::class, $storedUser);
+    $this->assertSame('Boss &amp; Co', $storedUser->display_name); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
     $subscriber = (new SubscriberFactory())
       ->withEmail('sub-encode-display@example.com')
@@ -172,15 +176,15 @@ class SubscriberTest extends \MailPoetTest {
       ['default' => 'member']
     );
 
-    $this->assertSame('Boss &amp; Co', $result);
+    $this->assertSame('Boss & Co', $result);
   }
 
-  public function testItEncodesTheDefaultFallbackValue(): void {
+  public function testItReturnsRawDefaultFallbackValue(): void {
     $result = $this->subscriber->getFirstName(
       ['recipient_email' => 'no-such-subscriber@example.com'],
       ['default' => 'Tom & Jerry']
     );
 
-    $this->assertSame('Tom &amp; Jerry', $result);
+    $this->assertSame('Tom & Jerry', $result);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
@@ -8,6 +8,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTagManager;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\PersonalizationTagLinkResolver;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\WpPostEntity;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerFactory;
@@ -90,6 +91,59 @@ class SendPreviewControllerTest extends \MailPoetTest {
       $mailerFactory,
       new MetaInfo(),
       $this->diContainer->get(Renderer::class),
+      new WPFunctions(),
+      $this->diContainer->get(SubscribersRepository::class),
+      $shortcodes,
+      $this->diContainer->get(PersonalizationTagManager::class),
+      $this->diContainer->get(WooCommerceDummyData::class),
+      $this->diContainer->get(PersonalizationTagLinkResolver::class)
+    );
+    $sendPreviewController->sendPreview($this->newsletter, 'test@subscriber.com');
+  }
+
+  public function testItPersonalizesSubjectHtmlAndTextWithProperEncoding() {
+    $postId = wp_insert_post([
+      'post_type' => 'mailpoet_email',
+      'post_status' => 'private',
+      'post_title' => 'Preview personalization',
+      'post_content' => '',
+    ]);
+    $this->assertIsInt($postId);
+    $this->assertGreaterThan(0, $postId);
+    $this->newsletter->setWpPost($this->entityManager->getReference(WpPostEntity::class, $postId));
+    $this->newsletter->setSubject('Hello <!--[mailpoet/subscriber-firstname default="subscriber"]-->');
+
+    $subscriber = $this->diContainer->get(SubscribersRepository::class)->findOneBy(['email' => 'test@subscriber.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $subscriber->setFirstName('Tom & <b>Jerry</b>');
+    $this->entityManager->flush();
+
+    $renderer = $this->makeEmpty(Renderer::class, [
+      'renderAsPreview' => [
+        'html' => '<p>Hi <!--[mailpoet/subscriber-firstname default="subscriber"]--></p>',
+        'text' => 'Hi <!--[mailpoet/subscriber-firstname default="subscriber"]-->',
+      ],
+    ]);
+
+    $mailer = $this->makeEmpty(Mailer::class, [
+      'send' => Expected::once(
+        function ($newsletter) {
+          verify($newsletter['subject'])->equals('Hello Tom & <b>Jerry</b>');
+          verify($newsletter['body']['text'])->equals('Hi Tom & <b>Jerry</b>');
+          verify($newsletter['body']['html'])->equals('<p>Hi Tom &amp; &lt;b&gt;Jerry&lt;/b&gt;</p>');
+          return ['response' => true];
+        }
+      ),
+    ]);
+
+    $mailerFactory = $this->createMock(MailerFactory::class);
+    $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
+    $shortcodes = $this->diContainer->get(Shortcodes::class);
+    $shortcodes->setQueue(null);
+    $sendPreviewController = new SendPreviewController(
+      $mailerFactory,
+      new MetaInfo(),
+      $renderer,
       new WPFunctions(),
       $this->diContainer->get(SubscribersRepository::class),
       $shortcodes,


### PR DESCRIPTION
## Description

In https://github.com/mailpoet/mailpoet/pull/6998, we started escaping personalization tag outputs. The problem is that we always escape, as the output is part of HTML, which causes tags to be incorrectly escaped when used in an email subject or in the text version of an email (e.g. Tom &amp; Jerry in email subject). This was flagged in STOMAIL-8316.

The new version of the email editor PHP package supports autoescaping for tags that declare they return plain text (which are most of our tags), and it also supports passing rendering context when it generates personalization tag values. Introduced in WOOPRD-3586.

This PR addresses the problem with incorrect escaping in subjects and text versions of emails by adopting the new email package features.

 - personalization tags now declare they return plain text during registration
 - they no longer escape output themselves
 - when we personalize subject, text version and HTML version, we pass the correct context parameter

**BC impact:** no public API, hook, or REST surface changes. MailPoet tag callbacks now return raw text instead of HTML-escaped values; the new `value_type` declaration communicates that to anything reading the registry.

**Premium follow-up:** `WooCommerceSubscription::getTitle` and `WooCommerceBooking::getProductName` in Premium still `esc_html()` themselves and are registered as HTML-type, so their values still reach subjects and plain-text bodies HTML-escaped (`Boss &amp; Co`).  [PR in the premium plugin](https://github.com/mailpoet/mailpoet-premium/pull/1130).

## Code review notes

- The `</title><script>` payload in `testItNeutralizesMaliciousTagValuesInHtmlOutput` pins down the one place where a text-context value re-enters an HTML document: the `<title>` element, which the package personalizes as text via `set_modifiable_text()`. WP escapes the `</title` closing sequence, so the RCDATA context can't be broken out of; the test guards against a package regression.
- WooCommerce 10.9 still bundles email-editor 2.13.0 (no `VALUE_TYPE_TEXT`). The Jetpack autoloader picks the newest versioned copy on both sides, so MailPoet's 2.16.0 wins — same mechanism as every previous package bump.

## QA notes

1. Create a subscriber with special characters in the first name, e.g. `Tom & <b>Jerry</b>`.
2. Create a newsletter in the block editor using the First name tag in the subject and body; send it and send a preview.
3. Verify in Mailpit: subject and plain-text version show `Tom & <b>Jerry</b>` raw; the HTML body shows the text escaped (no bold, no visible entities).
4. Same check with a WP user subscriber whose display name contains `&` and the Display name tag.

## Linked PRs

- [PR in the premium plugin](https://github.com/mailpoet/mailpoet-premium/pull/1130).

## Linked tickets

- [WOOPRD-3586](https://linear.app/a8c/issue/WOOPRD-3586) — context-aware rendering & escaping for personalization tags
- [STOMAIL-8316](https://linear.app/a8c/issue/STOMAIL-8316) — reported symptom: literal entities in subject lines and plain-text bodies
- [STOMAIL-8309](https://linear.app/a8c/issue/STOMAIL-8309) — introduced the callback-side escaping this PR replaces

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

| Place | Before | After |
| ------ | ------ | ------ |
| text | <img width="2560" height="1400" alt="before-text" src="https://github.com/user-attachments/assets/a5c10384-c2ff-4587-af19-5144d82284ff" /> |  <img width="2560" height="1400" alt="after-text" src="https://github.com/user-attachments/assets/d2e39538-1b0a-4eea-b024-aa45195a8305" /> |
| HTML Source | <img width="2560" height="1400" alt="before-html-source" src="https://github.com/user-attachments/assets/c25baaa4-fb74-4b1d-a804-879b247113f9" /> | <img width="2560" height="1400" alt="after-html-source" src="https://github.com/user-attachments/assets/9deea26b-008e-4a7d-bb10-cc8959fde7bb" /> |
| HTML | <img width="2560" height="1400" alt="before-html" src="https://github.com/user-attachments/assets/eb669cfe-698b-4125-93da-f42e7b6ac3e8" /> | <img width="2560" height="1400" alt="after-html" src="https://github.com/user-attachments/assets/35dd4696-f788-450f-8a83-aaa3bc356bc0" /> |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:personalized-tags-with-context)

_The latest successful build from `personalized-tags-with-context` will be used. If none is available, the link won't work._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->