### PR TITLE
Add gap between sending progress and Pause button

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
@@ -94,6 +94,16 @@ h1.title.mailpoet-newsletter-listing-heading {
   }
 }
 
+.mailpoet-listing-queue-status {
+  align-items: center;
+  display: flex;
+  gap: $grid-gap-half;
+
+  .mailpoet-listing-stats-too-early {
+    margin-top: 0;
+  }
+}
+
 .mailpoet-listing-status-column {
   .mailpoet-button {
     margin-top: $grid-gap-half;

--- a/mailpoet/assets/js/src/newsletters/listings/queue-status.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/queue-status.tsx
@@ -131,7 +131,7 @@ function QueueStatus({ newsletter, mailerLog }: QueueStatusProps) {
   const isMtaPaused = mailerLog.status === 'paused';
 
   const renderSentNewsletter = (
-    <>
+    <div className="mailpoet-listing-queue-status">
       <Link
         to={`/sending-status/${newsletter.id}`}
         data-automation-id={`sending_status_${newsletter.id}`}
@@ -149,7 +149,7 @@ function QueueStatus({ newsletter, mailerLog }: QueueStatusProps) {
       {newsletter.queue.status !== 'completed' &&
         !isNewsletterCancelled &&
         !isMtaPaused && <QueueSending newsletter={newsletter} />}
-    </>
+    </div>
   );
 
   const renderDraftOrScheduledNewsletter = (

--- a/mailpoet/changelog/2026-07-24-08-40-19-fixed-missing-gap-between-sending-progress-and-the-pause.md
+++ b/mailpoet/changelog/2026-07-24-08-40-19-fixed-missing-gap-between-sending-progress-and-the-pause.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Missing gap between sending progress and the pause button in the email listing


### PR DESCRIPTION
## Description

The pause button in the email listing's status column was rendered without a gap.

<img width="1237" height="304" alt="Screenshot 2026-07-24 at 10 28 12" src="https://github.com/user-attachments/assets/7b9c0454-cd86-44c5-a9f5-ff02ec9fb9ce" />

This PR fixes the issue by wrapping the two items into `div` and adding flex gap.

<img width="2760" height="540" alt="screenshot-status-fixed" src="https://github.com/user-attachments/assets/c23cb803-1c11-4b80-a56f-92571081fc7b" />

## Code review notes

_N/A_

## QA notes

1. Have a newsletter in `sending` state (send to a list, or pause the cron before it completes).
2. Go to MailPoet > Emails and check the Status column: there should be a clear gap between the progress (`0 / X`) and the Pause button, on one line, vertically centered.
3. Click Pause and verify the Resume button renders with the same spacing.

## Linked PRs

_N/A_

## Linked tickets

- [STOMAIL-8321](https://linear.app/a8c/issue/STOMAIL-8321/missing-gap-between-sending-progress-and-pause-button-in-email-listing)

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-button-in-status)

_The latest successful build from `fix-button-in-status` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->