### PR TITLE
Avoid optimizers re-minifying the subscription form script

### DIFF
--- a/mailpoet/.gitleaksignore
+++ b/mailpoet/.gitleaksignore
@@ -1,1 +1,2 @@
 /mailpoet/assets/dist/js/public.js:generic-api-key:2
+/mailpoet/assets/dist/js/public.min.js:generic-api-key:2

--- a/mailpoet/changelog/2026-07-27-04-11-00-fixed-subscription-form-scripts-breaking-when-siteground.md
+++ b/mailpoet/changelog/2026-07-27-04-11-00-fixed-subscription-form-scripts-breaking-when-siteground.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Subscription form scripts breaking when SiteGround Speed Optimizer JavaScript minification is enabled

--- a/mailpoet/lib/Captcha/ReCaptchaHooks.php
+++ b/mailpoet/lib/Captcha/ReCaptchaHooks.php
@@ -66,7 +66,7 @@ class ReCaptchaHooks {
 
     $this->wp->wpEnqueueScript(
       'mailpoet_public',
-      Env::$assetsUrl . '/dist/js/' . $this->renderer->getJsAsset('public.js'),
+      Env::$assetsUrl . '/dist/js/' . $this->renderer->getJsAsset('public.min.js'),
       ['jquery'],
       Env::$version,
       [
@@ -75,7 +75,7 @@ class ReCaptchaHooks {
       ]
     );
 
-    // necessary for public.js script
+    // necessary for the public form script
     $ajaxFailedErrorMessage = __('An error has happened while performing a request, please try again later.', 'mailpoet');
     $this->wp->wpLocalizeScript('mailpoet_public', 'MailPoetForm', [
       'ajax_url' => $this->wp->adminUrl('admin-ajax.php'),

--- a/mailpoet/lib/Captcha/TurnstileHooks.php
+++ b/mailpoet/lib/Captcha/TurnstileHooks.php
@@ -73,7 +73,7 @@ class TurnstileHooks {
 
     $this->wp->wpEnqueueScript(
       'mailpoet_public',
-      Env::$assetsUrl . '/dist/js/' . $this->renderer->getJsAsset('public.js'),
+      Env::$assetsUrl . '/dist/js/' . $this->renderer->getJsAsset('public.min.js'),
       ['jquery'],
       Env::$version,
       [

--- a/mailpoet/lib/Form/AssetsController.php
+++ b/mailpoet/lib/Form/AssetsController.php
@@ -97,7 +97,7 @@ class AssetsController {
 
     $this->wp->wpEnqueueScript(
       'mailpoet_public',
-      Env::$assetsUrl . '/dist/js/' . $this->renderer->getJsAsset('public.js'),
+      Env::$assetsUrl . '/dist/js/' . $this->renderer->getJsAsset('public.min.js'),
       ['jquery'],
       Env::$version,
       $enqueuePlacementParams

--- a/mailpoet/lib/Form/Util/Export.php
+++ b/mailpoet/lib/Form/Util/Export.php
@@ -79,7 +79,7 @@ class Export {
           Env::$assetsUrl . '/dist/js/vendor.js?mp_ver=' . MAILPOET_VERSION .
         '"></script>';
         $output[] = '<script type="text/javascript" src="' .
-          Env::$assetsUrl . '/dist/js/public.js?mp_ver=' . MAILPOET_VERSION .
+          Env::$assetsUrl . '/dist/js/public.min.js?mp_ver=' . MAILPOET_VERSION .
         '"></script>';
 
         $collectSubscriberTimeZones = SettingsController::getInstance()->isSettingEnabled(

--- a/mailpoet/tests/unit/Form/AssetsControllerTest.php
+++ b/mailpoet/tests/unit/Form/AssetsControllerTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Form;
+
+use MailPoet\Config\Renderer as TemplateRenderer;
+use MailPoet\Settings\SettingsController;
+use MailPoet\WP\Functions as WPFunctions;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AssetsControllerTest extends \MailPoetUnitTest {
+  /** @var WPFunctions & MockObject */
+  private $wp;
+
+  /** @var TemplateRenderer & MockObject */
+  private $renderer;
+
+  /** @var SettingsController & MockObject */
+  private $settings;
+
+  /** @var AssetsController */
+  private $controller;
+
+  public function _before() {
+    parent::_before();
+    $this->wp = $this->createMock(WPFunctions::class);
+    $this->renderer = $this->createMock(TemplateRenderer::class);
+    $this->renderer->method('getJsAsset')->willReturnArgument(0);
+    $this->renderer->method('getCssAsset')->willReturnArgument(0);
+    $this->settings = $this->createMock(SettingsController::class);
+    $this->settings->method('get')->willReturn([]);
+    $this->controller = new AssetsController($this->wp, $this->renderer, $this->settings);
+  }
+
+  public function testPublicScriptUsesMinJsNameSoOptimizersSkipReminifyingIt() {
+    $this->wp->expects($this->once())->method('wpEnqueueScript')->with(
+      'mailpoet_public',
+      $this->stringEndsWith('/dist/js/public.min.js')
+    );
+    $this->controller->setupFrontEndDependencies();
+  }
+}

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -351,6 +351,17 @@ const formEditorConfig = {
 const publicConfig = {
   name: 'public',
   entry: {
+    // The bundle ships under a .min.js name so optimizer plugins skip
+    // re-minifying it. SiteGround Speed Optimizer in particular pipes
+    // non-.min.js scripts through the host's tdewolff/minify binary on
+    // SiteGround servers, which reorders var declaration lists and breaks
+    // this bundle at load time, killing subscription forms.
+    'public.min': 'webpack-public-index.jsx',
+    // Kept only for backward compatibility: HTML embed snippets generated
+    // by the legacy form editor hardcode dist/js/public.js on third-party
+    // sites. Such snippets can no longer be generated since MailPoet 3.45.0
+    // (Feb 2020), when the legacy form editor was removed, but old copies
+    // may still be live. Nothing in the plugin itself loads this file.
     public: 'webpack-public-index.jsx',
   },
   plugins: [


### PR DESCRIPTION
## Description

SiteGround Speed Optimizer's "Minify JavaScript Files" feature behaves differently depending on hosting:
- On non-SiteGround hosts, it minifies scripts with a bundled PHP library
- On SiteGround servers, it shells out to the host platform's `minify` binary (tdewolff/minify), which also renames variables.
   - https://plugins.trac.wordpress.org/browser/sg-cachepress/tags/7.8.0/core/Minifier/Minifier.php#L245
      ```php
      // Fallback if we are not on a SiteGround Server.
      if ( ! Helper_Service::is_siteground() ) {
      	// ... omitted
      } else {
      	// The minified file doens't exists or the original file has been modified.
      	// Minify the file then.
      	exec(
      		sprintf(
      			'minify  --output=',
      			$original_filepath,
      			$new_file_path
      		),
      		$output,
      		$status
      	);
      }
      ```
   - https://plugins.trac.wordpress.org/browser/sg-cachepress/tags/7.8.0/vendor/siteground/siteground-helper/src/Helper_Service.php#L192

That binary has a correctness bug: when rewriting a `var` declaration list, it moves destructuring declarators ahead of the declarators they read from. MailPoet's `public.js` bundles `@wordpress/hooks`, whose module index contains `var defaultHooks = createHooks(), {addAction, ...} = defaultHooks`. After SiteGround's server-side minification, this becomes `var {addAction: ...} = ds, ..., ds = createHooks()`, which throws at load time because `ds` is still `undefined` when the destructuring runs.

The consequence on affected sites: `mailpoet_public.min.js` dies on its first statement group, so no form JS runs, forms fall back to native POST without `behavioral_signals`, and since 5.33.0 the server then escalates every submission to the built-in CAPTCHA, which can never be passed because signals stay absent. Subscriptions are fully broken. With "Combine JavaScript" also enabled, the corrupted content is inlined into the combined file, and its throw additionally kills every script after it.

The fix serves the front-end bundle under a `.min.js` name. SiteGround's minifier (and most optimizers by convention) skips any script whose src already contains `.min.js`, so the whole corruption path becomes unreachable, regardless of SiteGround plugin version or hosting. Affected sites heal by simply updating MailPoet: the enqueued src stops pointing at the stale corrupted copy in `wp-content/uploads/siteground-optimizer-assets/`, no cache cleanup needed.

**Backward compatibility impact**: the plugin's own enqueues (`AssetsController`, `ReCaptchaHooks`, `TurnstileHooks`) are updated in this PR, so on-site usage is unaffected. The one externally exposed consumer of the old filename is the legacy HTML embed snippet, which hardcodes `assets/dist/js/public.js` on third-party sites. Such snippets could only be generated before MailPoet 3.45.0 (Feb 2020, when the legacy form editor was removed), but old copies may still be live and cannot be enumerated. To keep them working, the build now emits the same bundle twice: `public.min.js` (used by the plugin) and `public.js` (legacy copy, loaded by nothing in the plugin itself). The two files are byte-identical except for the license banner filename.

## Code review notes

- The `public.min` / `public` dual entry in `webpack.config.js` compiles the same entry file twice; output is identical because the config uses deterministic ids with `splitChunks` disabled. The long comment on the entries is the single source of truth for why both files exist.
- `Form\Utilxport.php`'s `html` case now emits `public.min.js` too, so everything the plugin can emit points at the canonical asset. The branch itself is dead code (`Export::get('html')` has had no caller since the legacy form editor removal shipped in 3.45.0; the last PHP caller, the orphaned `Forms::exportsEditor()` endpoint, was removed in 2021, commit 61d73c1b6c), but it is a public static method a third party could still call; removing it would need a deprecation window and is left for a separate cleanup.

## QA notes

The bug only manifests on SiteGround hosting because the corrupting code path is gated by `Helper_Service::is_siteground()` (two filesystem markers) and by the host platform's `minify` binary (tdewolff/minify). This is why earlier reproduction attempts on clean installs failed: non-SiteGround hosts take a harmless PHP fallback instead. The steps below reproduce the full customer scenario in the local wp-env by simulating those two host traits inside the WordPress container.

### Reproducing the bug (on trunk)

1. Check out the current `trunk` 7f94ef78d4633e316b01b388b5d9f906a66f67b9, and build the assets in production mode (the dev build wraps modules in eval strings and does not trigger the bug):
   ```sh
   pnpm compile:js --env production --skip-tests
   ```
2. Enter the wp-env WordPress container as root and make it look like a SiteGround server:
   ```sh
   docker exec -it -u root <your-wordpress-container> bash
   ```
   1. Create the two filesystem markers checked by `Helper_Service::is_siteground()`:
      ```sh
      mkdir -p /etc/yum.repos.d
      touch /etc/yum.repos.d/baseos.repo /Z
      ```
   2. Install the tdewolff `minify` binary, the same tool SiteGround servers use:
      ```sh
      curl -sL https://github.com/tdewolff/minify/releases/download/v2.24.14/minify_linux_arm64.tar.gz -o /tmp/minify.tar.gz
      tar -xzf /tmp/minify.tar.gz -C /tmp minify
      mv /tmp/minify /usr/local/bin/minify
      chmod 755 /usr/local/bin/minify
      ```
   3. Confirm the binary works and leave the container:
      ```sh
      minify --version
      exit
      ```
3. Install SiteGround Speed Optimizer and enable only its JS minification:
   <img width="874" height="665" alt="image" src="https://github.com/user-attachments/assets/79531d61-4e0a-4caa-b09b-63a6794d0a9a" />
4. In MailPoet Settings > Advanced, set CAPTCHA to "Disable".
5. Create a page containing a MailPoet subscription form.
   1. Go to MailPoet > Forms, click "New Form", and pick any template. In the form settings, make sure a list is selected under "This form adds the subscribers to these lists", then save.
   2. Create a new page and insert the "MailPoet Subscription Form" block, picking the form created above. A Shortcode block also works, using the shortcode shown under Form Settings > Form Placement > Others (widget).
   3. Publish the page.
6. Open that page in an incognito window with DevTools. Expected: the form script src points to `wp-content/uploads/siteground-optimizer-assets/mailpoet_public.min.js` and the console shows:
   ```
   Uncaught TypeError: Cannot destructure property 'addAction' of 'ds' as it is undefined.
   ```
7. Submit the form with any email. Expected: a native POST redirects to the built-in CAPTCHA page even though CAPTCHA is disabled, and solving it correctly only produces another challenge (the session ID in the URL changes on a correct answer), forever. No subscriber is created.

### Verifying the fix (on this branch)

1. Switch to this PR's branch, rebuild the same way as reproduction step 1, and reload the form page in an incognito window. Expected: the script tag now points at the plugin's own asset and no console error appears:
   ```
   <script ... src=".../wp-content/plugins/mailpoet/assets/dist/js/public.min.js?ver=..."></script>
   ```
2. Submit the form with real interaction. Expected: No CAPTCHA redirect:
3. Legacy embed backward compatibility: confirm the old path still serves the bundle:
   ```sh
   curl -sI http://localhost:8888/wp-content/plugins/mailpoet/assets/dist/js/public.js
   ```
4. Combine JavaScript compatibility (the customer's original two-toggle configuration):
   1. wp-env only: exclude WooCommerce's Interactivity API script modules from combination first, using SG's own filters. SG merges ES modules into the classic combined file, and the resulting parse-time SyntaxError would mask the scenario under test; this is a separate SG defect that module-free sites like the customer's do not hit. Create `wp-content/mu-plugins/sgo-module-excludes.php` inside the WordPress container with:
      ```php
      add_filter( 'sgo_javascript_combine_exclude_all_inline_modules', '__return_true' );
      add_filter( 'sgo_javascript_combine_exclude_ids', function ( $ids ) {
        $ids[] = 'woocommerce/customer-account-js-module';
        return $ids;
      } );
      ```
   2. Enable the Combine JavaScript Files option of SiteGround Speed Optimizer:
   3. Reload the form page in an incognito window. Expected: the separate `public.min.js` tag is replaced by a single `siteground-optimizer-combined-js-<hash>.js`, the console shows no errors, and the form still subscribes via AJAX.

## Linked tickets

STOMAIL-8267

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="1279" height="601" alt="image" src="https://github.com/user-attachments/assets/ebaac81f-a4d0-4d22-82d6-6275eedd33f4" /> | <img width="1273" height="745" alt="image" src="https://github.com/user-attachments/assets/d1721b59-b9ad-496e-a641-7172fcabbad7" /> |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8267-behavioral-signals-broken-by-sg-optimizer)

_The latest successful build from `fix/stomail-8267-behavioral-signals-broken-by-sg-optimizer` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->