### PR TITLE
Access-consistency and query-binding fixes

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Analytics.php
+++ b/mailpoet/lib/API/JSON/v1/Analytics.php
@@ -12,7 +12,7 @@ class Analytics extends APIEndpoint {
   private $reporter;
 
   public $permissions = [
-    'global' => AccessControl::NO_ACCESS_RESTRICTION,
+    'global' => AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
   ];
 
   public function __construct(

--- a/mailpoet/lib/Newsletter/Embed/RestApi/Endpoints/NewsletterEmbedSelectorEndpoint.php
+++ b/mailpoet/lib/Newsletter/Embed/RestApi/Endpoints/NewsletterEmbedSelectorEndpoint.php
@@ -4,8 +4,10 @@ namespace MailPoet\Newsletter\Embed\RestApi\Endpoints;
 
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
+use MailPoet\Config\AccessControl;
 use MailPoet\Newsletter\Embed\NewsletterEmbedService;
 use MailPoet\Validator\Builder;
+use MailPoet\WP\Functions as WPFunctions;
 
 class NewsletterEmbedSelectorEndpoint extends NewsletterEmbedEndpoint {
   /** @var NewsletterEmbedService */
@@ -15,6 +17,10 @@ class NewsletterEmbedSelectorEndpoint extends NewsletterEmbedEndpoint {
     NewsletterEmbedService $newsletterEmbedService
   ) {
     $this->newsletterEmbedService = $newsletterEmbedService;
+  }
+
+  public function checkPermissions(): bool {
+    return WPFunctions::get()->currentUserCan(AccessControl::PERMISSION_MANAGE_EMAILS);
   }
 
   public function handle(Request $request): Response {

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
@@ -71,8 +71,14 @@ class ViewInBrowserController {
       return '';
     }
 
-    // if queue and subscriber exist, subscriber must have received the newsletter
+    // the queue must belong to the validated newsletter; otherwise its stored
+    // body is content the requester's newsletter/hash pair does not authorise
     $queue = isset($data['queue_id']) ? $this->sendingQueuesRepository->findOneById($data['queue_id']) : null;
+    if ($queue && (!$queue->getNewsletter() || $queue->getNewsletter()->getId() !== $newsletter->getId())) {
+      throw new \InvalidArgumentException("Invalid 'queue_id'");
+    }
+
+    // if queue and subscriber exist, subscriber must have received the newsletter
     if (!$isPreview && $queue && $subscriber->getId() && !$this->sendingQueuesRepository->isSubscriberProcessed($queue, $subscriber)) {
       throw new \InvalidArgumentException("Subscriber did not receive the newsletter yet");
     }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttribute.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttribute.php
@@ -69,12 +69,14 @@ class WooCommercePurchasedWithAttribute implements Filter {
   }
 
   private function applyTaxonomyAttributeJoin(QueryBuilder $queryBuilder, string $productAlias, $taxonomySlug, string $alias = 'attribute'): string {
+    $taxonomyParam = $this->filterHelper->getUniqueParameterName('attribute_taxonomy');
     $queryBuilder->innerJoin(
       $productAlias,
       $this->filterHelper->getPrefixedTable('wc_product_attributes_lookup'),
       $alias,
-      "product.product_id = attribute.product_id AND attribute.taxonomy = '$taxonomySlug'"
+      "product.product_id = attribute.product_id AND attribute.taxonomy = :$taxonomyParam"
     );
+    $queryBuilder->setParameter($taxonomyParam, $taxonomySlug);
 
     return $alias;
   }

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -139,6 +139,52 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
     $this->expectViewThrowsExceptionWithMessage($this->viewInBrowserController, $data, 'Subscriber did not receive the newsletter yet');
   }
 
+  public function testItThrowsWhenQueueDoesNotBelongToNewsletter() {
+    // A second newsletter with its own sending queue (a different campaign).
+    $otherNewsletter = (new Newsletter())->create();
+    $otherNewsletter->setHash(Security::generateHash());
+    $otherTask = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, null);
+    $otherQueue = (new SendingQueueFactory())->create($otherTask, $otherNewsletter);
+    $this->entityManager->flush();
+
+    // Data carries the first newsletter's id+hash but points queue_id at the
+    // other campaign's queue; preview=true would otherwise skip the recipient guard.
+    $data = $this->browserPreviewData;
+    $data['queue_id'] = $otherQueue->getId();
+    $data['preview'] = true;
+
+    $this->expectViewThrowsExceptionWithMessage($this->viewInBrowserController, $data, "Invalid 'queue_id'");
+  }
+
+  public function testItAllowsQueueBelongingToNotificationHistoryNewsletter() {
+    // Post-notification newsletters use a parent/child relationship; the sent
+    // "history" child owns its own queue. Its view-in-browser link must still work.
+    $parent = (new Newsletter())->create();
+    $history = (new Newsletter())->withPostNotificationHistoryType()->withParent($parent)->create();
+    $history->setHash(Security::generateHash());
+    $historyTask = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, null);
+    $historyQueue = (new SendingQueueFactory())->create($historyTask, $history);
+    $this->entityManager->flush();
+
+    $viewInBrowserRenderer = $this->make(ViewInBrowserRenderer::class, [
+      'render' => Expected::once(function () {
+        return 'rendered';
+      }),
+    ]);
+    $viewInBrowserController = $this->createController($viewInBrowserRenderer);
+
+    $data = [
+      'queue_id' => $historyQueue->getId(),
+      'subscriber_id' => 0,
+      'newsletter_id' => $history->getId(),
+      'newsletter_hash' => $history->getHash(),
+      'subscriber_token' => 0,
+      'preview' => true,
+    ];
+
+    $this->assertSame('rendered', $viewInBrowserController->view($data));
+  }
+
   public function testUsesEmptySubscriberWhenNotLoggedIn() {
 
     $viewInBrowserRenderer = $this->make(ViewInBrowserRenderer::class, [

--- a/mailpoet/tests/integration/REST/Newsletter/Embed/NewsletterEmbedSelectorEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Newsletter/Embed/NewsletterEmbedSelectorEndpointTest.php
@@ -95,4 +95,35 @@ class NewsletterEmbedSelectorEndpointTest extends Test {
 
     $this->assertSame('rest_forbidden', $data['code']);
   }
+
+  public function testItRejectsContributors(): void {
+    $userId = wp_create_user('newsletter_embed_contributor_' . uniqid(), 'password', 'newsletter-embed-contributor-' . uniqid() . '@localhost.test');
+    $this->assertIsInt($userId);
+    $user = new \WP_User($userId);
+    $user->set_role('contributor');
+    wp_set_current_user($userId);
+
+    $data = $this->get(self::BASE_PATH);
+
+    $this->assertSame('rest_forbidden', $data['code']);
+  }
+
+  public function testItAllowsEditors(): void {
+    (new NewsletterFactory())
+      ->withSubject('Editor embed')
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->create();
+
+    $userId = wp_create_user('newsletter_embed_editor_' . uniqid(), 'password', 'newsletter-embed-editor-' . uniqid() . '@localhost.test');
+    $this->assertIsInt($userId);
+    $user = new \WP_User($userId);
+    $user->set_role('editor');
+    wp_set_current_user($userId);
+
+    $data = $this->get(self::BASE_PATH, ['query' => ['limit' => 10]]);
+
+    $this->assertArrayNotHasKey('code', $data);
+    $this->assertArrayHasKey('items', $data['data']);
+  }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttributeTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttributeTest.php
@@ -96,6 +96,24 @@ class WooCommercePurchasedWithAttributeTest extends \MailPoetTest {
     $this->assertFilterReturnsEmailsForTaxonomyAttributes('all', 'pa_color', [$blueTermId, $redTermId], ['customer1@example.com']);
   }
 
+  public function testItTreatsTaxonomySlugWithSpecialCharactersAsLiteral(): void {
+    $product = $this->tester->createWooCommerceProduct([
+      'price' => 20,
+      'attributes' => [
+        $this->tester->getWooCommerceProductAttribute('color', ['blue']),
+      ],
+    ]);
+
+    $blueTermId = $this->tester->getWooCommerceProductAttributeTermId('color', 'blue');
+
+    $customer = $this->tester->createCustomer('customer1@example.com');
+    $this->createOrder($customer, [$product]);
+
+    // A slug that contains quote characters must be matched as a literal
+    // taxonomy name, so it never resolves to the real "pa_color" taxonomy.
+    $this->assertFilterReturnsEmailsForTaxonomyAttributes('any', "pa_color' OR '1'='1", [$blueTermId], []);
+  }
+
   public function testItWorksWithAnyOperatorForLocalAttributes(): void {
     $product1 = $this->tester->createWooCommerceProduct([
       'price' => 20,


### PR DESCRIPTION
A batch of small backend correctness and consistency fixes:

- **Analytics tracking endpoint** — require plugin admin access, consistent with the other data-bearing endpoints. Its only caller is the admin-side NPS poll, which already runs in that context.
- **"Purchased with attribute" segment filter** — bind the attribute taxonomy slug as a query parameter when building the join, matching the local-attribute path and the other segment filters.
- **Newsletter embed selector endpoint** — require the email-management capability, consistent with the other newsletter endpoints.
- **View-in-browser controller** — bind the queue to its validated newsletter so the rendered content matches the requested newsletter.

Each change ships with test coverage.

Ref: STOMAIL-8319

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:permission-and-query-binding-fixes)

_The latest successful build from `permission-and-query-binding-fixes` will be used. If none is available, the link won't work._

### Backward compatibility

`GET /mailpoet/v1/newsletter-embeds` now requires `mailpoet_manage_emails`
instead of `edit_posts`. By default, this removes access for Contributors and
Authors, who will see an empty newsletter picker in the Newsletter block.
Administrators and Editors are unaffected. Already-embedded blocks still
render. Sites can restore access through the `mailpoet_permission_manage_emails`
filter. 

