### PR TITLE
Update WPCS to 3.4.1

### DIFF
--- a/mailpoet/lib/Form/Templates/FormTemplate.php
+++ b/mailpoet/lib/Form/Templates/FormTemplate.php
@@ -9,7 +9,7 @@ use MailPoet\Util\Helpers;
 use MailPoet\WP\Functions as WPFunctions;
 
 abstract class FormTemplate {
-  const DEFAULT_STYLES = <<<EOL
+  const DEFAULT_STYLES = <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template10BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10BelowPages.php
@@ -211,7 +211,7 @@ class Template10BelowPages extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template10FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10FixedBar.php
@@ -249,7 +249,7 @@ class Template10FixedBar extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template10Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10Popup.php
@@ -181,7 +181,7 @@ class Template10Popup extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template10SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10SlideIn.php
@@ -180,7 +180,7 @@ class Template10SlideIn extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template10Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template10Widget.php
@@ -181,7 +181,7 @@ class Template10Widget extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template11BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11BelowPages.php
@@ -282,7 +282,7 @@ class Template11BelowPages extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template11FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11FixedBar.php
@@ -236,7 +236,7 @@ class Template11FixedBar extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template11Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11Popup.php
@@ -253,7 +253,7 @@ class Template11Popup extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template11SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11SlideIn.php
@@ -252,7 +252,7 @@ class Template11SlideIn extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template11Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template11Widget.php
@@ -189,7 +189,7 @@ class Template11Widget extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template12BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12BelowPages.php
@@ -221,7 +221,7 @@ class Template12BelowPages extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template12FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12FixedBar.php
@@ -266,7 +266,7 @@ class Template12FixedBar extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template12Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12Popup.php
@@ -236,7 +236,7 @@ class Template12Popup extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template12SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12SlideIn.php
@@ -236,7 +236,7 @@ class Template12SlideIn extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template12Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template12Widget.php
@@ -159,7 +159,7 @@ class Template12Widget extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template13BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13BelowPages.php
@@ -227,7 +227,7 @@ class Template13BelowPages extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template13FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13FixedBar.php
@@ -240,7 +240,7 @@ class Template13FixedBar extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template13Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13Popup.php
@@ -228,7 +228,7 @@ class Template13Popup extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template13SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13SlideIn.php
@@ -229,7 +229,7 @@ class Template13SlideIn extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template13Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template13Widget.php
@@ -213,7 +213,7 @@ class Template13Widget extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template14BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14BelowPages.php
@@ -213,7 +213,7 @@ class Template14BelowPages extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template14FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14FixedBar.php
@@ -226,7 +226,7 @@ class Template14FixedBar extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template14Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14Popup.php
@@ -214,7 +214,7 @@ class Template14Popup extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template14SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14SlideIn.php
@@ -215,7 +215,7 @@ class Template14SlideIn extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template14Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template14Widget.php
@@ -199,7 +199,7 @@ class Template14Widget extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template17BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17BelowPages.php
@@ -216,7 +216,7 @@ class Template17BelowPages extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template17FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17FixedBar.php
@@ -198,7 +198,7 @@ class Template17FixedBar extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template17Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17Popup.php
@@ -239,7 +239,7 @@ class Template17Popup extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template17SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17SlideIn.php
@@ -240,7 +240,7 @@ class Template17SlideIn extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template17Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template17Widget.php
@@ -187,7 +187,7 @@ class Template17Widget extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template18BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18BelowPages.php
@@ -297,7 +297,7 @@ class Template18BelowPages extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template18FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18FixedBar.php
@@ -313,7 +313,7 @@ class Template18FixedBar extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template18Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18Popup.php
@@ -258,7 +258,7 @@ class Template18Popup extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template18SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18SlideIn.php
@@ -267,7 +267,7 @@ class Template18SlideIn extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template18Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template18Widget.php
@@ -229,7 +229,7 @@ class Template18Widget extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template1BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1BelowPages.php
@@ -180,7 +180,7 @@ class Template1BelowPages extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 form.mailpoet_form {
   margin-bottom: 0;

--- a/mailpoet/lib/Form/Templates/Templates/Template1FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1FixedBar.php
@@ -210,7 +210,7 @@ class Template1FixedBar extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template1Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1Popup.php
@@ -153,7 +153,7 @@ class Template1Popup extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template1SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1SlideIn.php
@@ -154,7 +154,7 @@ class Template1SlideIn extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template1Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template1Widget.php
@@ -152,7 +152,7 @@ class Template1Widget extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template3BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3BelowPages.php
@@ -188,7 +188,7 @@ class Template3BelowPages extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template3FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3FixedBar.php
@@ -174,7 +174,7 @@ class Template3FixedBar extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template3Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3Popup.php
@@ -156,7 +156,7 @@ class Template3Popup extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template3SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3SlideIn.php
@@ -156,7 +156,7 @@ class Template3SlideIn extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template3Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template3Widget.php
@@ -156,7 +156,7 @@ class Template3Widget extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template4BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4BelowPages.php
@@ -173,7 +173,7 @@ class Template4BelowPages extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template4FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4FixedBar.php
@@ -174,7 +174,7 @@ class Template4FixedBar extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template4Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4Popup.php
@@ -192,7 +192,7 @@ class Template4Popup extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template4SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4SlideIn.php
@@ -193,7 +193,7 @@ class Template4SlideIn extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template4Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template4Widget.php
@@ -154,7 +154,7 @@ class Template4Widget extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template6BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6BelowPages.php
@@ -192,7 +192,7 @@ class Template6BelowPages extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template6FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6FixedBar.php
@@ -160,7 +160,7 @@ class Template6FixedBar extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template6Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6Popup.php
@@ -143,7 +143,7 @@ class Template6Popup extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template6SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6SlideIn.php
@@ -143,7 +143,7 @@ class Template6SlideIn extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template6Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template6Widget.php
@@ -141,7 +141,7 @@ class Template6Widget extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template7BelowPages.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7BelowPages.php
@@ -235,7 +235,7 @@ class Template7BelowPages extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template7FixedBar.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7FixedBar.php
@@ -192,7 +192,7 @@ class Template7FixedBar extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template7Popup.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7Popup.php
@@ -185,7 +185,7 @@ class Template7Popup extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template7SlideIn.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7SlideIn.php
@@ -186,7 +186,7 @@ class Template7SlideIn extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/lib/Form/Templates/Templates/Template7Widget.php
+++ b/mailpoet/lib/Form/Templates/Templates/Template7Widget.php
@@ -170,7 +170,7 @@ class Template7Widget extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 /* form */
 .mailpoet_form {
 }

--- a/mailpoet/prefixer/fix-carbon.php
+++ b/mailpoet/prefixer/fix-carbon.php
@@ -8,7 +8,7 @@ set_error_handler(function ($severity, $message, $file, $line) {
 // Remove all locales except default english
 // We don't use Carbon translate capabilities so we keep only default english locale to reduce size of the library
 exec('find ' . __DIR__ . "/../vendor-prefixed/nesbot/carbon/src/Carbon/Lang -type f -not -name 'en.php' -delete");
-$langList = <<<LANGUGES
+$langList = <<<'LANGUGES'
 <?php
 return [
   'en' => [

--- a/mailpoet/tasks/code_sniffer/composer.json
+++ b/mailpoet/tasks/code_sniffer/composer.json
@@ -8,7 +8,7 @@
     "phpcompatibility/php-compatibility": "^9.3",
     "slevomat/coding-standard": "^8.15",
     "squizlabs/php_codesniffer": "^3.9",
-    "wp-coding-standards/wpcs": "3.1"
+    "wp-coding-standards/wpcs": "3.4.1"
   },
   "repositories": [
     {

--- a/mailpoet/tasks/code_sniffer/composer.lock
+++ b/mailpoet/tasks/code_sniffer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f48e143b38e827c505ddb09d40b6b892",
+    "content-hash": "4afe58ba956282571a3077175d995fce",
     "packages": [],
     "packages-dev": [
         {
@@ -367,25 +367,25 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "de3789a59ee046291bb196c03862c871a692dc75"
+                "reference": "79351d0c9d9149d894411b56667cb7f6636916f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/de3789a59ee046291bb196c03862c871a692dc75",
-                "reference": "de3789a59ee046291bb196c03862c871a692dc75",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/79351d0c9d9149d894411b56667cb7f6636916f1",
+                "reference": "79351d0c9d9149d894411b56667cb7f6636916f1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.9",
-                "squizlabs/php_codesniffer": "^3.8.0"
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "default-branch": true,
             "type": "phpcodesniffer-standard",
@@ -436,9 +436,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-07-23T06:25:32+00:00"
+            "time": "2026-07-27T16:01:19+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
@@ -446,25 +450,25 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "8a1f3f533b9e359f4438c7c7dd46bb35a6ffcb89"
+                "reference": "170d55931d3190a1feb35b7985a4b725094908c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/8a1f3f533b9e359f4438c7c7dd46bb35a6ffcb89",
-                "reference": "8a1f3f533b9e359f4438c7c7dd46bb35a6ffcb89",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/170d55931d3190a1feb35b7985a4b725094908c7",
+                "reference": "170d55931d3190a1feb35b7985a4b725094908c7",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
             },
             "default-branch": true,
             "type": "phpcodesniffer-standard",
@@ -502,6 +506,7 @@
                 "phpcodesniffer-standard",
                 "phpcs",
                 "phpcs3",
+                "phpcs4",
                 "standards",
                 "static analysis",
                 "tokens",
@@ -525,9 +530,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-08-19T08:51:38+00:00"
+            "time": "2026-07-27T15:58:30+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -703,16 +712,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "dev-master",
+            "version": "3.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "41a426cac70d410183189bc31c63f474f6f53548"
+                "reference": "20d0f55e6bbaca7dba506f9fb200644e8f3aebb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/41a426cac70d410183189bc31c63f474f6f53548",
-                "reference": "41a426cac70d410183189bc31c63f474f6f53548",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/20d0f55e6bbaca7dba506f9fb200644e8f3aebb0",
+                "reference": "20d0f55e6bbaca7dba506f9fb200644e8f3aebb0",
                 "shasum": ""
             },
             "require": {
@@ -724,17 +733,11 @@
             "require-dev": {
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
-            "default-branch": true,
             "bin": [
                 "bin/phpcbf",
                 "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -778,22 +781,26 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-08-17T17:43:40+00:00"
+            "time": "2026-07-26T20:55:06+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.1.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7"
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/9333efcbff231f10dfd9c56bb7b65818b4733ca7",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
                 "shasum": ""
             },
             "require": {
@@ -801,17 +808,17 @@
                 "ext-libxml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
-                "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.2.1",
-                "phpcsstandards/phpcsutils": "^1.0.10",
-                "squizlabs/php_codesniffer": "^3.9.0"
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
                 "phpcsstandards/phpcsdevtools": "^1.2.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "suggest": {
                 "ext-iconv": "For improved results",
@@ -846,18 +853,18 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-03-25T16:39:00+00:00"
+            "time": "2026-07-27T11:53:23+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/mailpoet/tasks/form-export/Template.php
+++ b/mailpoet/tasks/form-export/Template.php
@@ -27,7 +27,7 @@ class Template extends FormTemplate {
   }
 
   public function getStyles(): string {
-    return <<<EOL
+    return <<<'EOL'
 TEMPLATE_STYLES
 EOL;
   }

--- a/mailpoet/tests/acceptance/Forms/FormsListingCest.php
+++ b/mailpoet/tests/acceptance/Forms/FormsListingCest.php
@@ -85,7 +85,7 @@ class FormsListingCest {
       const disabledAt = text.indexOf('{$disabledName}');
       return enabledAt !== -1 && disabledAt !== -1 && enabledAt < disabledAt;
     JS, 10);
-    $orderedNames = $i->executeJS(<<<JS
+    $orderedNames = $i->executeJS(<<<'JS'
       return Array.from(document.querySelectorAll('.mailpoet-forms-dataviews tbody tr'))
         .map((row) => row.textContent)
         .join('||');

--- a/mailpoet/tests/acceptance/Misc/LogsListingCest.php
+++ b/mailpoet/tests/acceptance/Misc/LogsListingCest.php
@@ -112,7 +112,7 @@ class LogsListingCest {
       const debugAt = text.indexOf('debug-message-{$suffix}');
       return errorAt !== -1 && debugAt !== -1 && errorAt < debugAt;
     JS, 10);
-    $orderedMessages = $i->executeJS(<<<JS
+    $orderedMessages = $i->executeJS(<<<'JS'
       return Array.from(document.querySelectorAll('.mailpoet-logs-dataviews tbody tr'))
         .map((row) => row.textContent)
         .join('||');

--- a/mailpoet/tests/integration/Newsletter/Editor/PostContentManagerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Editor/PostContentManagerTest.php
@@ -184,7 +184,7 @@ class PostContentManagerTest extends \MailPoetTest {
   }
 
   public function testItRemovesImageCaptionsFromGutenbergPosts() {
-    $content = <<<EOT
+    $content = <<<'EOT'
       <!-- wp:paragraph -->
       <p>Text</p>
       <!-- /wp:paragraph -->


### PR DESCRIPTION
## Description

Updates WPCS to 3.4.1, which fixes arbitrary command execution in the `WordPress.WP.EnqueuedResourceParameters` sniff — [GHSA-3pwp-g2mj-5p3v](https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/GHSA-3pwp-g2mj-5p3v), CVSS 8.6. The affected range is `>= 0.14.1, < 3.4.1`.

We were on WPCS 3.1.0. Our `shared-ruleset.xml` pulls in `WordPress-Extra`, one of the two rulesets that include the affected sniff, and `qa:php` runs on every branch — so a branch carrying crafted PHP could have run commands on the CI host.

Two parts to the diff:

**1. The bump.** Unlike our other plugins, `tasks/code_sniffer/composer.json` pinned WPCS to an exact `"3.1"`, so the constraint had to move too. I kept the exact-pin style rather than switching to a range, since it looked deliberate.

| Package | From | To |
|---|---|---|
| `wp-coding-standards/wpcs` | 3.1.0 | 3.4.1 |
| `phpcsstandards/phpcsextra` | `dev-develop` de3789a | `dev-develop` 79351d0 |
| `phpcsstandards/phpcsutils` | `dev-develop` 8a1f3f5 | `dev-develop` 170d559 |
| `squizlabs/php_codesniffer` | `dev-master` | `3.x-dev` |

The `php_codesniffer` move off `dev-master` is forced: WPCS 3.4.1 requires `^3.13.5`, and `dev-master` is now 4.x.

**2. Heredoc → nowdoc, 66 sites.** php_codesniffer 3.11 added `Generic.Strings.UnnecessaryHeredoc`, which flags heredocs that never interpolate. Without this, `qa:php` goes red.

`tasks/form-export/Template.php` is the generator stub behind the 65 `lib/Form/Templates/Templates/Template*.php` files, so it is fixed too — regenerating the templates will not undo this.

## Code review notes

The part worth your attention is whether the nowdoc conversion is really a no-op. I checked every one of the 66 bodies rather than trusting the sniff:

- **No `$` anywhere.** Not one body contains a dollar sign, so nothing was being interpolated and nothing could be.
- **No backslash anywhere.** This is the one that could have bitten us. Heredoc expands escape sequences (`\n`, `\t`, `\u{...}`) and nowdoc does not, and CSS can legitimately contain backslashes. There are none, so the two forms produce byte-identical strings here.

Only the opening delimiter changes in each file; no body content is touched.

## QA notes

No user-facing change, so there is nothing to click through. If you want to verify independently:

1. `cd mailpoet/tasks/code_sniffer && composer install`
2. `composer show wp-coding-standards/wpcs` reports **3.4.1**.
3. `vendor/wp-coding-standards/wpcs/WordPress/Sniffs/WP/EnqueuedResourceParametersSniff.php` no longer contains `eval(`.
4. `./do qa:php` from `mailpoet/` exits **0**.
5. The form templates should render identically — the four acceptance and four integration variants on this PR all pass, which is the empirical check on that.

## Linked PRs

_N/A_

## Linked tickets

_N/A_ — driven by the upstream advisory rather than a ticket.

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry — **intentionally skipped.** The valid types are `Added, Improved, Fixed, Changed, Updated, Removed`, all user-facing, and this only touches dev lint tooling. An entry here would surface as noise in the plugin's readme changelog. Happy to add one if you disagree.
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations — no strings added or changed.
- [x] I added sufficient test coverage — no behaviour change to cover; existing suites all pass.
- [x] I embraced TypeScript — no JavaScript touched.
