### PR TITLE
Bump oldest WooCommerce CI matrix to 10.9.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1172,14 +1172,13 @@ workflows:
             - build_release_zip
 
   nightly:
-    # TEMP: triggers disabled to run nightly on push for CI verification. REVERT before merge.
-    # triggers:
-    #   - schedule:
-    #       cron: '0 1 * * 1-5'
-    #       filters:
-    #         branches:
-    #           only:
-    #             - trunk
+    triggers:
+      - schedule:
+          cron: '0 1 * * 1-5'
+          filters:
+            branches:
+              only:
+                - trunk
     jobs:
       - build:
           <<: *slack-fail-post-step

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1172,13 +1172,14 @@ workflows:
             - build_release_zip
 
   nightly:
-    triggers:
-      - schedule:
-          cron: '0 1 * * 1-5'
-          filters:
-            branches:
-              only:
-                - trunk
+    # TEMP: triggers disabled to run nightly on push for CI verification. REVERT before merge.
+    # triggers:
+    #   - schedule:
+    #       cron: '0 1 * * 1-5'
+    #       filters:
+    #         branches:
+    #           only:
+    #             - trunk
     jobs:
       - build:
           <<: *slack-fail-post-step
@@ -1211,7 +1212,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 10.8.1
+          woo_core_version: 10.9.4
           woo_subscriptions_version: 8.8.1
           automate_woo_version: 6.6.0
           mysql_command: --max_allowed_packet=100M
@@ -1254,7 +1255,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          woo_core_version: 10.8.1
+          woo_core_version: 10.9.4
           woo_subscriptions_version: 8.8.1
           automate_woo_version: 6.6.0
           codeception_image_version: 7.4-cli_20220605.0
@@ -1316,7 +1317,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_with_premium_oldest
-          woo_core_version: 10.8.1
+          woo_core_version: 10.9.4
           woo_subscriptions_version: 8.8.1
           automate_woo_version: 6.6.0
           codeception_image_version: 7.4-cli_20220605.0
@@ -1327,7 +1328,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_with_premium_oldest
-          woo_core_version: 10.8.1
+          woo_core_version: 10.9.4
           woo_subscriptions_version: 8.8.1
           automate_woo_version: 6.6.0
           codeception_image_version: 7.4-cli_20220605.0


### PR DESCRIPTION
## Description

#7001 raised `MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION` from 10.8 to 10.9, but the `*_oldest` CI matrix still installed WooCommerce **10.8.1**. With WC below the new minimum, `mailpoet_check_requirements()` returns `false`, so the plugin initializer never loads, `Env::init()` never runs, `Env::$dbPrefix` stays `null`, and the integration/acceptance bootstrap throws at EntityManager creation, taking down the whole suite.

Pins the oldest matrix (4 jobs) to **10.9.4** (latest 10.9.x) to match the minimum.

## Code review notes

Verified on pipeline [24437](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/24437/workflows/cc3c634c-1ede-411c-97fc-307b685fa383): with the schedule trigger temporarily disabled, nightly ran on push and all 5 oldest jobs (`integration_oldest`, `integration_with_premium_oldest`, `unit_oldest`, `acceptance_oldest`, `acceptance_with_premium_oldest`) went green. The trigger has been restored in a follow-up commit on this branch.

The weekly version-check automation would not have fixed this. It writes the highest stable version whose major.minor differs from the latest, which is still 10.8.1 while 10.9.4 is the latest on wp.org. It only starts writing 10.9.4 once WooCommerce 11.0 ships.

## QA notes

CI config only; no plugin code changed.

## Linked tickets

STOMAIL-8327

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8327-ci-oldest-woocommerce-version)

_The latest successful build from `fix/stomail-8327-ci-oldest-woocommerce-version` will be used. If none is available, the link won't work._