### PR TITLE
Skip engagement score recalculation on SQLite

### DIFF
--- a/mailpoet/changelog/2026-07-29-09-04-39-fixed-restore-link-tracking-and-open-tracking-on-wordpre.md
+++ b/mailpoet/changelog/2026-07-29-09-04-39-fixed-restore-link-tracking-and-open-tracking-on-wordpre.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Restore link tracking and open tracking on WordPress Playground preview sites

--- a/mailpoet/lib/Cron/Workers/SubscribersEngagementScore.php
+++ b/mailpoet/lib/Cron/Workers/SubscribersEngagementScore.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Cron\Workers;
 
+use MailPoet\Doctrine\WPDB\Connection;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Statistics\StatisticsOpensRepository;
@@ -36,6 +37,15 @@ class SubscribersEngagementScore extends SimpleWorker {
   }
 
   public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+    // The recalculator relies on UPDATE ... LEFT JOIN, which the SQLite integration in
+    // WordPress Playground does not support. Make the task a no-op there: it never writes
+    // engagementScoreUpdatedAt, so the loop below would keep re-reading the same batch
+    // until the execution limit throws. Segment averages are skipped too because they
+    // average subscriber scores that stay unset.
+    if (Connection::isSQLite()) {
+      return true;
+    }
+
     while ($this->recalculateSubscribers() > 0) {
       $this->cronHelper->enforceExecutionLimit($timer); // Throws exception and interrupts process if over execution limit
     }

--- a/mailpoet/lib/Statistics/StatisticsOpensRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsOpensRepository.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Statistics;
 
 use MailPoet\Doctrine\Repository;
+use MailPoet\Doctrine\WPDB\Connection;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\StatisticsOpenEntity;
@@ -50,6 +51,14 @@ class StatisticsOpensRepository extends Repository {
    * @param int[] $subscriberIds
    */
   public function recalculateSubscribersScore(array $subscriberIds): void {
+    // The UPDATE ... LEFT JOIN below is not supported by the SQLite integration used in
+    // WordPress Playground. Scores stay unset there and the listing reports them as
+    // unknown; the sweep worker no-ops for the same reason (see SubscribersEngagementScore).
+    // Without this guard the tracking endpoint throws, which also breaks the click redirect.
+    if (Connection::isSQLite()) {
+      return;
+    }
+
     if (!$subscriberIds) {
       return;
     }


### PR DESCRIPTION
## Description

On WordPress Playground (SQLite) sites, opening a tracked email throws a database error and clicking a tracked link never redirects the reader to the destination URL. MySQL/MariaDB sites are unaffected.

`StatisticsOpensRepository::recalculateSubscribersScore()` was changed in 93c81124f2 to compute engagement scores with a single raw `UPDATE ... LEFT JOIN`. That syntax is not supported by the SQLite integration used in WordPress Playground — `SegmentsCountRecalculator::recalculateForSubscribers()` guards an identical query shape for exactly this reason. The previous implementation used Doctrine DQL, which the SQLite integration translates, so this is a regression that shipped in 5.34.x.

The path is reachable from the public tracking endpoint: `Opens::track()` recalculates the score on every recorded open, and `Clicks::track()` records the open *before* redirecting — so the thrown error aborts the click redirect.

Both the repository and the sweep worker are guarded. The worker guard is not cosmetic: `processTaskStrategy()` loops until a batch comes back empty, and batches are selected by `engagement_score_updated_at`. With only the repository guarded, that column would never advance, the same batch would be re-read until the execution limit interrupted the task, and this would repeat on every run.

Engagement scores now stay unset on Playground and the subscriber listing reports them as unknown — the same trade-off `SegmentsCountRecalculator` already makes for segment counts.

## Code review notes

- The alternative was to keep computing scores on SQLite through a portable fallback (grouped `SELECT`s plus per-row `UPDATE`s, or the old DQL path). I went with skipping the feature to stay consistent with the segment-count sibling. Happy to revisit if we think Playground previews should show real engagement scores — worth noting that with `MIN_SENT_EMAILS_FOR_ENGAGEMENT_SCORE = 3`, most Playground subscribers would score `NULL` anyway.
- Returning `true` from `processTaskStrategy()` marks the task complete; `CronWorkerRunner` reschedules it through `AUTOMATIC_SCHEDULING`, so skipping the explicit `$this->schedule()` call at the end of the method is intentional and matches `SubscribersSegmentsCountSync`.

## QA notes

Not covered by automated tests: the suite runs against MySQL only, and `Connection::isSQLite()` reads the `DB_ENGINE` constant, so the guarded branch can't be exercised there. No existing test in the repo covers the other `isSQLite()` guards either, for the same reason.

Manual check on the Playground preview below:

1. Send an email to a subscriber and open it — no database error, the tracking pixel returns normally.
2. Click a tracked link in the email — the reader is redirected to the destination URL.
3. On a MySQL site, confirm engagement scores still populate as before (subscriber listing, engagement filters).

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8303

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/regression-in-engagement-score)

_The latest successful build from `fix/regression-in-engagement-score` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

1 issue found:
- **Bug:** SQLite sites could fail during engagement-score recalculation, disrupting tracked email opens and link redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->