### PR TITLE
Sanitize WordPress user names when syncing subscribers

### DIFF
--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -207,10 +207,10 @@ class WP {
     }
 
     // get first name & last name
-    $firstName = html_entity_decode($wpUser->first_name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-    $lastName = html_entity_decode($wpUser->last_name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $firstName = $this->decodeUserName($wpUser->first_name); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $lastName = $this->decodeUserName($wpUser->last_name); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     if (empty($wpUser->first_name) && empty($wpUser->last_name)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      $firstName = html_entity_decode($wpUser->display_name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      $firstName = $this->decodeUserName($wpUser->display_name); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     }
     $signupConfirmationEnabled = SettingsController::getInstance()->get('signup_confirmation.enabled');
     $status = $signupConfirmationEnabled ? SubscriberEntity::STATUS_UNCONFIRMED : SubscriberEntity::STATUS_SUBSCRIBED;
@@ -362,6 +362,21 @@ class WP {
         (array)$oldWpUserData
       );
     }
+  }
+
+  /**
+   * WordPress stores user names entity-encoded (see the `pre_user_first_name`,
+   * `pre_user_last_name` and `pre_user_display_name` filters). We decode them so a
+   * name such as "Family & friends" is stored the way it was written, then run the
+   * same text sanitizer the other subscriber write paths use, so decoding can never
+   * turn encoded markup back into markup.
+   *
+   * @param mixed $name
+   */
+  private function decodeUserName($name): string {
+    $decoded = html_entity_decode(is_string($name) ? $name : '', ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
+
+    return sanitize_text_field($decoded);
   }
 
   private function createOrUpdateSubscriber(array $data, ?SubscriberEntity $subscriber = null): SubscriberEntity {

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -376,7 +376,7 @@ class WP {
   private function decodeUserName($name): string {
     $decoded = html_entity_decode(is_string($name) ? $name : '', ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
 
-    return sanitize_text_field($decoded);
+    return $this->wp->sanitizeTextField($decoded);
   }
 
   private function createOrUpdateSubscriber(array $data, ?SubscriberEntity $subscriber = null): SubscriberEntity {

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -966,6 +966,46 @@ class WPTest extends \MailPoetTest {
     wp_delete_user($userId);
   }
 
+  public function testItDoesNotStoreMarkupDecodedFromWpUserNames(): void {
+    $args = [
+      'user_login' => 'encoded-markup-name',
+      'user_email' => 'user-sync-test-encoded-markup@example.com',
+      'first_name' => '&lt;img src=x onerror=alert(1)&gt;',
+      'last_name' => '&lt;script&gt;alert(1)&lt;/script&gt;',
+      'role' => 'subscriber',
+      'user_pass' => 'password',
+    ];
+    $userId = wp_insert_user($args);
+    $this->assertIsNumeric($userId);
+
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => $args['user_email']]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->assertStringNotContainsString('<img', (string)$subscriber->getFirstName());
+    $this->assertStringNotContainsString('<script', (string)$subscriber->getLastName());
+
+    wp_delete_user((int)$userId);
+  }
+
+  public function testItDoesNotStoreMarkupDecodedFromWpUserDisplayName(): void {
+    $args = [
+      'user_login' => 'encoded-markup-display-name',
+      'user_email' => 'user-sync-test-encoded-markup-display@example.com',
+      'first_name' => '',
+      'last_name' => '',
+      'display_name' => '&lt;img src=x onerror=alert(1)&gt;',
+      'role' => 'subscriber',
+      'user_pass' => 'password',
+    ];
+    $userId = wp_insert_user($args);
+    $this->assertIsNumeric($userId);
+
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => $args['user_email']]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->assertStringNotContainsString('<img', (string)$subscriber->getFirstName());
+
+    wp_delete_user((int)$userId);
+  }
+
   public function testItDoesNotTrashNewUsersWhoHaveSomeSegmentsToDisabledWPSegment(): void {
     $this->disableWpSegment();
     $randomNumber = rand();


### PR DESCRIPTION
## Description

The WordPress user sync decodes HTML entities in first name, last name and display name, so a name written with an ampersand is stored the way it was typed rather than as `Family &amp; friends`. That decoding is deliberate and still needed.

On its own, though, decoding can also turn encoded markup back into markup before it is stored. The decoded value now goes through `sanitize_text_field()`, the same text sanitizer the other subscriber write paths already use, so what the sync writes is consistent with what those paths write.

Decoding still runs first, so real names are unchanged: `Family & friends` and `O'Brien` are stored exactly as before. The two existing entity-decoding tests still pass and are the guard for that.

Both name reads and the display-name fallback route through one new private helper, `WP::decodeUserName()`.

## Code review notes

- **Order matters.** Decode has to happen before sanitize. Reversing them, or dropping the decode, means WordPress's own encoding (`pre_user_first_name` and friends run `_wp_specialchars`) survives into MailPoet's table, and `Family & friends` then renders as a literal `&amp;`. `testItDecodesHtmlEntitesInFirstAndLastName` and `testItDecodesHtmlEntitesInDisplayName` fail if that happens, on purpose.
- **Why the parameter is untyped.** `WP_User` name fields are magic properties, so PHPStan sees `mixed`. A `?string` hint would push the error to the call sites, and a `(string)` cast trips `cast.string`. The `is_string()` guard satisfies both without changing behaviour, since `get_userdata()` always returns strings here.
- **Scope is the single-user sync path only.** The bulk sync (`updateFirstNames()`, `updateLastNames()`, `updateFirstNameIfMissing()`) copies usermeta with plain SQL and never decodes, so it is untouched and unaffected. Worth a separate look, since it means bulk-synced users miss the decoding behaviour entirely.

## QA notes

Ran against the Docker integration environment:

- `Segments/WPTest` — OK (49 tests, 186 assertions), including two new cases and the two existing entity-decoding cases
- `Segments/WooCommerceTest` — OK (34 tests, 117 assertions)
- `Subscribers/SubscriberSaveControllerTest` — OK (16 tests, 67 assertions)
- `Subscription/RegistrationTest` — OK (5 tests, 5 assertions)
- `parallel-lint` over `lib/`, `tests/`, `mailpoet.php` — 2158 files, no syntax errors
- `phpcs` (free ruleset) over `lib/Segments/` and `tests/integration/Segments/` — exit 0, no violations
- `phpstan` — `[OK] No errors`
- `prettier` — no PHP parser, so this diff is outside its scope; check passes

To QA by hand: edit a WordPress user's first name to `Family & friends`, save, and confirm the MailPoet subscriber shows `Family & friends` and that it renders correctly in an email using the first-name personalization tag.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8329

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- No changelog entry: stored names are unchanged for every valid name, so there is nothing user-visible to describe. No translatable strings and no JS/TS in this change. -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8329-sanitize-wp-user-names-on-sync)

_The latest successful build from `fix/stomail-8329-sanitize-wp-user-names-on-sync` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->