### PR TITLE
Update email editor packages

### DIFF
--- a/mailpoet/changelog/2026-07-31-12-20-54-updated-email-editor-packages-to-the-latest-versions.md
+++ b/mailpoet/changelog/2026-07-31-12-20-54-updated-email-editor-packages-to-the-latest-versions.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Email editor packages to the latest versions

--- a/mailpoet/changelog/2026-07-31-12-21-02-added-video-embeds-from-youtube-vimeo-tiktok-dailymotion.md
+++ b/mailpoet/changelog/2026-07-31-12-21-02-added-video-embeds-from-youtube-vimeo-tiktok-dailymotion.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Video embeds from YouTube, Vimeo, TikTok, Dailymotion and VideoPress in the new email editor

--- a/mailpoet/changelog/2026-07-31-12-21-03-improved-typing-responsiveness-in-the-new-email-editor-canv.md
+++ b/mailpoet/changelog/2026-07-31-12-21-03-improved-typing-responsiveness-in-the-new-email-editor-canv.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Typing responsiveness in the new email editor canvas

--- a/mailpoet/changelog/2026-07-31-12-21-11-fixed-rows-of-buttons-that-do-not-fit-on-one-line-now-wr.md
+++ b/mailpoet/changelog/2026-07-31-12-21-11-fixed-rows-of-buttons-that-do-not-fit-on-one-line-now-wr.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Rows of buttons that do not fit on one line now wrap instead of stretching the email past its content width

--- a/mailpoet/changelog/2026-07-31-12-21-12-fixed-full-width-blocks-now-display-full-width-in-the-ne.md
+++ b/mailpoet/changelog/2026-07-31-12-21-12-fixed-full-width-blocks-now-display-full-width-in-the-ne.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Full-width blocks now display full width in the new email editor canvas, matching the sent email

--- a/mailpoet/changelog/2026-07-31-12-21-13-fixed-crash-when-opening-the-typography-styles-panel-for.md
+++ b/mailpoet/changelog/2026-07-31-12-21-13-fixed-crash-when-opening-the-typography-styles-panel-for.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Crash when opening the typography styles panel for an element without typography styles

--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -6,7 +6,7 @@
     "dragonmantank/cron-expression": "^3.3",
     "mixpanel/mixpanel-php": "2.*",
     "woocommerce/action-scheduler": "3.9.2",
-    "woocommerce/email-editor": "2.13.0"
+    "woocommerce/email-editor": "2.15.1"
   },
   "require-dev": {
     "ext-gd": "*",

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "362475ab3000a6225facecf40e51a264",
+    "content-hash": "2769184bc03a099ec6f4dce25a325723",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -285,16 +285,16 @@
         },
         {
             "name": "woocommerce/email-editor",
-            "version": "2.13.0",
+            "version": "2.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/email-editor.git",
-                "reference": "bdd2aeaa5f2852b0ef1a6b84da1cff2990c13f40"
+                "reference": "620f16bc1ee7ad33b7b5df8f354286a0033a33da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/bdd2aeaa5f2852b0ef1a6b84da1cff2990c13f40",
-                "reference": "bdd2aeaa5f2852b0ef1a6b84da1cff2990c13f40",
+                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/620f16bc1ee7ad33b7b5df8f354286a0033a33da",
+                "reference": "620f16bc1ee7ad33b7b5df8f354286a0033a33da",
                 "shasum": ""
             },
             "require": {
@@ -336,9 +336,9 @@
             ],
             "description": "Email editor based on WordPress Gutenberg package.",
             "support": {
-                "source": "https://github.com/woocommerce/email-editor/tree/2.13.0"
+                "source": "https://github.com/woocommerce/email-editor/tree/2.15.1"
             },
-            "time": "2026-05-04T09:48:24+00:00"
+            "time": "2026-07-30T06:35:43+00:00"
         }
     ],
     "packages-dev": [

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -53,7 +53,7 @@
     "@woocommerce/components": "^13.1.0",
     "@woocommerce/currency": "^4.3.0",
     "@woocommerce/date": "^4.3.0",
-    "@woocommerce/email-editor": "2.1.0",
+    "@woocommerce/email-editor": "2.2.1",
     "@wordpress/a11y": "^4.43.0",
     "@wordpress/api-fetch": "^7.43.0",
     "@wordpress/block-editor": "^15.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0(lodash@4.18.1)
       '@woocommerce/email-editor':
-        specifier: 2.1.0
-        version: 2.1.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))
+        specifier: 2.2.1
+        version: 2.2.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))
       '@wordpress/a11y':
         specifier: ^4.43.0
         version: 4.44.0
@@ -4366,8 +4366,8 @@ packages:
     peerDependencies:
       lodash: ^4.17.0
 
-  '@woocommerce/email-editor@2.1.0':
-    resolution: {integrity: sha512-Zf0jyszKPP+E53OMMfowcjzuV2RZ0XpzETvPioqG7GJ8EaSo7M3ejcNSLcG1FM6I2pJmm0K7GSUTQ2fBUsS0Xg==}
+  '@woocommerce/email-editor@2.2.1':
+    resolution: {integrity: sha512-JNStqAIhASVN3w69/adR+hpjQU1Mheu80dQ8ntHhWfvk//PS9gFj/Z9ZZJUhQh0yDEYa3nqCrf19UftIxtur9Q==}
 
   '@woocommerce/navigation@8.2.0':
     resolution: {integrity: sha512-joAbrzdhrnWf91kEwuNO3hzT0IiUuh8SNOs0Qbth/heZaN+SixA5yJ98UqEHNa2Mitjm5BTC4M0Qk7X+I8uUvQ==}
@@ -17664,7 +17664,7 @@ snapshots:
       moment-timezone: 0.5.45
       qs: 6.15.2
 
-  '@woocommerce/email-editor@2.1.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))':
+  '@woocommerce/email-editor@2.2.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/api-fetch': 7.44.0
       '@wordpress/base-styles': 6.20.0


### PR DESCRIPTION
## Description

Updates both email editor packages to their latest versions:

- PHP `woocommerce/email-editor`: 2.13.0 → 2.15.1
- JS `@woocommerce/email-editor`: 2.1.0 → 2.2.1

Each package bump is its own commit. No code changes were needed on the MailPoet side.

Changelog entries were added for the user-facing changes that come with the update — video embeds, faster typing in the canvas, button-row wrapping, full-width blocks on the canvas, and the typography panel crash fix.

## Code review notes

Changelog entries were only added for changes users can actually reach. 

## QA notes

Worth checking in the new email editor:

- Insert a video embed (YouTube, Vimeo, TikTok, Dailymotion or VideoPress) and confirm it renders as a thumbnail with a play button in the sent email
- Type in the editor canvas and confirm it feels responsive
- Add a row of buttons wide enough not to fit on one line and confirm it wraps instead of stretching the email
- Open the typography styles panel on a few different blocks

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-email-editor-packages)

_The latest successful build from `update-email-editor-packages` will be used. If none is available, the link won't work._