### PR TITLE
Warn that deleting a WordPress user keeps the MailPoet subscriber

### DIFF
--- a/mailpoet/changelog/2026-07-31-10-43-16-added-notice-on-the-wordpress-delete-user-screen-explain.md
+++ b/mailpoet/changelog/2026-07-31-10-43-16-added-notice-on-the-wordpress-delete-user-screen-explain.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Notice on the WordPress delete user screen explaining that the linked MailPoet subscriber is kept

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -12,6 +12,7 @@ use MailPoet\Form\DisplayFormInWPContent;
 use MailPoet\Mailer\WordPress\WordpressMailerReplacer;
 use MailPoet\Newsletter\Scheduler\PostNotificationScheduler;
 use MailPoet\Segments\WP;
+use MailPoet\Segments\WPUserDeleteNotice;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Statistics\Track\SubscriberHandler;
 use MailPoet\Subscribers\SubscriberLimitNotificationScheduler;
@@ -73,6 +74,9 @@ class Hooks {
   /** @var WP */
   private $wpSegment;
 
+  /** @var WPUserDeleteNotice */
+  private $wpUserDeleteNotice;
+
   /** @var SubscriberHandler */
   private $subscriberHandler;
 
@@ -127,6 +131,7 @@ class Hooks {
     WordpressMailerReplacer $wordpressMailerReplacer,
     DisplayFormInWPContent $displayFormInWPContent,
     WP $wpSegment,
+    WPUserDeleteNotice $wpUserDeleteNotice,
     SubscriberHandler $subscriberHandler,
     HooksWooCommerce $hooksWooCommerce,
     SubscriberChangesNotifier $subscriberChangesNotifier,
@@ -153,6 +158,7 @@ class Hooks {
     $this->wordpressMailerReplacer = $wordpressMailerReplacer;
     $this->displayFormInWPContent = $displayFormInWPContent;
     $this->wpSegment = $wpSegment;
+    $this->wpUserDeleteNotice = $wpUserDeleteNotice;
     $this->subscriberHandler = $subscriberHandler;
     $this->hooksWooCommerce = $hooksWooCommerce;
     $this->captchaHooks = $captchaHooks;
@@ -421,6 +427,9 @@ class Hooks {
       [$this->wpSegment, 'synchronizeUser'],
       1
     );
+
+    // Warn on the delete-user confirmation screen that the subscriber is kept.
+    $this->wpUserDeleteNotice->setupHooks();
 
     // login
     $this->wp->addAction(

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -544,6 +544,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Segments
     $container->autowire(\MailPoet\Segments\WooCommerce::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\WP::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\WPUserDeleteNotice::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\SubscribersFinder::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\SegmentsFinder::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\SegmentsRepository::class)->setPublic(true);

--- a/mailpoet/lib/Segments/WPUserDeleteNotice.php
+++ b/mailpoet/lib/Segments/WPUserDeleteNotice.php
@@ -1,0 +1,168 @@
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+
+namespace MailPoet\Segments;
+
+use MailPoet\Config\AccessControl;
+use MailPoet\Config\Menu;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Util\Helpers;
+use MailPoet\WP\Functions as WPFunctions;
+
+/**
+ * Tells the admin, on the WordPress "Delete Users" confirmation screen, that deleting a
+ * WordPress user does not delete the MailPoet subscriber linked to it.
+ *
+ * Before MailPoet 5.26.0 the subscriber was hard-deleted along with the user. It is now
+ * unlinked and kept instead - see WP::unlinkSubscriberFromWpUser(). WordPress users are
+ * often deleted for privacy reasons, so the change is worth surfacing at the moment of
+ * deletion rather than only in the documentation.
+ *
+ * Sites that opted back into the old hard-delete behaviour with the
+ * `mailpoet_delete_subscriber_on_wp_user_delete` filter get what they expect already, so
+ * they are not counted and the notice stays hidden.
+ */
+class WPUserDeleteNotice {
+  const KB_ARTICLE_URL = 'https://kb.mailpoet.com/article/133-the-wordpress-users-list#remove-users-from-wordpress-list';
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var AccessControl */
+  private $accessControl;
+
+  public function __construct(
+    WPFunctions $wp,
+    SubscribersRepository $subscribersRepository,
+    AccessControl $accessControl
+  ) {
+    $this->wp = $wp;
+    $this->subscribersRepository = $subscribersRepository;
+    $this->accessControl = $accessControl;
+  }
+
+  public function setupHooks(): void {
+    // Fires at the end of the delete-users confirmation form, just before the confirm
+    // button. Used by both wp-admin/users.php (single site) and confirm_delete_users()
+    // in wp-admin/includes/ms.php (network admin).
+    $this->wp->addAction('delete_user_form', [$this, 'displayNotice'], 10, 2);
+  }
+
+  /**
+   * @param \WP_User|null $currentUser Part of the delete_user_form signature, unused.
+   * @param mixed $userIds IDs of the users about to be deleted. Network admin passes raw
+   *                       $_POST values, so this is not guaranteed to hold clean integers.
+   */
+  public function displayNotice($currentUser = null, $userIds = null): void {
+    if (!is_array($userIds)) {
+      return;
+    }
+
+    $userIds = $this->normalizeUserIds($userIds);
+    $count = $this->countSubscribersKeptOnDelete($userIds);
+    if ($count < 1) {
+      return;
+    }
+    $onlyOneUserSelected = count($userIds) === 1;
+
+    $allowedHtml = [
+      'strong' => [],
+      'a' => [
+        'href' => true,
+        'target' => true,
+        'rel' => true,
+      ],
+    ];
+
+    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    echo '<p>' . $this->wp->wpKses($this->getMessage($count, $onlyOneUserSelected), $allowedHtml) . '</p>';
+  }
+
+  /**
+   * @param array $userIds Raw ids, which on the network admin screen come straight from $_POST.
+   * @return int[]
+   */
+  private function normalizeUserIds(array $userIds): array {
+    $normalized = [];
+    foreach ($userIds as $userId) {
+      $userId = is_scalar($userId) ? (int)$userId : 0;
+      if ($userId > 0) {
+        $normalized[] = $userId;
+      }
+    }
+    return array_values(array_unique($normalized));
+  }
+
+  /**
+   * Number of the users about to be deleted whose MailPoet subscriber will survive.
+   *
+   * @param int[] $userIds Already normalised by displayNotice().
+   */
+  private function countSubscribersKeptOnDelete(array $userIds): int {
+    if (!$userIds) {
+      return 0;
+    }
+
+    $subscribers = $this->subscribersRepository->findBy(['wpUserId' => $userIds]);
+
+    $count = 0;
+    foreach ($subscribers as $subscriber) {
+      $wpUserId = $subscriber->getWpUserId();
+      if ($wpUserId === null) {
+        continue;
+      }
+      // Same filter call as WP::unlinkSubscriberFromWpUser(), so the count reflects what
+      // will actually happen on this site rather than the default behaviour.
+      $hardDelete = (bool)$this->wp->applyFilters(
+        'mailpoet_delete_subscriber_on_wp_user_delete',
+        false,
+        $subscriber,
+        (int)$wpUserId
+      );
+      if (!$hardDelete) {
+        $count++;
+      }
+    }
+
+    return $count;
+  }
+
+  private function getMessage(int $count, bool $onlyOneUserSelected): string {
+    if ($onlyOneUserSelected) {
+      // WordPress already says "You have specified this user for deletion", so a count
+      // here would only read as noise.
+      $message = __(
+        '<strong>MailPoet:</strong> This user is also a MailPoet subscriber. Deleting a WordPress user does not delete their MailPoet subscriber. The subscriber is removed from the "WordPress Users" list and kept in MailPoet.',
+        'mailpoet'
+      );
+    } else {
+      // translators: %d is the number of users being deleted who are also MailPoet subscribers.
+      $notice = _n(
+        '<strong>MailPoet:</strong> %d of the users you are deleting is also a MailPoet subscriber. Deleting a WordPress user does not delete their MailPoet subscriber. The subscriber is removed from the "WordPress Users" list and kept in MailPoet.',
+        '<strong>MailPoet:</strong> %d of the users you are deleting are also MailPoet subscribers. Deleting a WordPress user does not delete their MailPoet subscriber. The subscribers are removed from the "WordPress Users" list and kept in MailPoet.',
+        $count,
+        'mailpoet'
+      );
+      $message = sprintf($notice, $count);
+    }
+
+    $links = [];
+
+    if ($this->accessControl->validatePermission(AccessControl::PERMISSION_MANAGE_SUBSCRIBERS)) {
+      $links[] = Helpers::replaceLinkTags(
+        __('[link]Manage MailPoet subscribers[/link]', 'mailpoet'),
+        $this->wp->adminUrl('admin.php?page=' . Menu::SUBSCRIBERS_PAGE_SLUG)
+      );
+    }
+
+    $links[] = Helpers::replaceLinkTags(
+      __('[link]Read more about the WordPress Users list[/link]', 'mailpoet'),
+      self::KB_ARTICLE_URL,
+      ['target' => '_blank', 'rel' => 'noopener noreferrer']
+    );
+
+    return $message . ' ' . implode(' | ', $links);
+  }
+}

--- a/mailpoet/lib/Segments/WPUserDeleteNotice.php
+++ b/mailpoet/lib/Segments/WPUserDeleteNotice.php
@@ -17,6 +17,12 @@ use MailPoet\WP\Functions as WPFunctions;
  * often deleted for privacy reasons, so the change is worth surfacing at the moment of
  * deletion rather than only in the documentation.
  *
+ * The notice names the Trash on purpose. A subscriber who was only on the WP Users list
+ * and is not a WooCommerce customer is trashed rather than left on a list, and the
+ * subscribers listing hides trashed rows from every group except "trash". Without that
+ * pointer an admin checks the listing, finds nothing, and concludes the subscriber was
+ * deleted after all - which is the opposite of what this notice is for.
+ *
  * Sites that opted back into the old hard-delete behaviour with the
  * `mailpoet_delete_subscriber_on_wp_user_delete` filter get what they expect already, so
  * they are not counted and the notice stays hidden.
@@ -134,14 +140,14 @@ class WPUserDeleteNotice {
       // WordPress already says "You have specified this user for deletion", so a count
       // here would only read as noise.
       $message = __(
-        '<strong>MailPoet:</strong> This user is also a MailPoet subscriber. Deleting a WordPress user does not delete their MailPoet subscriber. The subscriber is removed from the "WordPress Users" list and kept in MailPoet.',
+        '<strong>MailPoet:</strong> This user is also a MailPoet subscriber. Deleting a WordPress user does not delete their MailPoet subscriber. The subscriber is removed from the "WordPress Users" list but kept in MailPoet, so look for them on their other lists or in the Trash.',
         'mailpoet'
       );
     } else {
       // translators: %d is the number of users being deleted who are also MailPoet subscribers.
       $notice = _n(
-        '<strong>MailPoet:</strong> %d of the users you are deleting is also a MailPoet subscriber. Deleting a WordPress user does not delete their MailPoet subscriber. The subscriber is removed from the "WordPress Users" list and kept in MailPoet.',
-        '<strong>MailPoet:</strong> %d of the users you are deleting are also MailPoet subscribers. Deleting a WordPress user does not delete their MailPoet subscriber. The subscribers are removed from the "WordPress Users" list and kept in MailPoet.',
+        '<strong>MailPoet:</strong> %d of the users you are deleting is also a MailPoet subscriber. Deleting a WordPress user does not delete their MailPoet subscriber. The subscriber is removed from the "WordPress Users" list but kept in MailPoet, so look for them on their other lists or in the Trash.',
+        '<strong>MailPoet:</strong> %d of the users you are deleting are also MailPoet subscribers. Deleting a WordPress user does not delete their MailPoet subscriber. The subscribers are removed from the "WordPress Users" list but kept in MailPoet, so look for them on their other lists or in the Trash.',
         $count,
         'mailpoet'
       );

--- a/mailpoet/tests/integration/Segments/WPUserDeleteNoticeTest.php
+++ b/mailpoet/tests/integration/Segments/WPUserDeleteNoticeTest.php
@@ -104,6 +104,23 @@ class WPUserDeleteNoticeTest extends \MailPoetTest {
     $this->assertStringContainsString('This user is also a MailPoet subscriber', $output);
   }
 
+  /**
+   * A subscriber who was only on the WP Users list gets trashed, and the subscribers
+   * listing hides trashed rows outside the "trash" group. Without this pointer the notice
+   * sends admins to a screen where they will not find the subscriber.
+   */
+  public function testItTellsTheAdminWhereToLookForTheSubscriber(): void {
+    $firstUserId = $this->insertUser();
+    $secondUserId = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    $single = $this->renderNotice([$firstUserId]);
+    $plural = $this->renderNotice([$firstUserId, $secondUserId]);
+
+    $this->assertStringContainsString('look for them on their other lists or in the Trash', $single);
+    $this->assertStringContainsString('look for them on their other lists or in the Trash', $plural);
+  }
+
   public function testItDropsTheCountOnlyWhenASingleUserIsSelected(): void {
     $firstUserId = $this->insertUser();
     $secondUserId = $this->insertUser();

--- a/mailpoet/tests/integration/Segments/WPUserDeleteNoticeTest.php
+++ b/mailpoet/tests/integration/Segments/WPUserDeleteNoticeTest.php
@@ -1,0 +1,172 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Segments;
+
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Segments\WP;
+use MailPoet\Segments\WPUserDeleteNotice;
+
+class WPUserDeleteNoticeTest extends \MailPoetTest {
+  /** @var WPUserDeleteNotice */
+  private $notice;
+
+  /** @var WP */
+  private $wpSegment;
+
+  public function _before(): void {
+    parent::_before();
+    $this->notice = $this->diContainer->get(WPUserDeleteNotice::class);
+    $this->wpSegment = $this->diContainer->get(WP::class);
+    $this->cleanData();
+  }
+
+  public function testItWarnsThatTheSubscriberIsKept(): void {
+    $userId = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    $output = $this->renderNotice([$userId]);
+
+    $this->assertStringContainsString('MailPoet', $output);
+    $this->assertStringContainsString('does not delete their MailPoet subscriber', $output);
+    // Only one user selected, so no count. WordPress already says "this user" above.
+    $this->assertStringContainsString('This user is also a MailPoet subscriber', $output);
+    $this->assertStringNotContainsString('of the users you are deleting', $output);
+  }
+
+  public function testItCountsOnlyUsersThatHaveASubscriber(): void {
+    $userWithSubscriber = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+    // Created after the sync, so it has no linked subscriber yet.
+    $userWithoutSubscriber = $this->insertUser();
+
+    $output = $this->renderNotice([$userWithSubscriber, $userWithoutSubscriber]);
+
+    // Two users selected, one affected, so the count earns its place.
+    $this->assertStringContainsString('1 of the users you are deleting is also a MailPoet subscriber', $output);
+  }
+
+  public function testItUsesThePluralFormForSeveralSubscribers(): void {
+    $firstUserId = $this->insertUser();
+    $secondUserId = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    $output = $this->renderNotice([$firstUserId, $secondUserId]);
+
+    $this->assertStringContainsString('2 of the users you are deleting are also MailPoet subscribers', $output);
+  }
+
+  public function testItRendersNothingWhenNoUserHasASubscriber(): void {
+    $userId = $this->insertUser();
+
+    $this->assertSame('', $this->renderNotice([$userId]));
+  }
+
+  public function testItRendersNothingWhenTheHardDeleteFilterIsEnabled(): void {
+    $userId = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    add_filter('mailpoet_delete_subscriber_on_wp_user_delete', '__return_true');
+    try {
+      $output = $this->renderNotice([$userId]);
+    } finally {
+      remove_filter('mailpoet_delete_subscriber_on_wp_user_delete', '__return_true');
+    }
+
+    $this->assertSame('', $output);
+  }
+
+  public function testItRendersNothingWithoutUserIds(): void {
+    $this->assertSame('', $this->renderNotice([]));
+    $this->assertSame('', $this->renderNotice(null));
+  }
+
+  public function testItHandlesTheRawPostValuesPassedByNetworkAdmin(): void {
+    $userId = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    // confirm_delete_users() in wp-admin/includes/ms.php passes (array) $_POST['allusers'],
+    // so the ids arrive as strings and the list can contain empty entries.
+    $output = $this->renderNotice(['', (string)$userId, '0']);
+
+    // The empty entries are dropped before the count, so this is a single-user delete.
+    $this->assertStringContainsString('This user is also a MailPoet subscriber', $output);
+  }
+
+  public function testItCountsEachSubscriberOnce(): void {
+    $userId = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    $output = $this->renderNotice([$userId, $userId]);
+
+    // Deduplicated first, so this counts as one user, not two.
+    $this->assertStringContainsString('This user is also a MailPoet subscriber', $output);
+  }
+
+  public function testItDropsTheCountOnlyWhenASingleUserIsSelected(): void {
+    $firstUserId = $this->insertUser();
+    $secondUserId = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    $single = $this->renderNotice([$firstUserId]);
+    $both = $this->renderNotice([$firstUserId, $secondUserId]);
+
+    $this->assertStringContainsString('This user is also a MailPoet subscriber', $single);
+    $this->assertStringNotContainsString('This user is also a MailPoet subscriber', $both);
+    $this->assertStringContainsString('2 of the users you are deleting are also MailPoet subscribers', $both);
+  }
+
+  public function testItLinksToTheKnowledgeBaseArticle(): void {
+    $userId = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    $output = $this->renderNotice([$userId]);
+
+    $this->assertStringContainsString(WPUserDeleteNotice::KB_ARTICLE_URL, $output);
+  }
+
+  /**
+   * @param mixed $userIds
+   */
+  private function renderNotice($userIds): string {
+    ob_start();
+    $this->notice->displayNotice(null, $userIds);
+    return (string)ob_get_clean();
+  }
+
+  private function insertUser(): int {
+    global $wpdb;
+
+    $this->connection->executeStatement(
+      "INSERT INTO {$wpdb->users} (user_login, user_nicename, user_email, user_registered)
+        VALUES (
+          CONCAT('user-delete-notice-test', rand()),
+          CONCAT('user-delete-notice-test', rand()),
+          CONCAT('user-delete-notice-test', rand(), '@example.com'),
+          '2017-01-02 12:31:12'
+        )"
+    );
+
+    return (int)$this->connection->lastInsertId();
+  }
+
+  private function cleanData(): void {
+    $this->truncateEntity(SegmentEntity::class);
+    $this->truncateEntity(SubscriberEntity::class);
+    $this->truncateEntity(SubscriberSegmentEntity::class);
+
+    global $wpdb;
+    $this->entityManager->getConnection()->executeQuery(
+      "DELETE FROM {$wpdb->users} WHERE user_login != 'admin'"
+    );
+    $this->entityManager->getConnection()->executeQuery(
+      "DELETE FROM {$wpdb->usermeta} WHERE user_id NOT IN (SELECT id FROM {$wpdb->users})"
+    );
+  }
+
+  public function _after(): void {
+    parent::_after();
+    $this->cleanData();
+  }
+}


### PR DESCRIPTION
## Description

Since 5.26.0, deleting a WordPress user no longer deletes the MailPoet subscriber linked to it. The subscriber is unlinked from the "WordPress Users" list and kept. Site owners delete WordPress users for privacy reasons, and nothing on screen told them the subscriber survived.

The delete-users confirmation screen now shows a short note, right above the Confirm Deletion button.

It only counts users that really have a linked subscriber, and it re-applies `mailpoet_delete_subscriber_on_wp_user_delete` for each one. A site that opted back into the old hard delete sees nothing, because for them the behaviour already matches what they expect.

When a single user is selected the count is dropped, because WordPress already says "You have specified this user for deletion" directly above.

The multisite "Remove Users from Site" screen has no equivalent hook, so `remove_user_from_blog` is not covered.

## Code review notes

- `delete_user_form` is the same hook WooCommerce core uses for its webhook warning (`Automattic\WooCommerce\Internal\Utilities\WebhookUtil::maybe_render_user_with_webhooks_warning`), and it fires for both `wp-admin/users.php` and `confirm_delete_users()` in `wp-admin/includes/ms.php`. WooCommerce Subscriptions uses it too, but reads `$_REQUEST` itself rather than the ids the hook passes. This follows core, not Subscriptions.
- The filter is re-applied here rather than read from a cached flag, because its signature takes the subscriber and the user id, so the answer can differ per user. It costs one `apply_filters` per affected subscriber on a screen that is already a confirmation step.
- Network admin passes `(array) $_POST['allusers']` straight through, so the ids can be strings and can contain empty entries. `normalizeUserIds()` handles that, and the single-user wording keys off the cleaned list rather than the raw one.
- The notice names the Trash on purpose, and this was found by testing rather than by reading the code. A subscriber who was only on the WP Users list and is not a WooCommerce customer is trashed by `WP::unlinkSubscriberFromWpUser()`, and `SubscriberListingRepository::applyGroup()` hides trashed rows from every group except `trash`. An earlier version of this notice said only "kept in MailPoet", and a MailPoet developer testing it read that, opened the subscribers page, found nothing and concluded the subscriber had been deleted. That is the common case, not an edge case, so the notice now says where to look.

## QA notes

Checked on wp-env with MailPoet Free, single site:

| Case | Expected | Result |
|---|---|---|
| 2 users selected, both subscribers | Notice with a count | ✅ |
| 1 user selected, a subscriber | Notice with no count | ✅ |
| 1 user selected, no subscriber row | Nothing rendered | ✅ |
| `mailpoet_delete_subscriber_on_wp_user_delete` returns true | Nothing rendered | ✅ (integration test) |

The "Manage MailPoet subscribers" link only renders for users who have the MailPoet subscribers permission. The KB link opens the right anchor.

Not checked by hand: the network-admin delete screen. A test covers the raw `$_POST` shape that screen passes, but nobody has loaded it.

To try it: create a user, confirm they appear under MailPoet → Subscribers, then go to Users and start deleting them.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8324

## After-merge notes

_N/A_

## Screenshots or screencast

What the screen shows, captured from wp-env.

One user selected:

> You have specified this user for deletion:
> ID #2: deletetest1
>
> **MailPoet:** This user is also a MailPoet subscriber. Deleting a WordPress user does not delete their MailPoet subscriber. The subscriber is removed from the "WordPress Users" list but kept in MailPoet, so look for them on their other lists or in the Trash. [Manage MailPoet subscribers] | [Read more about the WordPress Users list]
>
> `[ Confirm Deletion ]`

Two users selected:

> You have specified these users for deletion:
> ID #2: deletetest1
> ID #3: deletetest2
>
> **MailPoet:** 2 of the users you are deleting are also MailPoet subscribers. Deleting a WordPress user does not delete their MailPoet subscriber. The subscribers are removed from the "WordPress Users" list but kept in MailPoet, so look for them on their other lists or in the Trash. [Manage MailPoet subscribers] | [Read more about the WordPress Users list]
>
> `[ Confirm Deletion ]`

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8324-warn-wp-user-delete-keeps-subscriber)

_The latest successful build from `add/stomail-8324-warn-wp-user-delete-keeps-subscriber` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->