### PR TITLE
Hide subscriber timezone field when collection is disabled

### DIFF
--- a/mailpoet/assets/js/src/subscribers/form.tsx
+++ b/mailpoet/assets/js/src/subscribers/form.tsx
@@ -61,6 +61,7 @@ declare global {
     mailpoet_custom_fields: CustomField[];
     mailpoet_api_version: string;
     mailpoet_timezone_list: string[];
+    mailpoet_collect_subscriber_timezones: boolean;
   }
 }
 
@@ -111,6 +112,20 @@ type FormField =
   | TokenField
   | CustomFieldFormField;
 
+const timeZoneField: SelectField = {
+  name: 'timezone',
+  label: __('Timezone', 'mailpoet'),
+  type: 'select',
+  automationId: 'subscriber-timezone',
+  placeholder: __('Not set', 'mailpoet'),
+  values: Object.fromEntries(
+    (window.mailpoet_timezone_list || []).map((timezone) => [
+      timezone,
+      timezone.replaceAll('_', ' '),
+    ]),
+  ),
+};
+
 const fields: FormField[] = [
   {
     name: 'email',
@@ -158,19 +173,7 @@ const fields: FormField[] = [
       bounced: MailPoet.I18n.t('bounced'),
     },
   },
-  {
-    name: 'timezone',
-    label: __('Timezone', 'mailpoet'),
-    type: 'select',
-    automationId: 'subscriber-timezone',
-    placeholder: __('Not set', 'mailpoet'),
-    values: Object.fromEntries(
-      (window.mailpoet_timezone_list || []).map((timezone) => [
-        timezone,
-        timezone.replaceAll('_', ' '),
-      ]),
-    ),
-  },
+  ...(window.mailpoet_collect_subscriber_timezones ? [timeZoneField] : []),
   {
     name: 'segments',
     label: MailPoet.I18n.t('lists'),

--- a/mailpoet/changelog/2026-07-31-04-52-11-changed-timezone-field-in-the-subscriber-edit-form-is-now-.md
+++ b/mailpoet/changelog/2026-07-31-04-52-11-changed-timezone-field-in-the-subscriber-edit-form-is-now-.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+Timezone field in the subscriber edit form is now hidden when subscriber time zone collection is disabled

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -95,10 +95,12 @@ class Subscribers {
       'signup_confirmation.enabled'
     );
     $data['bulk_confirmation_resend_limit'] = BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT;
+    $collectSubscriberTimeZones = $this->settings->isSettingEnabled('collect_subscriber_timezones.enabled');
+    $data['collect_subscriber_timezones'] = $collectSubscriberTimeZones;
     // Same identifier list SubscriberEntity::isValidTimeZone() accepts when
     // storing browser-detected timezones, so the selector can offer exactly
     // the values that can be saved.
-    $data['timezone_list'] = \DateTimeZone::listIdentifiers();
+    $data['timezone_list'] = $collectSubscriberTimeZones ? \DateTimeZone::listIdentifiers() : [];
     $this->assetsController->setupDataViewsDependencies();
     $this->pageRenderer->displayPage('subscribers/subscribers.html', $data);
   }

--- a/mailpoet/tests/unit/AdminPages/SubscribersTest.php
+++ b/mailpoet/tests/unit/AdminPages/SubscribersTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\AssetsController;
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\API\JSON\ResponseBuilders\CustomFieldsResponseBuilder;
+use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\Form\Block;
+use MailPoet\Listing\PageLimit;
+use MailPoet\Segments\SegmentsSimpleListRepository;
+use MailPoet\Settings\SettingsController;
+use MailPoet\WP\Functions as WPFunctions;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class SubscribersTest extends \MailPoetUnitTest {
+  /** @var PageRenderer & MockObject */
+  private $pageRenderer;
+
+  /** @var SettingsController & MockObject */
+  private $settings;
+
+  /** @var Subscribers */
+  private $page;
+
+  public function _before() {
+    parent::_before();
+
+    $this->pageRenderer = $this->createMock(PageRenderer::class);
+    $this->settings = $this->createMock(SettingsController::class);
+
+    $customFieldsRepository = $this->createMock(CustomFieldsRepository::class);
+    $customFieldsRepository->method('findAllActive')->willReturn([]);
+
+    $segmentsListRepository = $this->createMock(SegmentsSimpleListRepository::class);
+    $segmentsListRepository->method('getListWithSubscribedSubscribersCounts')->willReturn([]);
+
+    $dateBlock = $this->createMock(Block\Date::class);
+    $dateBlock->method('getDateFormats')->willReturn([]);
+    $dateBlock->method('getMonthNames')->willReturn([]);
+
+    $wp = $this->createMock(WPFunctions::class);
+    $wp->method('escUrlRaw')->willReturnArgument(0);
+    $wp->method('restUrl')->willReturn('https://example.com/wp-json/');
+    $wp->method('wpCreateNonce')->willReturn('nonce');
+
+    $this->page = new Subscribers(
+      $this->pageRenderer,
+      $this->createMock(AssetsController::class),
+      $this->createMock(PageLimit::class),
+      $dateBlock,
+      $segmentsListRepository,
+      $customFieldsRepository,
+      $this->createMock(CustomFieldsResponseBuilder::class),
+      $this->settings,
+      $wp
+    );
+  }
+
+  public function testItPassesTimeZoneListWhenCollectionIsEnabled() {
+    $data = $this->renderWithTimeZoneCollection(true);
+
+    $this->assertTrue($data['collect_subscriber_timezones']);
+    $this->assertContains('Europe/Prague', $data['timezone_list']);
+  }
+
+  public function testItPassesNoTimeZoneListWhenCollectionIsDisabled() {
+    $data = $this->renderWithTimeZoneCollection(false);
+
+    $this->assertFalse($data['collect_subscriber_timezones']);
+    $this->assertSame([], $data['timezone_list']);
+  }
+
+  private function renderWithTimeZoneCollection(bool $enabled): array {
+    $this->settings
+      ->method('isSettingEnabled')
+      ->with('collect_subscriber_timezones.enabled')
+      ->willReturn($enabled);
+
+    $data = [];
+    $this->pageRenderer
+      ->expects($this->once())
+      ->method('displayPage')
+      ->willReturnCallback(function (string $template, array $renderedData) use (&$data): void {
+        $data = $renderedData;
+      });
+
+    $this->page->render();
+
+    return $data;
+  }
+}

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -13,6 +13,7 @@
     var mailpoet_bulk_confirmation_resend_limit = <%= json_encode(bulk_confirmation_resend_limit) %>;
     var mailpoet_subscribers_api = <%= json_encode(api) %>;
     var mailpoet_timezone_list = <%= json_encode(timezone_list) %>;
+    var mailpoet_collect_subscriber_timezones = <%= json_encode(collect_subscriber_timezones) %>;
   </script>
 
   <%= localize({


### PR DESCRIPTION
## Description

MailPoet 5.34.0 added a **Timezone** field to the subscriber edit form. It rendered unconditionally, so it showed up even for sites that had **MailPoet → Settings → Advanced → Collect subscribers' time zones** turned off. Because it is not a custom field, users who did not want it had no way to remove it — one reported hunting for it in the Custom fields UI and coming up empty.

The subscribers page now gates the field on that setting, and skips building the 419-entry timezone identifier list entirely when collection is off.

Scope is the admin edit form only. There is no timezone column in the subscribers listing, and the public form / browser-collection path was already gated on this setting.

## Code review notes

**Stored timezones are deliberately left alone.** Hiding the field does not clear or migrate anything. A subscriber who has a timezone from before the setting was switched off keeps it; the value is just no longer visible or editable in the admin. That is the behaviour the ticket asks for, but it does mean the data becomes invisible rather than gone — worth a second opinion if you disagree.

**Why that is safe against accidental wipes:** `SubscriberSaveController::updateTimeZoneManually()` clears the timezone when it receives `''`. The reason a hidden field cannot trigger that is the `array_key_exists('timezone', $data)` guard on the call — an absent key skips the branch entirely. I verified this end to end rather than trusting the read (see QA notes).

**The manual write path is intentionally left ungated.** `SubscriberSaveController.php:251` gates the browser-collected timezone on the setting; the manual path at `:260` stays open. The setting governs *collection via forms*, not admin/API writes, so gating it too would be a broader behaviour change than this ticket calls for. Happy to revisit if you read the setting's scope differently.

**Skipping the list when disabled** is a small side benefit, not the point — it drops a 419-element array from the page payload on every subscribers page load for sites with the setting off.

## QA notes

Verified manually against both setting states:

- **Setting on** — `window.mailpoet_collect_subscriber_timezones === true`, 419 timezones in the list, field renders between Status and Lists.
- **Setting off** — flag `false`, `timezone_list` empty, no `Timezone` label, no `[data-automation-id="subscriber-timezone"]` element. Layout reflows cleanly; Lists moves up into the slot, no gap.

**Data-safety check.** Seeded a subscriber with `America/New_York` / source `manual`, disabled the setting, then saved the form with the field hidden (changed Status → Subscribed). Re-read from the DB afterwards: `status=subscribed tz='America/New_York' src='manual'`. The stored value survives a save through the hidden field.

Automated:

- New `tests/unit/AdminPages/SubscribersTest.php` covers both branches of the gate — 2 tests, 6 assertions.
- Full JS suite: 395 passing.
- PHP unit suite: 998 passing across 30 directories. The `Mailer` directory could not run on this host — `PHPMailerLoader` does `require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php'` and there is no WordPress install on the host. Pre-existing and unrelated to this change; no mailer code is touched.
- PHPStan clean. ESLint + tsc clean. Prettier clean.
- `./do qa` does not pass locally: PHPCS reports 6,216 files with violations, all under `mailpoet/tests/plugins/` (the bundled WooCommerce plugins that bootstrap downloads at `latest`). `tests/plugins` is absent from the `$ignorePaths` list in `RoboFile.php:736`. Running PHPCS directly on the two changed PHP files is clean, and no violation path matches any file in this diff.

## Linked PRs

_N/A_ — free plugin only, no Premium counterpart needed.

## Linked tickets

[STOMAIL-8318](https://linear.app/a8c/issue/STOMAIL-8318/hide-timezone-field-from-subscriber-profile-when-collect-subscribers)

## After-merge notes

_N/A_

## Screenshots or screencast

Captured locally at both setting states; can attach on request. Summary of the difference:

| Before | After |
| ------ | ----- |
| With collection **disabled**, the edit form still showed: E-mail, First name, Last name, Status, **Timezone**, Lists, Tags | With collection **disabled**: E-mail, First name, Last name, Status, Lists, Tags. With collection **enabled**, the field is unchanged from before. |
| <img width="1287" height="723" alt="image" src="https://github.com/user-attachments/assets/ba75b480-5fb6-4c65-8264-7eb559144d62" /> | <img width="1170" height="605" alt="image" src="https://github.com/user-attachments/assets/e476c61e-b376-43c7-bffd-adaf4b436a24" /> |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/stomail-8318-hide-timezone-field-when-collection-disabled)

_The latest successful build from `update/stomail-8318-hide-timezone-field-when-collection-disabled` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->