### PR TITLE
Count repeated sends from the sending statistics

### DIFF
--- a/mailpoet/changelog/2026-08-03-09-48-28-fixed-open-and-click-rates-above-100-on-automation-and-w.md
+++ b/mailpoet/changelog/2026-08-03-09-48-28-fixed-open-and-click-rates-above-100-on-automation-and-w.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Open and click rates above 100% on automation and welcome email statistics

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
@@ -26,6 +26,18 @@ use MailPoetVendor\Doctrine\ORM\UnexpectedResultException;
  * @extends Repository<NewsletterEntity>
  */
 class NewsletterStatisticsRepository extends Repository {
+  /**
+   * Emails that are sent again for every trigger instead of once as a campaign, so they
+   * keep adding sending queues and scheduled tasks for as long as they stay active.
+   */
+  private const TYPES_SENT_REPEATEDLY = [
+    NewsletterEntity::TYPE_WELCOME,
+    NewsletterEntity::TYPE_AUTOMATIC,
+    NewsletterEntity::TYPE_AUTOMATION,
+    NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
+    NewsletterEntity::TYPE_AUTOMATION_NOTIFICATION,
+    NewsletterEntity::TYPE_RE_ENGAGEMENT,
+  ];
 
   /** @var WCHelper */
   private $wcHelper;
@@ -199,6 +211,29 @@ class NewsletterStatisticsRepository extends Repository {
   }
 
   private function getTotalSentCounts(array $newsletters, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null): array {
+    $sentRepeatedly = [];
+    $sentAsCampaign = [];
+    foreach ($newsletters as $newsletter) {
+      if (in_array($newsletter->getType(), self::TYPES_SENT_REPEATEDLY, true)) {
+        $sentRepeatedly[] = $newsletter;
+      } else {
+        $sentAsCampaign[] = $newsletter;
+      }
+    }
+
+    // no key collisions, a newsletter belongs to exactly one group
+    return $this->getQueuedSentCounts($sentAsCampaign, $from, $to)
+      + $this->getRecordedSentCounts($sentRepeatedly, $from, $to);
+  }
+
+  /**
+   * Counts sends from the sending queues, which hold one row per sending run.
+   */
+  private function getQueuedSentCounts(array $newsletters, ?\DateTimeImmutable $from, ?\DateTimeImmutable $to): array {
+    if (!$newsletters) {
+      return [];
+    }
+
     $query = $this->doctrineRepository
       ->createQueryBuilder('n')
       ->select('n.id, SUM(q.countProcessed) AS cnt')
@@ -219,6 +254,49 @@ class NewsletterStatisticsRepository extends Repository {
         ->setParameter('from', $from);
     } elseif ($from === null && $to) {
       $query->andWhere('q.createdAt <= :to')
+        ->setParameter('to', $to);
+    }
+
+    $results = $query->getQuery()
+      ->getResult();
+
+    $counts = [];
+    foreach ($results ?: [] as $result) {
+      $counts[(int)$result['id']] = (int)$result['cnt'];
+    }
+    return $counts;
+  }
+
+  /**
+   * Counts sends from the sending statistics, which hold one row per email actually sent.
+   *
+   * Counting a repeatedly sent email through its queues instead would make the total depend
+   * on a chain of rows that grows for the lifetime of the email, while the opens and clicks
+   * measured against that total are only ever removed along with the newsletter itself. The
+   * sending statistics share that same lifecycle, so both sides of a rate stay consistent
+   * even where the queue chain has lost rows.
+   */
+  private function getRecordedSentCounts(array $newsletters, ?\DateTimeImmutable $from, ?\DateTimeImmutable $to): array {
+    if (!$newsletters) {
+      return [];
+    }
+
+    $query = $this->entityManager->createQueryBuilder()
+      ->select('IDENTITY(stats.newsletter) AS id, COUNT(stats.id) AS cnt')
+      ->from(StatisticsNewsletterEntity::class, 'stats')
+      ->where('stats.newsletter IN (:newsletters)')
+      ->setParameter('newsletters', $newsletters)
+      ->groupBy('stats.newsletter');
+
+    if ($from && $to) {
+      $query->andWhere('stats.sentAt BETWEEN :from AND :to')
+        ->setParameter('from', $from)
+        ->setParameter('to', $to);
+    } elseif ($from && $to === null) {
+      $query->andWhere('stats.sentAt >= :from')
+        ->setParameter('from', $from);
+    } elseif ($from === null && $to) {
+      $query->andWhere('stats.sentAt <= :to')
         ->setParameter('to', $to);
     }
 

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
@@ -221,19 +221,9 @@ class NewsletterStatisticsRepository extends Repository {
       }
     }
 
-    $counts = $this->getQueuedSentCounts($sentAsCampaign, $from, $to);
-
-    // The queues and the sending statistics are two records of the same sends and either can
-    // lose rows, so the higher of the two is the closest reading available. It also means the
-    // count can never come out below what the queue chain reported on its own.
-    $queued = $this->getQueuedSentCounts($sentRepeatedly, $from, $to);
-    $recorded = $this->getRecordedSentCounts($sentRepeatedly, $from, $to);
-    foreach ($sentRepeatedly as $newsletter) {
-      $id = (int)$newsletter->getId();
-      $counts[$id] = max($queued[$id] ?? 0, $recorded[$id] ?? 0);
-    }
-
-    return $counts;
+    // no key collisions, a newsletter belongs to exactly one group
+    return $this->getQueuedSentCounts($sentAsCampaign, $from, $to)
+      + $this->getRecordedSentCounts($sentRepeatedly, $from, $to);
   }
 
   /**
@@ -280,11 +270,11 @@ class NewsletterStatisticsRepository extends Repository {
   /**
    * Counts sends from the sending statistics, which hold one row per email actually sent.
    *
-   * Counting a repeatedly sent email through its queues alone would make the total depend on
-   * a chain of rows that grows for the lifetime of the email, while the opens and clicks
+   * Counting a repeatedly sent email through its queues instead would make the total depend
+   * on a chain of rows that grows for the lifetime of the email, while the opens and clicks
    * measured against that total are only ever removed along with the newsletter itself. The
-   * sending statistics share that same lifecycle, so reading them keeps both sides of a rate
-   * consistent even where the queue chain has lost rows.
+   * sending statistics share that same lifecycle, so both sides of a rate stay consistent
+   * even where the queue chain has lost rows.
    */
   private function getRecordedSentCounts(array $newsletters, ?\DateTimeImmutable $from, ?\DateTimeImmutable $to): array {
     if (!$newsletters) {

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
@@ -221,9 +221,19 @@ class NewsletterStatisticsRepository extends Repository {
       }
     }
 
-    // no key collisions, a newsletter belongs to exactly one group
-    return $this->getQueuedSentCounts($sentAsCampaign, $from, $to)
-      + $this->getRecordedSentCounts($sentRepeatedly, $from, $to);
+    $counts = $this->getQueuedSentCounts($sentAsCampaign, $from, $to);
+
+    // The queues and the sending statistics are two records of the same sends and either can
+    // lose rows, so the higher of the two is the closest reading available. It also means the
+    // count can never come out below what the queue chain reported on its own.
+    $queued = $this->getQueuedSentCounts($sentRepeatedly, $from, $to);
+    $recorded = $this->getRecordedSentCounts($sentRepeatedly, $from, $to);
+    foreach ($sentRepeatedly as $newsletter) {
+      $id = (int)$newsletter->getId();
+      $counts[$id] = max($queued[$id] ?? 0, $recorded[$id] ?? 0);
+    }
+
+    return $counts;
   }
 
   /**
@@ -270,11 +280,11 @@ class NewsletterStatisticsRepository extends Repository {
   /**
    * Counts sends from the sending statistics, which hold one row per email actually sent.
    *
-   * Counting a repeatedly sent email through its queues instead would make the total depend
-   * on a chain of rows that grows for the lifetime of the email, while the opens and clicks
+   * Counting a repeatedly sent email through its queues alone would make the total depend on
+   * a chain of rows that grows for the lifetime of the email, while the opens and clicks
    * measured against that total are only ever removed along with the newsletter itself. The
-   * sending statistics share that same lifecycle, so both sides of a rate stay consistent
-   * even where the queue chain has lost rows.
+   * sending statistics share that same lifecycle, so reading them keeps both sides of a rate
+   * consistent even where the queue chain has lost rows.
    */
   private function getRecordedSentCounts(array $newsletters, ?\DateTimeImmutable $from, ?\DateTimeImmutable $to): array {
     if (!$newsletters) {

--- a/mailpoet/lib/SystemReport/SystemReportCollector.php
+++ b/mailpoet/lib/SystemReport/SystemReportCollector.php
@@ -99,6 +99,7 @@ class SystemReportCollector {
 
     $inconsistencyStatus = $this->dataInconsistencyController->getInconsistentDataStatus();
     unset($inconsistencyStatus['total']);
+    $inconsistencyStatus += $this->dataInconsistencyController->getUnfixableDataStatus();
 
     $pingBridgeResponse = $this->getBridgePingResponse();
     $pingResponse = $this->wp->isWpError($pingBridgeResponse)

--- a/mailpoet/lib/Util/DataInconsistency/DataInconsistencyController.php
+++ b/mailpoet/lib/Util/DataInconsistency/DataInconsistencyController.php
@@ -13,6 +13,7 @@ class DataInconsistencyController {
   const ORPHANED_SUBSCRIBER_TAGS = 'orphaned_subscriber_tags';
   const ORPHANED_LINKS = 'orphaned_links';
   const ORPHANED_NEWSLETTER_POSTS = 'orphaned_newsletter_posts';
+  const SENDING_QUEUE_WITHOUT_TASK = 'sending_queue_without_task';
 
   const SUPPORTED_INCONSISTENCY_CHECKS = [
     self::ORPHANED_SENDING_TASKS,
@@ -46,6 +47,16 @@ class DataInconsistencyController {
     ];
     $result['total'] = array_sum($result);
     return $result;
+  }
+
+  /**
+   * Damage that is worth reporting but has no safe automatic fix, so it is kept out of
+   * getInconsistentDataStatus() and the "Fix" actions built from it.
+   */
+  public function getUnfixableDataStatus(): array {
+    return [
+      self::SENDING_QUEUE_WITHOUT_TASK => $this->repository->getSendingQueuesWithoutTaskCount(),
+    ];
   }
 
   public function fixInconsistentData(string $inconsistency): void {

--- a/mailpoet/lib/Util/DataInconsistency/DataInconsistencyRepository.php
+++ b/mailpoet/lib/Util/DataInconsistency/DataInconsistencyRepository.php
@@ -56,6 +56,24 @@ class DataInconsistencyRepository {
     return intval($count);
   }
 
+  /**
+   * The mirror image of getOrphanedSendingTasksCount(): sending queues whose scheduled task
+   * is gone. Such a queue is the only remaining record of how many emails it sent, so there
+   * is no safe cleanup for it — it is reported so support can recognise a damaged sending
+   * history behind statistics that no longer add up.
+   */
+  public function getSendingQueuesWithoutTaskCount(): int {
+    $sqTable = $this->entityManager->getClassMetadata(SendingQueueEntity::class)->getTableName();
+    $stTable = $this->entityManager->getClassMetadata(ScheduledTaskEntity::class)->getTableName();
+    /** @var string $count */
+    $count = $this->entityManager->getConnection()->executeQuery("
+      SELECT count(*) FROM $sqTable sq
+      LEFT JOIN $stTable st ON st.`id` = sq.`task_id`
+      WHERE st.`id` IS NULL
+    ")->fetchOne();
+    return intval($count);
+  }
+
   public function getSendingQueuesWithoutNewsletterCount(): int {
     $sqTable = $this->entityManager->getClassMetadata(SendingQueueEntity::class)->getTableName();
     $newsletterTable = $this->entityManager->getClassMetadata(NewsletterEntity::class)->getTableName();

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -11,6 +11,7 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\WpPostEntity;
 use MailPoet\Util\Security;
@@ -31,6 +32,9 @@ class Newsletter {
 
   /** @var array */
   private $queues = [];
+
+  /** @var int */
+  private $recordedSends = 0;
 
   /** @var array */
   private $taskSubscribers;
@@ -387,6 +391,16 @@ class Newsletter {
     return $this;
   }
 
+  /**
+   * Records sends against the last queue, one row per email sent, the way the sending worker
+   * does. Emails that are sent repeatedly read their sent count from there rather than from
+   * the queue counts, so a fixture that only sets count_processed reads as never sent.
+   */
+  public function withRecordedSends(int $count) {
+    $this->recordedSends = $count;
+    return $this;
+  }
+
   public function withScheduledQueue(array $options = []) {
     $queue = [
       'status' => ScheduledTaskEntity::STATUS_SCHEDULED,
@@ -443,8 +457,26 @@ class Newsletter {
       $this->createQueues($newsletter);
     }
 
+    if ($this->recordedSends) {
+      $this->createRecordedSends($newsletter);
+    }
+
     $entityManager->flush();
     return $newsletter;
+  }
+
+  private function createRecordedSends(NewsletterEntity $newsletter): void {
+    $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
+    $queue = $newsletter->getQueues()->last();
+    Assert::assertInstanceOf(SendingQueueEntity::class, $queue);
+
+    for ($i = 0; $i < $this->recordedSends; $i++) {
+      $subscriber = new SubscriberEntity();
+      $subscriber->setEmail(sprintf('recorded-send-%s@example.com', Security::generateHash(12)));
+      $subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
+      $entityManager->persist($subscriber);
+      $entityManager->persist(new StatisticsNewsletterEntity($newsletter, $queue, $subscriber));
+    }
   }
 
   private function createNewsletter(): NewsletterEntity {

--- a/mailpoet/tests/acceptance/Automation/AutomationListingCest.php
+++ b/mailpoet/tests/acceptance/Automation/AutomationListingCest.php
@@ -92,6 +92,7 @@ class AutomationListingCest {
       ->withScheduledQueue(['count_to_process' => 2])
       ->withScheduledQueue()
       ->withScheduledQueue(['status' => ScheduledTaskEntity::STATUS_COMPLETED, 'count_processed' => 1])
+      ->withRecordedSends(1)
       ->create();
 
     (new DataFactories\Newsletter())

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
@@ -214,6 +214,7 @@ class AutomatedEmailsTest extends \MailPoetTest {
       ->withWelcomeTypeForSegment(1)
       ->withActiveStatus()
       ->withSendingQueue(['count_processed' => 10])
+      ->withRecordedSends(10)
       ->create();
 
     $this->createClicks($newsletter, 5);
@@ -226,6 +227,7 @@ class AutomatedEmailsTest extends \MailPoetTest {
       ->withAutomationType()
       ->withActiveStatus()
       ->withSendingQueue(['count_processed' => 10])
+      ->withRecordedSends(10)
       ->create();
 
     (new AutomationFactory())

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
@@ -115,15 +115,6 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
     ];
   }
 
-  public function testItFallsBackToTheQueuesWhenARepeatedlySentEmailHasNoSendingStatistics() {
-    $newsletter = (new Newsletter())
-      ->withAutomationType()
-      ->withSendingQueue(['count_processed' => 10, 'count_total' => 10])
-      ->create();
-
-    verify($this->testee->getTotalSentCount($newsletter))->equals(10);
-  }
-
   public function testItStillCountsRepeatedlySentEmailsWhenTheScheduledTaskIsGone() {
     $newsletter = (new Newsletter())
       ->withAutomationType()

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
@@ -115,6 +115,15 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
     ];
   }
 
+  public function testItFallsBackToTheQueuesWhenARepeatedlySentEmailHasNoSendingStatistics() {
+    $newsletter = (new Newsletter())
+      ->withAutomationType()
+      ->withSendingQueue(['count_processed' => 10, 'count_total' => 10])
+      ->create();
+
+    verify($this->testee->getTotalSentCount($newsletter))->equals(10);
+  }
+
   public function testItStillCountsRepeatedlySentEmailsWhenTheScheduledTaskIsGone() {
     $newsletter = (new Newsletter())
       ->withAutomationType()

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace integration\Newsletter\Statistics;
 
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
@@ -15,6 +16,7 @@ use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterLink;
 use MailPoet\Test\DataFactories\StatisticsClicks;
+use MailPoet\Test\DataFactories\StatisticsNewsletters;
 use MailPoet\Test\DataFactories\StatisticsOpens;
 use MailPoet\Test\DataFactories\StatisticsWooCommercePurchases;
 use MailPoet\Test\DataFactories\Subscriber;
@@ -79,6 +81,116 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
     SettingsController::getInstance()->set('tracking.opens', TrackingConfig::OPENS_SEPARATED);
     $count = $this->testee->getStatisticsOpenCount($this->newsletter);
     verify($count)->equals(1);
+  }
+
+  public function testItCountsCampaignSendsFromTheSendingQueues() {
+    $newsletter = (new Newsletter())
+      ->withSendingQueue(['count_processed' => 5, 'count_total' => 5])
+      ->create();
+
+    verify($this->testee->getTotalSentCount($newsletter))->equals(5);
+  }
+
+  /** @dataProvider repeatedlySentTypeProvider */
+  public function testItCountsRepeatedlySentEmailsFromTheSendingStatistics(string $type) {
+    $newsletter = (new Newsletter())
+      ->withType($type)
+      ->withSendingQueue()
+      ->create();
+
+    // the queue only accounts for the single most recent send
+    $this->recordSends($newsletter, 3);
+
+    verify($this->testee->getTotalSentCount($newsletter))->equals(3);
+  }
+
+  public function repeatedlySentTypeProvider(): array {
+    return [
+      'welcome' => [NewsletterEntity::TYPE_WELCOME],
+      'automatic' => [NewsletterEntity::TYPE_AUTOMATIC],
+      'automation' => [NewsletterEntity::TYPE_AUTOMATION],
+      'automation transactional' => [NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL],
+      'automation notification' => [NewsletterEntity::TYPE_AUTOMATION_NOTIFICATION],
+      're-engagement' => [NewsletterEntity::TYPE_RE_ENGAGEMENT],
+    ];
+  }
+
+  public function testItStillCountsRepeatedlySentEmailsWhenTheScheduledTaskIsGone() {
+    $newsletter = (new Newsletter())
+      ->withAutomationType()
+      ->withSendingQueue()
+      ->create();
+    $this->recordSends($newsletter, 3);
+
+    $this->deleteScheduledTask($newsletter);
+
+    verify($this->testee->getTotalSentCount($newsletter))->equals(3);
+  }
+
+  public function testItKeepsTheOpenRateWithinOneHundredPercentWhenTheQueueChainIsBroken() {
+    $newsletter = (new Newsletter())
+      ->withAutomationType()
+      ->withSendingQueue()
+      ->create();
+    $subscribers = $this->recordSends($newsletter, 3);
+    foreach ($subscribers as $subscriber) {
+      (new StatisticsOpens($newsletter, $subscriber))->create();
+    }
+
+    $this->deleteScheduledTask($newsletter);
+
+    $statistics = $this->testee->getStatistics($newsletter);
+    verify($statistics->getOpenCount())->equals(3);
+    verify($statistics->getTotalSentCount())->equals(3);
+    $this->assertLessThanOrEqual($statistics->getTotalSentCount(), $statistics->getOpenCount());
+  }
+
+  public function testItCountsEachNewsletterTypeFromItsOwnSourceInABatch() {
+    $campaign = (new Newsletter())
+      ->withSendingQueue(['count_processed' => 5, 'count_total' => 5])
+      ->create();
+    $automation = (new Newsletter())
+      ->withAutomationType()
+      ->withSendingQueue()
+      ->create();
+    $this->recordSends($automation, 3);
+
+    $statistics = $this->testee->getBatchStatistics([$campaign, $automation]);
+
+    verify($statistics[$campaign->getId()]->getTotalSentCount())->equals(5);
+    verify($statistics[$automation->getId()]->getTotalSentCount())->equals(3);
+  }
+
+  public function testItCountsRepeatedlySentEmailsWithinTheGivenTimeSpan() {
+    $newsletter = (new Newsletter())
+      ->withAutomationType()
+      ->withSendingQueue()
+      ->create();
+    $subscribers = $this->recordSends($newsletter, 3);
+
+    (new StatisticsNewsletters($newsletter, $subscribers[0]))
+      ->withSentAt(new \DateTimeImmutable('-6 months'))
+      ->create();
+
+    $statistics = $this->testee->getBatchStatistics(
+      [$newsletter],
+      new \DateTimeImmutable('-1 month'),
+      new \DateTimeImmutable('+1 day'),
+      ['totals']
+    );
+
+    verify($statistics[$newsletter->getId()]->getTotalSentCount())->equals(3);
+  }
+
+  public function testItLeavesCampaignsCountedFromTheQueueChain() {
+    $newsletter = (new Newsletter())
+      ->withSendingQueue(['count_processed' => 5, 'count_total' => 5])
+      ->create();
+
+    $this->deleteScheduledTask($newsletter);
+
+    // campaigns keep using the queue chain, so a missing task still hides the send
+    verify($this->testee->getTotalSentCount($newsletter))->equals(0);
   }
 
   public function testItGetsOnlyStatisticsWithTheCorrectStatus() {
@@ -188,6 +300,33 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
     $this->assertInstanceOf(WooCommerceRevenue::class, $revenue);
     $this->assertEquals(1, $revenue->getOrdersCount());
     $this->assertEquals(12, $revenue->getValue());
+  }
+
+  /**
+   * @return \MailPoet\Entities\SubscriberEntity[]
+   */
+  private function recordSends(NewsletterEntity $newsletter, int $count): array {
+    $subscribers = [];
+    for ($i = 0; $i < $count; $i++) {
+      $subscriber = (new Subscriber())->create();
+      (new StatisticsNewsletters($newsletter, $subscriber))->create();
+      $subscribers[] = $subscriber;
+    }
+    return $subscribers;
+  }
+
+  private function deleteScheduledTask(NewsletterEntity $newsletter): void {
+    $queue = $newsletter->getLatestQueue();
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
+    $task = $queue->getTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+
+    $this->entityManager->createQueryBuilder()
+      ->delete(ScheduledTaskEntity::class, 't')
+      ->where('t.id = :id')
+      ->setParameter('id', $task->getId())
+      ->getQuery()
+      ->execute();
   }
 
   private function enableWooBackedRevenueReadModel(): void {

--- a/mailpoet/tests/integration/Util/DataInconsistency/DataInconsistencyControllerTest.php
+++ b/mailpoet/tests/integration/Util/DataInconsistency/DataInconsistencyControllerTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util\DataInconsistency;
+
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Test\DataFactories\ScheduledTask;
+use MailPoet\Test\DataFactories\SendingQueue;
+use MailPoet\UnexpectedValueException;
+
+class DataInconsistencyControllerTest extends \MailPoetTest {
+  private DataInconsistencyController $controller;
+
+  public function _before(): void {
+    $this->controller = $this->diContainer->get(DataInconsistencyController::class);
+  }
+
+  public function testItReportsSendingQueuesWithoutTaskSeparatelyFromFixableInconsistencies(): void {
+    $task = (new ScheduledTask())->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED);
+    (new SendingQueue())->create($task);
+    $this->entityManager->createQueryBuilder()
+      ->delete(ScheduledTaskEntity::class, 't')
+      ->where('t.id = :id')
+      ->setParameter('id', $task->getId())
+      ->getQuery()
+      ->execute();
+
+    $unfixable = $this->controller->getUnfixableDataStatus();
+    verify($unfixable[DataInconsistencyController::SENDING_QUEUE_WITHOUT_TASK])->equals(1);
+
+    // it must stay out of the fixable set, which drives the "Fix" actions in the UI
+    $fixable = $this->controller->getInconsistentDataStatus();
+    verify(isset($fixable[DataInconsistencyController::SENDING_QUEUE_WITHOUT_TASK]))->false();
+  }
+
+  public function testItRefusesToFixSendingQueuesWithoutTask(): void {
+    $this->expectException(UnexpectedValueException::class);
+    $this->controller->fixInconsistentData(DataInconsistencyController::SENDING_QUEUE_WITHOUT_TASK);
+  }
+}

--- a/mailpoet/tests/integration/Util/DataInconsistency/DataInconsistencyRepositoryTest.php
+++ b/mailpoet/tests/integration/Util/DataInconsistency/DataInconsistencyRepositoryTest.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberTagEntity;
@@ -44,6 +45,27 @@ class DataInconsistencyRepositoryTest extends \MailPoetTest {
     (new ScheduledTask())->create(SendingQueueWorker::TASK_TYPE, null);
     $orphanedSendingTasksCount = $this->repository->getOrphanedSendingTasksCount();
     verify($orphanedSendingTasksCount)->equals(2);
+  }
+
+  public function testItFetchesSendingQueuesWithoutTaskCount(): void {
+    verify($this->repository->getSendingQueuesWithoutTaskCount())->equals(0);
+
+    $okTask = (new ScheduledTask())->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED);
+    (new SendingQueue())->create($okTask);
+    verify($this->repository->getSendingQueuesWithoutTaskCount())->equals(0);
+
+    $taskToDelete = (new ScheduledTask())->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED);
+    $queue = (new SendingQueue())->create($taskToDelete);
+    $this->entityManager->createQueryBuilder()
+      ->delete(ScheduledTaskEntity::class, 't')
+      ->where('t.id = :id')
+      ->setParameter('id', $taskToDelete->getId())
+      ->getQuery()
+      ->execute();
+
+    verify($this->repository->getSendingQueuesWithoutTaskCount())->equals(1);
+    // the queue itself is left alone, it holds the only record of the send
+    $this->assertNotNull($this->entityManager->find(SendingQueueEntity::class, $queue->getId()));
   }
 
   public function testItCleansUpOrphanedSendingTasks(): void {


### PR DESCRIPTION
## Description

A customer reported open and click rates over 100% in their welcome emails — one showed 372% opened and 175% clicked.

It was because they deleted sending queues and sending tasks for welcome and automation emails. These are tables that are sometimes cleaned by users with a long sending history. When they are deleted, the count of sent emails used in statistics goes down, and they get crazy numbers.

This PR uses a different table (`mailpoet_statistics_newsletter`) to fetch the count of emails sent to a single recipient per queue (automations, welcome, etc.). This is also a small performance improvement (we skip the join).

We keep using the sending_queues table for batch emails because switching to `mailpoet_statistics_newsletter` for these would cause a significant performance drop on listing pages (scanning multiple rows in `mailpoet_statistics_newsletter` vs one in sending_queues).

## Code review notes

_N/A_

## QA notes

1. Create an automation
2. Trigger it to send a couple of emails
3. Delete sending_queues for the emails
4. Observe that stats are still ok.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8328

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1250" height="353" alt="Screenshot 2026-08-07 at 19 43 23" src="https://github.com/user-attachments/assets/9349d824-b80b-4e2b-8b4a-e4593b51f5b6" />

<img width="1222" height="579" alt="Screenshot 2026-08-07 at 20 09 35" src="https://github.com/user-attachments/assets/1d737b68-04ec-4c11-9085-114fe51acc15" />


### After

<img width="931" height="369" alt="Screenshot 2026-08-07 at 19 32 24" src="https://github.com/user-attachments/assets/752c645d-7cc7-4984-8f5d-1063e040e182" />

<img width="1223" height="590" alt="Screenshot 2026-08-07 at 20 10 06" src="https://github.com/user-attachments/assets/997ea144-3a89-42a7-bb6e-2615ee327f1f" />


## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->