### PR TITLE
Scope Parsley validation to MailPoet's own forms

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -209,6 +209,7 @@ interface Window {
   mailpoet_date_storage_format?: string;
   mailpoet_current_date_time?: string;
   mailpoet_urls: Record<string, string>;
+  ParsleyConfig?: { autoBind?: boolean };
   recaptcha?: unknown;
   grecaptcha?: any;
   turnstile?: any;

--- a/mailpoet/assets/js/src/parsley-config.ts
+++ b/mailpoet/assets/js/src/parsley-config.ts
@@ -1,0 +1,16 @@
+/**
+ * Global Parsley options, applied before the library is loaded.
+ *
+ * By default Parsley walks the whole document on DOM ready and attaches itself to every
+ * `[data-parsley-validate]` element it finds. Our public bundle runs on pages we only partly
+ * own — post content, theme output and other plugins' markup share that document — so the walk
+ * can pick up fields that were never meant for our validator.
+ *
+ * MailPoet binds its own forms explicitly in `public.tsx`, so nothing of ours needs the walk.
+ *
+ * This must be assigned before `parsleyjs` is imported anywhere in the bundle: the library reads
+ * the flag once, while its module body runs. Keep it as the first import.
+ */
+window.ParsleyConfig = { autoBind: false };
+
+export {};

--- a/mailpoet/assets/js/src/parsley-config.ts
+++ b/mailpoet/assets/js/src/parsley-config.ts
@@ -10,6 +10,13 @@
  *
  * This must be assigned before `parsleyjs` is imported anywhere in the bundle: the library reads
  * the flag once, while its module body runs. Keep it as the first import.
+ *
+ * Assign, do not merge. It is tempting to spread whatever is already on `window` under this name
+ * so another plugin's options survive, but on a public page that value is not necessarily config:
+ * `window.ParsleyConfig` also resolves to any element in the document carrying
+ * `id="ParsleyConfig"`, and merging it would copy page markup into Parsley's options. Our forms
+ * should validate by our rules regardless of what else the page defines, so this states the
+ * options outright.
  */
 window.ParsleyConfig = { autoBind: false };
 

--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -1,3 +1,5 @@
+// Must stay above the `parsleyjs` import — it sets options the library reads as it loads.
+import './parsley-config';
 import { MailPoet } from 'mailpoet';
 import jQuery from 'jquery';
 import Cookies from 'js-cookie';


### PR DESCRIPTION
## Description

Parsley auto-binds to every `[data-parsley-validate]` element in the document on DOM ready. Our public bundle shares that document with post content, theme output and other plugins' markup, so the walk can attach our validator to fields that have nothing to do with MailPoet, and then act on their `data-parsley-*` attributes.

This turns auto-binding off and leaves MailPoet binding its own forms, which is what it already does.

- **new** `assets/js/src/parsley-config.ts` — sets `window.ParsleyConfig = { autoBind: false }`
- `assets/js/src/public.tsx` — imports it as the first import, ahead of `parsleyjs`
- `assets/js/src/global.d.ts` — types the global

## Code review notes

**Why a separate module instead of a line in `public.tsx`.** Parsley reads the flag once, while its own module body runs (`if (false !== window.ParsleyConfig.autoBind)`). Assigning it in the body of `public.tsx` is too late, because ES imports are evaluated before the importing module's statements. Putting it in its own module and importing that first is what makes the ordering explicit and reviewable. Both the module and the import carry a comment saying so, because it is the kind of thing an import sorter would happily break.

**Why nothing depends on the walk.** MailPoet binds its own forms by hand in `public.tsx:993-997`:

```js
$('form.mailpoet_form').each((_, element: HTMLFormElement) => {
  const form = $(element) as JQuery<HTMLFormElement>;
  form.parsley()…
```

The `data-parsley-*` attributes we emit (`Form/Block/BlockRendererHelper.php:87-100`) are per-field rules — `required`, `minlength`, `maxlength`, `names`, `type-message`, `errors-container` — applied to that form. We never emit `data-parsley-validate` on the front end. Checked on a rendered page carrying a real form: the only `data-parsley-validate` in the entire document came from the post body, not from us.

The four `data-parsley-validate` usages in `assets/js/src/` are all in the newsletter-editor coupon blocks, which are admin-only and not in this bundle. This change does not touch the admin.

## QA notes

Rebuilt with and without the change and compared the same measurements on a page carrying a real fixed-bar form:

| | Before | After |
|---|---|---|
| `Parsley.options.autoBind` | `undefined` | `false` |
| Parsley bound to an unrelated `[data-parsley-validate]` in the post body | yes | **no** |
| Parsley bound to `form.mailpoet_form` | yes | yes |
| `isValid()` — empty / malformed / valid email | false / false / false | identical |
| Rendered messages | "This value should be a valid email." + "This field is required." | identical |

Then exercised the form through the UI rather than trusting the programmatic calls:

- submit with the required email empty → *This field is required.*, field gets `parsley-error`, submit blocked
- submit `not-an-email` → *This value should be a valid email.*, blocked
- first name `<script>` → *Please specify a valid name.* — this is our own `names` validator registered via `Parsley.addValidator`, so the custom-validator path is covered too
- everything valid → subscriber row written, `unconfirmed`

`eslint --max-warnings 0` exit 0 · `prettier --check` clean · `tsc --noEmit` exit 0 · `./do test:javascript` 395 passing.

Worth knowing if you re-test by hand: a successful subscribe sets the `popup_form_dismissed_<formId>` cookie, which suppresses a fixed-bar form on later visits. Clear it or the form will look broken when it is not.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8334

## After-merge notes

_N/A_

## Tasks

<!--
No changelog entry: this changes no user-visible behaviour. MailPoet's own forms
validate exactly as before — same rules, same messages, same submit flow — so there
is nothing to describe to a site owner. Matches #6998 and #7007, which were the same
shape.
-->
- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations <!-- no user-facing strings -->
- [ ] I added sufficient test coverage <!-- no JS test harness covers public.tsx; verified in a browser against a live env instead, see QA notes -->
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8334-scope-form-validation)

_The latest successful build from `fix/stomail-8334-scope-form-validation` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->