### PR TITLE
Scope validation to our own forms everywhere, and fix message encoding - STOMAIL-8335

### DIFF
--- a/mailpoet/assets/js/src/parsley-validators.jsx
+++ b/mailpoet/assets/js/src/parsley-validators.jsx
@@ -1,3 +1,4 @@
+import 'parsley-config'; // must precede 'parsleyjs' — it sets options the library reads as it loads
 import jQuery from 'jquery';
 import Parsley from 'parsleyjs';
 

--- a/mailpoet/assets/js/src/settings/index.tsx
+++ b/mailpoet/assets/js/src/settings/index.tsx
@@ -1,3 +1,4 @@
+import 'parsley-config'; // must precede 'parsleyjs' — it sets options the library reads as it loads
 import 'parsleyjs';
 import { createRoot } from 'react-dom/client';
 import { GlobalContext, useGlobalContextValue } from 'context';

--- a/mailpoet/assets/js/src/webpack-mailpoet-index.jsx
+++ b/mailpoet/assets/js/src/webpack-mailpoet-index.jsx
@@ -4,6 +4,7 @@
 // This is to avoid undefined import order & messy WebPack config.
 // Code can be gradually refactored to avoid side effects completely.
 
+import 'parsley-config'; // side effect - sets Parsley options; must precede 'parsleyjs'
 import 'mailpoet'; // side effect - assigns MailPoet to window
 import 'dismissible-notice.jsx'; // side effect - adds jQuery event
 import 'jquery.serialize-object'; // side effect - extends jQuery

--- a/mailpoet/views/parsley-translations.html
+++ b/mailpoet/views/parsley-translations.html
@@ -1,27 +1,34 @@
 
+<#
+  Each message is emitted with json_encode(), which supplies its own quotes and escapes
+  anything that would otherwise end the JavaScript string. Interpolating a translation
+  straight into '...' breaks on the first apostrophe: the script then fails to parse and
+  every message here is silently lost, so Parsley falls back to its built-in English.
+  Most languages need an apostrophe somewhere, so this has to stay json_encode().
+#>
 Parsley.addMessages('mailpoet', {
-  defaultMessage: '<%= __("This value seems to be invalid.") %>',
+  defaultMessage: <%= json_encode(__("This value seems to be invalid.")) %>,
   type: {
-    email: '<%= __("This value should be a valid email.") %>',
-    url: '<%= __("This value should be a valid url.") %>',
-    number: '<%= __("This value should be a valid number.") %>',
-    integer: '<%= __("This value should be a valid integer.") %>',
-    digits: '<%= __("This value should be digits.") %>',
-    alphanum: '<%= __("This value should be alphanumeric.") %>'
+    email: <%= json_encode(__("This value should be a valid email.")) %>,
+    url: <%= json_encode(__("This value should be a valid url.")) %>,
+    number: <%= json_encode(__("This value should be a valid number.")) %>,
+    integer: <%= json_encode(__("This value should be a valid integer.")) %>,
+    digits: <%= json_encode(__("This value should be digits.")) %>,
+    alphanum: <%= json_encode(__("This value should be alphanumeric.")) %>
   },
-  notblank: '<%= __("This value should not be blank.") %>',
-  required: '<%= __("This value is required.") %>',
-  pattern: '<%= __("This value seems to be invalid.") %>',
-  min: '<%= __("This value should be greater than or equal to %s.") %>',
-  max: '<%= __("This value should be lower than or equal to %s.") %>',
-  range: '<%= __("This value should be between %s and %s.") %>',
-  minlength: '<%= __("This value is too short. It should have %s characters or more.") %>',
-  maxlength: '<%= __("This value is too long. It should have %s characters or fewer.") %>',
-  length: '<%= __("This value length is invalid. It should be between %s and %s characters long.") %>',
-  mincheck: '<%= __("You must select at least %s choices.") %>',
-  maxcheck: '<%= __("You must select %s choices or fewer.") %>',
-  check: '<%= __("You must select between %s and %s choices.") %>',
-  equalto: '<%= __("This value should be the same.") %>'
+  notblank: <%= json_encode(__("This value should not be blank.")) %>,
+  required: <%= json_encode(__("This value is required.")) %>,
+  pattern: <%= json_encode(__("This value seems to be invalid.")) %>,
+  min: <%= json_encode(__("This value should be greater than or equal to %s.")) %>,
+  max: <%= json_encode(__("This value should be lower than or equal to %s.")) %>,
+  range: <%= json_encode(__("This value should be between %s and %s.")) %>,
+  minlength: <%= json_encode(__("This value is too short. It should have %s characters or more.")) %>,
+  maxlength: <%= json_encode(__("This value is too long. It should have %s characters or fewer.")) %>,
+  length: <%= json_encode(__("This value length is invalid. It should be between %s and %s characters long.")) %>,
+  mincheck: <%= json_encode(__("You must select at least %s choices.")) %>,
+  maxcheck: <%= json_encode(__("You must select %s choices or fewer.")) %>,
+  check: <%= json_encode(__("You must select between %s and %s choices.")) %>,
+  equalto: <%= json_encode(__("This value should be the same.")) %>
 });
 
 Parsley.setLocale('mailpoet');

--- a/patches/parsleyjs@2.9.2.patch
+++ b/patches/parsleyjs@2.9.2.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/parsley.js b/dist/parsley.js
-index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..d2bef986c5fdafb86713651b871d995e83e13cc3 100644
+index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..fe1f7808c98cb0899f31ea02a7f98baf94b5ef93 100644
 --- a/dist/parsley.js
 +++ b/dist/parsley.js
 @@ -942,7 +942,7 @@
@@ -11,6 +11,57 @@ index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..d2bef986c5fdafb86713651b871d995e
      },
      _destroyUI: function _destroyUI() {
        // Reset all event listeners
+@@ -1049,7 +1049,7 @@
+ 
+           this._ui.$errorClassHandler.attr('aria-describedby', this._ui.errorsWrapperId);
+ 
+-          return this._ui.$errorsWrapper.addClass('filled').attr('aria-hidden', 'false').find('.parsley-custom-error-message').html(this.options.errorMessage);
++          return this._ui.$errorsWrapper.addClass('filled').attr('aria-hidden', 'false').find('.parsley-custom-error-message').text(this.options.errorMessage);
+         }
+ 
+         this._ui.$errorClassHandler.removeAttr('aria-describedby');
+@@ -1084,13 +1084,13 @@
+ 
+       this._ui.$errorClassHandler.attr('aria-describedby', this._ui.errorsWrapperId);
+ 
+-      this._ui.$errorsWrapper.addClass('filled').attr('aria-hidden', 'false').append($(this.options.errorTemplate).addClass('parsley-' + name).html(message || this._getErrorMessage(assert)));
++      this._ui.$errorsWrapper.addClass('filled').attr('aria-hidden', 'false').append($(this.options.errorTemplate).addClass('parsley-' + name).text(message || this._getErrorMessage(assert)));
+     },
+     _updateError: function _updateError(name, _ref5) {
+       var message = _ref5.message,
+           assert = _ref5.assert;
+ 
+-      this._ui.$errorsWrapper.addClass('filled').find('.parsley-' + name).html(message || this._getErrorMessage(assert));
++      this._ui.$errorsWrapper.addClass('filled').find('.parsley-' + name).text(message || this._getErrorMessage(assert));
+     },
+     _removeError: function _removeError(name) {
+       this._ui.$errorClassHandler.removeAttr('aria-describedby');
+@@ -1124,11 +1124,11 @@
+     // Determine which element will have `parsley-error` and `parsley-success` classes
+     _manageClassHandler: function _manageClassHandler() {
+       // Class handled could also be determined by function given in Parsley options
+-      if ('string' === typeof this.options.classHandler && $(this.options.classHandler).length) return $(this.options.classHandler); // Class handled could also be determined by function given in Parsley options
++      if ('string' === typeof this.options.classHandler && '<' !== this.options.classHandler.charAt(0) && $(this.options.classHandler).length) return $(this.options.classHandler); // Class handled could also be determined by function given in Parsley options
+ 
+       var $handlerFunction = this.options.classHandler; // It might also be the function name of a global function
+ 
+-      if ('string' === typeof this.options.classHandler && 'function' === typeof window[this.options.classHandler]) $handlerFunction = window[this.options.classHandler];
++      // Looking the handler up as a global by name lets a DOM attribute choose which function runs. Removed.
+ 
+       if ('function' === typeof $handlerFunction) {
+         var $handler = $handlerFunction.call(this, this); // If this function returned a valid existing DOM element, go for it
+@@ -1153,8 +1153,10 @@
+ 
+       if (0 !== this._ui.$errorsWrapper.parent().length) return this._ui.$errorsWrapper.parent();
+ 
++      if ('string' === typeof $errorsContainer && '<' === $errorsContainer.charAt(0)) $errorsContainer = '';
++
+       if ('string' === typeof $errorsContainer) {
+-        if ($($errorsContainer).length) return $($errorsContainer).append(this._ui.$errorsWrapper);else if ('function' === typeof window[$errorsContainer]) $errorsContainer = window[$errorsContainer];else Utils.warn('The errors container `' + $errorsContainer + '` does not exist in DOM nor as a global JS function');
++        if ($($errorsContainer).length) return $($errorsContainer).append(this._ui.$errorsWrapper);else Utils.warn('The errors container `' + $errorsContainer + '` does not exist in DOM');
+       }
+ 
+       if ('function' === typeof $errorsContainer) $errorsContainer = $errorsContainer.call(this, this);
 diff --git a/dist/parsley.js.map b/dist/parsley.js.map
 index e6b1578d1308c6b1ed1b6ba0ffdeb3c08d65337b..f7078d9c88250d38b7a8c12a1b15bbda3016ad34 100644
 --- a/dist/parsley.js.map

--- a/patches/parsleyjs@2.9.2.patch
+++ b/patches/parsleyjs@2.9.2.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/parsley.js b/dist/parsley.js
-index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..fe1f7808c98cb0899f31ea02a7f98baf94b5ef93 100644
+index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..e9ecdec34ffcb2fe75b6a4d30b6545aefeda6fb0 100644
 --- a/dist/parsley.js
 +++ b/dist/parsley.js
 @@ -942,7 +942,7 @@
@@ -41,7 +41,7 @@ index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..fe1f7808c98cb0899f31ea02a7f98baf
      _manageClassHandler: function _manageClassHandler() {
        // Class handled could also be determined by function given in Parsley options
 -      if ('string' === typeof this.options.classHandler && $(this.options.classHandler).length) return $(this.options.classHandler); // Class handled could also be determined by function given in Parsley options
-+      if ('string' === typeof this.options.classHandler && '<' !== this.options.classHandler.charAt(0) && $(this.options.classHandler).length) return $(this.options.classHandler); // Class handled could also be determined by function given in Parsley options
++      if ('string' === typeof this.options.classHandler && !/^\s*</.test(this.options.classHandler) && $(this.options.classHandler).length) return $(this.options.classHandler); // Class handled could also be determined by function given in Parsley options
  
        var $handlerFunction = this.options.classHandler; // It might also be the function name of a global function
  
@@ -54,7 +54,7 @@ index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..fe1f7808c98cb0899f31ea02a7f98baf
  
        if (0 !== this._ui.$errorsWrapper.parent().length) return this._ui.$errorsWrapper.parent();
  
-+      if ('string' === typeof $errorsContainer && '<' === $errorsContainer.charAt(0)) $errorsContainer = '';
++      if ('string' === typeof $errorsContainer && /^\s*</.test($errorsContainer)) $errorsContainer = '';
 +
        if ('string' === typeof $errorsContainer) {
 -        if ($($errorsContainer).length) return $($errorsContainer).append(this._ui.$errorsWrapper);else if ('function' === typeof window[$errorsContainer]) $errorsContainer = window[$errorsContainer];else Utils.warn('The errors container `' + $errorsContainer + '` does not exist in DOM nor as a global JS function');

--- a/patches/parsleyjs@2.9.2.patch
+++ b/patches/parsleyjs@2.9.2.patch
@@ -1,8 +1,45 @@
+What MailPoet changes in parsleyjs 2.9.2, and why.
+
+1. `.focus()` becomes `.trigger('focus')`. The shorthand is deprecated in jQuery 3.
+
+2. Error messages are written with `.text()` instead of `.html()`. Nothing we render
+   puts intentional HTML in a message, so treating them as text costs us nothing and
+   stops a translated or server-supplied string from being parsed as markup.
+
+3. Four options can be set from a `data-parsley-*` attribute and end up handed to
+   jQuery, which builds markup out of any string starting with `<`. They are closed
+   two different ways, because they are not the same kind of value:
+
+   - `classHandler` and `errorsContainer` hold selectors. A selector can never start
+     with `<`, so a value that does is rejected and Parsley falls back to its default.
+     Resolving these to a global function by name was also dropped: it let a DOM
+     attribute pick which function runs.
+
+   - `errorTemplate` and `errorsWrapper` hold markup by design. Their defaults are
+     `<li></li>` and `<ul class="parsley-errors-list"></ul>`, so the `<` check above
+     is not available to them. Instead they are removed from the attribute layer in
+     `actualizeOptions`, so an attribute cannot choose what gets built into the page.
+     Both stay settable from JavaScript, and both fall back to the defaults.
+
 diff --git a/dist/parsley.js b/dist/parsley.js
-index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..e9ecdec34ffcb2fe75b6a4d30b6545aefeda6fb0 100644
+index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..a26a0d5fbbdfae6b9e6640b7be7dd274eb1afdca 100644
 --- a/dist/parsley.js
 +++ b/dist/parsley.js
-@@ -942,7 +942,7 @@
+@@ -358,6 +358,13 @@
+     },
+     actualizeOptions: function actualizeOptions() {
+       Utils.attr(this.element, this.options.namespace, this.domOptions);
++      // errorTemplate and errorsWrapper are passed to jQuery as markup by design, so the
++      // `<`-guard used on classHandler and errorsContainer is not available to them. Drop
++      // them from the attribute layer instead: a DOM attribute must not choose what gets
++      // built into the page. Deleting the own property lets lookup fall through to the
++      // value set in JS, or to the default, so both remain configurable from code.
++      delete this.domOptions.errorTemplate;
++      delete this.domOptions.errorsWrapper;
+       if (this.parent && this.parent.actualizeOptions) this.parent.actualizeOptions();
+       return this;
+     },
+@@ -942,7 +949,7 @@
        }
  
        if (null === this._focusedField) return null;
@@ -11,7 +48,7 @@ index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..e9ecdec34ffcb2fe75b6a4d30b6545ae
      },
      _destroyUI: function _destroyUI() {
        // Reset all event listeners
-@@ -1049,7 +1049,7 @@
+@@ -1049,7 +1056,7 @@
  
            this._ui.$errorClassHandler.attr('aria-describedby', this._ui.errorsWrapperId);
  
@@ -20,7 +57,7 @@ index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..e9ecdec34ffcb2fe75b6a4d30b6545ae
          }
  
          this._ui.$errorClassHandler.removeAttr('aria-describedby');
-@@ -1084,13 +1084,13 @@
+@@ -1084,13 +1091,13 @@
  
        this._ui.$errorClassHandler.attr('aria-describedby', this._ui.errorsWrapperId);
  
@@ -36,7 +73,7 @@ index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..e9ecdec34ffcb2fe75b6a4d30b6545ae
      },
      _removeError: function _removeError(name) {
        this._ui.$errorClassHandler.removeAttr('aria-describedby');
-@@ -1124,11 +1124,11 @@
+@@ -1124,11 +1131,11 @@
      // Determine which element will have `parsley-error` and `parsley-success` classes
      _manageClassHandler: function _manageClassHandler() {
        // Class handled could also be determined by function given in Parsley options
@@ -50,7 +87,7 @@ index 0f5718d83c8e465984a22c345b0c50ff4a65ff5b..e9ecdec34ffcb2fe75b6a4d30b6545ae
  
        if ('function' === typeof $handlerFunction) {
          var $handler = $handlerFunction.call(this, this); // If this function returned a valid existing DOM element, go for it
-@@ -1153,8 +1153,10 @@
+@@ -1153,8 +1160,10 @@
  
        if (0 !== this._ui.$errorsWrapper.parent().length) return this._ui.$errorsWrapper.parent();
  

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ patchedDependencies:
     hash: c05c8d9713cb3570fd9217e4582e1b2f768fdb30386d9eb98ad6e1bedc897138
     path: patches/backbone.supermodel@1.2.0.patch
   parsleyjs@2.9.2:
-    hash: 0fb589ad806e09d7d8fa63e53c83bd334ed46e565b6d2cea64c50df7af70eaf4
+    hash: 62af750d129ebf07bedee7a287be1ec348636cedd15d456a325adcf288671b5d
     path: patches/parsleyjs@2.9.2.patch
   spectrum-colorpicker@1.8.1:
     hash: 160c884314aee911fb608e377fd0a78a9dfcb223d3f6f2c3888efe479ed208b1
@@ -274,7 +274,7 @@ importers:
         version: 5.4.1
       parsleyjs:
         specifier: ^2.9.2
-        version: 2.9.2(patch_hash=0fb589ad806e09d7d8fa63e53c83bd334ed46e565b6d2cea64c50df7af70eaf4)
+        version: 2.9.2(patch_hash=62af750d129ebf07bedee7a287be1ec348636cedd15d456a325adcf288671b5d)
       postcss:
         specifier: ^8.5.18
         version: 8.5.18
@@ -24894,7 +24894,7 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  parsleyjs@2.9.2(patch_hash=0fb589ad806e09d7d8fa63e53c83bd334ed46e565b6d2cea64c50df7af70eaf4):
+  parsleyjs@2.9.2(patch_hash=62af750d129ebf07bedee7a287be1ec348636cedd15d456a325adcf288671b5d):
     dependencies:
       jquery: 3.7.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ patchedDependencies:
     hash: c05c8d9713cb3570fd9217e4582e1b2f768fdb30386d9eb98ad6e1bedc897138
     path: patches/backbone.supermodel@1.2.0.patch
   parsleyjs@2.9.2:
-    hash: 34a80d04ed8f6efc9994e245166212830ee3d01224e30450dcf8c39d569aff82
+    hash: c1ee00165cd8f1c9132dcd3cd9f842e014662821d7bb9e187d17476bf9465cbe
     path: patches/parsleyjs@2.9.2.patch
   spectrum-colorpicker@1.8.1:
     hash: 160c884314aee911fb608e377fd0a78a9dfcb223d3f6f2c3888efe479ed208b1
@@ -274,7 +274,7 @@ importers:
         version: 5.4.1
       parsleyjs:
         specifier: ^2.9.2
-        version: 2.9.2(patch_hash=34a80d04ed8f6efc9994e245166212830ee3d01224e30450dcf8c39d569aff82)
+        version: 2.9.2(patch_hash=c1ee00165cd8f1c9132dcd3cd9f842e014662821d7bb9e187d17476bf9465cbe)
       postcss:
         specifier: ^8.5.18
         version: 8.5.18
@@ -24894,7 +24894,7 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  parsleyjs@2.9.2(patch_hash=34a80d04ed8f6efc9994e245166212830ee3d01224e30450dcf8c39d569aff82):
+  parsleyjs@2.9.2(patch_hash=c1ee00165cd8f1c9132dcd3cd9f842e014662821d7bb9e187d17476bf9465cbe):
     dependencies:
       jquery: 3.7.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ patchedDependencies:
     hash: c05c8d9713cb3570fd9217e4582e1b2f768fdb30386d9eb98ad6e1bedc897138
     path: patches/backbone.supermodel@1.2.0.patch
   parsleyjs@2.9.2:
-    hash: 62af750d129ebf07bedee7a287be1ec348636cedd15d456a325adcf288671b5d
+    hash: 34a80d04ed8f6efc9994e245166212830ee3d01224e30450dcf8c39d569aff82
     path: patches/parsleyjs@2.9.2.patch
   spectrum-colorpicker@1.8.1:
     hash: 160c884314aee911fb608e377fd0a78a9dfcb223d3f6f2c3888efe479ed208b1
@@ -274,7 +274,7 @@ importers:
         version: 5.4.1
       parsleyjs:
         specifier: ^2.9.2
-        version: 2.9.2(patch_hash=62af750d129ebf07bedee7a287be1ec348636cedd15d456a325adcf288671b5d)
+        version: 2.9.2(patch_hash=34a80d04ed8f6efc9994e245166212830ee3d01224e30450dcf8c39d569aff82)
       postcss:
         specifier: ^8.5.18
         version: 8.5.18
@@ -24894,7 +24894,7 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  parsleyjs@2.9.2(patch_hash=62af750d129ebf07bedee7a287be1ec348636cedd15d456a325adcf288671b5d):
+  parsleyjs@2.9.2(patch_hash=34a80d04ed8f6efc9994e245166212830ee3d01224e30450dcf8c39d569aff82):
     dependencies:
       jquery: 3.7.1
 


### PR DESCRIPTION
Follow-up to #7020. That PR stopped Parsley binding to markup we don't own in the **public** bundle. Auditing the rest of our Parsley usage afterwards turned up three more things worth doing, one of which has nothing to do with validation scoping.

## Description

**1. Auto-binding is off for the admin bundles too.** #7020 only covered `public.tsx`. Parsley is imported in three other places, and `commons.js` was still walking the document on DOM ready. `parsley-config` now comes first in all of them.

Nothing relied on that walk. The admin's `[data-parsley-validate]` fields are newsletter-editor coupon inputs that mount long after DOM ready — the walk could never have reached them — and they bind lazily through their own `onChange` handlers.

**2. Parsley renders messages as text, and a DOM attribute can no longer choose code or markup.** Edits to the existing patch:

- the three error-message sinks use `.text()` instead of `.html()`
- `window[this.options.classHandler]` and `window[$errorsContainer]` are gone — these let a DOM attribute name a global function for Parsley to call
- `classHandler` and `errorsContainer` ignore a value starting with `<`. Both are documented as CSS selectors, and a selector never begins with a tag; jQuery would otherwise build it as markup
- `errorTemplate` and `errorsWrapper` are removed from the attribute layer in `actualizeOptions`. These two hold markup by design, their defaults being `<li></li>` and `<ul class="parsley-errors-list"></ul>`, so the `<` check above is not available to them. They also differ from the first two in that what they build does get attached to the page. Deleting the own property lets lookup fall through to whatever was set in JavaScript, or to the default, so both stay configurable from code and only the attribute route closes

**3. Validation translations are emitted with `json_encode()`.** They were interpolated straight into a single-quoted JavaScript literal. Twig's autoescaping is on, but it never reaches these: `lib/Twig/I18n.php` registers `__`, `_n`, `_x` and the rest with `is_safe => ['all']`, so a translation is emitted exactly as it is stored. One apostrophe ended the string, broke the script, and dropped every message in the block — leaving Parsley on its built-in English with nothing in the console pointing at the cause.

## Code review notes

**On `.html()` → `.text()`, which is the change most likely to raise an eyebrow.** Every message we hand Parsley is plain text on both routes: the translations arrive unescaped (see below), and a `data-parsley-*-message` attribute has already been decoded by `getAttribute()` before Parsley sees it. So there is nothing to double-encode.

It also fixes a case the old path got wrong. A message containing angle brackets lost them silently:

```
source:               Don't leave it blank & don"t use <brackets>.
old .html() rendered: Don't leave it blank & don"t use .
new .text() renders:  Don't leave it blank & don"t use <brackets>.
```

**On the translations.** Worth being concrete, because it is easy to assume Twig escaped these. Autoescaping is on, but every translation function is registered `is_safe => ['all']`, so it never applies to them. The `json_encode()` in the view is our own Twig function (`lib/Twig/Functions.php`), which forces `JSON_HEX_TAG` on top of the usual escaping, so a translation containing `</script>` cannot close the inline script either. I confirmed the behaviour with a probe translation containing `'`, `&`, `"` and `<>`:

| | Before | After |
|---|---|---|
| Inline script parses | ✗ `SyntaxError: Unexpected identifier` | ✓ |
| Locales Parsley has loaded | `["en"]` — our whole catalogue lost | `["en","mailpoet"]` |
| Active locale | `en` | `mailpoet` |

No shipped translation trips it today: these strings are largely untranslated (fr/it/pt-BR 0 of 19, nl 7 of 19), and translators overwhelmingly use the typographic `’`, which is safe inside `'…'` — only 6 of 1016 French entries use a straight apostrophe. But the failure is total and silent for whichever language hits it first, and a large share of our users are not on English. `json_encode()` matches what `views/homepage.html` and `views/help.html` already do.

**On reachability.** None of the four options above can be set through anything we render today, so nothing here changes behaviour for an existing store. Every rule name in `BlockRendererHelper::getInputValidation()` is a literal; the form editor's HTML block runs `wp_kses_post()`, which allows no `input`, `select`, `textarea` or `form` tag at all, so a custom block cannot introduce a field for Parsley to bind; and with `autoBind: false` Parsley only touches the forms we bind ourselves. The reason to close them anyway is that all four are one stray attribute away from mattering, and the guard costs nothing.

**On the patch file.** Regenerated through `pnpm patch` / `patch-commit`. Three things to know:

- The pre-existing jQuery 3 `.focus()` → `.trigger('focus')` fix is untouched — verified present in the patch workspace before editing and in the installed package after.
- `patch-commit` wanted to rewrite 38 unrelated `resolution:` lines in the lockfile and drop a trailing-newline marker in the `parsley.min.js.map` hunk, which would have added a byte to a file nothing loads. Both reverted, so the lockfile diff is 3 lines and the patch changes only what it should.
- The patch now opens with a short header saying what we change and why, so the next person reading it does not have to work out why two of these options are guarded and two are stripped. pnpm ignores leading text before the first `diff --git`; `pnpm install --frozen-lockfile` exits 0 with it in place and the patch still applies.

## QA notes

Public subscription form, driven through the UI: empty required email → *This field is required.*; `bad-email` → *This value should be a valid email.*; `<script>` in first name → *Please specify a valid name.* (our own `names` validator, so the custom-validator path is covered); everything valid → subscriber row written.

Admin **Emails** and **Settings** — separate webpack entries — both load Parsley with `autoBind: false`, the `mailpoet` catalogue active, `scheduledAt` and `segmentsWithSubscribers` registered, and errors rendering.

`pnpm install --frozen-lockfile` exit 0 · `eslint --max-warnings 0` exit 0 · `prettier --check` clean · `tsc --noEmit` exit 0 · `./do test:javascript` 395 passing.

Worth knowing if you re-test the form by hand: a successful subscribe sets `popup_form_dismissed_<formId>`, which hides a fixed-bar form on later visits. Clear it or the form looks broken when it isn't.

## Linked PRs

#7020

## Linked tickets

STOMAIL-8335

## After-merge notes

_N/A_

## Tasks

<!--
No changelog entry. Items 1 and 2 change no user-visible behaviour. Item 3 is
user-visible only on a site whose language would otherwise have hit the parse
error, where the result is "validation messages are translated" — there is no
released version where anyone saw them break, so there is nothing to tell a
site owner they need to know about. Matches #6998, #7007, #7013 and #7020.
-->
- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage <!-- no JS harness covers these paths; verified in a browser against a live env, see QA notes -->
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8334-harden-parsley-and-fix-message-encoding)

_The latest successful build from `fix/stomail-8334-harden-parsley-and-fix-message-encoding` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
