### PR TITLE
Add full post content block for latest posts template

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/index.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/index.tsx
@@ -2,11 +2,13 @@ import './style.scss';
 import { registerBlockType } from '@wordpress/blocks';
 import type { BlockEditProps } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/block-editor';
-import { layout, postList } from '@wordpress/icons';
+import { layout, postContent, postList } from '@wordpress/icons';
 import latestPostsMetadata from './block.json';
 import postTemplateMetadata from './post-template/block.json';
+import postContentMetadata from './post-content/block.json';
 import { Edit as LatestPostsEdit } from './edit';
 import { Edit as PostTemplateEdit } from './post-template/edit';
+import { Edit as PostContentEdit } from './post-content/edit';
 
 const saveInnerBlocks = (): JSX.Element => <InnerBlocks.Content />;
 
@@ -24,4 +26,12 @@ registerBlockType(postTemplateMetadata, {
     BlockEditProps<Record<string, unknown>>
   >,
   save: saveInnerBlocks,
+});
+
+registerBlockType(postContentMetadata, {
+  icon: { src: postContent },
+  edit: PostContentEdit as unknown as React.ComponentType<
+    BlockEditProps<Record<string, unknown>>
+  >,
+  save: () => null,
 });

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/block.json
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/block.json
@@ -1,0 +1,18 @@
+{
+  "name": "mailpoet/post-content",
+  "version": "1.0.0",
+  "title": "Post Content",
+  "description": "Displays the full content of each post. Blocks that cannot be rendered in emails are left out when the email is sent.",
+  "category": "mailpoet",
+  "parent": ["mailpoet/latest-posts-template"],
+  "textdomain": "mailpoet",
+  "icon": "align-left",
+  "supports": {
+    "html": false,
+    "reusable": false,
+    "email": true
+  },
+  "usesContext": ["postId", "postType"],
+  "apiVersion": 3,
+  "$schema": "https://schemas.wp.org/trunk/block.json"
+}

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/edit.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/edit.tsx
@@ -1,0 +1,60 @@
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { useBlockProps } from '@wordpress/block-editor';
+import { Spinner } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+
+type EditProps = {
+  context: {
+    postId?: number;
+    postType?: string;
+  };
+};
+
+type ContentRecord = { content?: { rendered?: string } };
+
+export function Edit({ context }: EditProps): JSX.Element {
+  const { postId, postType } = context;
+  const blockProps = useBlockProps({
+    className: 'mailpoet-latest-posts__post-content',
+  });
+
+  const record = useSelect(
+    (select) => {
+      if (!postId || !postType) {
+        return null;
+      }
+      return select(coreStore).getEntityRecord(
+        'postType',
+        postType,
+        postId,
+      ) as ContentRecord | null;
+    },
+    [postId, postType],
+  );
+
+  if (!postId || !postType) {
+    return (
+      <div {...blockProps}>
+        <p>{__('Displays the content of each post.', 'mailpoet')}</p>
+      </div>
+    );
+  }
+
+  if (!record) {
+    return (
+      <div {...blockProps}>
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      {...blockProps}
+      // Read-only preview using the rendered content from the site's own REST API.
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: record.content?.rendered ?? '' }}
+    />
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/edit.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/edit.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
@@ -19,16 +19,22 @@ export function Edit({ context }: EditProps): JSX.Element {
     className: 'mailpoet-latest-posts__post-content',
   });
 
-  const record = useSelect(
+  const { record, hasResolved } = useSelect(
     (select) => {
       if (!postId || !postType) {
-        return null;
+        return { record: null, hasResolved: false };
       }
-      return select(coreStore).getEntityRecord(
-        'postType',
-        postType,
-        postId,
-      ) as ContentRecord | null;
+      return {
+        record: select(coreStore).getEntityRecord(
+          'postType',
+          postType,
+          postId,
+        ) as ContentRecord | null,
+        hasResolved: select(coreStore).hasFinishedResolution(
+          'getEntityRecord',
+          ['postType', postType, postId],
+        ),
+      };
     },
     [postId, postType],
   );
@@ -41,10 +47,24 @@ export function Edit({ context }: EditProps): JSX.Element {
     );
   }
 
-  if (!record) {
+  if (!hasResolved) {
     return (
       <div {...blockProps}>
         <Spinner />
+      </div>
+    );
+  }
+
+  if (!record) {
+    return (
+      <div {...blockProps}>
+        <p>
+          {sprintf(
+            // translators: %d is the post ID.
+            __('Could not load the post (ID: %d). Was it deleted?', 'mailpoet'),
+            postId,
+          )}
+        </p>
       </div>
     );
   }

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/style.scss
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/style.scss
@@ -11,3 +11,8 @@
   margin: 0;
   min-width: 0;
 }
+
+.mailpoet-latest-posts__post-content img {
+  height: auto;
+  max-width: 100%;
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -315,9 +315,11 @@ class LatestPosts extends AbstractBlock {
   }
 
   /**
-   * Renders the full content of the post provided by the template loop.
-   * Block-based content keeps only blocks the email engine can render;
-   * classic content is reduced to an email-safe subset of HTML.
+   * Renders the post content for the current post in the template loop.
+   * Block posts keep only the blocks the email engine can render, and
+   * classic posts are reduced to email-safe HTML. Password-protected
+   * posts render nothing here, because an email would expose the
+   * protected content to anyone who receives it.
    *
    * @param array<string, mixed>|\WP_Block $attributes
    * @param string $content

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -31,6 +31,7 @@ class LatestPosts extends AbstractBlock {
   protected $blockName = 'latest-posts';
 
   private const TEMPLATE_BLOCK = 'mailpoet/latest-posts-template';
+  private const POST_CONTENT_BLOCK = 'mailpoet/post-content';
   private const DEFAULT_COLUMNS = 1;
   private const MAX_COLUMNS = 2;
   private const DEFAULT_POSTS = 3;
@@ -62,8 +63,52 @@ class LatestPosts extends AbstractBlock {
     'core/avatar',
   ];
 
+  /**
+   * HTML kept when rendering classic (non-block) post content.
+   * Text-level markup email clients handle well.
+   * Everything else (scripts, embeds, forms, ...) is stripped.
+   */
+  private const CLASSIC_CONTENT_ALLOWED_HTML = [
+    'a' => ['href' => true, 'title' => true],
+    'b' => [],
+    'blockquote' => ['cite' => true],
+    'br' => [],
+    'cite' => [],
+    'code' => [],
+    'em' => [],
+    'figcaption' => [],
+    'figure' => [],
+    'h1' => [],
+    'h2' => [],
+    'h3' => [],
+    'h4' => [],
+    'h5' => [],
+    'h6' => [],
+    'hr' => [],
+    'i' => [],
+    'img' => ['src' => true, 'alt' => true, 'width' => true, 'height' => true],
+    'li' => [],
+    'ol' => ['start' => true],
+    'p' => [],
+    'pre' => [],
+    's' => [],
+    'span' => [],
+    'strong' => [],
+    'table' => [],
+    'tbody' => [],
+    'td' => ['colspan' => true, 'rowspan' => true],
+    'tfoot' => [],
+    'th' => ['colspan' => true, 'rowspan' => true],
+    'thead' => [],
+    'tr' => [],
+    'u' => [],
+    'ul' => [],
+  ];
+
   /** @var array<int, int[]> */
   private $renderedPostsByRequest = [];
+
+  private bool $isRenderingPostContent = false;
 
   private AutomatedLatestContent $automatedLatestContent;
   private NewsletterPostsRepository $newsletterPostsRepository;
@@ -85,6 +130,7 @@ class LatestPosts extends AbstractBlock {
   public function initialize() {
     parent::initialize();
     $this->registerTemplateBlock();
+    $this->registerPostContentBlock();
     $this->wp->addFilter('block_categories_all', [$this, 'addBlockCategory']);
     $this->wp->addFilter('allowed_block_types_all', [$this, 'restrictBlocksToEmailEditor'], 10, 2);
     $this->wp->addFilter('block_type_metadata_settings', [$this, 'enableEmailSupportForCoreBlocks']);
@@ -142,7 +188,7 @@ class LatestPosts extends AbstractBlock {
       $allowedBlocks = array_keys(\WP_Block_Type_Registry::get_instance()->get_all_registered());
     }
 
-    $ownBlocks = [$this->getBlockType(), self::TEMPLATE_BLOCK];
+    $ownBlocks = [$this->getBlockType(), self::TEMPLATE_BLOCK, self::POST_CONTENT_BLOCK];
     return array_values(array_filter($allowedBlocks, static function ($blockName) use ($ownBlocks) {
       return !in_array($blockName, $ownBlocks, true);
     }));
@@ -268,6 +314,157 @@ class LatestPosts extends AbstractBlock {
     return $width > 0 ? $width : null;
   }
 
+  /**
+   * Renders the full content of the post provided by the template loop.
+   * Block-based content keeps only blocks the email engine can render;
+   * classic content is reduced to an email-safe subset of HTML.
+   *
+   * @param array<string, mixed>|\WP_Block $attributes
+   * @param string $content
+   * @param \WP_Block|null $block
+   */
+  public function renderPostContent($attributes, $content, $block): string {
+    if ($this->isRenderingPostContent || !$block instanceof \WP_Block) {
+      return '';
+    }
+    $postId = (int)($block->context['postId'] ?? 0);
+    if ($postId <= 0) {
+      return '';
+    }
+    $post = $this->wp->getPost($postId);
+    if (!$post instanceof \WP_Post || $this->wp->postPasswordRequired($post)) {
+      return '';
+    }
+
+    $this->isRenderingPostContent = true;
+    try {
+      if ($this->wp->hasBlocks($post->post_content)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        return $this->renderPostContentBlocks($post, $block);
+      }
+      return $this->renderClassicPostContent($post);
+    } finally {
+      $this->isRenderingPostContent = false;
+    }
+  }
+
+  private function renderPostContentBlocks(\WP_Post $post, \WP_Block $block): string {
+    // The plain core parser, so the engine's email parser does not preprocess
+    // these blocks with the email root padding.
+    $blocks = (new \WP_Block_Parser())->parse($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $blocks = $this->filterEmailRenderableBlocks($blocks);
+    if (!$blocks) {
+      return '';
+    }
+
+    $renderingContext = $this->resolveRenderingContext(null);
+    $availableWidth = $this->getAvailableWidth($block->parsed_block, $renderingContext); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $blocks = $this->preprocessBlocks($this->normalizeInnerBlocks($blocks), $availableWidth, $renderingContext);
+
+    $html = '';
+    foreach ($blocks as $contentBlock) {
+      if (is_array($contentBlock)) {
+        $html .= render_block($this->normalizeBlock($contentBlock));
+      }
+    }
+    return $html;
+  }
+
+  private function renderClassicPostContent(\WP_Post $post): string {
+    $content = $this->wp->stripShortcodes($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $content = $this->wp->wpautop($content);
+    $content = trim($this->wp->wpKses($content, self::CLASSIC_CONTENT_ALLOWED_HTML));
+    if ($content === '') {
+      return '';
+    }
+    return '<div class="mailpoet-post-content">' . $content . '</div>';
+  }
+
+  /**
+   * Keeps only blocks the email engine can render: those opted into email
+   * support or given an email render callback (render-only blocks such as
+   * core/embed). Our own blocks and core/post-content are excluded so post
+   * content cannot render recursively.
+   *
+   * @param array<mixed> $blocks
+   * @return array<int, array<string, mixed>>
+   */
+  private function filterEmailRenderableBlocks(array $blocks): array {
+    $kept = [];
+    foreach ($blocks as $block) {
+      if ($this->isEmailRenderableBlock($block)) {
+        $kept[] = $this->filterInnerEmailRenderableBlocks($block);
+      }
+    }
+    return $kept;
+  }
+
+  /**
+   * @param mixed $block
+   * @phpstan-assert-if-true array<string, mixed> $block
+   */
+  private function isEmailRenderableBlock($block): bool {
+    if (!is_array($block)) {
+      return false;
+    }
+    $name = $block['blockName'] ?? null;
+    if (!is_string($name) || $name === '') {
+      return false;
+    }
+    if (in_array($name, [$this->getBlockType(), self::TEMPLATE_BLOCK, self::POST_CONTENT_BLOCK, 'core/post-content'], true)) {
+      return false;
+    }
+    $blockType = \WP_Block_Type_Registry::get_instance()->get_registered($name);
+    if (!$blockType instanceof \WP_Block_Type) {
+      return false;
+    }
+    $supports = is_array($blockType->supports) ? $blockType->supports : [];
+    if (($supports['email'] ?? false) === true) {
+      return true;
+    }
+    return isset($blockType->render_email_callback) && is_callable($blockType->render_email_callback); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  }
+
+  /**
+   * @param array<string, mixed> $block
+   * @return array<string, mixed>
+   */
+  private function filterInnerEmailRenderableBlocks(array $block): array {
+    $innerBlocks = isset($block['innerBlocks']) && is_array($block['innerBlocks']) ? $block['innerBlocks'] : [];
+    if (!$innerBlocks) {
+      return $block;
+    }
+
+    $keptFlags = [];
+    $kept = [];
+    foreach ($innerBlocks as $innerBlock) {
+      $keep = $this->isEmailRenderableBlock($innerBlock);
+      $keptFlags[] = $keep;
+      if ($keep) {
+        $kept[] = $this->filterInnerEmailRenderableBlocks($innerBlock);
+      }
+    }
+
+    // innerContent holds one null placeholder per inner block; drop the
+    // placeholders of removed blocks so markers and blocks stay aligned.
+    $rawInnerContent = isset($block['innerContent']) && is_array($block['innerContent']) ? $block['innerContent'] : [];
+    $innerContent = [];
+    $innerBlockIndex = 0;
+    foreach ($rawInnerContent as $chunk) {
+      if ($chunk !== null) {
+        $innerContent[] = $chunk;
+        continue;
+      }
+      if ($keptFlags[$innerBlockIndex] ?? false) {
+        $innerContent[] = null;
+      }
+      $innerBlockIndex++;
+    }
+
+    $block['innerBlocks'] = $kept;
+    $block['innerContent'] = $innerContent;
+    return $block;
+  }
+
   private function registerTemplateBlock(): void {
     if (\WP_Block_Type_Registry::get_instance()->is_registered(self::TEMPLATE_BLOCK)) {
       return;
@@ -283,6 +480,29 @@ class LatestPosts extends AbstractBlock {
       'editor_script' => $this->getEditorScript('handle'),
       'editor_style' => $this->getEditorStyle('handle'),
     ]);
+  }
+
+  private function registerPostContentBlock(): void {
+    if (\WP_Block_Type_Registry::get_instance()->is_registered(self::POST_CONTENT_BLOCK)) {
+      return;
+    }
+    $metadataPath = Env::$assetsPath . '/dist/js/email-editor-blocks/latest-posts-post-content/block.json';
+    if (!file_exists($metadataPath)) {
+      return;
+    }
+    $blockType = register_block_type_from_metadata($metadataPath, [
+      'render_callback' => [$this, 'renderPostContent'],
+      'editor_script' => $this->getEditorScript('handle'),
+      'editor_style' => $this->getEditorStyle('handle'),
+    ]);
+    if ($blockType instanceof \WP_Block_Type) {
+      // The render callback already produces email-ready markup; without an
+      // identity callback the engine would wrap it in the fallback text renderer.
+      // @phpstan-ignore-next-line -- WooCommerce email editor reads this dynamic block setting.
+      $blockType->render_email_callback = static function (string $blockContent): string { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        return $blockContent;
+      };
+    }
   }
 
   private function registerEmailRenderCallback(): void {

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -759,6 +759,24 @@ class Functions {
     return wpautop($pee, $br);
   }
 
+  /**
+   * @param int|string|\WP_Post|null $post
+   */
+  public function hasBlocks($post = null): bool {
+    return has_blocks($post);
+  }
+
+  /**
+   * @param int|\WP_Post|null $post
+   */
+  public function postPasswordRequired($post = null): bool {
+    return post_password_required($post);
+  }
+
+  public function stripShortcodes(string $content): string {
+    return strip_shortcodes($content);
+  }
+
   public function inTheLoop(): bool {
     return in_the_loop();
   }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -480,6 +480,7 @@ class LatestPostsTest extends \MailPoetTest {
     $this->assertIsArray($allowed);
     verify(in_array('mailpoet/latest-posts', $allowed, true))->false();
     verify(in_array('mailpoet/latest-posts-template', $allowed, true))->false();
+    verify(in_array('mailpoet/post-content', $allowed, true))->false();
     // Other blocks remain available.
     verify(in_array('core/paragraph', $allowed, true))->true();
   }
@@ -525,6 +526,114 @@ class LatestPostsTest extends \MailPoetTest {
 
     verify($result)->stringContainsString('a:not(.wp-element-button)');
     verify($result)->stringNotContainsString(':where(');
+  }
+
+  public function testItRendersFullContentOfBlockPosts(): void {
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts full content',
+      '<!-- wp:paragraph --><p>Full block paragraph</p><!-- /wp:paragraph -->'
+      . '<!-- wp:verse --><pre class="wp-block-verse">Verse text here</pre><!-- /wp:verse -->'
+    );
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1], [], [$this->block('mailpoet/post-content')]);
+
+    verify($html)->stringContainsString('Full block paragraph');
+    // core/verse has no email support, so it is left out.
+    verify($html)->stringNotContainsString('Verse text here');
+  }
+
+  public function testItDropsUnsupportedBlocksNestedInSupportedOnes(): void {
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts nested content',
+      '<!-- wp:group --><div class="wp-block-group">'
+      . '<!-- wp:paragraph --><p>Nested safe paragraph</p><!-- /wp:paragraph -->'
+      . '<!-- wp:verse --><pre class="wp-block-verse">Nested verse</pre><!-- /wp:verse -->'
+      . '</div><!-- /wp:group -->'
+    );
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1], [], [$this->block('mailpoet/post-content')]);
+
+    verify($html)->stringContainsString('Nested safe paragraph');
+    verify($html)->stringNotContainsString('Nested verse');
+  }
+
+  public function testItRendersClassicContentAsEmailSafeHtml(): void {
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts classic content',
+      "Classic intro text\n\n<iframe src=\"https://example.com/embed\"></iframe>More classic text [gallery]"
+    );
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1], [], [$this->block('mailpoet/post-content')]);
+
+    verify($html)->stringContainsString('<p>Classic intro text</p>');
+    verify($html)->stringContainsString('More classic text');
+    verify($html)->stringNotContainsString('<iframe');
+    verify($html)->stringNotContainsString('[gallery]');
+  }
+
+  public function testItSkipsContentOfPasswordProtectedPosts(): void {
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts protected content',
+      '<!-- wp:paragraph --><p>Hidden protected content</p><!-- /wp:paragraph -->',
+      ['post_password' => 'secret']
+    );
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1], [], [$this->block('mailpoet/post-content')]);
+
+    verify($html)->stringNotContainsString('Hidden protected content');
+  }
+
+  public function testItDoesNotRenderItsOwnBlocksInsidePostContent(): void {
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts recursive content',
+      '<!-- wp:paragraph --><p>Recursive safe paragraph</p><!-- /wp:paragraph -->'
+      . '<!-- wp:mailpoet/post-content /-->'
+      . '<!-- wp:mailpoet/latest-posts /-->'
+    );
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1], [], [$this->block('mailpoet/post-content')]);
+
+    verify($html)->stringContainsString('Recursive safe paragraph');
+    // Rendering exactly one post means the nested blocks did not run the loop again.
+    verify(substr_count($html, 'Recursive safe paragraph'))->equals(1);
+  }
+
+  public function testItDoesNotWrapPostContentInnerBlocksWithRootPadding(): void {
+    // The whole block already sits inside the email root padding; inner blocks
+    // with their own wrapper would be indented twice.
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts padding post',
+      '<!-- wp:paragraph --><p>Padding check paragraph</p><!-- /wp:paragraph -->'
+      . '<!-- wp:heading --><h2 class="wp-block-heading">Padding check heading</h2><!-- /wp:heading -->'
+    );
+    $content = '<!-- wp:mailpoet/latest-posts {"query":{"perPage":1},"displayLayout":{"columns":1}} -->'
+      . '<!-- wp:mailpoet/latest-posts-template --><!-- wp:post-title /--><!-- wp:mailpoet/post-content /--><!-- /wp:mailpoet/latest-posts-template -->'
+      . '<!-- /wp:mailpoet/latest-posts -->';
+    $newsletter = $this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD, null, $content);
+
+    $rendered = $this->diContainer->get(Renderer::class)->renderAsPreview($newsletter);
+    $this->assertIsArray($rendered);
+    $html = $rendered['html'] ?? '';
+    $this->assertIsString($html);
+
+    $start = strpos($html, 'data-post-id');
+    $end = strpos($html, 'Padding check heading');
+    $this->assertIsInt($start);
+    $this->assertIsInt($end);
+    $this->assertGreaterThan($start, $end);
+
+    verify(substr($html, $start, $end - $start))->stringNotContainsString('email-root-padding');
   }
 
   /**
@@ -582,6 +691,31 @@ class LatestPostsTest extends \MailPoetTest {
     }
     $this->assertIsArray($term);
     return (int)$term['term_id'];
+  }
+
+  private function ensurePostContentBlockRegistered(): void {
+    if (!\WP_Block_Type_Registry::get_instance()->is_registered('mailpoet/post-content')) {
+      $this->block->initialize();
+    }
+    $this->assertTrue(
+      \WP_Block_Type_Registry::get_instance()->is_registered('mailpoet/post-content'),
+      'mailpoet/post-content is not registered; run `pnpm compile:js` to generate its dist block.json first.'
+    );
+  }
+
+  /**
+   * @param array<string, mixed> $extra
+   */
+  private function createPostWithContent(string $title, string $content, array $extra = []): int {
+    $publishDate = '2020-05-01 01:01:01';
+    return $this->wp->wpInsertPost(array_merge([
+      'post_title' => $title,
+      'post_content' => $content,
+      'post_status' => 'publish',
+      'post_date' => $publishDate,
+      'post_date_gmt' => $this->wp->getGmtFromDate($publishDate),
+      'post_type' => 'post',
+    ], $extra));
   }
 
   private function createPost(string $title, string $publishDate, string $postType = 'post'): int {

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -631,6 +631,10 @@ const emailEditorBlocks = Object.assign({}, wpScriptConfig, {
           from: 'assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-template/block.json',
           to: 'latest-posts-template/block.json',
         },
+        {
+          from: 'assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/post-content/block.json',
+          to: 'latest-posts-post-content/block.json',
+        },
       ],
     }),
   ],


### PR DESCRIPTION
## Description

Follow-up to https://github.com/mailpoet/mailpoet/pull/6917.

Adds a new `mailpoet/post-content` block that can be inserted only inside the Latest Posts → Post Template block. It enders the full content of each post, similar to the "Full post" display type in the legacy editor.

## Code review notes

_N/A_

## QA notes

1. Run `pnpm compile` and open the email editor.
2. Insert the **Latest Posts** block, select the **Post Template**, and insert the **Post Content** block inside it. It should not be offered anywhere else (including the regular post editor).
3. The editor should show a read-only preview of each post's content.
4. Send the email (or use preview) and check:
   - A post written with blocks shows its content. Blocks that emails cannot render (e.g. video, verse, custom HTML) are left out.
   - A post with classic content renders as simple, email-safe HTML.
   - A password-protected post renders no content.

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/6917

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Latest Posts with Post Content block |
| ------------------------------- |
| <img width="2814" height="1506" alt="t08QiHVBCmj9P3Vj@2x" src="https://github.com/user-attachments/assets/0d484796-74b9-4fb6-8bf5-e21b0453a69e" /> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8179-add-latest-posts-post-content-block)

_The latest successful build from `stomail-8179-add-latest-posts-post-content-block` will be used. If none is available, the link won't work._