### PR TITLE
Stop rewriting click links at send time for untracked subscribers

### DIFF
--- a/mailpoet/changelog/2026-08-05-13-29-00-fixed-links-sent-to-subscribers-who-opted-out-of-trackin.md
+++ b/mailpoet/changelog/2026-08-05-13-29-00-fixed-links-sent-to-subscribers-who-opted-out-of-trackin.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Links sent to subscribers who opted out of tracking are no longer rewritten to redirect through click tracking

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -26,6 +26,7 @@ use MailPoet\Newsletter\Renderer\Renderer;
 use MailPoet\Newsletter\Sending\NewsletterReplayMetadata;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Shortcodes\Categories\Link as LinkShortcodeCategory;
 use MailPoet\NewsletterProcessingException;
 use MailPoet\RuntimeException;
 use MailPoet\Segments\SegmentsRepository;
@@ -92,6 +93,8 @@ class Newsletter {
 
   private TrackingConsentController $trackingConsentController;
 
+  private LinkShortcodeCategory $linkShortcodeCategory;
+
   public function __construct(
     ?WPFunctions $wp = null,
     ?PostsTask $postsTask = null,
@@ -130,6 +133,45 @@ class Newsletter {
     $this->couponBlockDetector = ContainerWrapper::getInstance()->get(CouponBlockDetector::class);
     $this->orderReviewUrl = ContainerWrapper::getInstance()->get(OrderReviewUrl::class);
     $this->trackingConsentController = ContainerWrapper::getInstance()->get(TrackingConsentController::class);
+    $this->linkShortcodeCategory = ContainerWrapper::getInstance()->get(LinkShortcodeCategory::class);
+  }
+
+  /**
+   * Put real destinations back for a recipient we may not track.
+   *
+   * Restoring the saved link turns a plain URL back into itself, but a link
+   * shortcode back into raw `[link:...]` text: the shortcode pass deliberately
+   * leaves those alone while site tracking is on, because the click redirect is
+   * normally what resolves them. Since these recipients get no redirect, we
+   * resolve the shortcodes here with the same call the redirect would have
+   * made, so they land on exactly the same page.
+   */
+  private function untrackLinks(
+    string $content,
+    NewsletterEntity $newsletter,
+    SubscriberEntity $subscriber,
+    SendingQueueEntity $queue
+  ): string {
+    $content = $this->newsletterLinks->convertHashedLinksToShortcodesAndUrls(
+      $content,
+      $queue->getId(),
+      $convertAll = true
+    );
+
+    return (string)preg_replace_callback(
+      '/\[link:(\w+)\]/',
+      function (array $matches) use ($newsletter, $subscriber, $queue): string {
+        $url = $this->linkShortcodeCategory->processShortcodeAction(
+          $matches[1],
+          $newsletter,
+          $subscriber,
+          $queue
+        );
+        // An unresolvable shortcode would otherwise ship as literal text.
+        return $url ?? '';
+      },
+      $content
+    );
   }
 
   public function getNewsletterFromQueue(ScheduledTaskEntity $task): ?NewsletterEntity {
@@ -376,18 +418,20 @@ class Newsletter {
       $queue
     );
     if ($this->trackingEnabled) {
-      if (!$this->trackingConsentController->isTrackingAllowed($subscriber)) {
-        // CNIL/Garante: withdrawal must stop the reading operation on future
-        // emails, not merely the recording. Remove the pixel before it is
-        // given a real tracking URL below. Click links are still rewritten —
-        // Clicks::track suppresses their recording (see follow-up note).
+      if ($this->trackingConsentController->isTrackingAllowed($subscriber)) {
+        $preparedNewsletter = $this->newsletterLinks->replaceSubscriberData(
+          $subscriber->getId(),
+          $queue->getId(),
+          $preparedNewsletter
+        );
+      } else {
+        // CNIL/Garante: withdrawal must stop the reading operation itself, not
+        // merely the recording of it. A tracked link still tells our server the
+        // recipient clicked, so these recipients get the plain destination
+        // instead of a redirect through us.
+        $preparedNewsletter = $this->untrackLinks($preparedNewsletter, $newsletter, $subscriber, $queue);
         $preparedNewsletter = OpenTracking::removeTrackingImage($preparedNewsletter);
       }
-      $preparedNewsletter = $this->newsletterLinks->replaceSubscriberData(
-        $subscriber->getId(),
-        $queue->getId(),
-        $preparedNewsletter
-      );
     }
     $preparedNewsletter = Helpers::splitObject($preparedNewsletter);
     if ($newsletter->getWpPostId() !== null) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -152,17 +152,25 @@ class Newsletter {
     SubscriberEntity $subscriber,
     SendingQueueEntity $queue
   ): string {
+    // true = convert every hashed link, not only the shortcode ones.
     $content = $this->newsletterLinks->convertHashedLinksToShortcodesAndUrls(
       $content,
       $queue->getId(),
-      $convertAll = true
+      true
     );
 
+    // Matches the whole shortcode, arguments included, because a link shortcode
+    // may carry one: [link:action | name:value]. The (?!\/\/) guard mirrors the
+    // extractor in Shortcodes::extract() so text like [link://example.com] is
+    // left alone rather than resolved to nothing and dropped.
     return (string)preg_replace_callback(
-      '/\[link:(\w+)\]/',
+      '/\[link:(?!\/\/)(?<action>[^\]]+)\]/',
       function (array $matches) use ($newsletter, $subscriber, $queue): string {
+        // Pass the full shortcode, as Statistics\Track\Clicks::processUrl() does:
+        // processShortcodeAction() parses the brackets itself, and only sees the
+        // arguments when they are still attached.
         $url = $this->linkShortcodeCategory->processShortcodeAction(
-          $matches[1],
+          $matches[0],
           $newsletter,
           $subscriber,
           $queue

--- a/mailpoet/tests/DataFactories/Subscriber.php
+++ b/mailpoet/tests/DataFactories/Subscriber.php
@@ -272,6 +272,15 @@ class Subscriber {
   }
 
   /**
+   * @param string $consent One of the SubscriberEntity::TRACKING_CONSENT_* values.
+   * @return $this
+   */
+  public function withTrackingConsent($consent) {
+    $this->data['tracking_consent'] = $consent;
+    return $this;
+  }
+
+  /**
    * @throws \Exception
    */
   public function create(): SubscriberEntity {
@@ -279,6 +288,7 @@ class Subscriber {
     $subscriber = new SubscriberEntity();
     $subscriber->setStatus($this->data['status']);
     $subscriber->setEmail($this->data['email']);
+    if (isset($this->data['tracking_consent'])) $subscriber->setTrackingConsent($this->data['tracking_consent']);
     if (isset($this->data['count_confirmations'])) $subscriber->setConfirmationsCount($this->data['count_confirmations']);
     if (isset($this->data['engagement_score'])) $subscriber->setEngagementScore($this->data['engagement_score']);
     if (isset($this->data['last_name'])) $subscriber->setLastName($this->data['last_name']);

--- a/mailpoet/tests/acceptance/Newsletters/TrackingOptOutLinksCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/TrackingOptOutLinksCest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use Codeception\Util\Locator;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Settings;
+use MailPoet\Test\DataFactories\Subscriber;
+
+/**
+ * @group frontend
+ */
+class TrackingOptOutLinksCest {
+  private const PLAIN_LINK = 'Post link';
+  private const UNSUBSCRIBE_LINK = 'Unsubscribe link';
+
+  public function _before() {
+    $settings = new Settings();
+    $settings->withTrackingEnabled();
+    $settings->withCronTriggerMethod('Action Scheduler');
+  }
+
+  public function itDoesNotSendTrackedLinksToSubscriberWithoutTrackingConsent(\AcceptanceTester $i) {
+    $i->wantTo('Verify a subscriber who opted out of tracking receives plain links, not click-tracking redirects');
+
+    $subject = 'Untracked links for opted-out subscriber';
+    $segment = (new Segment())->withName('Tracking opt-out send list')->create();
+    (new Subscriber())
+      ->withEmail('optout-links@example.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->withTrackingConsent(SubscriberEntity::TRACKING_CONSENT_DENIED)
+      ->withSegments([$segment])
+      ->create();
+
+    // Spelled out rather than reusing a fixture, so the two links asserted on
+    // below are visible here: one plain external URL, one link shortcode.
+    $newsletter = (new Newsletter())
+      ->withSubject($subject)
+      ->withBody($this->bodyWithBothLinkKinds())
+      ->create();
+
+    $i->login();
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-newsletters#/send/' . $newsletter->getId());
+    $i->waitForElement('[data-automation-id="newsletter_send_form"]');
+    $i->selectOptionInSelect2($segment->getName());
+    $i->click('Send');
+    $i->waitForEmailSendingOrSent();
+    $i->triggerMailPoetActionScheduler();
+
+    $i->amOnMailboxAppPage();
+    $i->checkEmailWasReceived($subject);
+    $i->click(Locator::contains('span.subject', $subject));
+    $i->switchToIframe('#preview-html');
+
+    $i->wantTo('See the external link keep its real destination instead of a tracking redirect');
+    $plainLink = ['xpath' => '//a[normalize-space(text())="' . self::PLAIN_LINK . '"]'];
+    $i->assertAttributeNotContains($plainLink, 'href', 'endpoint=track');
+    $i->assertAttributeContains($plainLink, 'href', 'example.com');
+
+    $i->wantTo('See the unsubscribe shortcode resolved to a working URL, not left as raw shortcode text');
+    $unsubscribeLink = ['xpath' => '//a[normalize-space(text())="' . self::UNSUBSCRIBE_LINK . '"]'];
+    $i->assertAttributeNotContains($unsubscribeLink, 'href', 'endpoint=track');
+    $i->assertAttributeNotContains($unsubscribeLink, 'href', '[link:');
+    $i->assertAttributeContains($unsubscribeLink, 'href', 'action=confirm_unsubscribe');
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function bodyWithBothLinkKinds(): array {
+    $text = sprintf(
+      '<a href="http://example.com/8307-plain-link">%s</a> <a href="[link:subscription_unsubscribe_url]">%s</a>',
+      self::PLAIN_LINK,
+      self::UNSUBSCRIBE_LINK
+    );
+
+    return [
+      'content' => [
+        'type' => 'container',
+        'orientation' => 'vertical',
+        'styles' => ['block' => []],
+        'blocks' => [
+          [
+            'type' => 'container',
+            'orientation' => 'horizontal',
+            'styles' => ['block' => []],
+            'blocks' => [
+              [
+                'type' => 'container',
+                'orientation' => 'vertical',
+                'styles' => ['block' => []],
+                'blocks' => [
+                  [
+                    'type' => 'text',
+                    'text' => $text,
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+  }
+}

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -417,6 +417,52 @@ class NewsletterTest extends \MailPoetTest {
     $this->assertStringNotContainsString('endpoint=track&action=open', $result['body']['html']);
   }
 
+  public function testItDoesNotRewriteClickLinksForSubscriberWithoutConsent() {
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK
+    );
+    $this->entityManager->flush();
+
+    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
+    $result = $this->newsletterTask->prepareNewsletterForSending(
+      $newsletterEntity,
+      $this->subscriber,
+      $this->sendingQueueEntity
+    );
+
+    // No tracked click URL may ship: following one tells our server they
+    // clicked, whether or not we record it.
+    $this->assertStringNotContainsString('endpoint=track&action=click', $result['body']['html']);
+    $this->assertStringNotContainsString('endpoint=track&action=click', $result['body']['text']);
+    // And no placeholder may leak into the delivered email either.
+    $this->assertStringNotContainsString(Links::DATA_TAG_CLICK, $result['body']['html']);
+  }
+
+  public function testItStillDeliversWorkingLinksToSubscriberWithoutConsent() {
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK
+    );
+    $this->entityManager->flush();
+
+    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
+    $result = $this->newsletterTask->prepareNewsletterForSending(
+      $newsletterEntity,
+      $this->subscriber,
+      $this->sendingQueueEntity
+    );
+
+    // Untracking must not break the email: the real destination still ships,
+    // and link shortcodes (unsubscribe, manage subscription) are still
+    // resolved to real URLs rather than left as raw shortcode text.
+    $this->assertStringContainsString('http://example.com', $result['body']['html']);
+    $this->assertStringNotContainsString('[link:', $result['body']['html']);
+    $this->assertStringNotContainsString('[link:', $result['body']['text']);
+  }
+
   public function testItKeepsOpenTrackingPixelForConsentingSubscriber() {
     $this->subscriber->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_GRANTED);
     $this->entityManager->flush();

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -463,6 +463,90 @@ class NewsletterTest extends \MailPoetTest {
     $this->assertStringNotContainsString('[link:', $result['body']['text']);
   }
 
+  public function testItResolvesLinkShortcodesWithArgumentsForSubscriberWithoutConsent() {
+    // Link shortcodes may carry an argument ([link:action | name:value]); the
+    // stored link keeps the whole thing, so untracking has to resolve it rather
+    // than shipping the raw shortcode as an href.
+    $shortcode = '[link:mailpoet_test_custom_url | token:abc123]';
+    $resolvedUrl = 'http://example.com/resolved-custom-url';
+    $receivedArguments = null;
+    $wp = new WPFunctions();
+    $wp->addFilter(
+      'mailpoet_newsletter_shortcode_link',
+      function ($url, $newsletter, $subscriber, $queue, $arguments) use ($resolvedUrl, &$receivedArguments) {
+        $receivedArguments = $arguments;
+        return $resolvedUrl;
+      },
+      10,
+      6
+    );
+
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK
+    );
+    $this->entityManager->flush();
+
+    $newsletter = (new NewsletterFactory())
+      ->withType(NewsletterEntity::TYPE_STANDARD)
+      ->withStatus(NewsletterEntity::STATUS_ACTIVE)
+      ->withSubject('Parameterised link shortcode')
+      ->withBody($this->bodyWithLink('<a href="' . $shortcode . '">Custom link</a>'))
+      ->create();
+    $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $queue = (new SendingQueueFactory())->create($task, $newsletter);
+
+    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($newsletter, $task);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
+    $result = $this->newsletterTask->prepareNewsletterForSending(
+      $newsletterEntity,
+      $this->subscriber,
+      $queue
+    );
+
+    $wp->removeAllFilters('mailpoet_newsletter_shortcode_link');
+
+    $this->assertStringNotContainsString('[link:', $result['body']['html']);
+    $this->assertStringContainsString($resolvedUrl, $result['body']['html']);
+    // The argument has to survive too. Passing only the inner text of the
+    // shortcode resolves the action but silently loses the arguments, which
+    // would still satisfy the two assertions above.
+    $this->assertSame(['token' => 'abc123'], $receivedArguments);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function bodyWithLink(string $html): array {
+    return [
+      'content' => [
+        'type' => 'container',
+        'orientation' => 'vertical',
+        'styles' => ['block' => []],
+        'blocks' => [
+          [
+            'type' => 'container',
+            'orientation' => 'horizontal',
+            'styles' => ['block' => []],
+            'blocks' => [
+              [
+                'type' => 'container',
+                'orientation' => 'vertical',
+                'styles' => ['block' => []],
+                'blocks' => [
+                  [
+                    'type' => 'text',
+                    'text' => $html,
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+  }
+
   public function testItKeepsOpenTrackingPixelForConsentingSubscriber() {
     $this->subscriber->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_GRANTED);
     $this->entityManager->flush();


### PR DESCRIPTION
## Description

#6986 removed the open **pixel** for subscribers who opted out of tracking, but their links were still rewritten into click-tracking redirects. Only the *recording* was suppressed. Following such a link still tells our server the recipient clicked, and CNIL and Garante treat that read as the thing consent covers — so it has to stop happening, not just go unrecorded.

Untracked recipients now get the real destination instead of a redirect through us. Everyone else is unchanged.

**The non-obvious part.** Restoring a saved link puts a plain URL back as itself, but puts a link shortcode back as raw `[link:...]` text. The shortcode pass will not resolve those while site tracking is on — see `Newsletter\Shortcodes\Categories\Link::processUrl()`, which deliberately returns the shortcode unchanged whenever there is a queue and tracking is enabled, because the click redirect is normally what resolves it. Since these recipients get no redirect, `untrackLinks()` resolves the leftovers with `Link::processShortcodeAction()` — the same call `Statistics\Track\Clicks` makes at click time — so they land on exactly the same page a tracked recipient would.

Without that second step the email ships literal `[link:subscription_unsubscribe_url]` text as an href, i.e. **a broken unsubscribe link for precisely the people who asked not to be tracked.** Both tests below fail if it is removed.

## Code review notes

- The change is in `Newsletter::prepareNewsletterForSending()`. Tracked subscribers take the existing `replaceSubscriberData()` path untouched; untracked ones take `untrackLinks()` plus the pixel removal that was already there.
- `untrackLinks()` runs **after** the shortcode pass, not before. Running it before looks tidier and does not work, for the `processUrl()` reason above — that was the first attempt and the acceptance test caught it.
- An unresolvable shortcode is replaced with an empty string rather than left as literal text. Worth a second opinion on whether silently dropping is right, or whether it should be loud.
- Worth confirming the `/\[link:(\w+)\]/` pattern is tight enough. It matches what `Link::getFullShortcode()` produces; link shortcodes with arguments are handled inside `processShortcodeAction()` via `parseShortcode()`.
- `Links::replaceSubscriberData()` is the send-time lever, not `convertHashedLinksToShortcodesAndUrls()` — the latter has a single caller and is view-in-browser only. Noting it because an earlier internal note pointed at the wrong method.

## QA notes

Needs a real send; the plugin preview will not show it.

1. Settings > Advanced: set Engagement analytics tracking to **Partial** or **Full**.
2. Create two subscribers on one list. Send them an email containing an ordinary link (e.g. `https://example.com/x`), plus the footer Unsubscribe and Manage your subscription links and the `[link:subscription_tracking_opt_out_url]` shortcode.
3. In the first email, follow the tracking opt-out link for **one** subscriber and confirm the opt-out.
4. Send the same email again to the same list, then compare the two copies:

| | opted-out subscriber | other subscriber |
|---|---|---|
| link URLs | real destinations | `endpoint=track&action=click` redirects |
| open pixel | absent | present |
| raw `[link:` anywhere | none | none |

5. **Click Unsubscribe and Manage your subscription in the opted-out copy.** They must load the right subscriber's pages. This is the regression that nearly shipped, so it is the step worth doing by hand.
6. Confirm nothing changed for the still-tracked subscriber: clicks are recorded and stats update as before.

Verified locally end to end this way with two real sends through Mailpit, plus: `NewsletterTest` 33 tests / 204 assertions; Links, Clicks, ViewInBrowser and SendingQueue suites (99 tests); the new acceptance test; phpcs and PHPStan clean.

## Linked PRs

Follow-up to #6986, which shipped the per-subscriber opt-out. Related: #7025 gates the feature behind a "Subscriber choice" setting. The two are independent — this fix is internal handling and is deliberately **not** gated on that setting.

## Linked tickets

- [STOMAIL-8307](https://linear.app/a8c/issue/STOMAIL-8307/stop-click-link-tracking-at-send-time-for-opted-out-subscribers)
- Origin: [STOMAIL-8268](https://linear.app/a8c/issue/STOMAIL-8268/assess-cnil-compliance-per-subscriber-tracking-pixel-opt-out-mechanism)

## After-merge notes

Still open, deliberately out of scope: **the opt-out link itself is click-tracked for subscribers we are allowed to track.** This PR only untracks links for recipients we may not track, so a tracked subscriber's route to opting out still runs through our redirect. That was noted as a follow-up when #6986 landed and needs its own decision.

Sites that had already collected opt-outs will see click counts drop for those recipients after this ships. That is the intended effect, not a regression.

## Screenshots or screencast

<!-- Not really a visual change. The evidence is in the delivered email's hrefs; the QA table above is the useful comparison. -->

| Before | After |
| ------ | ----- |
| Opted-out recipient's links pointed at `?mailpoet_router&endpoint=track&action=click&data=…`, which resolved on click but told the server about it. | Opted-out recipient's links point straight at the real destination. No redirect, no pixel. |

<img width="1493" height="812" alt="mailpoet-tracking-consent-5-8307-mailpit-opted-out-email" src="https://github.com/user-attachments/assets/ac6199be-d24d-4e4c-927d-22ddea26ca0a" />


## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8307-stop-click-link-tracking-opted-out)

_The latest successful build from `fix/stomail-8307-stop-click-link-tracking-opted-out` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->