### PR TITLE
Resolve shortcodes inside restored URLs when untracking links

### DIFF
--- a/mailpoet/changelog/2026-08-05-19-35-33-fixed-links-whose-address-contains-a-personalisation-sho.md
+++ b/mailpoet/changelog/2026-08-05-19-35-33-fixed-links-whose-address-contains-a-personalisation-sho.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Links whose address contains a personalisation shortcode now work for subscribers who opted out of open and click tracking

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -145,6 +145,11 @@ class Newsletter {
    * normally what resolves them. Since these recipients get no redirect, we
    * resolve the shortcodes here with the same call the redirect would have
    * made, so they land on exactly the same page.
+   *
+   * A restored URL may also carry a non-link shortcode of its own, such as
+   * `http://example.com/?email=[subscriber:email]`. Clicks::processUrl() runs a
+   * full shortcode pass over those at click time, so this does the same at send
+   * time (STOMAIL-8340).
    */
   private function untrackLinks(
     string $content,
@@ -162,9 +167,10 @@ class Newsletter {
     // Matches the whole shortcode, arguments included, because a link shortcode
     // may carry one: [link:action | name:value]. The (?!\/\/) guard mirrors the
     // extractor in Shortcodes::extract() so text like [link://example.com] is
-    // left alone rather than resolved to nothing and dropped.
-    return (string)preg_replace_callback(
-      '/\[link:(?!\/\/)(?<action>[^\]]+)\]/',
+    // left alone rather than resolved to nothing and dropped. Case-insensitive
+    // for the same reason: that extractor is too, so [LINK:...] gets stored.
+    $content = (string)preg_replace_callback(
+      '/\[link:(?!\/\/)(?<action>[^\]]+)\]/i',
       function (array $matches) use ($newsletter, $subscriber, $queue): string {
         // Pass the full shortcode, as Statistics\Track\Clicks::processUrl() does:
         // processShortcodeAction() parses the brackets itself, and only sees the
@@ -179,6 +185,18 @@ class Newsletter {
         return $url ?? '';
       },
       $content
+    );
+
+    // Anything still unresolved was reintroduced by the restore above: the pass
+    // in prepareNewsletterForSending() already ran, and at that point every link
+    // was a hashed tag, so URL-embedded shortcodes were not in the content to be
+    // seen. Running it again therefore only touches the restored URLs.
+    return ShortcodesTask::process(
+      $content,
+      null,
+      $newsletter,
+      $subscriber,
+      $queue
     );
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/Tasks/NewsletterTest.php
@@ -547,6 +547,65 @@ class NewsletterTest extends \MailPoetTest {
     ];
   }
 
+  public function testItResolvesUrlEmbeddedShortcodesForSubscriberWithoutConsent() {
+    // A link URL may itself contain a personalisation shortcode. The tracked
+    // path resolves those at click time in Clicks::processUrl(); the untracked
+    // path has to do it at send time or the recipient gets a literal
+    // placeholder in the address (STOMAIL-8340).
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK
+    );
+    $this->entityManager->flush();
+
+    $result = $this->prepareWithBody(
+      '<a href="http://example.com/?email=[subscriber:email]">Personalised link</a>'
+    );
+
+    $this->assertStringNotContainsString('[subscriber:email]', $result['body']['html']);
+    $this->assertStringContainsString(
+      'http://example.com/?email=' . $this->subscriber->getEmail(),
+      $result['body']['html']
+    );
+  }
+
+  public function testItResolvesUppercaseLinkShortcodesForSubscriberWithoutConsent() {
+    // The extractor that stores these is case-insensitive (Shortcodes::extract),
+    // so an uppercased shortcode reaches the untracked path too.
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK
+    );
+    $this->entityManager->flush();
+
+    $result = $this->prepareWithBody(
+      '<a href="[LINK:subscription_unsubscribe_url]">Unsubscribe</a>'
+    );
+
+    $this->assertStringNotContainsString('[LINK:', $result['body']['html']);
+    $this->assertStringContainsString('action=confirm_unsubscribe', $result['body']['html']);
+  }
+
+  private function prepareWithBody(string $linkHtml): array {
+    $newsletter = (new NewsletterFactory())
+      ->withType(NewsletterEntity::TYPE_STANDARD)
+      ->withStatus(NewsletterEntity::STATUS_ACTIVE)
+      ->withSubject('Untracking shortcodes in URLs')
+      ->withBody($this->bodyWithLink($linkHtml))
+      ->create();
+    $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $queue = (new SendingQueueFactory())->create($task, $newsletter);
+
+    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($newsletter, $task);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
+
+    return $this->newsletterTask->prepareNewsletterForSending(
+      $newsletterEntity,
+      $this->subscriber,
+      $queue
+    );
+  }
+
   public function testItKeepsOpenTrackingPixelForConsentingSubscriber() {
     $this->subscriber->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_GRANTED);
     $this->entityManager->flush();


### PR DESCRIPTION
## Description

Fixes [STOMAIL-8340](https://linear.app/a8c/issue/STOMAIL-8340/ai-regression-reviewtrunk-untracklinks-resolves-only-link-shortcodes), a regression from #7026.

A link address can itself contain a personalisation shortcode, for example `http://example.com/?email=[subscriber:email]`. For tracked recipients those resolve at click time, in the `else` branch of `Clicks::processUrl()`. Untracked recipients get no redirect, so nothing resolved them and **the placeholder shipped literally in the href** — a wrong or broken destination, silently, and only for the people who asked not to be tracked.

Reproduced before fixing, same newsletter body, two recipients:

| | literal `[subscriber:email]` in href | resolved | tracked redirect |
|---|---|---|---|
| opted out | **YES** | no | no |
| still tracked | no | — | YES |

**Why it could not be resolved earlier.** Links are hashed while the newsletter is rendered — once, shared across every recipient — so a per-recipient shortcode cannot be resolved at that point. By the time the send-time shortcode pass runs, every link is a `[mailpoet_click_data]-hash` tag and the embedded shortcode is not in the content to be seen. `untrackLinks()` then puts the real URL back, *after* that pass has finished.

So the fix runs the pass again once the URLs are restored. That is narrow rather than wasteful: the first pass already resolved everything else, so the only shortcodes left are the ones the restore just reintroduced.

## Code review notes

- The second `ShortcodesTask::process()` call is the whole fix. If you are weighing "why not resolve per URL instead": that would mean reimplementing the restore loop to intercept each link, where this reuses the existing pass and relies on the ordering argument above. Happy to switch if you would rather have it scoped per URL.
- **`[LINK:...]` is now matched case-insensitively**, because `Shortcodes::extract()` — which stores these — is case-insensitive, so an uppercased shortcode reaches this code too. I checked this resolves rather than deletes: the MailPoet-style pattern in `parseShortcode()` is case-sensitive and misses it, but the WordPress-style branch sets `$action` first and the final fallback returns it, so the switch still matches. There is a test for it.
- Unchanged for tracked recipients — they still get the redirect and resolve at click time. `ClicksTest` is untouched and green.
- The `?? ''` fallback for an unresolvable shortcode now applies to a slightly wider set of input. Still think dropping beats shipping literal `[...]` text, but it is a deliberate choice worth a second opinion.

## QA notes

Needs a real send; the preview will not show it.

1. Settings > Advanced: set Engagement analytics tracking to **Partial** or **Full**.
2. Two subscribers on one list; opt **one** out of tracking.
3. Send them an email containing a link whose address holds a shortcode, e.g. `http://example.com/?email=[subscriber:email]`, plus a normal `[link:subscription_unsubscribe_url]` footer link.
4. Compare the delivered copies:

| | opted-out subscriber | other subscriber |
|---|---|---|
| personalised link | real address, shortcode replaced with their email | tracking redirect |
| unsubscribe | real subscription URL | tracking redirect |
| literal `[subscriber:email]` or `[link:` | none | none |

5. **Click the personalised link in the opted-out copy** and confirm the address carries the right subscriber's email.
6. Worth repeating in **both** the legacy editor and the new email editor — they render through different pipelines.

Verified locally exactly that way, with real sends through Mailpit in both editors. Both opted-out copies delivered `http://example.com/?email=optout-8340@example.com`; both tracked copies were unchanged. Automated: `NewsletterTest` 36 tests / 223 assertions, plus Clicks (23), Links (15) and SendingQueue (53). phpcs and PHPStan clean.

## Linked PRs

Fixes a regression from #7026. Related: #7025.

## Linked tickets

- [STOMAIL-8340](https://linear.app/a8c/issue/STOMAIL-8340/ai-regression-reviewtrunk-untracklinks-resolves-only-link-shortcodes)
- Origin: [STOMAIL-8307](https://linear.app/a8c/issue/STOMAIL-8307/stop-click-link-tracking-at-send-time-for-opted-out-subscribers) · [STOMAIL-8268](https://linear.app/a8c/issue/STOMAIL-8268/assess-cnil-compliance-per-subscriber-tracking-pixel-opt-out-mechanism)

## After-merge notes

Still open from #7026, unchanged by this PR and not filed anywhere yet: **the opt-out link is itself click-tracked for subscribers we are allowed to track.** `untrackLinks()` only runs for recipients we may not track, so a trackable subscriber's route to opting out still goes through our redirect.

## Screenshots or screencast

<!-- The evidence is in the delivered href, so the QA table above is the useful comparison. -->

| Before | After |
| ------ | ----- |
| Opted-out recipient's href was `http://example.com/?email=[subscriber:email]` — literal placeholder, broken destination. | Opted-out recipient's href is `http://example.com/?email=their@address` — resolved, no redirect. |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8340-resolve-url-embedded-shortcodes-when-untracking)

_The latest successful build from `fix/stomail-8340-resolve-url-embedded-shortcodes-when-untracking` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Issues found: 1

- Bug: Shortcodes remained unresolved in restored URLs for untracked recipients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->