### PR TITLE
Remove the broken premium unit test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ pnpm test:integration          # Integration tests (tests_env)
 pnpm test:acceptance           # Acceptance tests with Selenium (tests_env)
 pnpm test:javascript           # Mocha JS tests
 
-pnpm test:unit:premium         # Premium unit tests
 pnpm test:integration:premium  # Premium integration tests
 pnpm test:acceptance:premium   # Premium acceptance tests
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "test:integration": "cd mailpoet && ./do test:integration --skip-deps",
     "test:acceptance": "cd mailpoet && ./do test:acceptance --skip-deps",
     "test:javascript": "cd mailpoet && ./do test:javascript",
-    "test:unit:premium": "cd mailpoet-premium && ./do test:unit --skip-deps",
     "test:integration:premium": "cd mailpoet-premium && ./do test:integration --skip-deps",
     "test:acceptance:premium": "cd mailpoet-premium && ./do test:acceptance --skip-deps",
     "test:install-deps": "cd mailpoet && ./do test:integration",


### PR DESCRIPTION
## Description

The `test:unit:premium` script in `package.json` did not work. It called `./do test:unit` in `mailpoet-premium`, but the premium `RoboFile.php` has no `testUnit` task, because the premium plugin unit tests are in the free plugin repository.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:remove/premium-unit-test-script)

_The latest successful build from `remove/premium-unit-test-script` will be used. If none is available, the link won't work._