### PR TITLE
Remove hardcoded underline style on Newsletter footer links

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/validate-email-content.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/validate-email-content.ts
@@ -5,10 +5,10 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
 import type { EmailContentValidationRule } from '@woocommerce/email-editor/build-types/store';
 
-const contentLink = `<a data-link-href="[mailpoet/subscription-unsubscribe-url]" contenteditable="false" style="text-decoration: underline;" class="mailpoet-email-editor__personalization-tags-link">${__(
+const contentLink = `<a data-link-href="[mailpoet/subscription-unsubscribe-url]" contenteditable="false" class="mailpoet-email-editor__personalization-tags-link">${__(
   'Unsubscribe',
   'mailpoet',
-)}</a> | <a data-link-href="[mailpoet/subscription-manage-url]" contenteditable="false" style="text-decoration: underline;" class="mailpoet-email-editor__personalization-tags-link">${__(
+)}</a> | <a data-link-href="[mailpoet/subscription-manage-url]" contenteditable="false" class="mailpoet-email-editor__personalization-tags-link">${__(
   'Manage subscription',
   'mailpoet',
 )}</a>`;

--- a/mailpoet/changelog/2026-08-10-10-07-29-fixed-footer-links-in-the-block-editor-now-follow-the-un.md
+++ b/mailpoet/changelog/2026-08-10-10-07-29-fixed-footer-links-in-the-block-editor-now-follow-the-un.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Footer links in the block editor now follow the underline setting from the email styles

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/Library/Newsletter.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/Library/Newsletter.php
@@ -66,7 +66,7 @@ class Newsletter {
               padding-top: var(--wp--preset--spacing--20);
               padding-bottom: var(--wp--preset--spacing--20);
             "
-              >' . $footerText . '<br /><a data-link-href="[mailpoet/subscription-unsubscribe-url]" contenteditable="false" style="text-decoration: underline;" class="mailpoet-email-editor__personalization-tags-link">' . __('Unsubscribe', 'mailpoet') . '</a> | <a data-link-href="[mailpoet/subscription-manage-url]" contenteditable="false" style="text-decoration: underline;" class="mailpoet-email-editor__personalization-tags-link">' . __('Manage subscription', 'mailpoet') . '</a>
+              >' . $footerText . '<br /><a data-link-href="[mailpoet/subscription-unsubscribe-url]" contenteditable="false" class="mailpoet-email-editor__personalization-tags-link">' . __('Unsubscribe', 'mailpoet') . '</a> | <a data-link-href="[mailpoet/subscription-manage-url]" contenteditable="false" class="mailpoet-email-editor__personalization-tags-link">' . __('Manage subscription', 'mailpoet') . '</a>
           </p>
           <!-- /wp:paragraph -->
         </div>

--- a/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/Templates/Library/NewsletterTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/Templates/Library/NewsletterTest.php
@@ -34,4 +34,14 @@ class NewsletterTest extends \MailPoetUnitTest {
     $this->assertStringNotContainsString('wp:site-logo', $content);
     $this->assertStringNotContainsString('your-logo-placeholder.png', $content);
   }
+
+  public function testFooterLinksDoNotForceTextDecoration() {
+    $this->wp->method('hasCustomLogo')->willReturn(false);
+
+    $content = (new Newsletter($this->wp))->getContent();
+
+    $this->assertStringContainsString('[mailpoet/subscription-unsubscribe-url]', $content);
+    $this->assertStringContainsString('[mailpoet/subscription-manage-url]', $content);
+    $this->assertStringNotContainsString('text-decoration', $content);
+  }
 }


### PR DESCRIPTION
## Description

Footer links in the block editor had `text-decoration: underline` hardcoded in the markup. The inline style won over the global email styles, so Styles > Typography > Links > Text decoration had no effect on the footer.

This PR removes the hardcoded style. Footer links now follow the link styles.

## Code review notes

The same hardcoded underline text-decoration lives in two places, so both changed:

- `Newsletter.php` the footer of the Newsletter block template.
- `validate-email-content.ts` the "Insert link" action on the missing unsubscribe link notice.

## QA notes

1. Create a new email with the Newsletter template.
2. Open Styles > Typography > Links and set Text decoration to None.
3. The footer links should not be underlined.
4. Set it back to Underline. The links should be underlined again.
5. Send a preview email and check the footer links there too.

If you tested this template before, delete the saved copy first (`wp post delete <id> --force` for the `newsletter` `wp_template` post).

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8343: Cannot adjust underline for header and footer links](https://linear.app/a8c/issue/STOMAIL-8343/cannot-adjust-underline-for-header-and-footer-links)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="2356" height="1737" alt="YkJfgSuAboXDdNea@2x" src="https://github.com/user-attachments/assets/09b87a88-3188-492e-a296-549536d0adc5" /> | <img width="2356" height="1740" alt="mLQcycJk6m6CKNaa@2x" src="https://github.com/user-attachments/assets/91e30812-a452-4fa0-bef4-c797a8c3de8a" /> |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8343-cannot-adjust-underline-for-header-and-footer-links)

_The latest successful build from `stomail-8343-cannot-adjust-underline-for-header-and-footer-links` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->