### PR TITLE
Scope the mailer test-send action to the Settings capability

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Mailer.php
+++ b/mailpoet/lib/API/JSON/v1/Mailer.php
@@ -31,6 +31,13 @@ class Mailer extends APIEndpoint {
 
   public $permissions = [
     'global' => AccessControl::PERMISSION_MANAGE_EMAILS,
+    'methods' => [
+      // `send` is the backend of the Settings "test this sending method" flow: it takes a full
+      // sending-method configuration and connects out with it. That is a Settings operation, so it
+      // uses the same capability as the Settings screen. The read-only and resume methods stay on
+      // the global capability.
+      'send' => AccessControl::PERMISSION_MANAGE_SETTINGS,
+    ],
   ];
 
   public function __construct(

--- a/mailpoet/tests/integration/API/JSON/v1/MailerTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/MailerTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\API\JSON\v1;
 use Codeception\Stub\Expected;
 use MailPoet\API\JSON\Response as APIResponse;
 use MailPoet\API\JSON\v1\Mailer;
+use MailPoet\Config\AccessControl;
 use MailPoet\Mailer\MailerFactory;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\MetaInfo;
@@ -13,6 +14,22 @@ use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Settings\SettingsController;
 
 class MailerTest extends \MailPoetTest {
+  public function testSendRequiresManageSettingsCapability() {
+    // `send` builds a sending method from caller-supplied config and connects out with it, so it is
+    // scoped to the Settings capability rather than the endpoint-wide "manage emails" capability.
+    $settings = SettingsController::getInstance();
+    $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
+    $mailerEndpoint = new Mailer(
+      $this->makeEmpty(AuthorizedEmailsController::class),
+      $settings,
+      $this->diContainer->get(MailerFactory::class),
+      new MetaInfo,
+      $senderDomainController
+    );
+    verify($mailerEndpoint->permissions['global'])->equals(AccessControl::PERMISSION_MANAGE_EMAILS);
+    verify($mailerEndpoint->permissions['methods']['send'])->equals(AccessControl::PERMISSION_MANAGE_SETTINGS);
+  }
+
   public function testItResumesSending() {
     // create mailer log with a "paused" status
     $mailerLog = MailerLog::getMailerLog();


### PR DESCRIPTION
## Description

The mailer JSON endpoint gates every method on a single global capability (`manage_emails`). Its `send` method is the backend of the Settings "test this sending method" flow: it builds a sending method from the request data and connects out with it. That is a Settings operation, so it should sit with the Settings screen, not the broader endpoint-wide capability.

This adds a per-method permission override so `send` requires `manage_settings`, while the read-only and resume methods (`resumeSending`, `getAuthorizedEmailAddresses`, `getVerifiedSenderDomains`) keep the global `manage_emails` capability.

## Code review notes

- The dispatcher already supports per-method overrides — `API::validatePermissions()` prefers `permissions['methods'][$method]` and falls back to `permissions['global']`. This is the same shape `Services.php` uses for `pingBridge`.
- The only UI caller of `send` is the Settings test-send button (`settings/store/actions/send-test-email.ts` → `test-sending.tsx`), which lives on the admin-only Settings screen. Newsletter sending goes through the `SendingQueue` endpoint, not this one. So no non-admin workflow uses `send`.
- The three other methods stay on the global capability and are unchanged.

## QA notes

- New test `MailerTest::testSendRequiresManageSettingsCapability` pins the override so it can't be dropped silently.
- Verified against a local env: a non-admin holding only `manage_emails` now gets a 403 on `send` and still gets 200 on the read/resume methods; an administrator's test-send is unchanged.
- `MailerTest` integration suite 3/3 pass; `phpcs` clean; `./do qa:phpstan` reports no errors.

## Linked tickets

STOMAIL-8358

## Tasks

- [ ] I have added a changelog entry — n/a, no user-visible behaviour change for supported configurations.
- [x] I followed best practices for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript — n/a, PHP-only change

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8358-scope-mailer-test-send)

_The latest successful build from `fix/stomail-8358-scope-mailer-test-send` will be used. If none is available, the link won't work._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->