### PR TITLE
Base open and click rates on tracked recipients, and show tracking coverage

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
@@ -321,6 +321,15 @@ h1.title.mailpoet-newsletter-listing-heading {
   font-weight: normal;
 }
 
+// Only rendered when some recipients were not tracked, so the row keeps its
+// current density on the large majority of sites.
+.mailpoet-listing-stats-coverage {
+  color: $color-primary-inactive;
+  font-size: $font-size-extra-small;
+  font-weight: normal;
+  white-space: nowrap;
+}
+
 .mailpoet-share-email-modal.components-modal__frame {
   max-width: 640px;
   width: calc(100vw - 64px);

--- a/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
@@ -330,6 +330,13 @@ h1.title.mailpoet-newsletter-listing-heading {
   white-space: nowrap;
 }
 
+// The explanation is two sentences, and .mailpoet-tooltip sets nowrap for the
+// short one-liners it was built for, so opt back into wrapping here.
+.mailpoet-listing-stats-coverage-tooltip {
+  max-width: 260px;
+  white-space: normal;
+}
+
 .mailpoet-share-email-modal.components-modal__frame {
   max-width: 640px;
   width: calc(100vw - 64px);

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import { StatsBadge } from './newsletter-stats/stats';
+import { TrackingCoverage } from './newsletter-stats/tracking-coverage';
 import { Tooltip } from '../tooltip/tooltip';
 import { Tag } from '../tag/tag';
 
@@ -12,6 +13,9 @@ type NewsletterStatsProps = {
   hideBadges?: boolean;
   newsletterId?: number; // used for tooltip IDs
   wrapContentInLink?: (content: ReactNode, idPrefix: string) => JSX.Element;
+  /** Recipients whose tracking consent kept them out of the rates above. */
+  notTracked?: number;
+  totalSent?: number;
 };
 
 export function NewsletterStats({
@@ -21,6 +25,8 @@ export function NewsletterStats({
   hideBadges,
   newsletterId,
   wrapContentInLink,
+  notTracked,
+  totalSent,
 }: NewsletterStatsProps) {
   // format to 1 decimal place
   const openedDisplay = MailPoet.Num.toLocaleFixed(opened, 1);
@@ -35,6 +41,11 @@ export function NewsletterStats({
         <span className="mailpoet-listing-stats-percentages-opens">
           {openedDisplay}%
         </span>
+        <TrackingCoverage
+          totalSent={totalSent ?? 0}
+          notTracked={notTracked ?? 0}
+          tooltipId={`tracking-coverage-${newsletterId || '0'}`}
+        />
       </div>
       {!hideBadges && (
         <div>

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats/tracking-coverage.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats/tracking-coverage.tsx
@@ -3,12 +3,17 @@ import { MailPoet } from 'mailpoet';
 import { Tooltip } from '../../tooltip/tooltip';
 
 /**
- * How much of a campaign's audience the open and click rates actually rest on.
- *
- * Clamped to 0-100: count_processed and the per-recipient statistics rows have
- * different writers, so on a site where they have drifted the raw ratio can
- * land outside that range.
+ * count_processed and the per-recipient statistics rows have different writers
+ * — a failed send writes a statistics row without bumping count_processed — so
+ * the two can genuinely drift. Bound the untracked count to the audience it is
+ * describing, so the percentage and the tooltip stay consistent instead of
+ * reading "3 of 1 recipients are not tracked" next to "0% tracked".
  */
+function getBoundedNotTracked(totalSent: number, notTracked: number): number {
+  return Math.min(Math.max(0, totalSent), Math.max(0, notTracked));
+}
+
+/** How much of a campaign's audience the open and click rates rest on. */
 export function getTrackingCoveragePercentage(
   totalSent: number,
   notTracked: number,
@@ -16,8 +21,8 @@ export function getTrackingCoveragePercentage(
   if (totalSent <= 0) {
     return 0;
   }
-  const tracked = Math.max(0, totalSent - notTracked);
-  return Math.min(100, (tracked * 100) / totalSent);
+  const tracked = totalSent - getBoundedNotTracked(totalSent, notTracked);
+  return (tracked * 100) / totalSent;
 }
 
 /**
@@ -29,14 +34,15 @@ export function getTrackingCoverageTooltipText(
   totalSent: number,
   notTracked: number,
 ): string {
-  const tracked = Math.max(0, totalSent - notTracked);
+  const boundedNotTracked = getBoundedNotTracked(totalSent, notTracked);
+  const tracked = Math.max(0, totalSent - boundedNotTracked);
   return sprintf(
     /* translators: %1$s is the number of recipients not tracked, %2$s the total number of recipients, %3$s the number of recipients that were tracked. */
     __(
       '%1$s of %2$s recipients are not tracked, because of their email tracking consent. Open and click rates are based on the %3$s recipients we were able to measure.',
       'mailpoet',
     ),
-    notTracked.toLocaleString(),
+    boundedNotTracked.toLocaleString(),
     totalSent.toLocaleString(),
     tracked.toLocaleString(),
   );

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats/tracking-coverage.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats/tracking-coverage.tsx
@@ -1,0 +1,88 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { MailPoet } from 'mailpoet';
+import { Tooltip } from '../../tooltip/tooltip';
+
+/**
+ * How much of a campaign's audience the open and click rates actually rest on.
+ *
+ * Clamped to 0-100: count_processed and the per-recipient statistics rows have
+ * different writers, so on a site where they have drifted the raw ratio can
+ * land outside that range.
+ */
+export function getTrackingCoveragePercentage(
+  totalSent: number,
+  notTracked: number,
+): number {
+  if (totalSent <= 0) {
+    return 0;
+  }
+  const tracked = Math.max(0, totalSent - notTracked);
+  return Math.min(100, (tracked * 100) / totalSent);
+}
+
+/**
+ * "not tracked" rather than "opted out" on purpose. When a site asks everyone
+ * for consent, most of the untracked group are people we simply never asked,
+ * and calling that an opt-out would be wrong.
+ */
+export function getTrackingCoverageTooltipText(
+  totalSent: number,
+  notTracked: number,
+): string {
+  const tracked = Math.max(0, totalSent - notTracked);
+  return sprintf(
+    /* translators: %1$s is the number of recipients not tracked, %2$s the total number of recipients, %3$s the number of recipients that were tracked. */
+    __(
+      '%1$s of %2$s recipients are not tracked, because of their email tracking consent. Open and click rates are based on the %3$s recipients we were able to measure.',
+      'mailpoet',
+    ),
+    notTracked.toLocaleString(),
+    totalSent.toLocaleString(),
+    tracked.toLocaleString(),
+  );
+}
+
+type Props = {
+  totalSent: number;
+  notTracked: number;
+  /** Unique per screen so two coverage tooltips never share an id. */
+  tooltipId: string;
+  className?: string;
+};
+
+/**
+ * Shown only when something is untracked. On a site with no opt-outs every
+ * screen looks exactly as it does today, which is the issue's third acceptance
+ * criterion.
+ */
+export function TrackingCoverage({
+  totalSent,
+  notTracked,
+  tooltipId,
+  className,
+}: Props): JSX.Element | null {
+  if (notTracked <= 0 || totalSent <= 0) {
+    return null;
+  }
+
+  const coverage = getTrackingCoveragePercentage(totalSent, notTracked);
+
+  return (
+    <div className={className ?? 'mailpoet-listing-stats-coverage'}>
+      <span data-tooltip-id={tooltipId}>
+        {sprintf(
+          /* translators: %s is a percentage, e.g. "95". */
+          __('%s%% tracked', 'mailpoet'),
+          MailPoet.Num.toLocaleFixed(coverage, 1),
+        )}
+      </span>
+      <Tooltip place="top" id={tooltipId}>
+        <div className="mailpoet-listing-stats-tooltip-content">
+          {getTrackingCoverageTooltipText(totalSent, notTracked)}
+        </div>
+      </Tooltip>
+    </div>
+  );
+}
+
+TrackingCoverage.displayName = 'TrackingCoverage';

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats/tracking-coverage.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats/tracking-coverage.tsx
@@ -9,7 +9,10 @@ import { Tooltip } from '../../tooltip/tooltip';
  * describing, so the percentage and the tooltip stay consistent instead of
  * reading "3 of 1 recipients are not tracked" next to "0% tracked".
  */
-function getBoundedNotTracked(totalSent: number, notTracked: number): number {
+export function getBoundedNotTracked(
+  totalSent: number,
+  notTracked: number,
+): number {
   return Math.min(Math.max(0, totalSent), Math.max(0, notTracked));
 }
 

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats/tracking-coverage.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats/tracking-coverage.tsx
@@ -77,7 +77,7 @@ export function TrackingCoverage({
         )}
       </span>
       <Tooltip place="top" id={tooltipId}>
-        <div className="mailpoet-listing-stats-tooltip-content">
+        <div className="mailpoet-listing-stats-tooltip-content mailpoet-listing-stats-coverage-tooltip">
           {getTrackingCoverageTooltipText(totalSent, notTracked)}
         </div>
       </Tooltip>

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-general-stats.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-general-stats.tsx
@@ -1,5 +1,5 @@
 import ReactStringReplace from 'react-string-replace';
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import { Hooks } from 'wp-js-hooks';
 import { Grid } from 'common/grid';
@@ -7,6 +7,10 @@ import {
   getBadgeType,
   StatsBadge,
 } from 'common/listings/newsletter-stats/stats';
+import {
+  getTrackingCoveragePercentage,
+  getTrackingCoverageTooltipText,
+} from 'common/listings/newsletter-stats/tracking-coverage';
 import { Tooltip } from 'help-tooltip';
 
 import { NewsletterType } from './newsletter-type';
@@ -40,17 +44,30 @@ const formatForStats = (value: number): number => {
 
 function NewsletterGeneralStats({ newsletter, isWoocommerceActive }: Props) {
   const totalSent = newsletter.total_sent || 0;
+  const notTracked = newsletter.statistics.notTracked ?? 0;
+  // Recipients we were allowed to measure. Comes off the statistics object
+  // rather than being derived here, so the numerator and the denominator always
+  // come from the same read. Older cached payloads have no trackedSent, so fall
+  // back to the full count.
+  const trackedSent = newsletter.statistics.trackedSent ?? totalSent;
 
   let percentageClicked = 0;
   let percentageOpened = 0;
   let percentageMachineOpened = 0;
   let percentageUnsubscribed = 0;
   let percentageBounced = 0;
-  if (totalSent > 0) {
-    percentageClicked = (newsletter.statistics.clicked * 100) / totalSent;
-    percentageOpened = (newsletter.statistics.opened * 100) / totalSent;
+  // Opens and clicks are divided by the recipients we could measure: an
+  // opted-out subscriber can never register either, so counting them only drags
+  // the figure down. Unsubscribes and bounces keep the full count — those are
+  // recorded for opted-out people too, so shrinking their denominator would
+  // overstate them.
+  if (trackedSent > 0) {
+    percentageClicked = (newsletter.statistics.clicked * 100) / trackedSent;
+    percentageOpened = (newsletter.statistics.opened * 100) / trackedSent;
     percentageMachineOpened =
-      (newsletter.statistics.machineOpened * 100) / totalSent;
+      (newsletter.statistics.machineOpened * 100) / trackedSent;
+  }
+  if (totalSent > 0) {
     percentageUnsubscribed =
       (newsletter.statistics.unsubscribed * 100) / totalSent;
     percentageBounced = (newsletter.statistics.bounced * 100) / totalSent;
@@ -245,6 +262,22 @@ function NewsletterGeneralStats({ newsletter, isWoocommerceActive }: Props) {
               {totalSent.toLocaleString()}
             </span>
           </div>
+          {notTracked > 0 && totalSent > 0 && (
+            <div className="mailpoet-statistics-value-small">
+              {sprintf(
+                /* translators: %1$s is a percentage, e.g. "95", %2$s is a number of recipients. */
+                __('Tracking coverage: %1$s%% — %2$s not tracked', 'mailpoet'),
+                MailPoet.Num.toLocaleFixed(
+                  getTrackingCoveragePercentage(totalSent, notTracked),
+                  1,
+                ),
+                notTracked.toLocaleString(),
+              )}
+              <Tooltip
+                tooltip={getTrackingCoverageTooltipText(totalSent, notTracked)}
+              />
+            </div>
+          )}
         </div>
         <div className="mailpoet-statistics-with-left-separator">
           {unsubscribed}

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-general-stats.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-general-stats.tsx
@@ -8,6 +8,7 @@ import {
   StatsBadge,
 } from 'common/listings/newsletter-stats/stats';
 import {
+  getBoundedNotTracked,
   getTrackingCoveragePercentage,
   getTrackingCoverageTooltipText,
 } from 'common/listings/newsletter-stats/tracking-coverage';
@@ -271,7 +272,7 @@ function NewsletterGeneralStats({ newsletter, isWoocommerceActive }: Props) {
                   getTrackingCoveragePercentage(totalSent, notTracked),
                   1,
                 ),
-                notTracked.toLocaleString(),
+                getBoundedNotTracked(totalSent, notTracked).toLocaleString(),
               )}
               <Tooltip
                 tooltip={getTrackingCoverageTooltipText(totalSent, notTracked)}

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-type.ts
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-type.ts
@@ -27,6 +27,11 @@ export type NewsletterType = {
     machineOpened: number;
     unsubscribed: number;
     bounced: number;
+    // Recipients whose tracking consent, as it stood when we sent, did not let
+    // us measure them, and the denominator that leaves for open/click rates.
+    // Optional so an older cached payload does not break the page.
+    notTracked?: number;
+    trackedSent?: number;
     revenue: {
       value: number;
       formatted: string;

--- a/mailpoet/assets/js/src/newsletters/listings/statistics.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/statistics.jsx
@@ -66,13 +66,23 @@ function Statistics({
     return null;
   }
 
+  const notTracked = newsletter.statistics.notTracked ?? 0;
+  // Recipients we were allowed to measure. Read off the statistics object
+  // rather than derived here, so numerator and denominator come from the same
+  // read. Older cached payloads carry no trackedSent, so fall back.
+  const trackedSent = newsletter.statistics.trackedSent ?? totalSent;
+
   let percentageClicked = 0;
   let percentageOpened = 0;
   let revenue = null;
 
+  // Opted-out recipients can never register an open or a click, so counting
+  // them in the denominator only drags the rate down.
+  if (trackedSent > 0) {
+    percentageClicked = (newsletter.statistics.clicked * 100) / trackedSent;
+    percentageOpened = (newsletter.statistics.opened * 100) / trackedSent;
+  }
   if (totalSent > 0) {
-    percentageClicked = (newsletter.statistics.clicked * 100) / totalSent;
-    percentageOpened = (newsletter.statistics.opened * 100) / totalSent;
     revenue = newsletter.statistics.revenue;
   }
 
@@ -124,6 +134,8 @@ function Statistics({
       hideBadges={!showBadges}
       newsletterId={newsletter.id}
       wrapContentInLink={wrapContentInLink}
+      notTracked={notTracked}
+      totalSent={totalSent}
     />
   );
 
@@ -187,6 +199,8 @@ const StatisticsPropType = PropTypes.shape({
   clicked: PropTypes.number,
   opened: PropTypes.number,
   unsubscribed: PropTypes.number,
+  notTracked: PropTypes.number,
+  trackedSent: PropTypes.number,
   revenue: PropTypes.shape({
     count: PropTypes.number,
     currency: PropTypes.string,

--- a/mailpoet/changelog/2026-08-12-16-26-34-improved-open-and-click-rates-are-now-based-on-the-recipien.md
+++ b/mailpoet/changelog/2026-08-12-16-26-34-improved-open-and-click-rates-are-now-based-on-the-recipien.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Open and click rates are now based on the recipients who allow email tracking, instead of everyone the campaign was sent to. Subscribers who opted out of tracking can never register an open or a click, so counting them was pulling the figures down. Rates will go up on sites that capture tracking consent; nothing broke, the old number was understated. The listing and the campaign stats page now also show a tracking coverage figure, so you can see how many recipients the rate rests on. Unsubscribe and bounce rates are unchanged
+Open, machine-open and click rates are now based on the recipients who allow email tracking, instead of everyone the campaign was sent to. Subscribers who opted out of tracking can never register an open or a click, so counting them was pulling the figures down. Rates will go up on sites that capture tracking consent; nothing broke, the old number was understated. The listing and the campaign stats page now also show a tracking coverage figure, so you can see how many recipients the rate rests on. Unsubscribe and bounce rates are unchanged

--- a/mailpoet/changelog/2026-08-12-16-26-34-improved-open-and-click-rates-are-now-based-on-the-recipien.md
+++ b/mailpoet/changelog/2026-08-12-16-26-34-improved-open-and-click-rates-are-now-based-on-the-recipien.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Open and click rates are now based on the recipients who allow email tracking, instead of everyone the campaign was sent to. Subscribers who opted out of tracking can never register an open or a click, so counting them was pulling the figures down. Rates will go up on sites that capture tracking consent; nothing broke, the old number was understated. The listing and the campaign stats page now also show a tracking coverage figure, so you can see how many recipients the rate rests on. Unsubscribe and bounce rates are unchanged

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -25,6 +25,7 @@ use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Statistics\StatisticsNewslettersRepository;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoet\Tasks\Subscribers\BatchIterator;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -99,6 +100,9 @@ class SendingQueue {
   /** @var TimeZoneCampaignScheduler|null */
   private $timeZoneCampaignScheduler;
 
+  /** @var TrackingConsentController */
+  private $trackingConsentController;
+
   public function __construct(
     SendingErrorHandler $errorHandler,
     SendingThrottlingHandler $throttlingHandler,
@@ -117,6 +121,7 @@ class SendingQueue {
     EntityManager $entityManager,
     StatisticsNewslettersRepository $statisticsNewslettersRepository,
     AuthorizedEmailsController $authorizedEmailsController,
+    TrackingConsentController $trackingConsentController,
     ?TimeZoneCampaignScheduler $timeZoneCampaignScheduler = null,
     $newsletterTask = false
   ) {
@@ -139,6 +144,7 @@ class SendingQueue {
     $this->entityManager = $entityManager;
     $this->statisticsNewslettersRepository = $statisticsNewslettersRepository;
     $this->authorizedEmailsController = $authorizedEmailsController;
+    $this->trackingConsentController = $trackingConsentController;
     $this->timeZoneCampaignScheduler = $timeZoneCampaignScheduler;
   }
 
@@ -465,6 +471,11 @@ class SendingQueue {
         'newsletter_id' => $newsletter->getId(),
         'subscriber_id' => $subscriber->getId(),
         'queue_id' => $sendingQueueEntity->getId(),
+        // Snapshot of "were we allowed to measure this person" at send time, so
+        // open and click rates can be divided by the recipients we could
+        // actually track. Consent only — the site-wide tracking switch is
+        // deliberately excluded, see TrackingConsentController.
+        'tracking_allowed' => $this->trackingConsentController->isConsentGivenForTracking($subscriber),
       ];
       if ($processingMethod === 'individual') {
         $this->sendNewsletter(

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -670,6 +670,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\Shortcodes\Categories\Site::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Embed\NewsletterEmbedService::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Embed\RestApi\Endpoints\NewsletterEmbedSelectorEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Doctrine\SchemaGuard::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Statistics\Export\StatisticsExporter::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Scheduler\AutomaticEmailScheduler::class)->setPublic(true);

--- a/mailpoet/lib/Doctrine/SchemaGuard.php
+++ b/mailpoet/lib/Doctrine/SchemaGuard.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Doctrine;
+
+use MailPoetVendor\Doctrine\DBAL\Exception\InvalidFieldNameException;
+use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
+
+/**
+ * Runs a read that touches a column or table a migration may not have added yet.
+ *
+ * During a plugin update the new code is live before its migrations have run, so
+ * anything mapping a new column can hit a database that does not have it. Each
+ * new column has reintroduced this: tracking_consent in STOMAIL-8268, then
+ * tracking_allowed in STOMAIL-8310, which returned a 500 from the automation
+ * analytics endpoint on an ordinary page load.
+ *
+ * Two things have to happen, and doing only the first is what made the
+ * tracking_allowed fix look complete when it was not:
+ *
+ * 1. Catch the schema exception, so the caller can fall back instead of dying.
+ * 2. Suppress wpdb's error output. wpdb prints the failed query before Doctrine
+ *    ever raises it, so a caught exception still leaves a block of "WordPress
+ *    database error" HTML glued to the front of the response body — which broke
+ *    the newsletters listing JSON even after the exception was handled.
+ *
+ * Deliberately narrow. It catches only the two schema exceptions, so a genuine
+ * database fault still surfaces rather than being quietly turned into a
+ * fallback value, and it suppresses errors for the wrapped read only.
+ *
+ * This is not the schema-readiness gate described in STOMAIL-8268's follow-ups.
+ * It is the shared piece those per-call-site guards should have had, so the next
+ * column does not need a fourth hand-written copy of the same try/catch.
+ */
+class SchemaGuard {
+  /**
+   * @template T
+   * @param callable():T $read Executed immediately.
+   * @param T $fallback Returned when the schema is not ready yet.
+   * @return T
+   */
+  public function readOr(callable $read, $fallback) {
+    global $wpdb;
+    $suppressErrors = $wpdb->suppress_errors();
+    try {
+      return $read();
+    } catch (InvalidFieldNameException | TableNotFoundException $e) {
+      return $fallback;
+    } finally {
+      $wpdb->suppress_errors($suppressErrors);
+    }
+  }
+}

--- a/mailpoet/lib/Entities/StatisticsNewsletterEntity.php
+++ b/mailpoet/lib/Entities/StatisticsNewsletterEntity.php
@@ -41,16 +41,32 @@ class StatisticsNewsletterEntity {
    */
   private $sentAt;
 
+  /**
+   * Whether the subscriber's tracking consent let us measure this send, as it
+   * stood at the moment we sent. A snapshot, deliberately: consent is a current
+   * fact about a person while a rate describes a past send, so reading consent
+   * live would move historical rates and could push one over 100%.
+   *
+   * Defaults to true, so rows written before per-subscriber opt-out existed —
+   * and any caller that does not care — keep today's meaning.
+   *
+   * @ORM\Column(type="boolean")
+   * @var bool
+   */
+  private $trackingAllowed = true;
+
   public function __construct(
     NewsletterEntity $newsletter,
     SendingQueueEntity $queue,
     SubscriberEntity $subscriber,
-    ?\DateTimeInterface $sentAt = null
+    ?\DateTimeInterface $sentAt = null,
+    bool $trackingAllowed = true
   ) {
     $this->newsletter = $newsletter;
     $this->queue = $queue;
     $this->subscriber = $subscriber;
     $this->sentAt = $sentAt ?: new \DateTimeImmutable();
+    $this->trackingAllowed = $trackingAllowed;
   }
 
   /**
@@ -89,5 +105,13 @@ class StatisticsNewsletterEntity {
    */
   public function setSentAt(\DateTimeInterface $sentAt) {
     $this->sentAt = $sentAt;
+  }
+
+  public function getTrackingAllowed(): bool {
+    return $this->trackingAllowed;
+  }
+
+  public function setTrackingAllowed(bool $trackingAllowed): void {
+    $this->trackingAllowed = $trackingAllowed;
   }
 }

--- a/mailpoet/lib/Migrations/Db/Migration_20260812_120000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260812_120000_Db.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\StatisticsNewsletterEntity;
+use MailPoet\Migrator\DbMigration;
+
+/**
+ * Records, per recipient, whether we were allowed to track them at the moment
+ * we sent to them (STOMAIL-8310). Open and click rates are then divided by the
+ * recipients we could actually measure, instead of by everyone.
+ *
+ * The flag is a snapshot, not a live read. Consent is a current fact about a
+ * subscriber while a rate describes a past send, so reading consent at display
+ * time would move every historical rate whenever somebody opted out — and,
+ * because an open recorded before the opt-out stays in the numerator while its
+ * recipient leaves the denominator, it could push a rate over 100%.
+ *
+ * DEFAULT 1 is the right answer for every row written before per-subscriber
+ * opt-out shipped: those sends really were tracked.
+ *
+ * Cost: statistics_newsletters is the largest table in a MailPoet install.
+ * Adding a column with a default is instant on MySQL 8.0.12+ (INSTANT
+ * algorithm, metadata only). The index build is not instant and is what a very
+ * large store will feel during the update; it is the same shape of change as
+ * Migration_20260709_120000_Db, which added an index to this table in July
+ * 2026. The index makes the per-newsletter untracked count an index-only scan
+ * of the opted-out rows rather than a read of every recipient.
+ */
+class Migration_20260812_120000_Db extends DbMigration {
+  public function run(): void {
+    $statisticsNewslettersTable = $this->getTableName(StatisticsNewsletterEntity::class);
+
+    if (!$this->columnExists($statisticsNewslettersTable, 'tracking_allowed')) {
+      $this->connection->executeStatement("
+        ALTER TABLE `{$statisticsNewslettersTable}`
+        ADD COLUMN `tracking_allowed` tinyint(1) NOT NULL DEFAULT 1
+      ");
+    }
+
+    if (!$this->indexExists($statisticsNewslettersTable, 'newsletter_id_tracking_allowed')) {
+      $this->connection->executeStatement("
+        ALTER TABLE `{$statisticsNewslettersTable}`
+        ADD INDEX `newsletter_id_tracking_allowed` (`newsletter_id`, `tracking_allowed`)
+      ");
+    }
+  }
+}

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatistics.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatistics.php
@@ -22,6 +22,15 @@ class NewsletterStatistics {
   /** @var int */
   private $totalSentCount;
 
+  /**
+   * Recipients whose tracking consent, as it stood when we sent, did not let us
+   * measure them. Zero unless the site captures consent, which keeps every
+   * screen looking exactly as it does today for sites with no opt-outs.
+   *
+   * @var int
+   */
+  private $notTrackedCount = 0;
+
   /** @var WooCommerceRevenue|null */
   private $wooCommerceRevenue;
 
@@ -61,6 +70,27 @@ class NewsletterStatistics {
     return $this->totalSentCount;
   }
 
+  public function setNotTrackedCount(int $notTrackedCount): void {
+    $this->notTrackedCount = $notTrackedCount;
+  }
+
+  public function getNotTrackedCount(): int {
+    return $this->notTrackedCount;
+  }
+
+  /**
+   * The denominator for open and click rates: the recipients we were allowed
+   * to measure.
+   *
+   * Clamped at zero because the two counters have different writers —
+   * count_processed is recomputed from the database on every batch, while
+   * statistics_newsletters rows are written even for a failed send — so they
+   * can genuinely drift apart.
+   */
+  public function getTrackedSentCount(): int {
+    return max(0, $this->totalSentCount - $this->notTrackedCount);
+  }
+
   public function getWooCommerceRevenue(): ?WooCommerceRevenue {
     return $this->wooCommerceRevenue;
   }
@@ -80,6 +110,11 @@ class NewsletterStatistics {
       'machineOpened' => $this->machineOpenCount,
       'unsubscribed' => $this->unsubscribeCount,
       'bounced' => $this->bounceCount,
+      // Deliberately inside asArray() rather than beside it: MailPoet Premium
+      // re-emits this array verbatim, so keeping the new keys here is what
+      // makes tracked-only rates a free-plugin-only change.
+      'notTracked' => $this->notTrackedCount,
+      'trackedSent' => $this->getTrackedSentCount(),
       'revenue' => empty($this->wooCommerceRevenue) ? null : $this->wooCommerceRevenue->asArray(),
     ];
   }

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Newsletter\Statistics;
 
 use MailPoet\Doctrine\Repository;
+use MailPoet\Doctrine\SchemaGuard;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
@@ -17,8 +18,6 @@ use MailPoet\Entities\UserAgentEntity;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\WooCommerce\Helper as WCHelper;
 use MailPoet\WooCommerce\OrderAttributionRevenueReader;
-use MailPoetVendor\Doctrine\DBAL\Exception\InvalidFieldNameException;
-use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\ORM\Query\Expr\Join;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
@@ -38,16 +37,21 @@ class NewsletterStatisticsRepository extends Repository {
   /** @var OrderAttributionRevenueReader */
   private $orderAttributionRevenueReader;
 
+  /** @var SchemaGuard */
+  private $schemaGuard;
+
   public function __construct(
     EntityManager $entityManager,
     WCHelper $wcHelper,
     TrackingConfig $trackingConfig,
-    OrderAttributionRevenueReader $orderAttributionRevenueReader
+    OrderAttributionRevenueReader $orderAttributionRevenueReader,
+    SchemaGuard $schemaGuard
   ) {
     parent::__construct($entityManager);
     $this->wcHelper = $wcHelper;
     $this->trackingConfig = $trackingConfig;
     $this->orderAttributionRevenueReader = $orderAttributionRevenueReader;
+    $this->schemaGuard = $schemaGuard;
   }
 
   protected function getEntityClassName() {
@@ -261,27 +265,18 @@ class NewsletterStatisticsRepository extends Repository {
    * analytics endpoint 500s outright. Every caller treats an absent count as
    * "nobody was untracked", so rates fall back to the whole audience until the
    * migration lands, which is exactly the behaviour from before this feature.
-   * Mirrors the guards added for tracking_consent in SubscriberActivityTracker
-   * and SendingQueue.
-   *
-   * wpdb errors are suppressed for the duration, because catching the exception
-   * is not enough on its own: wpdb prints the failure before Doctrine ever
-   * raises it, so the listing endpoint returned valid JSON with a block of
-   * "WordPress database error" HTML glued to the front of it. DbMigration's own
-   * columnExists() suppresses for the same reason. Scoped to this one query and
-   * restored in finally, so nothing else loses its errors — and on the normal
-   * path there is no error to suppress, which makes it a no-op there.
+   * SchemaGuard handles both halves of that: it catches the schema exception and
+   * suppresses wpdb's own error output, which prints the failed query before
+   * Doctrine ever raises it. See its docblock for why catching alone is not
+   * enough.
    */
   private function getNotTrackedCounts(array $newsletters, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null): array {
-    global $wpdb;
-    $suppressErrors = $wpdb->suppress_errors();
-    try {
-      return $this->queryNotTrackedCounts($newsletters, $from, $to);
-    } catch (InvalidFieldNameException | TableNotFoundException $e) {
-      return [];
-    } finally {
-      $wpdb->suppress_errors($suppressErrors);
-    }
+    return $this->schemaGuard->readOr(
+      function () use ($newsletters, $from, $to): array {
+        return $this->queryNotTrackedCounts($newsletters, $from, $to);
+      },
+      []
+    );
   }
 
   /**

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
@@ -17,6 +17,8 @@ use MailPoet\Entities\UserAgentEntity;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\WooCommerce\Helper as WCHelper;
 use MailPoet\WooCommerce\OrderAttributionRevenueReader;
+use MailPoetVendor\Doctrine\DBAL\Exception\InvalidFieldNameException;
+use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\ORM\Query\Expr\Join;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
@@ -252,8 +254,28 @@ class NewsletterStatisticsRepository extends Repository {
    * tasks only, same created-at window — because the two numbers are subtracted
    * from one another. Counting rows from a queue outside that set would make
    * the subtraction meaningless and could drive the result negative.
+   *
+   * Returns no counts while the tracking_allowed column is missing. During a
+   * plugin update this code can run before the migration that adds it, and
+   * these read paths are reachable from ordinary page loads — the automation
+   * analytics endpoint 500s outright. Every caller treats an absent count as
+   * "nobody was untracked", so rates fall back to the whole audience until the
+   * migration lands, which is exactly the behaviour from before this feature.
+   * Mirrors the guards added for tracking_consent in SubscriberActivityTracker
+   * and SendingQueue.
    */
   private function getNotTrackedCounts(array $newsletters, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null): array {
+    try {
+      return $this->queryNotTrackedCounts($newsletters, $from, $to);
+    } catch (InvalidFieldNameException | TableNotFoundException $e) {
+      return [];
+    }
+  }
+
+  /**
+   * @return array<int, int>
+   */
+  private function queryNotTrackedCounts(array $newsletters, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null): array {
     $query = $this->entityManager
       ->createQueryBuilder()
       ->select('IDENTITY(stats.newsletter) AS id, COUNT(stats.id) AS cnt')

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
@@ -263,12 +263,24 @@ class NewsletterStatisticsRepository extends Repository {
    * migration lands, which is exactly the behaviour from before this feature.
    * Mirrors the guards added for tracking_consent in SubscriberActivityTracker
    * and SendingQueue.
+   *
+   * wpdb errors are suppressed for the duration, because catching the exception
+   * is not enough on its own: wpdb prints the failure before Doctrine ever
+   * raises it, so the listing endpoint returned valid JSON with a block of
+   * "WordPress database error" HTML glued to the front of it. DbMigration's own
+   * columnExists() suppresses for the same reason. Scoped to this one query and
+   * restored in finally, so nothing else loses its errors — and on the normal
+   * path there is no error to suppress, which makes it a no-op there.
    */
   private function getNotTrackedCounts(array $newsletters, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null): array {
+    global $wpdb;
+    $suppressErrors = $wpdb->suppress_errors();
     try {
       return $this->queryNotTrackedCounts($newsletters, $from, $to);
     } catch (InvalidFieldNameException | TableNotFoundException $e) {
       return [];
+    } finally {
+      $wpdb->suppress_errors($suppressErrors);
     }
   }
 

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
@@ -62,6 +62,7 @@ class NewsletterStatisticsRepository extends Repository {
       $this->getWooCommerceRevenue($newsletter)
     );
     $stats->setMachineOpenCount($this->getStatisticsMachineOpenCount($newsletter));
+    $stats->setNotTrackedCount($this->getNotTrackedCount($newsletter));
     return $stats;
   }
 
@@ -83,7 +84,13 @@ class NewsletterStatisticsRepository extends Repository {
     ]
   ): array {
 
-    $totalSentCounts = in_array('totals', $include, true) ? $this->getTotalSentCounts($newsletters, $from, $to) : [];
+    $includeTotals = in_array('totals', $include, true);
+    $totalSentCounts = $includeTotals ? $this->getTotalSentCounts($newsletters, $from, $to) : [];
+    // Tied to 'totals' rather than being its own include member on purpose:
+    // getTrackedSentCount() subtracts one from the other, so a caller that got
+    // the sent count without the untracked count would silently be told every
+    // recipient was tracked.
+    $notTrackedCounts = $includeTotals ? $this->getNotTrackedCounts($newsletters, $from, $to) : [];
     $clickCounts = in_array(StatisticsClickEntity::class, $include, true) ? $this->getStatisticCounts(StatisticsClickEntity::class, $newsletters, $from, $to) : [];
     $openCounts = in_array(StatisticsOpenEntity::class, $include, true) ? $this->getStatisticCounts(StatisticsOpenEntity::class, $newsletters, $from, $to) : [];
     $unsubscribeCounts = in_array(StatisticsUnsubscribeEntity::class, $include, true) ? $this->getStatisticCounts(StatisticsUnsubscribeEntity::class, $newsletters, $from, $to) : [];
@@ -101,12 +108,18 @@ class NewsletterStatisticsRepository extends Repository {
         $totalSentCounts[$id] ?? 0,
         $wooCommerceRevenues[$id] ?? null
       );
+      $statistics[$id]->setNotTrackedCount($notTrackedCounts[$id] ?? 0);
     }
     return $statistics;
   }
 
   public function getTotalSentCount(NewsletterEntity $newsletter): int {
     $counts = $this->getTotalSentCounts([$newsletter]);
+    return $counts[$newsletter->getId()] ?? 0;
+  }
+
+  public function getNotTrackedCount(NewsletterEntity $newsletter): int {
+    $counts = $this->getNotTrackedCounts([$newsletter]);
     return $counts[$newsletter->getId()] ?? 0;
   }
 
@@ -224,6 +237,50 @@ class NewsletterStatisticsRepository extends Repository {
 
     $results = $query->getQuery()
       ->getResult();
+
+    $counts = [];
+    foreach ($results ?: [] as $result) {
+      $counts[(int)$result['id']] = (int)$result['cnt'];
+    }
+    return $counts;
+  }
+
+  /**
+   * Recipients we were not allowed to measure, per newsletter.
+   *
+   * Filtered over exactly the same queues getTotalSentCounts() sums — completed
+   * tasks only, same created-at window — because the two numbers are subtracted
+   * from one another. Counting rows from a queue outside that set would make
+   * the subtraction meaningless and could drive the result negative.
+   */
+  private function getNotTrackedCounts(array $newsletters, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null): array {
+    $query = $this->entityManager
+      ->createQueryBuilder()
+      ->select('IDENTITY(stats.newsletter) AS id, COUNT(stats.id) AS cnt')
+      ->from(StatisticsNewsletterEntity::class, 'stats')
+      ->join('stats.queue', 'q')
+      ->join('q.task', 't')
+      ->where('t.status = :status')
+      ->setParameter('status', ScheduledTaskEntity::STATUS_COMPLETED)
+      ->andWhere('stats.newsletter IN (:newsletters)')
+      ->setParameter('newsletters', $newsletters)
+      ->andWhere('stats.trackingAllowed = :trackingAllowed')
+      ->setParameter('trackingAllowed', false)
+      ->groupBy('stats.newsletter');
+
+    if ($from && $to) {
+      $query->andWhere('q.createdAt BETWEEN :from AND :to')
+        ->setParameter('from', $from)
+        ->setParameter('to', $to);
+    } elseif ($from && $to === null) {
+      $query->andWhere('q.createdAt >= :from')
+        ->setParameter('from', $from);
+    } elseif ($from === null && $to) {
+      $query->andWhere('q.createdAt <= :to')
+        ->setParameter('to', $to);
+    }
+
+    $results = $query->getQuery()->getResult();
 
     $counts = [];
     foreach ($results ?: [] as $result) {

--- a/mailpoet/lib/Statistics/StatisticsNewslettersRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsNewslettersRepository.php
@@ -31,7 +31,10 @@ class StatisticsNewslettersRepository extends Repository {
         }
 
         $sentAt = Carbon::now()->millisecond(0);
-        $entity = new StatisticsNewsletterEntity($newsletter, $queue, $subscriber, $sentAt);
+        // A missing key means "tracked", matching the column default, so any
+        // caller that does not know about consent keeps writing rows as before.
+        $trackingAllowed = !array_key_exists('tracking_allowed', $value) || (bool)$value['tracking_allowed'];
+        $entity = new StatisticsNewsletterEntity($newsletter, $queue, $subscriber, $sentAt, $trackingAllowed);
 
         $this->entityManager->persist($entity);
         $entities[] = $entity;

--- a/mailpoet/lib/Subscribers/TrackingConsentController.php
+++ b/mailpoet/lib/Subscribers/TrackingConsentController.php
@@ -49,6 +49,22 @@ class TrackingConsentController {
       return false;
     }
 
+    return $this->isConsentGivenForTracking($subscriber);
+  }
+
+  /**
+   * The consent half of isTrackingAllowed(), without the site-wide switch.
+   *
+   * Stats stamp this on every sent row, so a campaign's tracking coverage is
+   * fixed the moment it is sent. The global switch is deliberately left out:
+   * it is a current site setting, not a fact about the send, so folding it in
+   * would freeze every campaign sent while tracking was off at 0% coverage for
+   * good, even after the merchant turns tracking back on.
+   *
+   * Callers deciding whether to track someone *right now* want
+   * isTrackingAllowed() instead.
+   */
+  public function isConsentGivenForTracking(SubscriberEntity $subscriber): bool {
     switch ($subscriber->getTrackingConsent()) {
       case SubscriberEntity::TRACKING_CONSENT_GRANTED:
         return true;

--- a/mailpoet/tests/DataFactories/StatisticsNewsletters.php
+++ b/mailpoet/tests/DataFactories/StatisticsNewsletters.php
@@ -38,14 +38,32 @@ class StatisticsNewsletters {
     return $this;
   }
 
+  /** @return $this */
+  public function withTrackingAllowed(bool $trackingAllowed) {
+    $this->data['trackingAllowed'] = $trackingAllowed;
+    return $this;
+  }
+
+  /**
+   * Attach the row to a specific queue rather than the newsletter's latest one.
+   *
+   * @return $this
+   */
+  public function withQueue(SendingQueueEntity $queue) {
+    $this->data['queue'] = $queue;
+    return $this;
+  }
+
   public function create(): StatisticsNewsletterEntity {
     $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
-    $queue = $this->newsletter->getLatestQueue();
+    $queue = $this->data['queue'] ?? $this->newsletter->getLatestQueue();
     Assert::assertInstanceOf(SendingQueueEntity::class, $queue);
     $entity = new StatisticsNewsletterEntity(
       $this->newsletter,
       $queue,
-      $this->subscriber
+      $this->subscriber,
+      null,
+      $this->data['trackingAllowed'] ?? true
     );
     if (isset($this->data['sentAt'])) {
       $entity->setSentAt($this->data['sentAt']);

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
@@ -39,12 +39,17 @@ class NewslettersResponseBuilderTest extends \MailPoetTest {
         'unsubscribed' => 2,
         'bounced' => 1,
         'machineOpened' => 9,
+        // 2 of the 10 recipients could not be tracked, so open and click rates
+        // are based on the remaining 8.
+        'notTracked' => 2,
+        'trackedSent' => 8,
         'revenue' => null,
         'unsubscribeReasons' => [],
       ],
     ];
     $statistics = new NewsletterStatistics(4, 6, 2, 1, 10, null);
     $statistics->setMachineOpenCount(9);
+    $statistics->setNotTrackedCount(2);
     $newsletterStatsRepository = Stub::make(NewsletterStatisticsRepository::class, [
       'getTotalSentCount' => $stats['total_sent'],
       'getChildrenCount' => $stats['children_count'],

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -9,6 +9,7 @@ use MailPoet\API\JSON\Response as APIResponse;
 use MailPoet\API\JSON\ResponseBuilders\NewslettersResponseBuilder;
 use MailPoet\API\JSON\v1\Newsletters;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Doctrine\SchemaGuard;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Logging\LogRepository;
@@ -61,7 +62,8 @@ class NewslettersTest extends \MailPoetTest {
             $this->diContainer->get(EntityManager::class),
             $this->makeEmpty(WCHelper::class),
             $this->diContainer->get(TrackingConfig::class),
-            $this->diContainer->get(OrderAttributionRevenueReader::class)
+            $this->diContainer->get(OrderAttributionRevenueReader::class),
+            $this->diContainer->get(SchemaGuard::class)
           ),
           $this->diContainer->get(Url::class),
           $this->diContainer->get(SendingQueuesRepository::class),

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -1827,6 +1827,7 @@ class SendingQueueTest extends \MailPoetTest {
       [$this->newsletter->getId(), $subscriber->getId()]
     );
     $this->assertNotFalse($value, 'No statistics_newsletters row was written for this recipient.');
+    $this->assertIsNumeric($value);
     return (int)$value;
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -24,6 +24,7 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Logging\LoggerFactory;
@@ -47,6 +48,7 @@ use MailPoet\Statistics\StatisticsNewslettersRepository;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\Source;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoet\Subscription\SubscriptionUrlFactory;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
@@ -225,7 +227,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->sendingQueuesRepository,
       $this->entityManager,
       $this->statisticsNewslettersRepository,
-      $this->authorizedEmailsController
+      $this->authorizedEmailsController,
+      $this->diContainer->get(TrackingConsentController::class)
     );
     try {
       $sendingQueueWorker->process();
@@ -264,7 +267,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->sendingQueuesRepository,
       $this->entityManager,
       $this->statisticsNewslettersRepository,
-      $this->authorizedEmailsController
+      $this->authorizedEmailsController,
+      $this->diContainer->get(TrackingConsentController::class)
     );
     $sendingQueueWorker->sendNewsletters(
       $this->scheduledTask,
@@ -315,7 +319,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->sendingQueuesRepository,
       $this->entityManager,
       $this->statisticsNewslettersRepository,
-      $this->authorizedEmailsController
+      $this->authorizedEmailsController,
+      $this->diContainer->get(TrackingConsentController::class)
     );
     $sendingQueueWorker->sendNewsletters(
       $this->scheduledTask,
@@ -359,7 +364,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->sendingQueuesRepository,
       $this->entityManager,
       $this->statisticsNewslettersRepository,
-      $this->authorizedEmailsController
+      $this->authorizedEmailsController,
+      $this->diContainer->get(TrackingConsentController::class)
     );
     $sendingQueueWorker->process();
   }
@@ -667,7 +673,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->sendingQueuesRepository,
       $this->entityManager,
       $this->statisticsNewslettersRepository,
-      $this->authorizedEmailsController
+      $this->authorizedEmailsController,
+      $this->diContainer->get(TrackingConsentController::class)
     );
 
     $sendingQueueWorker->sendNewsletters(
@@ -1383,7 +1390,8 @@ class SendingQueueTest extends \MailPoetTest {
       $this->sendingQueuesRepository,
       $this->entityManager,
       $this->statisticsNewslettersRepository,
-      $this->authorizedEmailsController
+      $this->authorizedEmailsController,
+      $this->diContainer->get(TrackingConsentController::class)
     );
     try {
       $sendingQueueWorker->sendNewsletters(
@@ -1748,6 +1756,80 @@ class SendingQueueTest extends \MailPoetTest {
     return $subscriber;
   }
 
+  /**
+   * The guard against risk 7 in the plan: if the worker is never wired to write
+   * the flag, everything still compiles, the column stays all-1s, and the
+   * feature does nothing while looking done. These assert on the persisted row,
+   * not on a mock call.
+   */
+  public function testItStampsTrackingAllowedOnTheSentRowFromConsent() {
+    $granted = $this->createSubscriber('granted@example.com', 'Granted', 'Person', [$this->segment]);
+    $granted->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    $denied = $this->createSubscriber('denied@example.com', 'Denied', 'Person', [$this->segment]);
+    $denied->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_DENIED);
+    $this->entityManager->flush();
+    $this->scheduledTaskSubscribersRepository->setSubscribers(
+      $this->scheduledTask,
+      [(int)$granted->getId(), (int)$denied->getId()]
+    );
+
+    $this->sendingQueueWorker->process();
+
+    verify($this->getStoredTrackingAllowed($granted))->equals(1);
+    verify($this->getStoredTrackingAllowed($denied))->equals(0);
+  }
+
+  public function testItStampsUnknownConsentAccordingToTheSubscriberChoiceSetting() {
+    $this->settings->set(TrackingConsentController::SETTING_SUBSCRIBER_CHOICE, TrackingConsentController::CHOICE_ASK_ALL);
+    $unknown = $this->createSubscriber('unknown@example.com', 'Unknown', 'Person', [$this->segment]);
+    $unknown->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    $this->entityManager->flush();
+    $this->scheduledTaskSubscribersRepository->setSubscribers($this->scheduledTask, [(int)$unknown->getId()]);
+
+    $this->sendingQueueWorker->process();
+
+    verify($this->getStoredTrackingAllowed($unknown))->equals(0);
+  }
+
+  public function testItStampsUnknownConsentAsTrackedWhenOnlyNewSubscribersAreAsked() {
+    $this->settings->set(TrackingConsentController::SETTING_SUBSCRIBER_CHOICE, TrackingConsentController::CHOICE_ASK_NEW);
+    $unknown = $this->createSubscriber('unknown-asknew@example.com', 'Unknown', 'Person', [$this->segment]);
+    $unknown->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    $this->entityManager->flush();
+    $this->scheduledTaskSubscribersRepository->setSubscribers($this->scheduledTask, [(int)$unknown->getId()]);
+
+    $this->sendingQueueWorker->process();
+
+    verify($this->getStoredTrackingAllowed($unknown))->equals(1);
+  }
+
+  /**
+   * The global switch must NOT be baked into the stored row — otherwise every
+   * campaign sent while site-wide tracking was off would be frozen at 0%
+   * coverage for good, even after the merchant turns tracking back on.
+   */
+  public function testItStampsConsentEvenWhenSiteWideTrackingIsOff() {
+    $this->settings->set('tracking.level', TrackingConfig::LEVEL_BASIC);
+    $granted = $this->createSubscriber('granted-notracking@example.com', 'Granted', 'Person', [$this->segment]);
+    $granted->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    $this->entityManager->flush();
+    $this->scheduledTaskSubscribersRepository->setSubscribers($this->scheduledTask, [(int)$granted->getId()]);
+
+    $this->sendingQueueWorker->process();
+
+    verify($this->getStoredTrackingAllowed($granted))->equals(1);
+  }
+
+  private function getStoredTrackingAllowed(SubscriberEntity $subscriber): int {
+    $table = $this->entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName();
+    $value = $this->entityManager->getConnection()->fetchOne(
+      "SELECT tracking_allowed FROM `{$table}` WHERE newsletter_id = ? AND subscriber_id = ?",
+      [$this->newsletter->getId(), $subscriber->getId()]
+    );
+    $this->assertNotFalse($value, 'No statistics_newsletters row was written for this recipient.');
+    return (int)$value;
+  }
+
   private function createSegment(string $name, string $type): SegmentEntity {
     $segment = new SegmentEntity($name, $type, 'Description');
     $this->entityManager->persist($segment);
@@ -1801,6 +1883,7 @@ class SendingQueueTest extends \MailPoetTest {
       $this->entityManager,
       $this->statisticsNewslettersRepository,
       $authorizedEmailControllerMock ?? $this->authorizedEmailsController,
+      $this->diContainer->get(TrackingConsentController::class),
     );
   }
 

--- a/mailpoet/tests/integration/Doctrine/SchemaGuardTest.php
+++ b/mailpoet/tests/integration/Doctrine/SchemaGuardTest.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Doctrine;
+
+use MailPoetVendor\Doctrine\DBAL\Exception\InvalidFieldNameException;
+use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
+
+/**
+ * The guard has to do two things, and each is asserted separately because
+ * getting only the first is what made the tracking_allowed fix look complete
+ * when the response body was still being corrupted.
+ */
+class SchemaGuardTest extends \MailPoetTest {
+  /** @var SchemaGuard */
+  private $guard;
+
+  public function _before() {
+    parent::_before();
+    $this->guard = $this->diContainer->get(SchemaGuard::class);
+  }
+
+  public function testItReturnsTheReadResultWhenTheSchemaIsFine() {
+    $result = $this->guard->readOr(function () {
+      return ['a' => 1];
+    }, []);
+
+    verify($result)->equals(['a' => 1]);
+  }
+
+  public function testItFallsBackWhenAColumnIsMissing() {
+    $result = $this->guard->readOr(function () {
+      throw $this->makeInvalidFieldNameException();
+    }, ['fallback']);
+
+    verify($result)->equals(['fallback']);
+  }
+
+  public function testItFallsBackWhenATableIsMissing() {
+    $result = $this->guard->readOr(function () {
+      throw $this->makeTableNotFoundException();
+    }, 0);
+
+    verify($result)->equals(0);
+  }
+
+  /**
+   * The half that is easy to miss. wpdb prints the failed query before Doctrine
+   * raises it, so a caught exception still leaves "WordPress database error"
+   * HTML in the response body.
+   */
+  public function testItPrintsNothingWhileTheSchemaIsNotReady() {
+    global $wpdb;
+    $showErrors = $wpdb->show_errors(true);
+
+    try {
+      ob_start();
+      $this->guard->readOr(function () {
+        // A real failing query, so wpdb genuinely tries to print.
+        return $this->entityManager->getConnection()
+          ->executeQuery('SELECT column_that_does_not_exist FROM ' . $wpdb->prefix . 'mailpoet_newsletters')
+          ->fetchAllAssociative();
+      }, []);
+      $printed = (string)ob_get_clean();
+
+      verify($printed)->equals('');
+    } finally {
+      $wpdb->show_errors($showErrors);
+    }
+  }
+
+  /** A genuine fault must still surface rather than being turned into a fallback. */
+  public function testItDoesNotSwallowOtherExceptions() {
+    $this->expectException(\RuntimeException::class);
+    $this->guard->readOr(function () {
+      throw new \RuntimeException('something else');
+    }, []);
+  }
+
+  /** Suppression is scoped to the read, so nothing after it loses its errors. */
+  public function testItRestoresThePreviousSuppressionSetting() {
+    global $wpdb;
+    $before = $this->currentSuppression();
+
+    $wpdb->suppress_errors(false);
+    $this->guard->readOr(function () {
+      throw $this->makeInvalidFieldNameException();
+    }, []);
+    verify($this->currentSuppression())->false();
+
+    $wpdb->suppress_errors(true);
+    $this->guard->readOr(function () {
+      return null;
+    }, null);
+    verify($this->currentSuppression())->true();
+
+    $wpdb->suppress_errors($before);
+  }
+
+  /** Reads the flag without touching the snake_case property directly. */
+  private function currentSuppression(): bool {
+    global $wpdb;
+    $value = (bool)$wpdb->suppress_errors(false);
+    $wpdb->suppress_errors($value);
+    return $value;
+  }
+
+  private function makeInvalidFieldNameException(): InvalidFieldNameException {
+    $reflection = new \ReflectionClass(InvalidFieldNameException::class);
+    $exception = $reflection->newInstanceWithoutConstructor();
+    $this->assertInstanceOf(InvalidFieldNameException::class, $exception);
+    return $exception;
+  }
+
+  private function makeTableNotFoundException(): TableNotFoundException {
+    $reflection = new \ReflectionClass(TableNotFoundException::class);
+    $exception = $reflection->newInstanceWithoutConstructor();
+    $this->assertInstanceOf(TableNotFoundException::class, $exception);
+    return $exception;
+  }
+}

--- a/mailpoet/tests/integration/Doctrine/SchemaGuardTest.php
+++ b/mailpoet/tests/integration/Doctrine/SchemaGuardTest.php
@@ -51,13 +51,14 @@ class SchemaGuardTest extends \MailPoetTest {
   public function testItPrintsNothingWhileTheSchemaIsNotReady() {
     global $wpdb;
     $showErrors = $wpdb->show_errors(true);
+    $table = $wpdb->prefix . 'mailpoet_newsletters';
 
     try {
       ob_start();
-      $this->guard->readOr(function () {
+      $this->guard->readOr(function () use ($table) {
         // A real failing query, so wpdb genuinely tries to print.
         return $this->entityManager->getConnection()
-          ->executeQuery('SELECT column_that_does_not_exist FROM ' . $wpdb->prefix . 'mailpoet_newsletters')
+          ->executeQuery("SELECT column_that_does_not_exist FROM {$table}")
           ->fetchAllAssociative();
       }, []);
       $printed = (string)ob_get_clean();

--- a/mailpoet/tests/integration/Migrations/Db/Migration_20260812_120000_Db_Test.php
+++ b/mailpoet/tests/integration/Migrations/Db/Migration_20260812_120000_Db_Test.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\StatisticsNewsletterEntity;
+
+require_once __DIR__ . '/../../../../lib/Migrations/Db/Migration_20260812_120000_Db.php';
+
+//phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class Migration_20260812_120000_Db_Test extends \MailPoetTest {
+  /** @var Migration_20260812_120000_Db */
+  private $migration;
+
+  /** @var string */
+  private $statisticsTable;
+
+  public function _before() {
+    parent::_before();
+    $this->migration = new Migration_20260812_120000_Db($this->diContainer);
+    $this->statisticsTable = $this->entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName();
+
+    // The migration has normally already run against the test database, so
+    // undo it to get a realistic "before" state.
+    $connection = $this->entityManager->getConnection();
+    if ($connection->fetchAllAssociative("SHOW INDEX FROM `{$this->statisticsTable}` WHERE Key_name = 'newsletter_id_tracking_allowed'")) {
+      $connection->executeStatement("ALTER TABLE `{$this->statisticsTable}` DROP INDEX `newsletter_id_tracking_allowed`");
+    }
+    if ($connection->fetchAllAssociative("SHOW COLUMNS FROM `{$this->statisticsTable}` LIKE 'tracking_allowed'")) {
+      $connection->executeStatement("ALTER TABLE `{$this->statisticsTable}` DROP COLUMN `tracking_allowed`");
+    }
+  }
+
+  public function testItAddsTheColumnDefaultingExistingRowsToTracked(): void {
+    $connection = $this->entityManager->getConnection();
+    $connection->executeStatement(
+      "INSERT INTO `{$this->statisticsTable}` (newsletter_id, subscriber_id, queue_id, sent_at) VALUES (1, 1, 1, NOW())"
+    );
+    $rowId = (int)$connection->lastInsertId();
+
+    $this->migration->run();
+
+    // Everything sent before per-subscriber opt-out existed was tracked, so
+    // pre-existing rows must land on 1 — not 0, which would zero every
+    // historical campaign's coverage.
+    $trackingAllowed = $connection->fetchOne(
+      "SELECT tracking_allowed FROM `{$this->statisticsTable}` WHERE id = ?",
+      [$rowId]
+    );
+    verify((int)$trackingAllowed)->equals(1);
+  }
+
+  public function testItAddsANotNullColumnDefaultingToOne(): void {
+    $this->migration->run();
+
+    $column = $this->entityManager->getConnection()->fetchAssociative(
+      "SHOW COLUMNS FROM `{$this->statisticsTable}` LIKE 'tracking_allowed'"
+    );
+    $this->assertIsArray($column);
+    verify($column['Null'])->equals('NO');
+    verify($column['Default'])->equals('1');
+    verify($column['Type'])->stringContainsString('tinyint(1)');
+  }
+
+  public function testItAddsTheCoverageIndex(): void {
+    $this->migration->run();
+
+    $index = $this->entityManager->getConnection()->fetchAllAssociative(
+      "SHOW INDEX FROM `{$this->statisticsTable}` WHERE Key_name = 'newsletter_id_tracking_allowed'"
+    );
+    verify(count($index))->equals(2);
+    verify($index[0]['Column_name'])->equals('newsletter_id');
+    verify($index[1]['Column_name'])->equals('tracking_allowed');
+  }
+
+  public function testItCanRunTwice(): void {
+    $this->migration->run();
+    $this->migration->run();
+
+    $columns = $this->entityManager->getConnection()->fetchAllAssociative(
+      "SHOW COLUMNS FROM `{$this->statisticsTable}` LIKE 'tracking_allowed'"
+    );
+    verify(count($columns))->equals(1);
+
+    $index = $this->entityManager->getConnection()->fetchAllAssociative(
+      "SHOW INDEX FROM `{$this->statisticsTable}` WHERE Key_name = 'newsletter_id_tracking_allowed'"
+    );
+    verify(count($index))->equals(2);
+  }
+}

--- a/mailpoet/tests/integration/Migrations/Db/Migration_20260812_120000_Db_Test.php
+++ b/mailpoet/tests/integration/Migrations/Db/Migration_20260812_120000_Db_Test.php
@@ -46,6 +46,7 @@ class Migration_20260812_120000_Db_Test extends \MailPoetTest {
       "SELECT tracking_allowed FROM `{$this->statisticsTable}` WHERE id = ?",
       [$rowId]
     );
+    $this->assertIsNumeric($trackingAllowed);
     verify((int)$trackingAllowed)->equals(1);
   }
 

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsTrackingCoverageTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsTrackingCoverageTest.php
@@ -244,20 +244,33 @@ class NewsletterStatisticsTrackingCoverageTest extends \MailPoetTest {
     $newsletter = $this->createSentNewsletter(4);
     $this->createRecipients($newsletter, [true, true, true, false]);
 
+    global $wpdb;
     $table = $this->entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName();
     $connection = $this->entityManager->getConnection();
     $connection->executeStatement("ALTER TABLE `{$table}` DROP COLUMN `tracking_allowed`");
+    $showErrors = $wpdb->show_errors(true);
 
     try {
       $this->entityManager->clear();
-      $statistics = $this->repository->getStatistics($this->reloadNewsletter($newsletter));
 
-      // No exception, and rates fall back to the whole audience — the exact
-      // behaviour from before this feature, rather than a 500.
+      // Catching the exception is not enough on its own: wpdb prints the failed
+      // query before Doctrine raises it, which glued a block of "WordPress
+      // database error" HTML to the front of the listing endpoint's JSON. So
+      // assert on what the request would emit, not only on the return value.
+      ob_start();
+      $statistics = $this->repository->getStatistics($this->reloadNewsletter($newsletter));
+      $printed = (string)ob_get_clean();
+
+      verify($printed)->stringNotContainsString('WordPress database error');
+      verify($printed)->equals('');
+
+      // Rates fall back to the whole audience — the exact behaviour from
+      // before this feature, rather than a 500.
       verify($statistics->getTotalSentCount())->equals(4);
       verify($statistics->getNotTrackedCount())->equals(0);
       verify($statistics->getTrackedSentCount())->equals(4);
     } finally {
+      $wpdb->show_errors($showErrors);
       $connection->executeStatement(
         "ALTER TABLE `{$table}` ADD COLUMN `tracking_allowed` tinyint(1) NOT NULL DEFAULT 1"
       );

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsTrackingCoverageTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsTrackingCoverageTest.php
@@ -4,6 +4,7 @@ namespace integration\Newsletter\Statistics;
 
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Settings\SettingsController;
@@ -227,6 +228,40 @@ class NewsletterStatisticsTrackingCoverageTest extends \MailPoetTest {
     // so keeping the new keys here is what makes the change free-plugin-only.
     verify($array['notTracked'])->equals(1);
     verify($array['trackedSent'])->equals(3);
+  }
+
+  /**
+   * The update window. A site can run this code before the migration that adds
+   * tracking_allowed, and these read paths are reachable from ordinary page
+   * loads — the automation analytics endpoint returned a 500 with
+   * "Unknown column 'tracking_allowed' in 'where clause'".
+   *
+   * Reproduced by dropping the column, which is the only faithful way to test
+   * it: every other suite runs against a fully migrated database, which is
+   * exactly why this class of bug survives CI.
+   */
+  public function testItSurvivesAMissingTrackingAllowedColumn() {
+    $newsletter = $this->createSentNewsletter(4);
+    $this->createRecipients($newsletter, [true, true, true, false]);
+
+    $table = $this->entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName();
+    $connection = $this->entityManager->getConnection();
+    $connection->executeStatement("ALTER TABLE `{$table}` DROP COLUMN `tracking_allowed`");
+
+    try {
+      $this->entityManager->clear();
+      $statistics = $this->repository->getStatistics($this->reloadNewsletter($newsletter));
+
+      // No exception, and rates fall back to the whole audience — the exact
+      // behaviour from before this feature, rather than a 500.
+      verify($statistics->getTotalSentCount())->equals(4);
+      verify($statistics->getNotTrackedCount())->equals(0);
+      verify($statistics->getTrackedSentCount())->equals(4);
+    } finally {
+      $connection->executeStatement(
+        "ALTER TABLE `{$table}` ADD COLUMN `tracking_allowed` tinyint(1) NOT NULL DEFAULT 1"
+      );
+    }
   }
 
   private function createSentNewsletter(int $countProcessed): NewsletterEntity {

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsTrackingCoverageTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsTrackingCoverageTest.php
@@ -1,0 +1,259 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Newsletter\Statistics;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Subscribers\TrackingConsentController;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\StatisticsNewsletters;
+use MailPoet\Test\DataFactories\StatisticsOpens;
+use MailPoet\Test\DataFactories\Subscriber;
+
+/**
+ * Tracking coverage: how many of a campaign's recipients we were allowed to
+ * measure, and the tracked-only denominator that open and click rates use.
+ *
+ * Every assertion here pins an exact integer. A test asserting only that
+ * notTracked >= 0, or that a coverage figure exists, would pass whether or not
+ * the denominator actually changed.
+ */
+class NewsletterStatisticsTrackingCoverageTest extends \MailPoetTest {
+  /** @var NewsletterStatisticsRepository */
+  private $repository;
+
+  public function _before() {
+    parent::_before();
+    $this->repository = $this->diContainer->get(NewsletterStatisticsRepository::class);
+  }
+
+  /**
+   * The headline case from the issue. Four recipients, one opted out at send
+   * time, two opens. The honest rate is 2/3, not 2/4.
+   */
+  public function testItTakesUntrackedRecipientsOutOfTheOpenRateDenominator() {
+    $newsletter = $this->createSentNewsletter(4);
+    $subscribers = $this->createRecipients($newsletter, [true, true, true, false]);
+    (new StatisticsOpens($newsletter, $subscribers[0]))->create();
+    (new StatisticsOpens($newsletter, $subscribers[1]))->create();
+
+    $statistics = $this->repository->getStatistics($newsletter);
+
+    verify($statistics->getTotalSentCount())->equals(4);
+    verify($statistics->getNotTrackedCount())->equals(1);
+    verify($statistics->getTrackedSentCount())->equals(3);
+
+    // 66.7%, not 50%. This is the whole point of the change.
+    $openRate = ($statistics->getOpenCount() * 100) / $statistics->getTrackedSentCount();
+    verify(round($openRate, 1))->equals(66.7);
+    verify(round(($statistics->getOpenCount() * 100) / $statistics->getTotalSentCount(), 1))->equals(50.0);
+  }
+
+  /**
+   * The snapshot guard, and the one test that makes Option B (store the
+   * decision at send time) distinguishable from Option A (read current consent
+   * at display time). Without it, a later refactor can quietly turn one into
+   * the other and nothing fails.
+   */
+  public function testTheUntrackedCountDoesNotMoveWhenTheSubscriberChoiceSettingChanges() {
+    $settings = $this->diContainer->get(SettingsController::class);
+    $settings->set(TrackingConsentController::SETTING_SUBSCRIBER_CHOICE, TrackingConsentController::CHOICE_ASK_NEW);
+
+    $newsletter = $this->createSentNewsletter(3);
+    // One denied, two never asked. Under ask_new the unknown pair counted as
+    // tracked at send time, so that is what the campaign records forever.
+    $subscribers = $this->createRecipients($newsletter, [true, true, false]);
+    $subscribers[0]->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    $subscribers[1]->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    $subscribers[2]->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_DENIED);
+    $this->entityManager->flush();
+
+    verify($this->repository->getStatistics($newsletter)->getNotTrackedCount())->equals(1);
+
+    foreach (TrackingConsentController::CHOICES as $choice) {
+      $settings->set(TrackingConsentController::SETTING_SUBSCRIBER_CHOICE, $choice);
+      $this->entityManager->clear();
+      $newsletter = $this->reloadNewsletter($newsletter);
+      $statistics = $this->repository->getStatistics($newsletter);
+      verify($statistics->getNotTrackedCount())->equals(1);
+      verify($statistics->getTrackedSentCount())->equals(2);
+    }
+  }
+
+  /**
+   * Someone tracked at send, who opened, and who opted out afterwards. Their
+   * open stays in the numerator, so they must stay in the denominator too —
+   * otherwise the rate can exceed 100%.
+   */
+  public function testAnOptOutAfterTheSendCannotPushTheRateOverOneHundred() {
+    $newsletter = $this->createSentNewsletter(1);
+    $subscribers = $this->createRecipients($newsletter, [true]);
+    (new StatisticsOpens($newsletter, $subscribers[0]))->create();
+
+    $subscribers[0]->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_DENIED);
+    $this->entityManager->flush();
+    $this->entityManager->clear();
+    $newsletter = $this->reloadNewsletter($newsletter);
+
+    $statistics = $this->repository->getStatistics($newsletter);
+
+    verify($statistics->getNotTrackedCount())->equals(0);
+    verify($statistics->getTrackedSentCount())->equals(1);
+    verify(($statistics->getOpenCount() * 100) / $statistics->getTrackedSentCount())->equals(100.0);
+  }
+
+  /**
+   * bulkDelete() cleans segments, custom fields and tags but not
+   * statistics_newsletters, so deleting a recipient leaves an orphan row. The
+   * snapshot keeps counting it, which is what stops the denominator shrinking
+   * out from under a recorded open.
+   */
+  public function testDeletingARecipientDoesNotChangeTheCoverage() {
+    $newsletter = $this->createSentNewsletter(3);
+    $subscribers = $this->createRecipients($newsletter, [true, true, false]);
+
+    $subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+    $subscribersRepository->bulkDelete([(int)$subscribers[2]->getId()]);
+    $this->entityManager->clear();
+    $newsletter = $this->reloadNewsletter($newsletter);
+
+    $statistics = $this->repository->getStatistics($newsletter);
+
+    verify($statistics->getNotTrackedCount())->equals(1);
+    verify($statistics->getTrackedSentCount())->equals(2);
+  }
+
+  /**
+   * The acceptance criterion "behavior is unchanged for sites with no opted-out
+   * subscribers", asserted as exact integer equality rather than "close".
+   */
+  public function testWithNoOptOutsTheTrackedDenominatorIsTheFullSentCount() {
+    $newsletter = $this->createSentNewsletter(5);
+    $this->createRecipients($newsletter, [true, true, true, true, true]);
+
+    $statistics = $this->repository->getStatistics($newsletter);
+
+    verify($statistics->getNotTrackedCount())->equals(0);
+    verify($statistics->getTrackedSentCount())->equals($statistics->getTotalSentCount());
+    verify($statistics->getTrackedSentCount())->equals(5);
+  }
+
+  /**
+   * count_processed and the statistics_newsletters row count come from two
+   * different writers — a failed send writes stats rows without bumping
+   * count_processed — so they can genuinely drift. The clamp keeps a drifting
+   * site from showing a negative denominator.
+   */
+  public function testTheTrackedCountIsClampedAtZeroWhenTheCountersDrift() {
+    $newsletter = $this->createSentNewsletter(1);
+    $this->createRecipients($newsletter, [false, false, false]);
+
+    $statistics = $this->repository->getStatistics($newsletter);
+
+    verify($statistics->getTotalSentCount())->equals(1);
+    verify($statistics->getNotTrackedCount())->equals(3);
+    verify($statistics->getTrackedSentCount())->equals(0);
+  }
+
+  /**
+   * The window must select the same queues the sent count sums, or subtracting
+   * one from the other is meaningless.
+   */
+  public function testTheUntrackedCountRespectsTheSameTimeWindowAsTheSentCount() {
+    $old = new \DateTimeImmutable('-40 days');
+    $newsletter = (new Newsletter())
+      ->withSendingQueue(['count_processed' => 2, 'count_total' => 2, 'created_at' => $old])
+      ->withSendingQueue(['count_processed' => 2, 'count_total' => 2])
+      ->create();
+    $queues = $newsletter->getQueues()->toArray();
+    verify(count($queues))->equals(2);
+    /** @var SendingQueueEntity $oldQueue */
+    $oldQueue = $queues[0];
+    /** @var SendingQueueEntity $recentQueue */
+    $recentQueue = $queues[1];
+
+    // One untracked recipient in each queue.
+    foreach ([$oldQueue, $recentQueue] as $queue) {
+      (new StatisticsNewsletters($newsletter, (new Subscriber())->create()))
+        ->withQueue($queue)->withTrackingAllowed(false)->create();
+      (new StatisticsNewsletters($newsletter, (new Subscriber())->create()))
+        ->withQueue($queue)->withTrackingAllowed(true)->create();
+    }
+
+    $from = new \DateTimeImmutable('-7 days');
+    $batch = $this->repository->getBatchStatistics([$newsletter], $from, null);
+    $statistics = $batch[$newsletter->getId()];
+
+    // Only the recent queue is in the window, on both sides of the subtraction.
+    verify($statistics->getTotalSentCount())->equals(2);
+    verify($statistics->getNotTrackedCount())->equals(1);
+    verify($statistics->getTrackedSentCount())->equals(1);
+
+    $all = $this->repository->getBatchStatistics([$newsletter]);
+    verify($all[$newsletter->getId()]->getTotalSentCount())->equals(4);
+    verify($all[$newsletter->getId()]->getNotTrackedCount())->equals(2);
+    verify($all[$newsletter->getId()]->getTrackedSentCount())->equals(2);
+  }
+
+  /**
+   * The listing reads batch statistics and the campaign stats page reads single
+   * statistics. A merchant seeing two different open rates for one campaign
+   * trusts neither, so the two paths must agree.
+   */
+  public function testTheBatchAndSingleReadsAgree() {
+    $newsletter = $this->createSentNewsletter(4);
+    $this->createRecipients($newsletter, [true, true, false, false]);
+
+    $single = $this->repository->getStatistics($newsletter);
+    $batch = $this->repository->getBatchStatistics([$newsletter])[$newsletter->getId()];
+
+    verify($batch->getNotTrackedCount())->equals($single->getNotTrackedCount());
+    verify($batch->getTrackedSentCount())->equals($single->getTrackedSentCount());
+    verify($batch->getNotTrackedCount())->equals(2);
+    verify($batch->getTrackedSentCount())->equals(2);
+  }
+
+  public function testItExposesTheNewKeysInsideAsArray() {
+    $newsletter = $this->createSentNewsletter(4);
+    $this->createRecipients($newsletter, [true, true, true, false]);
+
+    $array = $this->repository->getStatistics($newsletter)->asArray();
+
+    // Inside asArray(), not alongside it: Premium re-emits this array verbatim,
+    // so keeping the new keys here is what makes the change free-plugin-only.
+    verify($array['notTracked'])->equals(1);
+    verify($array['trackedSent'])->equals(3);
+  }
+
+  private function createSentNewsletter(int $countProcessed): NewsletterEntity {
+    return (new Newsletter())
+      ->withSendingQueue(['count_processed' => $countProcessed, 'count_total' => $countProcessed])
+      ->create();
+  }
+
+  /**
+   * @param bool[] $trackingAllowedFlags
+   * @return SubscriberEntity[]
+   */
+  private function createRecipients(NewsletterEntity $newsletter, array $trackingAllowedFlags): array {
+    $subscribers = [];
+    foreach ($trackingAllowedFlags as $trackingAllowed) {
+      $subscriber = (new Subscriber())->create();
+      (new StatisticsNewsletters($newsletter, $subscriber))
+        ->withTrackingAllowed($trackingAllowed)
+        ->create();
+      $subscribers[] = $subscriber;
+    }
+    return $subscribers;
+  }
+
+  private function reloadNewsletter(NewsletterEntity $newsletter): NewsletterEntity {
+    $reloaded = $this->entityManager->find(NewsletterEntity::class, $newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $reloaded);
+    return $reloaded;
+  }
+}

--- a/mailpoet/tests/integration/Subscribers/TrackingConsentControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/TrackingConsentControllerTest.php
@@ -90,4 +90,41 @@ class TrackingConsentControllerTest extends \MailPoetTest {
 
     $this->assertFalse($controller->isTrackingAllowed($subscriber));
   }
+
+  /**
+   * The deliberate split between the two methods. isConsentGivenForTracking()
+   * answers "did this person allow it?", which is what we stamp on a sent row;
+   * isTrackingAllowed() folds in the site-wide switch, which must never be
+   * baked into stored history — a site that turns tracking off for a month and
+   * back on would otherwise freeze that month's campaigns at 0% coverage.
+   */
+  public function testConsentOnlyCheckIgnoresTheGlobalTrackingSwitch() {
+    $settings = $this->diContainer->get(SettingsController::class);
+    $settings->set('tracking.level', TrackingConfig::LEVEL_BASIC);
+    $controller = $this->diContainer->get(TrackingConsentController::class);
+    $subscriber = new SubscriberEntity();
+    $subscriber->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+
+    verify($controller->isTrackingAllowed($subscriber))->false();
+    verify($controller->isConsentGivenForTracking($subscriber))->true();
+  }
+
+  public function testConsentOnlyCheckFollowsTheSubscriberChoiceForUnknown() {
+    $settings = $this->diContainer->get(SettingsController::class);
+    $controller = $this->diContainer->get(TrackingConsentController::class);
+    $unknown = new SubscriberEntity(); // defaults to unknown
+    $denied = new SubscriberEntity();
+    $denied->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_DENIED);
+
+    $settings->set(TrackingConsentController::SETTING_SUBSCRIBER_CHOICE, TrackingConsentController::CHOICE_TRACK_ALL);
+    verify($controller->isConsentGivenForTracking($unknown))->true();
+    verify($controller->isConsentGivenForTracking($denied))->false();
+
+    $settings->set(TrackingConsentController::SETTING_SUBSCRIBER_CHOICE, TrackingConsentController::CHOICE_ASK_NEW);
+    verify($controller->isConsentGivenForTracking($unknown))->true();
+
+    $settings->set(TrackingConsentController::SETTING_SUBSCRIBER_CHOICE, TrackingConsentController::CHOICE_ASK_ALL);
+    verify($controller->isConsentGivenForTracking($unknown))->false();
+    verify($controller->isConsentGivenForTracking($denied))->false();
+  }
 }


### PR DESCRIPTION
## Description

Open and click rates are divided by everyone we sent to. Subscribers who opted out of tracking can never register an open or a click, so they only ever drag the number down — the more consent capture succeeds, the worse a merchant's stats look. This bases those two rates on the recipients we were actually allowed to measure, and shows the coverage the figure rests on.

**The rates people see will jump the day this ships on any site with opt-outs. Nothing broke — the old number was understated.** That is the point of the change, and it is worth saying plainly because it will otherwise look like a data glitch. The coverage line sits on the same screen as the number that moved.

**Only open and click rates move.** Unsubscribe and bounce rates keep the whole denominator: neither `Statistics/Track/Unsubscribes.php` nor `StatisticsBouncesRepository` consults consent, so opted-out people can and do produce both. Shrinking their denominator would overstate them on a compliant site.

**Retroactivity: snapshot at send time.** A new `tracking_allowed` column on `statistics_newsletters` is stamped when the send happens, from the subscriber's consent as it stood then. Consent is a *current* fact about a person while a rate describes a *past* send, so reading consent at display time would move every historical rate whenever somebody opted out — and because an open recorded before the opt-out stays in the numerator while its recipient leaves the denominator, it could push a rate over 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8310-tracked-only-rates)

_The latest successful build from `add/stomail-8310-tracked-only-rates` will be used. If none is available, the link won't work._