### PR TITLE
Base automation and stats-email open/click rates on tracked recipients

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/email-click-badge/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/email-click-badge/index.tsx
@@ -38,10 +38,11 @@ export function Badge({ email, property }: BadgeProps): JSX.Element {
     return <>{`${email[property]}`}</>;
   }
 
-  // Shows the percentage of clicked emails compared to the number of sent emails
+  // Based on the recipients we were allowed to measure, so the badge matches
+  // the rate shown next to it.
   const clickedPercentage = calculatePercentage(
     email[property],
-    email.sent.current,
+    email.trackedSent ?? email.sent.current,
   );
   const clickedBadge = percentageBadgeCalculation(clickedPercentage);
 

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/overview/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/overview/index.tsx
@@ -52,7 +52,7 @@ function getTrackingCoverage(): number | undefined {
   if (sent <= 0) {
     return 0;
   }
-  return Math.min(1, tracked / sent);
+  return Math.min(1, Math.max(0, tracked / sent));
 }
 
 function getNotTrackedCount(): number {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/overview/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/overview/index.tsx
@@ -26,12 +26,38 @@ function getEmailPercentage(
   }
 
   const data = overview.data[type] ?? null;
-  const sent = overview.data?.sent ?? null;
-  if (!data || !sent || !data[period] || !sent[period]) {
+  // Divide by the recipients we were allowed to measure. An opted-out
+  // subscriber can never register an open or a click, so counting them only
+  // drags the rate down. Older payloads have no trackedSent, so fall back.
+  const base = overview.data?.trackedSent ?? overview.data?.sent ?? null;
+  if (!data || !base || !data[period] || !base[period]) {
     return 0;
   }
 
-  return (data[period] * 100) / sent[period] / 100;
+  return (data[period] * 100) / base[period] / 100;
+}
+
+/**
+ * How much of the audience the rates above rest on. Clamped to 0-100 because
+ * the sent counter and the per-recipient rows have different writers and can
+ * drift apart.
+ */
+function getTrackingCoverage(): number | undefined {
+  const overview = select(storeName).getSection('overview') as OverviewSection;
+  if (overview.data === undefined) {
+    return undefined;
+  }
+  const sent = overview.data.sent?.current ?? 0;
+  const tracked = overview.data.trackedSent?.current ?? sent;
+  if (sent <= 0) {
+    return 0;
+  }
+  return Math.min(1, tracked / sent);
+}
+
+function getNotTrackedCount(): number {
+  const overview = select(storeName).getSection('overview') as OverviewSection;
+  return overview.data?.notTracked?.current ?? 0;
 }
 
 function getEmailDelta(type: 'opened' | 'clicked'): number | undefined {
@@ -109,6 +135,17 @@ export function Overview(): JSX.Element | null {
         delta={Number(getEmailDelta('clicked').toFixed(2))}
       />,
     );
+    // Only when something is untracked, so an automation with no opted-out
+    // recipients looks exactly as it does today.
+    if (getNotTrackedCount() > 0) {
+      items.push(
+        <SummaryNumber
+          key="overview-tracking-coverage"
+          label={__('Tracking coverage', 'mailpoet')}
+          value={percentageFormatter.format(getTrackingCoverage())}
+        />,
+      );
+    }
   }
   if (overview.data !== undefined && MailPoet.isWoocommerceActive) {
     items.push(

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/rows.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/rows.tsx
@@ -18,11 +18,11 @@ const percentageFormatter = Intl.NumberFormat(locale.toString(), {
 
 export function transformEmailsToRows(emails: EmailStats[]) {
   return emails.map((email) => {
-    // Shows the percentage of clicked emails compared to the number of sent emails
-    const clickedPercentage = calculatePercentage(
-      email.clicked,
-      email.sent.current,
-    );
+    // Open and click rates are based on the recipients we were allowed to
+    // measure, not on everyone we sent to. Older payloads carry no
+    // trackedSent, so fall back to the full count.
+    const trackedSent = email.trackedSent ?? email.sent.current;
+    const clickedPercentage = calculatePercentage(email.clicked, trackedSent);
 
     const rows = [
       {
@@ -67,9 +67,9 @@ export function transformEmailsToRows(emails: EmailStats[]) {
           <Cell
             value={email.opened}
             subValue={
-              // Shows the percentage of opened emails compared to the number of sent emails
+              // Percentage of the recipients we could measure who opened.
               percentageFormatter.format(
-                calculatePercentage(email.opened, email.sent.current) / 100,
+                calculatePercentage(email.opened, trackedSent) / 100,
               )
             }
           />

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
@@ -16,6 +16,10 @@ export type EmailStats = {
   name: string;
   previewUrl: string;
   sent: CurrentAndPrevious;
+  // Recipients we were allowed to measure, and the ones we were not. Open and
+  // click rates divide by trackedSent; sent stays whole.
+  trackedSent?: number;
+  notTracked?: number;
   opened: number;
   clicked: number;
   orders: number;
@@ -25,6 +29,8 @@ export type EmailStats = {
 };
 
 type OverviewSectionData = SectionData & {
+  trackedSent?: CurrentAndPrevious;
+  notTracked?: CurrentAndPrevious;
   opened: CurrentAndPrevious;
   clicked: CurrentAndPrevious;
   orders: CurrentAndPrevious;

--- a/mailpoet/changelog/2026-08-12-16-56-39-improved-automation-stats-and-the-stats-notification-emails.md
+++ b/mailpoet/changelog/2026-08-12-16-56-39-improved-automation-stats-and-the-stats-notification-emails.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Automation stats and the stats notification emails now base open and click rates on the recipients who allow email tracking, matching the change to the email listing and campaign stats. Both also show a tracking coverage figure when some recipients are not tracked. Unsubscribe and bounce rates are unchanged

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/OverviewStatisticsController.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/OverviewStatisticsController.php
@@ -41,6 +41,11 @@ class OverviewStatisticsController {
     $previousEmails = $this->automationTimeSpanController->getAutomationEmailsInTimeSpan($automation, $query->getCompareWithAfter(), $query->getCompareWithBefore(), $query->getVersionId());
     $data = [
       'sent' => ['current' => 0, 'previous' => 0],
+      // Recipients we were allowed to measure, and the ones we were not.
+      // Open and click rates divide by trackedSent; sent stays whole so the
+      // "emails sent" figure keeps meaning what it says.
+      'trackedSent' => ['current' => 0, 'previous' => 0],
+      'notTracked' => ['current' => 0, 'previous' => 0],
       'opened' => ['current' => 0, 'previous' => 0],
       'clicked' => ['current' => 0, 'previous' => 0],
       'orders' => ['current' => 0, 'previous' => 0],
@@ -67,6 +72,8 @@ class OverviewStatisticsController {
     );
     foreach ($currentStatistics as $newsletterId => $statistic) {
       $data['sent']['current'] += $statistic->getTotalSentCount();
+      $data['trackedSent']['current'] += $statistic->getTrackedSentCount();
+      $data['notTracked']['current'] += $statistic->getNotTrackedCount();
       $data['opened']['current'] += $statistic->getOpenCount();
       $data['clicked']['current'] += $statistic->getClickCount();
       $data['unsubscribed']['current'] += $statistic->getUnsubscribeCount();
@@ -77,6 +84,8 @@ class OverviewStatisticsController {
       $data['emails'][$newsletterId]['name'] = $newsletter ? $newsletter->getSubject() : '';
       $data['emails'][$newsletterId]['sent']['current'] = $statistic->getTotalSentCount();
       $data['emails'][$newsletterId]['sent']['previous'] = 0;
+      $data['emails'][$newsletterId]['trackedSent'] = $statistic->getTrackedSentCount();
+      $data['emails'][$newsletterId]['notTracked'] = $statistic->getNotTrackedCount();
       $data['emails'][$newsletterId]['opened'] = $statistic->getOpenCount();
       $data['emails'][$newsletterId]['clicked'] = $statistic->getClickCount();
       $data['emails'][$newsletterId]['unsubscribed'] = $statistic->getUnsubscribeCount();
@@ -96,6 +105,8 @@ class OverviewStatisticsController {
 
     foreach ($previousStatistics as $newsletterId => $statistic) {
       $data['sent']['previous'] += $statistic->getTotalSentCount();
+      $data['trackedSent']['previous'] += $statistic->getTrackedSentCount();
+      $data['notTracked']['previous'] += $statistic->getNotTrackedCount();
       $data['opened']['previous'] += $statistic->getOpenCount();
       $data['clicked']['previous'] += $statistic->getClickCount();
       $data['unsubscribed']['previous'] += $statistic->getUnsubscribeCount();

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
@@ -194,9 +194,12 @@ class AutomatedEmails extends SimpleWorker {
       $statistics = $row['statistics'];
       $newsletter = $row['newsletter'];
       $totalSentCount = $statistics->getTotalSentCount() ?: 1;
-      $clicked = ($statistics->getClickCount() * 100) / $totalSentCount;
-      $opened = ($statistics->getOpenCount() * 100) / $totalSentCount;
-      $machineOpened = ($statistics->getMachineOpenCount() * 100) / $totalSentCount;
+      // Same split as the per-campaign digest: opens and clicks over the
+      // recipients we could measure, unsubscribes and bounces over everyone.
+      $trackedSentCount = $statistics->getTrackedSentCount() ?: 1;
+      $clicked = ($statistics->getClickCount() * 100) / $trackedSentCount;
+      $opened = ($statistics->getOpenCount() * 100) / $trackedSentCount;
+      $machineOpened = ($statistics->getMachineOpenCount() * 100) / $trackedSentCount;
       $unsubscribed = ($statistics->getUnsubscribeCount() * 100) / $totalSentCount;
       $bounced = ($statistics->getBounceCount() * 100) / $totalSentCount;
       $context['newsletters'][] = [
@@ -210,6 +213,10 @@ class AutomatedEmails extends SimpleWorker {
         'machineOpened' => $machineOpened,
         'unsubscribed' => $unsubscribed,
         'bounced' => $bounced,
+        'notTracked' => $statistics->getNotTrackedCount(),
+        'trackingCoverage' => $statistics->getTotalSentCount() > 0
+          ? ($statistics->getTrackedSentCount() * 100) / $statistics->getTotalSentCount()
+          : 100,
         'subject' => $newsletter->getSubject(),
       ];
     }

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -153,9 +153,14 @@ class Worker {
   private function prepareContext(NewsletterEntity $newsletter, SendingQueueEntity $sendingQueue, ?NewsletterLinkEntity $link = null, array $settings = []) {
     $statistics = $this->newsletterStatisticsRepository->getStatistics($newsletter);
     $totalSentCount = $statistics->getTotalSentCount() ?: 1;
-    $clicked = ($statistics->getClickCount() * 100) / $totalSentCount;
-    $opened = ($statistics->getOpenCount() * 100) / $totalSentCount;
-    $machineOpened = ($statistics->getMachineOpenCount() * 100) / $totalSentCount;
+    // Opens and clicks are divided by the recipients we were allowed to
+    // measure; an opted-out subscriber can never register either. Unsubscribes
+    // and bounces keep the whole count, because those are recorded for
+    // opted-out people too. The ?: 1 guard is pre-existing.
+    $trackedSentCount = $statistics->getTrackedSentCount() ?: 1;
+    $clicked = ($statistics->getClickCount() * 100) / $trackedSentCount;
+    $opened = ($statistics->getOpenCount() * 100) / $trackedSentCount;
+    $machineOpened = ($statistics->getMachineOpenCount() * 100) / $trackedSentCount;
     $unsubscribed = ($statistics->getUnsubscribeCount() * 100) / $totalSentCount;
     $bounced = ($statistics->getBounceCount() * 100) / $totalSentCount;
     $subject = $sendingQueue->getNewsletterRenderedSubject();
@@ -189,6 +194,13 @@ class Worker {
       'machineOpened' => $machineOpened,
       'unsubscribed' => $unsubscribed,
       'bounced' => $bounced,
+      // The digest is a push, not a pull, so for many merchants this is the
+      // first place they will see the jumped open rate. The coverage line
+      // matters more here than anywhere else.
+      'notTracked' => $statistics->getNotTrackedCount(),
+      'trackingCoverage' => $statistics->getTotalSentCount() > 0
+        ? ($statistics->getTrackedSentCount() * 100) / $statistics->getTotalSentCount()
+        : 100,
       'subscribersLimitReached' => $this->subscribersFeature->check(),
       'hasValidApiKey' => $hasValidApiKey,
       'subscribersLimit' => $this->subscribersFeature->getSubscribersLimit(),

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Analytics/Controller/OverviewStatisticsControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Analytics/Controller/OverviewStatisticsControllerTest.php
@@ -1,0 +1,145 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\MailPoet\Analytics\Controller;
+
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
+use MailPoet\Automation\Integrations\MailPoet\Analytics\Controller\OverviewStatisticsController;
+use MailPoet\Automation\Integrations\MailPoet\Analytics\Entities\QueryWithCompare;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\StatisticsNewsletters;
+use MailPoet\Test\DataFactories\StatisticsOpens;
+use MailPoet\Test\DataFactories\Subscriber;
+
+/**
+ * Automation analytics must reach the same tracked-only denominator the email
+ * screens use, or a merchant sees two different open rates for one email and
+ * trusts neither.
+ */
+class OverviewStatisticsControllerTest extends \MailPoetTest {
+  /** @var OverviewStatisticsController */
+  private $testee;
+
+  public function _before() {
+    parent::_before();
+    $this->testee = $this->diContainer->get(OverviewStatisticsController::class);
+  }
+
+  public function testItReportsUntrackedAndTrackedSentAlongsideSent() {
+    $newsletter = $this->createAutomationEmail(4);
+    $this->createRecipients($newsletter, [true, true, true, false]);
+
+    $data = $this->getStatistics($newsletter);
+
+    verify($data['sent']['current'])->equals(4);
+    verify($data['notTracked']['current'])->equals(1);
+    verify($data['trackedSent']['current'])->equals(3);
+    verify($data['opened']['current'])->equals(2);
+
+    // 66.7%, not 50%.
+    verify(round(($data['opened']['current'] * 100) / $data['trackedSent']['current'], 1))->equals(66.7);
+
+    $email = array_values($data['emails'])[0];
+    verify($email['sent']['current'])->equals(4);
+    verify($email['notTracked'])->equals(1);
+    verify($email['trackedSent'])->equals(3);
+  }
+
+  public function testTheAutomationTotalsSumTheUntrackedCountsAcrossEmails() {
+    $first = $this->createAutomationEmail(4);
+    $second = $this->createAutomationEmail(2);
+    $this->createRecipients($first, [true, true, true, false]);
+    $this->createRecipients($second, [true, false]);
+
+    $data = $this->getStatistics($first, $second);
+
+    verify($data['sent']['current'])->equals(6);
+    verify($data['notTracked']['current'])->equals(2);
+    verify($data['trackedSent']['current'])->equals(4);
+  }
+
+  public function testWithNoOptOutsTheTrackedFigureMatchesTheSentFigure() {
+    $newsletter = $this->createAutomationEmail(3);
+    $this->createRecipients($newsletter, [true, true, true]);
+
+    $data = $this->getStatistics($newsletter);
+
+    verify($data['notTracked']['current'])->equals(0);
+    verify($data['trackedSent']['current'])->equals($data['sent']['current']);
+    verify($data['trackedSent']['current'])->equals(3);
+  }
+
+  /**
+   * The untracked figure must move with the window the same way sent does, or
+   * subtracting one from the other stops meaning anything.
+   */
+  public function testTheUntrackedFigureRespectsTheQueryWindow() {
+    $newsletter = $this->createAutomationEmail(2);
+    $this->createRecipients($newsletter, [true, false]);
+
+    $future = new \DateTimeImmutable('+10 days');
+    $data = $this->getStatistics($newsletter, null, $future, $future->modify('+20 days'));
+
+    verify($data['sent']['current'])->equals(0);
+    verify($data['notTracked']['current'])->equals(0);
+    verify($data['trackedSent']['current'])->equals(0);
+  }
+
+  private function createAutomationEmail(int $countProcessed): NewsletterEntity {
+    return (new Newsletter())
+      ->withType(NewsletterEntity::TYPE_AUTOMATION)
+      ->withSendingQueue(['count_processed' => $countProcessed, 'count_total' => $countProcessed])
+      ->create();
+  }
+
+  /**
+   * @param bool[] $trackingAllowedFlags
+   * @return SubscriberEntity[]
+   */
+  private function createRecipients(NewsletterEntity $newsletter, array $trackingAllowedFlags): array {
+    $subscribers = [];
+    foreach ($trackingAllowedFlags as $index => $trackingAllowed) {
+      $subscriber = (new Subscriber())->create();
+      (new StatisticsNewsletters($newsletter, $subscriber))
+        ->withTrackingAllowed($trackingAllowed)
+        ->create();
+      // Two tracked recipients on the first email open it.
+      if ($trackingAllowed && $index < 2) {
+        (new StatisticsOpens($newsletter, $subscriber))->create();
+      }
+      $subscribers[] = $subscriber;
+    }
+    return $subscribers;
+  }
+
+  private function getStatistics(
+    NewsletterEntity $newsletter,
+    ?NewsletterEntity $second = null,
+    ?\DateTimeImmutable $after = null,
+    ?\DateTimeImmutable $before = null
+  ): array {
+    $steps = [
+      new Step('trigger', Step::TYPE_TRIGGER, 'trigger', [], [new NextStep('email-1')]),
+      new Step('email-1', Step::TYPE_ACTION, SendEmailAction::KEY, ['email_id' => $newsletter->getId()], $second ? [new NextStep('email-2')] : []),
+    ];
+    if ($second) {
+      $steps[] = new Step('email-2', Step::TYPE_ACTION, SendEmailAction::KEY, ['email_id' => $second->getId()], []);
+    }
+    $automation = $this->tester->createAutomation('test', ...$steps);
+    $this->assertNotNull($automation);
+
+    $after = $after ?? new \DateTimeImmutable('-30 days');
+    $before = $before ?? new \DateTimeImmutable('+1 day');
+    $query = new QueryWithCompare(
+      $after,
+      $before,
+      $after->modify('-60 days'),
+      $after
+    );
+
+    return $this->testee->getStatisticsForAutomation($automation, $query);
+  }
+}

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/StatsNotificationTemplatesTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/StatsNotificationTemplatesTest.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\Workers\StatsNotifications;
+
+use MailPoet\Config\Renderer;
+
+/**
+ * WorkerTest and AutomatedEmailsTest both mock the Renderer, so nothing else
+ * actually renders these templates — a Twig error in one of them would ship
+ * unnoticed. This renders all six for real, with and without untracked
+ * recipients, so both branches of the coverage line are exercised.
+ */
+class StatsNotificationTemplatesTest extends \MailPoetTest {
+  /** @var Renderer */
+  private $renderer;
+
+  public function _before() {
+    parent::_before();
+    $this->renderer = $this->diContainer->get(Renderer::class);
+  }
+
+  public function testItRendersTheCampaignDigestWithACoverageLine() {
+    foreach (['emails/statsNotification.html', 'emails/statsNotificationGarden.html', 'emails/statsNotification.txt'] as $template) {
+      $output = $this->renderer->render($template, $this->campaignContext(37, 92.6));
+      verify($output)->stringContainsString('37');
+      verify($output)->stringContainsString('not tracked');
+    }
+  }
+
+  public function testItRendersTheCampaignDigestWithoutACoverageLineWhenNothingIsUntracked() {
+    foreach (['emails/statsNotification.html', 'emails/statsNotificationGarden.html', 'emails/statsNotification.txt'] as $template) {
+      $output = $this->renderer->render($template, $this->campaignContext(0, 100.0));
+      verify($output)->stringNotContainsString('not tracked');
+    }
+  }
+
+  public function testItRendersTheAutomatedDigestWithACoverageLine() {
+    $templates = [
+      'emails/statsNotificationAutomatedEmails.html',
+      'emails/statsNotificationAutomatedEmailsGarden.html',
+      'emails/statsNotificationAutomatedEmails.txt',
+    ];
+    foreach ($templates as $template) {
+      $output = $this->renderer->render($template, $this->automatedContext(12, 88.0));
+      verify($output)->stringContainsString('12');
+      verify($output)->stringContainsString('not tracked');
+    }
+  }
+
+  public function testItRendersTheAutomatedDigestWithoutACoverageLineWhenNothingIsUntracked() {
+    $templates = [
+      'emails/statsNotificationAutomatedEmails.html',
+      'emails/statsNotificationAutomatedEmailsGarden.html',
+      'emails/statsNotificationAutomatedEmails.txt',
+    ];
+    foreach ($templates as $template) {
+      $output = $this->renderer->render($template, $this->automatedContext(0, 100.0));
+      verify($output)->stringNotContainsString('not tracked');
+    }
+  }
+
+  private function campaignContext(int $notTracked, float $coverage): array {
+    return array_merge($this->statBlock($notTracked, $coverage), [
+      'subject' => 'Test campaign',
+      'preheader' => 'preheader',
+      'topLinkClicks' => 2,
+      'topLink' => 'https://example.com',
+      'linkSettings' => 'https://example.com/settings',
+      'linkStats' => 'https://example.com/stats',
+      'subscribersLimitReached' => false,
+      'hasValidApiKey' => true,
+      'subscribersLimit' => 1000,
+      'upgradeNowLink' => 'https://example.com/upgrade',
+      'blogName' => 'Test blog',
+      'recipientFirstName' => 'Admin',
+    ]);
+  }
+
+  private function automatedContext(int $notTracked, float $coverage): array {
+    return [
+      'linkSettings' => 'https://example.com/settings',
+      'blogName' => 'Test blog',
+      'recipientFirstName' => 'Admin',
+      'newsletters' => [
+        array_merge($this->statBlock($notTracked, $coverage), [
+          'linkStats' => 'https://example.com/stats',
+          'subject' => 'Test automation email',
+        ]),
+      ],
+    ];
+  }
+
+  private function statBlock(int $notTracked, float $coverage): array {
+    return [
+      'clicked' => 12.5,
+      'opened' => 40.0,
+      'machineOpened' => 3.0,
+      'unsubscribed' => 1.0,
+      'bounced' => 0.5,
+      'notTracked' => $notTracked,
+      'trackingCoverage' => $coverage,
+    ];
+  }
+}

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/StatsNotificationTemplatesTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/StatsNotificationTemplatesTest.php
@@ -24,6 +24,10 @@ class StatsNotificationTemplatesTest extends \MailPoetTest {
       $output = $this->renderer->render($template, $this->campaignContext(37, 92.6));
       verify($output)->stringContainsString('37');
       verify($output)->stringContainsString('not tracked');
+      // The coverage line is built with Twig's |replace, not sprintf, so a
+      // doubled %% would print literally. Caught exactly that once.
+      verify($output)->stringContainsString('92.6%');
+      verify($output)->stringNotContainsString('%%');
     }
   }
 
@@ -44,6 +48,8 @@ class StatsNotificationTemplatesTest extends \MailPoetTest {
       $output = $this->renderer->render($template, $this->automatedContext(12, 88.0));
       verify($output)->stringContainsString('12');
       verify($output)->stringContainsString('not tracked');
+      verify($output)->stringContainsString('88.0%');
+      verify($output)->stringNotContainsString('%%');
     }
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
@@ -23,6 +23,7 @@ use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\NewsletterLink as NewsletterLinkFactory;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\StatisticsClicks as StatisticsClicksFactory;
+use MailPoet\Test\DataFactories\StatisticsNewsletters as StatisticsNewslettersFactory;
 use MailPoet\Test\DataFactories\StatisticsOpens as StatisticsOpensFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
@@ -195,6 +196,65 @@ class WorkerTest extends \MailPoetTest {
       );
 
     $this->statsNotifications->process();
+  }
+
+  /**
+   * Pins both sides. Asserting that all five rates moved would be wrong, and
+   * asserting that none moved would pass on a no-op — only open and click rates
+   * are based on the recipients we could measure. Unsubscribes and bounces are
+   * recorded for opted-out people too, so their denominator stays whole.
+   *
+   * Fixture: 5 sent, 3 clicks, 2 opens, 1 unsubscribe, 0 bounces. With one
+   * recipient untracked the tracked denominator is 4.
+   */
+  public function testItBasesOnlyOpenAndClickRatesOnTrackedRecipients() {
+    $this->createRecipientRows([true, true, true, true, false]);
+
+    $this->renderer->expects($this->exactly(2)) // html + text template
+      ->method('render')
+      ->with(
+        $this->anything(),
+        $this->callback(function($context) {
+          verify(round($context['clicked'], 2))->equals(75.0); // 3 of 4, not 3 of 5
+          verify(round($context['opened'], 2))->equals(50.0); // 2 of 4, not 2 of 5
+          verify(round($context['unsubscribed'], 2))->equals(20.0); // 1 of 5, unchanged
+          verify(round($context['bounced'], 2))->equals(0.0); // unchanged
+          verify($context['notTracked'])->equals(1);
+          verify(round($context['trackingCoverage'], 1))->equals(80.0);
+          return true;
+        })
+      );
+
+    $this->statsNotifications->process();
+  }
+
+  public function testItLeavesTheRatesAloneWhenEveryRecipientIsTracked() {
+    $this->createRecipientRows([true, true, true, true, true]);
+
+    $this->renderer->expects($this->exactly(2)) // html + text template
+      ->method('render')
+      ->with(
+        $this->anything(),
+        $this->callback(function($context) {
+          verify(round($context['clicked'], 2))->equals(60.0);
+          verify(round($context['opened'], 2))->equals(40.0);
+          verify($context['notTracked'])->equals(0);
+          return true;
+        })
+      );
+
+    $this->statsNotifications->process();
+  }
+
+  /** @param bool[] $trackingAllowedFlags */
+  private function createRecipientRows(array $trackingAllowedFlags): void {
+    $newsletter = $this->newslettersRepository->findOneById($this->newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    foreach ($trackingAllowedFlags as $trackingAllowed) {
+      (new StatisticsNewslettersFactory($newsletter, (new SubscriberFactory())->create()))
+        ->withTrackingAllowed($trackingAllowed)
+        ->create();
+    }
   }
 
   public function testAddsWPUrlsToContext() {

--- a/mailpoet/views/emails/statsNotification.html
+++ b/mailpoet/views/emails/statsNotification.html
@@ -374,6 +374,21 @@
       </table>
     </td>
   </tr>
+  <% if notTracked > 0 %>
+    <tr>
+      <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+        <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+          <tbody>
+          <tr>
+            <td class="mailpoet_paragraph mailpoet_padded_side" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#7f7f7f;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px;padding-left:20px;padding-right:20px;padding-bottom:10px">
+              <%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(trackingCoverage), '%2$s': notTracked}) %>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+  <% endif %>
   <% if topLinkClicks > 0 %>
     <tr>
       <td class="mailpoet_content" align="center" style="border-collapse:collapse">

--- a/mailpoet/views/emails/statsNotification.html
+++ b/mailpoet/views/emails/statsNotification.html
@@ -381,7 +381,7 @@
           <tbody>
           <tr>
             <td class="mailpoet_paragraph mailpoet_padded_side" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#7f7f7f;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px;padding-left:20px;padding-right:20px;padding-bottom:10px">
-              <%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(trackingCoverage), '%2$s': notTracked}) %>
+              <%= __('Tracking coverage: %1$s%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(trackingCoverage), '%2$s': notTracked}) %>
             </td>
           </tr>
           </tbody>

--- a/mailpoet/views/emails/statsNotification.txt
+++ b/mailpoet/views/emails/statsNotification.txt
@@ -17,7 +17,7 @@
 <%= __('Unsubscribed') %>: <%= stats_number_format_i18n(unsubscribed) %>%
 <%= __('Bounced') %>: <%= stats_number_format_i18n(bounced) %>%
 <% if notTracked > 0 %>
-<%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(trackingCoverage), '%2$s': notTracked}) %>
+<%= __('Tracking coverage: %1$s%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(trackingCoverage), '%2$s': notTracked}) %>
 <% endif %>
 
 <%= __('View full campaign report') %>
@@ -53,7 +53,7 @@
 <%= stats_number_format_i18n(bounced) %>% <%= __('bounced') %>
 
 <% if notTracked > 0 %>
-<%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(trackingCoverage), '%2$s': notTracked}) %>
+<%= __('Tracking coverage: %1$s%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(trackingCoverage), '%2$s': notTracked}) %>
 <% endif %>
 
 <% if topLinkClicks > 0 %>

--- a/mailpoet/views/emails/statsNotification.txt
+++ b/mailpoet/views/emails/statsNotification.txt
@@ -16,6 +16,9 @@
 <%= __('Machine-opened') %>: <%= stats_number_format_i18n(machineOpened) %>%
 <%= __('Unsubscribed') %>: <%= stats_number_format_i18n(unsubscribed) %>%
 <%= __('Bounced') %>: <%= stats_number_format_i18n(bounced) %>%
+<% if notTracked > 0 %>
+<%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(trackingCoverage), '%2$s': notTracked}) %>
+<% endif %>
 
 <%= __('View full campaign report') %>
   <%= linkStats|raw %>
@@ -48,6 +51,10 @@
 <%= stats_number_format_i18n(unsubscribed) %>% <%= __('unsubscribed') %>
 
 <%= stats_number_format_i18n(bounced) %>% <%= __('bounced') %>
+
+<% if notTracked > 0 %>
+<%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(trackingCoverage), '%2$s': notTracked}) %>
+<% endif %>
 
 <% if topLinkClicks > 0 %>
 <%= __('Most clicked link') %>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.html
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.html
@@ -279,6 +279,21 @@
       </table>
     </td>
   </tr>
+  <% if newsletter.notTracked > 0 %>
+  <tr>
+    <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+      <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+        <tbody>
+        <tr>
+          <td class="mailpoet_paragraph mailpoet_padded_side" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#7f7f7f;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px;padding-left:20px;padding-right:20px;padding-bottom:10px">
+            <%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(newsletter.trackingCoverage), '%2$s': newsletter.notTracked}) %>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </td>
+  </tr>
+  <% endif %>
 <% endfor %>
 
 <tr>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.html
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.html
@@ -286,7 +286,7 @@
         <tbody>
         <tr>
           <td class="mailpoet_paragraph mailpoet_padded_side" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#7f7f7f;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px;padding-left:20px;padding-right:20px;padding-bottom:10px">
-            <%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(newsletter.trackingCoverage), '%2$s': newsletter.notTracked}) %>
+            <%= __('Tracking coverage: %1$s%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(newsletter.trackingCoverage), '%2$s': newsletter.notTracked}) %>
           </td>
         </tr>
         </tbody>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.txt
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.txt
@@ -20,6 +20,9 @@
 <%= __('Machine-opened') %>: <%= stats_number_format_i18n(newsletter.machineOpened) %>%
 <%= __('Unsubscribed') %>: <%= stats_number_format_i18n(newsletter.unsubscribed) %>%
 <%= __('Bounced') %>: <%= stats_number_format_i18n(newsletter.bounced) %>%
+<% if newsletter.notTracked > 0 %>
+<%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(newsletter.trackingCoverage), '%2$s': newsletter.notTracked}) %>
+<% endif %>
 
 <%= __('View automation report') %>
   <%= newsletter.linkStats|raw %>
@@ -36,6 +39,9 @@
   <%= stats_number_format_i18n(newsletter.machineOpened) %>% <%= __('machine-opened') %>
   <%= stats_number_format_i18n(newsletter.unsubscribed) %>% <%= __('unsubscribed') %>
   <%= stats_number_format_i18n(newsletter.bounced) %>% <%= __('bounced') %>
+<% if newsletter.notTracked > 0 %>
+  <%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(newsletter.trackingCoverage), '%2$s': newsletter.notTracked}) %>
+<% endif %>
   <%= __('View all stats') %>
     <%= newsletter.linkStats|raw %>
 <% endfor %>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.txt
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.txt
@@ -21,7 +21,7 @@
 <%= __('Unsubscribed') %>: <%= stats_number_format_i18n(newsletter.unsubscribed) %>%
 <%= __('Bounced') %>: <%= stats_number_format_i18n(newsletter.bounced) %>%
 <% if newsletter.notTracked > 0 %>
-<%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(newsletter.trackingCoverage), '%2$s': newsletter.notTracked}) %>
+<%= __('Tracking coverage: %1$s%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(newsletter.trackingCoverage), '%2$s': newsletter.notTracked}) %>
 <% endif %>
 
 <%= __('View automation report') %>
@@ -40,7 +40,7 @@
   <%= stats_number_format_i18n(newsletter.unsubscribed) %>% <%= __('unsubscribed') %>
   <%= stats_number_format_i18n(newsletter.bounced) %>% <%= __('bounced') %>
 <% if newsletter.notTracked > 0 %>
-  <%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(newsletter.trackingCoverage), '%2$s': newsletter.notTracked}) %>
+  <%= __('Tracking coverage: %1$s%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(newsletter.trackingCoverage), '%2$s': newsletter.notTracked}) %>
 <% endif %>
   <%= __('View all stats') %>
     <%= newsletter.linkStats|raw %>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmailsGarden.html
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmailsGarden.html
@@ -291,6 +291,21 @@
     </table>
   </td>
 </tr>
+<% if newsletter.notTracked > 0 %>
+<tr>
+  <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td class="mailpoet_paragraph mailpoet_padded_side" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#7f7f7f;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px;padding-left:20px;padding-right:20px;padding-bottom:10px">
+          <%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(newsletter.trackingCoverage), '%2$s': newsletter.notTracked}) %>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+<% endif %>
 <tr>
   <td class="mailpoet_spacer" height="48" valign="top" style="border-collapse:collapse"></td>
 </tr>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmailsGarden.html
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmailsGarden.html
@@ -298,7 +298,7 @@
       <tbody>
       <tr>
         <td class="mailpoet_paragraph mailpoet_padded_side" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#7f7f7f;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px;padding-left:20px;padding-right:20px;padding-bottom:10px">
-          <%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(newsletter.trackingCoverage), '%2$s': newsletter.notTracked}) %>
+          <%= __('Tracking coverage: %1$s%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(newsletter.trackingCoverage), '%2$s': newsletter.notTracked}) %>
         </td>
       </tr>
       </tbody>

--- a/mailpoet/views/emails/statsNotificationGarden.html
+++ b/mailpoet/views/emails/statsNotificationGarden.html
@@ -259,7 +259,7 @@
       <tbody>
       <tr>
         <td class="mailpoet_paragraph mailpoet_padded_side" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#7f7f7f;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px;padding-left:20px;padding-right:20px;padding-bottom:10px">
-          <%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(trackingCoverage), '%2$s': notTracked}) %>
+          <%= __('Tracking coverage: %1$s%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(trackingCoverage), '%2$s': notTracked}) %>
         </td>
       </tr>
       </tbody>

--- a/mailpoet/views/emails/statsNotificationGarden.html
+++ b/mailpoet/views/emails/statsNotificationGarden.html
@@ -252,6 +252,21 @@
     </table>
   </td>
 </tr>
+<% if notTracked > 0 %>
+<tr>
+  <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td class="mailpoet_paragraph mailpoet_padded_side" style="word-break:break-word;word-wrap:break-word;text-align:center;border-collapse:collapse;color:#7f7f7f;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px;padding-left:20px;padding-right:20px;padding-bottom:10px">
+          <%= __('Tracking coverage: %1$s%%. %2$s of your recipients are not tracked, so open and click rates are based on the rest.')|replace({'%1$s': stats_number_format_i18n(trackingCoverage), '%2$s': notTracked}) %>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+<% endif %>
 <tr>
   <td class="mailpoet_content" align="center" style="border-collapse:collapse">
     <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">


### PR DESCRIPTION
## Description

Second half of STOMAIL-8310. #7038 rebased the **email** open and click rates on the recipients we were allowed to measure; this does the same for the two remaining surfaces: **automation stats** and the **stats notification emails**.

> **Stacked on #7038.** Base branch is `add/stomail-8310-tracked-only-rates`, not `trunk` — everything here depends on `getTrackedSentCount()` / `getNotTrackedCount()`, which #7038 introduces. Merge #7038 first, and this retargets to `trunk` on its own.
>
> #7038 is the PR with the payload *and* its first two consumers, so it stands alone. **This one must not ship without it.**

The issue asks for the change to apply "consistently across Email stats and Automation stats". There are seven rate calculation sites in total; #7038 covered the two email screens, this covers the other five.

**The stats notification digest matters more than it looks.** It is a push, not a pull. For a lot of merchants it will be the first place they see the jumped open rate, before they ever open the plugin or read a changelog — so the coverage line lands there too.

Same split as #7038: **only open and click rates move.** Unsubscribes and bounces keep the whole denominator in both workers, because both are recorded for opted-out people.

## Code review notes

**`OverviewStatisticsController` gains `trackedSent` and `notTracked`**, as automation totals and per email, taken from the same statistics objects it already reads. `sent` itself stays whole — "emails sent" should keep meaning what it says.

**Front end divides by `trackedSent`** in the overview cards, the email rows and the click badge. All three fall back to `sent` when `trackedSent` is absent, so an older cached payload cannot break the page. The badge now matches the rate printed next to it.

**Both notification workers** switch `clicked` / `opened` / `machineOpened` to `getTrackedSentCount() ?: 1` and leave `unsubscribed` / `bounced` on the full count. The `?: 1` guard shape is pre-existing and kept deliberately.

**Six templates** gain a coverage line, rendered only when `notTracked > 0`.

**Two things worth knowing about the tests:**

1. **There was no test for `OverviewStatisticsController` at all** — that directory held only `AutomationTimeSpanControllerTest`. This adds one. The window test is the one that matters: it keeps the untracked figure moving with the same query window as the sent figure, since the two are subtracted from each other.
2. **Nothing rendered the notification templates.** `WorkerTest` and `AutomatedEmailsTest` both mock the `Renderer` and only assert *which* template was asked for. A Twig syntax error in any of the six would have shipped unnoticed. `StatsNotificationTemplatesTest` now renders all six for real, in both the coverage and no-coverage branches. Verified it is a real guard: breaking one tag in `statsNotificationAutomatedEmailsGarden.html` gives `[Twig^[rror\SyntaxError] Unexpected token "operator" of value "<"` rather than a pass.

## QA notes

**The rendering check found a real bug, which is why it is in here.** The coverage line was first written with an escaped `

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8310-tracked-rates-automations-and-emails)

_The latest successful build from `add/stomail-8310-tracked-rates-automations-and-emails` will be used. If none is available, the link won't work._