### PR TITLE
Retry tool downloads so a GitHub hiccup cannot fail CI

### DIFF
--- a/mailpoet/tools/install.php
+++ b/mailpoet/tools/install.php
@@ -31,21 +31,54 @@ if (!file_exists($vendorDir)) {
   mkdir($vendorDir);
 }
 
-function downloadFile($url, $filePath, $fileInfoPath) {
+/**
+ * Every CI job whose container PHP differs from the one that built the workspace
+ * re-downloads at least one of these, because the cached copy records a different
+ * URL. On PHP 8.4+ that is php-scoper, on every acceptance run. A single hiccup
+ * reaching GitHub therefore killed the whole job before a test had run, so the
+ * download is retried the way the CircleCI config already retries docker pulls.
+ */
+function downloadFile($url, $filePath, $fileInfoPath, $attempts = 5) {
   fwrite(STDERR, "Downloading '$url'...");
   if (file_exists($filePath) && file_exists($fileInfoPath) && file_get_contents($fileInfoPath) === $url) {
     fwrite(STDERR, " skipped (already exists).\n");
     return;
   }
 
-  $resource = fopen($url, 'r');
-  if ($resource === false) {
-    throw new \RuntimeException("Could not connect to '$url'");
+  // Without a timeout a stalled connection hangs until CI kills the whole job.
+  $context = stream_context_create([
+    'http' => [
+      'timeout' => 30,
+      'follow_location' => 1,
+      'user_agent' => 'mailpoet-tools-installer',
+    ],
+  ]);
+
+  $lastError = 'unknown error';
+  for ($attempt = 1; $attempt <= $attempts; $attempt++) {
+    $contents = @file_get_contents($url, false, $context);
+
+    // Write only once the body is fully in hand. Streaming straight to disk could
+    // leave a truncated phar behind *and* record it as valid in the .info file,
+    // so every later run would skip the download and use the broken copy.
+    if (is_string($contents) && $contents !== '') {
+      file_put_contents($filePath, $contents);
+      file_put_contents($fileInfoPath, $url);
+      chmod($filePath, 0755);
+      fwrite(STDERR, " done.\n");
+      return;
+    }
+
+    $error = error_get_last();
+    $lastError = isset($error['message']) ? $error['message'] : 'empty response';
+    if ($attempt < $attempts) {
+      $delay = $attempt * 2;
+      fwrite(STDERR, " attempt $attempt/$attempts failed, retrying in {$delay}s...");
+      sleep($delay);
+    }
   }
-  file_put_contents($filePath, $resource);
-  file_put_contents($fileInfoPath, $url);
-  chmod($filePath, 0755);
-  fwrite(STDERR, " done.\n");
+
+  throw new \RuntimeException("Could not download '$url' after $attempts attempts. Last error: $lastError");
 }
 
 // download all tools


### PR DESCRIPTION
## Description

The four acceptance jobs have been failing on `trunk` and on every open PR. They fail in **`Ensure correct versions of tools`**, before a single test runs:

```
Downloading 'https://github.com/composer/composer/releases/download/2.10.0/composer.phar'... skipped (already exists).
Downloading 'https://github.com/humbug/php-scoper/releases/download/0.18.19/php-scoper.phar'...
Warning: fopen(...): Failed to open stream: HTTP request failed! in /project/tools/install.php on line 41
Fatal error: Uncaught RuntimeException: Could not connect to '...php-scoper.phar'
```

### Why php-scoper is downloaded on every single acceptance run

`tools/install.php` picks the php-scoper version from the PHP it is running under:

```php
$phpScoperUrl = PHP_VERSION_ID >= 80400 ? $phpScoperVersion : $legacyPhpScoperVersion;
```

The `build` job runs on an older PHP, so the workspace it hands over carries **0.17.2**, and `php-scoper.phar.info` records that URL. The acceptance jobs then re-run `install.php` **inside the acceptance container**, which is `mailpoet/wordpress:8.4-cli`. That needs **0.18.19**, the `.info` URL does not match, and the phar is fetched from GitHub again.

The acceptance jobs use `attach_workspace` rather than `restore_cache`, so no cache can help. **Every acceptance job of every pipeline downloads this file live.**

That is why `acceptance_oldest` passes while `acceptance_latest` fails, and why `composer.phar` is always "skipped" — its URL is the same on every PHP version, so it always matches.

### Why that killed the build

The download had **no retry and no timeout**. One refused connection ended the job. With four acceptance jobs, each with many parallel containers, all fetching the same unauthenticated GitHub release asset on every run, hitting a hiccup stopped being unlikely.

The artifact itself is fine — it returns HTTP 200 and 2,033,358 bytes, and a plain `fopen()` of that URL succeeds from outside CI. Nothing is wrong with the release, the version pin, or the code. This is purely an unguarded network call in a setup step.

## Code review notes

Retry five times with a widening delay (2s, 4s, 6s, 8s), matching what `.circleci/config.yml` already does a few steps earlier for docker pulls ("Pull docker images with 3 retries") and container creation ("we do it explicitly with one retry"). Adds a 30s timeout so a stalled connection cannot hang the job until CI kills it.

The body is now buffered before anything is written. The previous version streamed the resource straight to disk and then wrote the `.info` file unconditionally, so a connection dropping mid-read could leave a truncated phar on disk **recorded as valid** — after which every later run would skip the download and use the broken copy. Secondary to the reported failure, but it is the more unpleasant of the two.

A `user_agent` is also set, since PHP sends none by default.

The retry count is a parameter so it can be exercised in isolation without waiting on real backoff.

## QA notes

Verified by running the modified script directly.

**Happy path** — cold run downloads all four tools, second run skips all four:

```
Downloading '.../composer.phar'... done.
Downloading '.../0.17.2/php-scoper.phar'... done.
Downloading '.../v2.9.4/tracy.phar'... done.
Downloading '.../v2.11.1/tracy.phar'... done.
# re-run
Downloading '.../composer.phar'... skipped (already exists).
...
```

**Failure path**, unreachable host, 3 attempts:

```
Downloading '...'... attempt 1/3 failed, retrying in 2s... attempt 2/3 failed, retrying in 4s...
threw after 6.0s: Could not download '...' after 3 attempts. Last error: ... getaddrinfo ... failed
  file written?  no
  .info written? no
```

**Failure path**, real GitHub 404, 2 attempts: same handling, and `.info` is not written, so the cache is not poisoned.

`php -l` clean. `phpcs` against `MailPoet/free-ruleset.xml` exits 0.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

**This invalidates the tools cache once.** The CircleCI key is `tools-{{ checksum "tools/install.php" }}`, so the first pipeline after merge re-downloads all four tools on the jobs that use that cache. That is the intended one-off cost, and the retry added here is what makes it safe.

This does **not** stop php-scoper being re-downloaded on every acceptance run — it only stops that download being able to fail the build. Removing the repeated download would mean either keying the cache on the container PHP version, or shipping both php-scoper versions under separate names the way `tracy.phar` / `tracy-legacy.phar` already are. Both are larger changes and neither is needed to get CI green.

## Tasks

- [ ] I have added a changelog entry — n/a, build tooling only, no user-facing change
- [x] I followed best practices for translations — n/a
- [x] I added sufficient test coverage — verified by direct execution, see QA notes; this file has no test harness
- [x] I embraced TypeScript — n/a, PHP build script

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/ci-tools-download-retry)

_The latest successful build from `fix/ci-tools-download-retry` will be used. If none is available, the link won't work._