### PR TITLE
Fix URL navigation overwriting deep links on the campaign stats page

### DIFF
--- a/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
@@ -171,7 +171,9 @@ export function CampaignStatsPage() {
         <Tabs
           activeKey={activeTab}
           onSwitch={(tabKey) => {
-            navigate(getStatsTabUrl(newsletter.id, tabKey));
+            if (tabKey !== requestedTab) {
+              navigate(getStatsTabUrl(newsletter.id, tabKey));
+            }
           }}
         >
           <Tab key="clicked" title={__('Clicked Links', 'mailpoet')}>

--- a/mailpoet/changelog/2026-08-13-09-31-23-fixed-campaign-stats-no-longer-drop-link-filter-deep-lin.md
+++ b/mailpoet/changelog/2026-08-13-09-31-23-fixed-campaign-stats-no-longer-drop-link-filter-deep-lin.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Campaign stats no longer drop link filter deep links when switching tabs


### PR DESCRIPTION
## Description

The campaign stats page dropped extra URL parts (for example `engagement/filter[link=1]`) when the active tab changed through the URL.

The `Tabs` component fires `onSwitch` even when the tab change comes from a URL update, not a user click. The page then navigated to the plain tab URL again, which removed the deep link parts before the tab content could read them.

## Code review notes

_N/A_

## QA notes

See the linked PR. 

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8359-stats-tab-navigation)

_The latest successful build from `fix/stomail-8359-stats-tab-navigation` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->