### PR TITLE
Require WordPress 7.0 and test up to 7.1

### DIFF
--- a/mailpoet/changelog/2026-08-18-10-39-06-updated-bump-the-minimum-required-wordpress-version-to-70-.md
+++ b/mailpoet/changelog/2026-08-18-10-39-06-updated-bump-the-minimum-required-wordpress-version-to-70-.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Bump the minimum required WordPress version to 7.0 and tested up to version to 7.1

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -7,7 +7,7 @@
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
  * Author URI: https://www.mailpoet.com
- * Requires at least: 6.9
+ * Requires at least: 7.0
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
@@ -27,7 +27,7 @@ $mailpoetPlugin = [
   'initializer' => dirname(__FILE__) . '/mailpoet_initializer.php',
 ];
 
-const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.9'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '7.0'; // L-1 version, not the latest
 const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.9'; // L-1 version, not the latest
 
 

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -1,8 +1,8 @@
 === MailPoet - Newsletters, Email Marketing, and Automation ===
 Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
-Requires at least: 6.9
-Tested up to: 7.0
+Requires at least: 7.0
+Tested up to: 7.1
 Stable tag: 5.35.1
 Requires PHP: 7.4
 License: GPLv3


### PR DESCRIPTION
## Description

WordPress 7.1 is released tomorrow. We publicly support the last two WordPress versions, so this moves the support window from 6.9–7.0 to 7.0–7.1:

- `Requires at least: 7.0` and `Tested up to: 7.1` in `readme.txt`
- `Requires at least: 7.0` header and `MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '7.0'` in `mailpoet.php`

## Code review notes

The minimum is bumped together with "Tested up to" because `MAILPOET_MINIMUM_REQUIRED_WP_VERSION` is documented as the L-1 version. Leaving it at 6.9 would widen the public support window to three versions.

No CI change here on purpose. The `wordpress_version:` pins on the `*_oldest` jobs look like they should follow the new minimum, but `.github/workflows/update-wordpress-and-plugins.yml` rewrites them every Monday to the L-1 release derived from the published `wordpress` Docker tags, so a hand-edit would be reverted until the 7.1 images land. Same for the image default in `tests_env/docker/docker-compose.yml`.

No functional code changed — `MAILPOET_MINIMUM_REQUIRED_WP_VERSION` only feeds the existing activation guard in `mailpoet.php`, which now blocks activation on WP 6.9.

## QA notes

_N/A_ — metadata only.

MailPoet was already tested against the WP 7.1 RCs, so this PR only records that in the plugin metadata; no new compatibility testing was run for it.

## Linked PRs

MailPoet Premium: https://github.com/mailpoet/mailpoet-premium/pull/1127

## Linked tickets

_N/A_

## After-merge notes

This is meant to ship in 5.36.0. The original 5.36.0 release PRs were closed, so 5.36.0 needs to be re-prepared from `trunk` after this merges — otherwise the release goes out still declaring WP 7.0.

Once the `wordpress:7.1.x-php8.4` images are published, `update-wordpress-and-plugins` can be dispatched manually instead of waiting for the Monday run, so the `*_oldest` CI jobs move from 6.9.4 to 7.0.4.

Users on WP 6.9 stop receiving plugin updates once this is released.

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/bump-wordpress-tested-up-to-7-1)

_The latest successful build from `update/bump-wordpress-tested-up-to-7-1` will be used. If none is available, the link won't work._