### PR TITLE
Show drafts, scheduled and sending emails in the Recent tab

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -190,6 +190,8 @@ addFilter(
 );
 
 // Also list draft, scheduled and sending emails. They all use the `draft` post status.
+// Keep the query in sync with the preloaded route in EditorPageRenderer.php. If the two
+// differ, the preloaded data is not used and the editor makes an extra request.
 addFilter(
   'woocommerce_email_editor_recent_emails_query',
   'mailpoet/email-editor-integration',

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -10,7 +10,10 @@ import { store as editorStore } from '@wordpress/editor';
 import { store as noticesStore } from '@wordpress/notices';
 import { registerPlugin } from '@wordpress/plugins';
 import { MailPoet } from 'mailpoet';
-import type { EmailContentValidationRule } from '@woocommerce/email-editor/build-types/store';
+import type {
+  EmailContentValidationRule,
+  RecentEmailsQuery,
+} from '@woocommerce/email-editor/build-types/store';
 import { registerTranslations } from 'common';
 import { withSatismeterSurvey } from './satismeter-survey';
 import './index.scss';
@@ -183,6 +186,18 @@ addFilter(
     const [, post] = args;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return post?.mailpoet_data?.subject || ''; // use MailPoet subject as title
+  },
+);
+
+// Also list draft, scheduled and sending emails. They all use the `draft` post status.
+addFilter(
+  'woocommerce_email_editor_recent_emails_query',
+  'mailpoet/email-editor-integration',
+  (query: RecentEmailsQuery, postType: string) => {
+    if (postType !== MAILPOET_EMAIL_POST_TYPE) {
+      return query;
+    }
+    return { ...query, status: 'publish,sent,draft' };
   },
 );
 

--- a/mailpoet/changelog/2026-08-19-14-34-55-improved-recent-category-of-the-email-template-modal-now-li.md
+++ b/mailpoet/changelog/2026-08-19-14-34-55-improved-recent-category-of-the-email-template-modal-now-li.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Recent category of the email template modal now lists draft, scheduled and sending emails

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -299,6 +299,9 @@ JS;
     if (is_string($templateSlug) && $templateSlug !== '') {
       $routes[] = '/wp/v2/templates/lookup?slug=' . $templateSlug;
     } else {
+      // Keep the query in sync with the woocommerce_email_editor_recent_emails_query filter
+      // in assets/js/src/mailpoet-email-editor-integration/index.ts. If the two differ,
+      // the editor asks for a different path and the preloaded data is not used.
       $routes[] = '/wp/v2/mailpoet_email?context=edit&per_page=30&status=publish,sent,draft';
     }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -299,7 +299,7 @@ JS;
     if (is_string($templateSlug) && $templateSlug !== '') {
       $routes[] = '/wp/v2/templates/lookup?slug=' . $templateSlug;
     } else {
-      $routes[] = '/wp/v2/mailpoet_email?context=edit&per_page=30&status=publish,sent';
+      $routes[] = '/wp/v2/mailpoet_email?context=edit&per_page=30&status=publish,sent,draft';
     }
 
     // Preload personalization tags for automation emails

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -53,7 +53,7 @@
     "@woocommerce/components": "^13.1.0",
     "@woocommerce/currency": "^4.3.0",
     "@woocommerce/date": "^4.3.0",
-    "@woocommerce/email-editor": "2.3.0",
+    "@woocommerce/email-editor": "2.4.0",
     "@wordpress/a11y": "^4.43.0",
     "@wordpress/api-fetch": "^7.43.0",
     "@wordpress/block-editor": "^15.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0(lodash@4.18.1)
       '@woocommerce/email-editor':
-        specifier: 2.3.0
-        version: 2.3.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))
+        specifier: 2.4.0
+        version: 2.4.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))
       '@wordpress/a11y':
         specifier: ^4.43.0
         version: 4.44.0
@@ -4366,8 +4366,8 @@ packages:
     peerDependencies:
       lodash: ^4.17.0
 
-  '@woocommerce/email-editor@2.3.0':
-    resolution: {integrity: sha512-CfX7RuofzT4hVkBKlucBoJnWOE5d+kO3wCf2ieTLATFit2dlCcMsldWP6aIMr2A5/HKWl6JrSbPTGqRcrxqouw==, tarball: https://registry.npmjs.org/@woocommerce/email-editor/-/email-editor-2.3.0.tgz}
+  '@woocommerce/email-editor@2.4.0':
+    resolution: {integrity: sha512-1EF0SoSc3rzJIBmjCZp19j3wbkiTVrrn2Dhuo6j6zagPYShl3XI5LWWSMIbx0m/Fnu1Mus4kcAzvKoZFtSg6bQ==, tarball: https://registry.npmjs.org/@woocommerce/email-editor/-/email-editor-2.4.0.tgz}
 
   '@woocommerce/navigation@8.2.0':
     resolution: {integrity: sha512-joAbrzdhrnWf91kEwuNO3hzT0IiUuh8SNOs0Qbth/heZaN+SixA5yJ98UqEHNa2Mitjm5BTC4M0Qk7X+I8uUvQ==}
@@ -17672,7 +17672,7 @@ snapshots:
       moment-timezone: 0.5.45
       qs: 6.15.2
 
-  '@woocommerce/email-editor@2.3.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))':
+  '@woocommerce/email-editor@2.4.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/api-fetch': 7.44.0
       '@wordpress/base-styles': 6.20.0


### PR DESCRIPTION
## Description

The "Recent" category of the template selection modal only listed sent emails, so a draft could not be reused. This adds a handler for the `woocommerce_email_editor_recent_emails_query` filter and asks for the `publish`, `sent` and `draft` post statuses.

MailPoet keeps the WP post in `draft` while the newsletter is a draft, scheduled or sending, and moves it to `sent` after sending. So `draft` covers all three statuses.

## Code review notes

The filter is added to the email editor package in https://github.com/woocommerce/woocommerce/pull/67859.

The filter is skipped for other post types, because WooCommerce transactional emails use the same editor on the same site.

## QA notes

1. Create a draft, a scheduled and a sent email.
2. Create a new email with the block editor and open the "Recent" category.
3. All three are listed. Trashed, automation and empty emails are not.
4. The email you are editing is not listed as a starting point for itself.

## Linked PRs

_N/A_

## Linked tickets

- [STOMAIL-8372: Show drafts, scheduled and sending emails in the "Recent" tab](https://linear.app/a8c/issue/STOMAIL-8372/show-drafts-scheduled-and-sending-emails-in-the-recent-tab)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <!-- Before screenshot here --> | <!-- After screenshot here --> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8372-show-drafts-scheduled-and-sending-emails-in-the-recent-tab)

_The latest successful build from `stomail-8372-show-drafts-scheduled-and-sending-emails-in-the-recent-tab` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->