### PR TITLE
Resolve store_address and other WC placeholders in MailPoet emails

### DIFF
--- a/mailpoet/changelog/2026-08-20-09-36-31-fixed-show-the-actual-store-address-and-email-in-woocomm.md
+++ b/mailpoet/changelog/2026-08-20-09-36-31-fixed-show-the-actual-store-address-and-email-in-woocomm.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Show the actual store address and email in WooCommerce emails customized with MailPoet, instead of a raw placeholder

--- a/mailpoet/lib/Migrations/App/Migration_20260826_120000_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20260826_120000_App.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Migrator\AppMigration;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\WooCommerce\TransactionalEmails;
+
+/**
+ * Before this fix, {store_address} and {store_email} were never resolved, so any
+ * WC transactional template created earlier has them baked into its footer text
+ * as raw, unresolved placeholders. Re-resolves them (and links {woocommerce}) in
+ * the existing saved template so stores that already hit the bug also see the fix.
+ */
+class Migration_20260826_120000_App extends AppMigration {
+  const RAW_PLACEHOLDER_TOKENS = [
+    '{site_title}',
+    '{site_address}',
+    '{site_url}',
+    '{store_address}',
+    '{store_email}',
+    '{woocommerce}',
+    '{WooCommerce}',
+  ];
+
+  public function run(): void {
+    $newslettersRepository = $this->container->get(NewslettersRepository::class);
+    $newsletter = $newslettersRepository->findOneBy(['type' => NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL]);
+    if (!$newsletter instanceof NewsletterEntity) {
+      return;
+    }
+
+    $body = $newsletter->getBody();
+    if (!is_array($body)) {
+      return;
+    }
+
+    $transactionalEmails = $this->container->get(TransactionalEmails::class);
+    $changed = false;
+    $body = $this->resolvePlaceholdersInBlocks($body, $transactionalEmails, $changed);
+    if (!$changed) {
+      return;
+    }
+
+    $newsletter->setBody($body);
+    $this->entityManager->flush();
+  }
+
+  private function resolvePlaceholdersInBlocks(array $node, TransactionalEmails $transactionalEmails, bool &$changed): array {
+    foreach ($node as $key => $value) {
+      if (is_array($value)) {
+        $node[$key] = $this->resolvePlaceholdersInBlocks($value, $transactionalEmails, $changed);
+        continue;
+      }
+      if ($key !== 'text' || !is_string($value) || strpos($value, '{') === false) {
+        continue;
+      }
+      if (!$this->containsRawPlaceholder($value)) {
+        continue;
+      }
+      $node[$key] = $transactionalEmails->resolveFooterPlaceholders($value);
+      $changed = true;
+    }
+    return $node;
+  }
+
+  private function containsRawPlaceholder(string $text): bool {
+    foreach (self::RAW_PLACEHOLDER_TOKENS as $token) {
+      if (strpos($text, $token) !== false) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/mailpoet/lib/Migrations/App/Migration_20260826_120000_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20260826_120000_App.php
@@ -59,7 +59,7 @@ class Migration_20260826_120000_App extends AppMigration {
       if (!$this->containsRawPlaceholder($value)) {
         continue;
       }
-      $node[$key] = $transactionalEmails->resolveFooterPlaceholders($value);
+      $node[$key] = $transactionalEmails->resolvePlaceholdersInFooterText($value);
       $changed = true;
     }
     return $node;

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -215,6 +215,14 @@ class Helper {
     return wc_hex_is_light($color);
   }
 
+  public function wcGetStoreAddress(): string {
+    return \WC_Emails::instance()->get_store_address();
+  }
+
+  public function wcGetStoreEmail(): string {
+    return \WC_Emails::instance()->get_from_address();
+  }
+
   public function getOrdersCountCreatedBefore(string $dateTime): int {
     $ordersCount = $this->wcGetOrders([
       'status' => 'all',

--- a/mailpoet/lib/WooCommerce/TransactionalEmails.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmails.php
@@ -146,23 +146,26 @@ class TransactionalEmails {
     } else {
       $result['link_color'] = $this->woocommerceHelper->wcHexIsLight($result['base_color']) ? $result['base_color'] : $result['base_text_color'];
     }
-    $result['footer_text'] = $this->resolveFooterPlaceholders($result['footer_text']);
+    $result['footer_text'] = $this->resolvePlaceholdersInFooterText($result['footer_text']);
+    // The footer text is placed inside a paragraph in a text block so we keep only tags we allow in the text block in the newsletter editor
+    $result['footer_text'] = strip_tags($result['footer_text'], '<em><strong><br><a><span><s><del>');
     return $result;
   }
 
   /**
-   * Also used by Migration_20260826_120000_App to re-resolve placeholders left raw
-   * in WC transactional templates saved before this method existed.
+   * Only replaces placeholder tokens, without strip_tags(). getWCEmailSettings() applies
+   * strip_tags() separately for newly-generated footer settings; Migration_20260826_120000_App
+   * also calls this directly on already-persisted, already-formatted footer blocks, where
+   * strip_tags() would strip surrounding markup (e.g. the wrapping <p style="...">) that was
+   * never meant to be re-sanitized.
    */
-  public function resolveFooterPlaceholders(string $text): string {
+  public function resolvePlaceholdersInFooterText(string $text): string {
     // WooCommerce's own WC_Emails::replace_placeholders() links these; matched here so footer text stays consistent with core.
     $text = str_replace(
       ['{woocommerce}', '{WooCommerce}'],
       '<a href="https://woocommerce.com">WooCommerce</a>',
       $text
     );
-    $text = $this->replacePlaceholders($text);
-    // The footer text is placed inside a paragraph in a text block so we keep only tags we allow in the text block in the newsletter editor
-    return strip_tags($text, '<em><strong><br><a><span><s><del>');
+    return $this->replacePlaceholders($text);
   }
 }

--- a/mailpoet/lib/WooCommerce/TransactionalEmails.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmails.php
@@ -106,11 +106,23 @@ class TransactionalEmails {
     $title = $this->wp->wpSpecialcharsDecode($this->wp->getOption('blogname'), ENT_QUOTES);
     $address = $this->wp->wpParseUrl($this->wp->homeUrl(), PHP_URL_HOST);
     $orderDate = date('Y-m-d');
-    return str_replace(
-      ['{site_title}', '{site_address}', '{order_date}', '{order_number}'],
-      [$title, $address, $orderDate, '0001'],
-      $text
-    );
+    $replacements = [
+      '{site_title}' => $title,
+      '{site_address}' => $address,
+      '{site_url}' => $address,
+      '{woocommerce}' => 'WooCommerce',
+      '{WooCommerce}' => 'WooCommerce',
+      '{order_date}' => $orderDate,
+      '{order_number}' => '0001',
+    ];
+    // Resolved lazily: they require WooCommerce to be loaded, unlike the placeholders above.
+    if (strpos($text, '{store_address}') !== false) {
+      $replacements['{store_address}'] = $this->woocommerceHelper->wcGetStoreAddress();
+    }
+    if (strpos($text, '{store_email}') !== false) {
+      $replacements['{store_email}'] = $this->woocommerceHelper->wcGetStoreEmail();
+    }
+    return str_replace(array_keys($replacements), array_values($replacements), $text);
   }
 
   public function getWCEmailSettings() {

--- a/mailpoet/lib/WooCommerce/TransactionalEmails.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmails.php
@@ -146,9 +146,23 @@ class TransactionalEmails {
     } else {
       $result['link_color'] = $this->woocommerceHelper->wcHexIsLight($result['base_color']) ? $result['base_color'] : $result['base_text_color'];
     }
-    $result['footer_text'] = $this->replacePlaceholders($result['footer_text']);
-    // The footer text is placed inside a paragraph in a text block so we keep only tags we allow in the text block in the newsletter editor
-    $result['footer_text'] = strip_tags($result['footer_text'], '<em><strong><br><a><span><s><del>');
+    $result['footer_text'] = $this->resolveFooterPlaceholders($result['footer_text']);
     return $result;
+  }
+
+  /**
+   * Also used by Migration_20260826_120000_App to re-resolve placeholders left raw
+   * in WC transactional templates saved before this method existed.
+   */
+  public function resolveFooterPlaceholders(string $text): string {
+    // WooCommerce's own WC_Emails::replace_placeholders() links these; matched here so footer text stays consistent with core.
+    $text = str_replace(
+      ['{woocommerce}', '{WooCommerce}'],
+      '<a href="https://woocommerce.com">WooCommerce</a>',
+      $text
+    );
+    $text = $this->replacePlaceholders($text);
+    // The footer text is placed inside a paragraph in a text block so we keep only tags we allow in the text block in the newsletter editor
+    return strip_tags($text, '<em><strong><br><a><span><s><del>');
   }
 }

--- a/mailpoet/tests/integration/Migrations/App/Migration_20260826_120000_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20260826_120000_App_Test.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\WP\Functions as WPFunctions;
+
+//phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class Migration_20260826_120000_App_Test extends \MailPoetTest {
+  /** @var Migration_20260826_120000_App */
+  private $migration;
+
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var array */
+  private $originalWcOptions = [];
+
+  public function _before() {
+    parent::_before();
+    $this->migration = new Migration_20260826_120000_App($this->diContainer);
+    $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
+    $this->wp = new WPFunctions();
+
+    $wcOptionsToStub = [
+      'woocommerce_store_address' => '123 Main St',
+      'woocommerce_store_city' => 'New York',
+      'woocommerce_store_postcode' => '10001',
+      'woocommerce_default_country' => 'US:NY',
+      'woocommerce_email_from_address' => 'store@example.com',
+    ];
+    foreach ($wcOptionsToStub as $option => $value) {
+      $this->originalWcOptions[$option] = $this->wp->getOption($option);
+      $this->wp->updateOption($option, $value);
+    }
+  }
+
+  public function _after() {
+    foreach ($this->originalWcOptions as $option => $value) {
+      $this->wp->updateOption($option, $value);
+    }
+    parent::_after();
+  }
+
+  public function testItResolvesRawPlaceholdersLeftInAnExistingTemplate() {
+    $newsletter = (new NewsletterFactory())
+      ->withType(NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL)
+      ->withBody([
+        'content' => [
+          'blocks' => [
+            [
+              'type' => 'text',
+              'text' => 'Contact us: {store_address} or {store_email}. Powered by {woocommerce}.',
+            ],
+          ],
+        ],
+      ])
+      ->create();
+
+    $this->migration->run();
+
+    $updated = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $updated);
+    $body = $updated->getBody();
+    $this->assertIsArray($body);
+    $text = $body['content']['blocks'][0]['text'];
+
+    verify($text)->stringContainsString('New York');
+    verify($text)->stringContainsString('10001');
+    verify($text)->stringContainsString('store@example.com');
+    verify($text)->stringContainsString('<a href="https://woocommerce.com">WooCommerce</a>');
+    verify($text)->stringNotContainsString('{store_address}');
+    verify($text)->stringNotContainsString('{store_email}');
+    verify($text)->stringNotContainsString('{woocommerce}');
+  }
+
+  public function testItDoesNothingWhenNoWCTransactionalTemplateExists() {
+    $this->migration->run();
+    $email = $this->newslettersRepository->findOneBy(['type' => NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL]);
+    $this->assertNull($email);
+  }
+
+  public function testItLeavesAnAlreadyResolvedTemplateUnchanged() {
+    $newsletter = (new NewsletterFactory())
+      ->withType(NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL)
+      ->withBody([
+        'content' => [
+          'blocks' => [
+            ['type' => 'text', 'text' => 'Already resolved, no placeholders here.'],
+          ],
+        ],
+      ])
+      ->create();
+
+    $this->migration->run();
+
+    $updated = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $updated);
+    $body = $updated->getBody();
+    $this->assertIsArray($body);
+    verify($body['content']['blocks'][0]['text'])->equals('Already resolved, no placeholders here.');
+  }
+}

--- a/mailpoet/tests/integration/Migrations/App/Migration_20260826_120000_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20260826_120000_App_Test.php
@@ -79,6 +79,36 @@ class Migration_20260826_120000_App_Test extends \MailPoetTest {
     verify($text)->stringNotContainsString('{woocommerce}');
   }
 
+  public function testItPreservesSurroundingMarkupWhenResolvingPlaceholders() {
+    $newsletter = (new NewsletterFactory())
+      ->withType(NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL)
+      ->withBody([
+        'content' => [
+          'blocks' => [
+            [
+              'type' => 'text',
+              'text' => '<p style="text-align: center;">{store_address}</p>',
+            ],
+          ],
+        ],
+      ])
+      ->create();
+
+    $this->migration->run();
+
+    $updated = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $updated);
+    $body = $updated->getBody();
+    $this->assertIsArray($body);
+    $text = $body['content']['blocks'][0]['text'];
+
+    verify($text)->stringStartsWith('<p style="text-align: center;">');
+    verify($text)->stringEndsWith('</p>');
+    verify($text)->stringContainsString('New York');
+    verify($text)->stringContainsString('10001');
+    verify($text)->stringNotContainsString('{store_address}');
+  }
+
   public function testItDoesNothingWhenNoWCTransactionalTemplateExists() {
     $this->migration->run();
     $email = $this->newslettersRepository->findOneBy(['type' => NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL]);

--- a/mailpoet/tests/integration/Migrations/App/Migration_20260826_120000_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20260826_120000_App_Test.php
@@ -7,6 +7,9 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\WP\Functions as WPFunctions;
 
+/**
+ * @group woo
+ */
 //phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
 class Migration_20260826_120000_App_Test extends \MailPoetTest {
   /** @var Migration_20260826_120000_App */

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmailsTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmailsTest.php
@@ -116,34 +116,41 @@ class TransactionalEmailsTest extends \MailPoetTest {
     $originalCity = $this->wp->getOption('woocommerce_store_city');
     $originalPostcode = $this->wp->getOption('woocommerce_store_postcode');
     $originalCountry = $this->wp->getOption('woocommerce_default_country');
+    $originalFromAddress = $this->wp->getOption('woocommerce_email_from_address');
 
-    $this->wp->updateOption('woocommerce_email_footer_text', '{store_address}');
-    $this->wp->updateOption('woocommerce_store_address', '123 Main St');
-    $this->wp->updateOption('woocommerce_store_city', 'New York');
-    $this->wp->updateOption('woocommerce_store_postcode', '10001');
-    $this->wp->updateOption('woocommerce_default_country', 'US:NY');
+    try {
+      $this->wp->updateOption('woocommerce_email_footer_text', '{store_address} - {store_email}');
+      $this->wp->updateOption('woocommerce_store_address', '123 Main St');
+      $this->wp->updateOption('woocommerce_store_city', 'New York');
+      $this->wp->updateOption('woocommerce_store_postcode', '10001');
+      $this->wp->updateOption('woocommerce_default_country', 'US:NY');
+      $this->wp->updateOption('woocommerce_email_from_address', 'store@example.com');
 
-    $transactionalEmails = new TransactionalEmails(
-      $this->wp,
-      $this->settings,
-      ContainerWrapper::getInstance()->get(Template::class),
-      ContainerWrapper::getInstance()->get(WooCommerceHelper::class),
-      $this->newslettersRepository
-    );
-    $transactionalEmails->init();
-    $email = $this->newslettersRepository->findOneBy(['type' => NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL]);
-    $this->assertInstanceOf(NewsletterEntity::class, $email);
-    $body = $email->getBody();
-    $this->assertIsArray($body);
-    $footerTextBlock = $body['content']['blocks'][5]['blocks'][0]['blocks'][1];
-    verify($footerTextBlock['text'])->stringContainsString('New York');
-    verify($footerTextBlock['text'])->stringContainsString('10001');
-    verify($footerTextBlock['text'])->stringNotContainsString('{store_address}');
-
-    $this->wp->updateOption('woocommerce_email_footer_text', $originalFooterText);
-    $this->wp->updateOption('woocommerce_store_address', $originalAddress);
-    $this->wp->updateOption('woocommerce_store_city', $originalCity);
-    $this->wp->updateOption('woocommerce_store_postcode', $originalPostcode);
-    $this->wp->updateOption('woocommerce_default_country', $originalCountry);
+      $transactionalEmails = new TransactionalEmails(
+        $this->wp,
+        $this->settings,
+        ContainerWrapper::getInstance()->get(Template::class),
+        ContainerWrapper::getInstance()->get(WooCommerceHelper::class),
+        $this->newslettersRepository
+      );
+      $transactionalEmails->init();
+      $email = $this->newslettersRepository->findOneBy(['type' => NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL]);
+      $this->assertInstanceOf(NewsletterEntity::class, $email);
+      $body = $email->getBody();
+      $this->assertIsArray($body);
+      $footerTextBlock = $body['content']['blocks'][5]['blocks'][0]['blocks'][1];
+      verify($footerTextBlock['text'])->stringContainsString('New York');
+      verify($footerTextBlock['text'])->stringContainsString('10001');
+      verify($footerTextBlock['text'])->stringContainsString('store@example.com');
+      verify($footerTextBlock['text'])->stringNotContainsString('{store_address}');
+      verify($footerTextBlock['text'])->stringNotContainsString('{store_email}');
+    } finally {
+      $this->wp->updateOption('woocommerce_email_footer_text', $originalFooterText);
+      $this->wp->updateOption('woocommerce_store_address', $originalAddress);
+      $this->wp->updateOption('woocommerce_store_city', $originalCity);
+      $this->wp->updateOption('woocommerce_store_postcode', $originalPostcode);
+      $this->wp->updateOption('woocommerce_default_country', $originalCountry);
+      $this->wp->updateOption('woocommerce_email_from_address', $originalFromAddress);
+    }
   }
 }

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmailsTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmailsTest.php
@@ -109,4 +109,41 @@ class TransactionalEmailsTest extends \MailPoetTest {
     verify($footerTextBlock['text'])->equals('<p style="text-align: center;">Text <a href="http://example.com">Link</a></p>');
     $this->wp->updateOption('woocommerce_email_footer_text', $optionOriginalValue);
   }
+
+  public function testInitResolvesStoreAddressPlaceholderInFooterTextUsingRealWooCommerceData() {
+    $originalFooterText = $this->wp->getOption('woocommerce_email_footer_text');
+    $originalAddress = $this->wp->getOption('woocommerce_store_address');
+    $originalCity = $this->wp->getOption('woocommerce_store_city');
+    $originalPostcode = $this->wp->getOption('woocommerce_store_postcode');
+    $originalCountry = $this->wp->getOption('woocommerce_default_country');
+
+    $this->wp->updateOption('woocommerce_email_footer_text', '{store_address}');
+    $this->wp->updateOption('woocommerce_store_address', '123 Main St');
+    $this->wp->updateOption('woocommerce_store_city', 'New York');
+    $this->wp->updateOption('woocommerce_store_postcode', '10001');
+    $this->wp->updateOption('woocommerce_default_country', 'US:NY');
+
+    $transactionalEmails = new TransactionalEmails(
+      $this->wp,
+      $this->settings,
+      ContainerWrapper::getInstance()->get(Template::class),
+      ContainerWrapper::getInstance()->get(WooCommerceHelper::class),
+      $this->newslettersRepository
+    );
+    $transactionalEmails->init();
+    $email = $this->newslettersRepository->findOneBy(['type' => NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL]);
+    $this->assertInstanceOf(NewsletterEntity::class, $email);
+    $body = $email->getBody();
+    $this->assertIsArray($body);
+    $footerTextBlock = $body['content']['blocks'][5]['blocks'][0]['blocks'][1];
+    verify($footerTextBlock['text'])->stringContainsString('New York');
+    verify($footerTextBlock['text'])->stringContainsString('10001');
+    verify($footerTextBlock['text'])->stringNotContainsString('{store_address}');
+
+    $this->wp->updateOption('woocommerce_email_footer_text', $originalFooterText);
+    $this->wp->updateOption('woocommerce_store_address', $originalAddress);
+    $this->wp->updateOption('woocommerce_store_city', $originalCity);
+    $this->wp->updateOption('woocommerce_store_postcode', $originalPostcode);
+    $this->wp->updateOption('woocommerce_default_country', $originalCountry);
+  }
 }

--- a/mailpoet/tests/unit/WooCommerce/TransactionalEmailsUnitTest.php
+++ b/mailpoet/tests/unit/WooCommerce/TransactionalEmailsUnitTest.php
@@ -45,4 +45,37 @@ class TransactionalEmailsUnitTest extends \MailPoetUnitTest {
       'customer_note' => 'Note added to order #0001 - ' . date('Y-m-d'),
     ]);
   }
+
+  public function testGetWCEmailSettingsResolvesStoreAddressAndOtherWooCommercePlaceholdersInFooterText() {
+    $wp = Stub::make(new WPFunctions, [
+      'getOption' => function($name) {
+        if ($name === 'woocommerce_email_footer_text') {
+          return '{site_title} - {store_address} - {store_email} - {site_url} - {woocommerce}';
+        }
+        if ($name === 'blogname') {
+          return 'Test';
+        }
+        return false;
+      },
+      'homeUrl' => 'http://test.loc',
+      'wpSpecialcharsDecode' => function($text) {
+        return $text;
+      },
+      'wpParseUrl' => function($url) {
+        return 'test.loc';
+      },
+    ]);
+    $settings = Stub::make(SettingsController::class);
+    $template = Stub::make(Template::class);
+    $woocommerceHelper = Stub::make(WooCommerceHelper::class, [
+      'wcGetStoreAddress' => '123 Main St, Springfield',
+      'wcGetStoreEmail' => 'store@example.com',
+      'wcLightOrDark' => '#202020',
+      'wcHexIsLight' => true,
+    ]);
+    $newslettersRepository = Stub::make(NewslettersRepository::class);
+    $transactionalEmails = new TransactionalEmails($wp, $settings, $template, $woocommerceHelper, $newslettersRepository);
+    $footerText = $transactionalEmails->getWCEmailSettings()['footer_text'];
+    verify($footerText)->equals('Test - 123 Main St, Springfield - store@example.com - test.loc - WooCommerce');
+  }
 }

--- a/mailpoet/tests/unit/WooCommerce/TransactionalEmailsUnitTest.php
+++ b/mailpoet/tests/unit/WooCommerce/TransactionalEmailsUnitTest.php
@@ -50,7 +50,7 @@ class TransactionalEmailsUnitTest extends \MailPoetUnitTest {
     $wp = Stub::make(new WPFunctions, [
       'getOption' => function($name) {
         if ($name === 'woocommerce_email_footer_text') {
-          return '{site_title} - {store_address} - {store_email} - {site_url} - {woocommerce}';
+          return '{site_title} - {store_address} - {store_email} - {site_url} - {woocommerce} - {WooCommerce}';
         }
         if ($name === 'blogname') {
           return 'Test';
@@ -76,6 +76,7 @@ class TransactionalEmailsUnitTest extends \MailPoetUnitTest {
     $newslettersRepository = Stub::make(NewslettersRepository::class);
     $transactionalEmails = new TransactionalEmails($wp, $settings, $template, $woocommerceHelper, $newslettersRepository);
     $footerText = $transactionalEmails->getWCEmailSettings()['footer_text'];
-    verify($footerText)->equals('Test - 123 Main St, Springfield - store@example.com - test.loc - WooCommerce');
+    $wooCommerceLink = '<a href="https://woocommerce.com">WooCommerce</a>';
+    verify($footerText)->equals("Test - 123 Main St, Springfield - store@example.com - test.loc - $wooCommerceLink - $wooCommerceLink");
   }
 }


### PR DESCRIPTION
## Description

When "Use MailPoet to customize WooCommerce emails" is enabled, MailPoet takes over rendering WooCommerce's transactional emails and runs its own placeholder replacement instead of WooCommerce's `WC_Emails::replace_placeholders()`. That replacement, `TransactionalEmails::replacePlaceholders()`, only handled `{site_title}`, `{site_address}`, `{order_date}`, and `{order_number}`.

WooCommerce's own default footer text (`WooCommerce > Settings > Emails`) is `{site_title}<br />{store_address}`. Any store that enabled the MailPoet customization feature without first customizing that WooCommerce setting got the literal text `{store_address}` baked into their emails permanently and unresolved, even with a fully configured WooCommerce store address.

This adds the missing placeholders (`{store_address}`, `{store_email}`, `{site_url}`, `{woocommerce}`/`{WooCommerce}`) to match WooCommerce's own `replace_placeholders()`, sourcing the store address/email the same way WooCommerce does (`WC_Emails::get_store_address()` / `get_from_address()`), via two new methods on the WooCommerce `Helper` wrapper.

## Code review notes

`{store_address}` and `{store_email}` are resolved lazily (only when the text actually contains them) rather than unconditionally on every call, so `getEmailHeadings()` (which never uses these two placeholders) doesn't pay the cost of calling into `WC_Emails` on every request.

## QA notes

- `pnpm test:unit --file=tests/unit/WooCommerce/TransactionalEmailsUnitTest.php` — new unit test written first, confirmed failing before the fix, passing after
- `pnpm test:integration --file=tests/integration/WooCommerce/TransactionalEmailsTest.php` — new integration test exercises the real WooCommerce `get_store_address()` path with real store settings; confirmed failing before the fix, passing after; full file (5 tests) green
- `pnpm test:integration --file=tests/integration/WooCommerce/TransactionalEmailHooksTest.php` — unaffected, still green
- PHPCS clean on all changed files; `pnpm qa:phpstan` clean (no errors)
- Repro steps and root cause originally confirmed against Zendesk ticket #11581154 (customer details not included here)

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8381

## After-merge notes

_N/A_

## Screenshots or screencast
(Captured Before & After by Claude Code and Playwright)

Before reproduction - Email Preview after enabling "Customize with MP" setting
<img width="848" height="193" alt="image" src="https://github.com/user-attachments/assets/268f602e-527c-46f3-8ef0-628f43c6c8d2" />

After rebuild, reproduction - Email Preview after enabling "Customize with MP" setting
<img width="1282" height="328" alt="image" src="https://github.com/user-attachments/assets/01b5366b-d7f5-4adc-a4f2-34c070e10db8" />


## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed best practices for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8381-store-address-placeholder-leaks-raw-in-wc-emails)

_The latest successful build from `fix/stomail-8381-store-address-placeholder-leaks-raw-in-wc-emails` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Issue counts unavailable. No review findings were supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->