### PR TITLE
Fix acceptance tests for the Gutenberg 23.8 block appender change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1082,18 +1082,6 @@ workflows:
           blockbased_theme: 1
           requires:
             - build
-      # TEMPORARY: mirrors the nightly acceptance_gutenberg_latest job so the
-      # Gutenberg 23.8 fix can be verified on CI. Revert before merging.
-      - acceptance_tests:
-          <<: *slack-fail-post-step
-          name: acceptance_gutenberg_latest
-          group: gutenberg-latest
-          gutenberg_version: latest
-          parallelism: 5
-          mysql_image: mysql:8.3
-          mysql_command: --default-authentication-plugin=mysql_native_password
-          requires:
-            - build
       - js_tests:
           <<: *slack-fail-post-step
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1082,6 +1082,18 @@ workflows:
           blockbased_theme: 1
           requires:
             - build
+      # TEMPORARY: mirrors the nightly acceptance_gutenberg_latest job so the
+      # Gutenberg 23.8 fix can be verified on CI. Revert before merging.
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_gutenberg_latest
+          group: gutenberg-latest
+          gutenberg_version: latest
+          parallelism: 5
+          mysql_image: mysql:8.3
+          mysql_command: --default-authentication-plugin=mysql_native_password
+          requires:
+            - build
       - js_tests:
           <<: *slack-fail-post-step
           requires:

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -126,9 +126,10 @@ class GutenbergFormBlockCest {
     $i->waitForElement('iframe[name="editor-canvas"]', 30);
     $i->switchToIframe('iframe[name="editor-canvas"]');
     $i->click('[aria-label="Add title"]');
-    $i->click('[aria-label="Add block"]');
     $i->switchToIFrame();
-    $i->fillField('[placeholder="Search"]', 'MailPoet Subscription Form');
+    $i->click('[aria-label="Block Inserter"]');
+    $i->waitForElementVisible('.block-editor-inserter__search [placeholder="Search"]');
+    $i->fillField('.block-editor-inserter__search [placeholder="Search"]', 'MailPoet Subscription Form');
     $i->waitForElement(Locator::contains('button', 'MailPoet Subscription Form'));
     $i->click(Locator::contains('button', 'MailPoet Subscription Form'));
     $i->switchToIframe('iframe[name="editor-canvas"]');

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -233,12 +233,15 @@ class WooCheckoutBlocksCest {
     $this->closeDialog($i);
     $i->waitForElement('iframe[name="editor-canvas"]', 30);
     $i->switchToIframe('iframe[name="editor-canvas"]');
-    $i->click('[aria-label="Add title"]'); // For block inserter to show up
-    $i->click('[aria-label="Add block"]');
+    $i->click('[aria-label="Add title"]');
     $i->switchToIframe();
-    $i->fillField('[placeholder="Search"]', 'Checkout');
-    $i->waitForElement(Locator::contains('button > span > span', 'Checkout'));
-    $i->click(Locator::contains('button > span > span', 'Checkout')); // Select Checkout block
+    $i->click('[aria-label="Block Inserter"]');
+    $i->waitForElementVisible('.block-editor-inserter__search [placeholder="Search"]');
+    $i->fillField('.block-editor-inserter__search [placeholder="Search"]', 'Checkout');
+    // Match the block title exactly, a substring match also hits the "Classic Checkout" block.
+    $checkoutBlockTitle = '//*[contains(@class, "block-editor-block-types-list__item-title")][normalize-space() = "Checkout"]';
+    $i->waitForElement($checkoutBlockTitle);
+    $i->click($checkoutBlockTitle);
     $i->switchToIframe('iframe[name="editor-canvas"]');
     $i->waitForElement('[aria-label="Block: Checkout"]');
 


### PR DESCRIPTION
## Description

The nightly `acceptance_gutenberg_latest` job failed with `Link or Button or CSS or XPath element with '[aria-label="Add block"]' was not found`.

Gutenberg 23.8.0, released 2026-08-19, includes [WordPress/gutenberg#81231](https://github.com/WordPress/gutenberg/pull/81231), which renders a real ghost default block in place of the in-canvas default block appender. That appender carried the quick inserter toggle labelled `Add block`, which is the button the test clicked. It no longer exists inside the editor canvas: the failure artifact shows the canvas contains no `button` element at all, only an empty paragraph labelled `Add default block`.

Both tests now open the inserter from the editor header via `[aria-label="Block Inserter"]`, which is present in the old and the new markup alike.

`WooCheckoutBlocksCest` used the same `[aria-label="Add block"]` selector. It is green today because WordPress core still ships the old appender, so that half of the change is pre-emptive rather than a fix for a current failure.

No changelog entry is included: the change is limited to acceptance tests and is not user-facing.

## Code review notes

The “acceptance_gutenberg_latest” job has been tested on CI using a temporary commit 98e87f768ff29a05687002c0174144f091473237. See: https://app.circleci.com/pipelines/github/mailpoet/mailpoet/24618/details?workflowId=8b58e0f6-cdd1-4523-82fb-5000a33d9cae

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/gutenberg-latest-add-block-selector)

_The latest successful build from `fix/gutenberg-latest-add-block-selector` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->