### PR TITLE
Include tracking consent in subscriber import and export

### DIFF
--- a/mailpoet/changelog/2026-08-24-12-15-00-improved-subscriber-import-and-export-now-carry-tracking.md
+++ b/mailpoet/changelog/2026-08-24-12-15-00-improved-subscriber-import-and-export-now-carry-tracking.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Subscriber import and export now carry tracking consent: the state, when it changed, how it was collected, and the wording the subscriber saw. Exporting a list and importing it back keeps who opted in or out, and a CSV can set consent directly when you are migrating it from another system. A blank consent cell, or a CSV with no consent column, never changes what a subscriber already chose.
+Subscriber import and export now carry tracking consent: the state, when it changed, how it was collected, and the wording the subscriber saw. Exporting a list and importing it back keeps who opted in or out, and a CSV can set consent directly when you are migrating it from another system. A blank consent cell, or a CSV with no consent column, never changes what a subscriber already chose

--- a/mailpoet/changelog/2026-08-24-12-15-00-improved-subscriber-import-and-export-now-carry-tracking.md
+++ b/mailpoet/changelog/2026-08-24-12-15-00-improved-subscriber-import-and-export-now-carry-tracking.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Subscriber import and export now carry tracking consent: the state, when it changed, how it was collected, and the wording the subscriber saw. Exporting a list and importing it back keeps who opted in or out, and a CSV can set consent directly when you are migrating it from another system. A blank consent cell, or a CSV with no consent column, never changes what a subscriber already chose.

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Cli.php
@@ -26,6 +26,9 @@ class Cli {
     'created_at',
     'confirmed_at',
     'confirmed_ip',
+    'tracking_consent',
+    'tracking_consent_method',
+    'tracking_consent_copy',
   ];
 
   private const NEW_SUBSCRIBER_STATUSES = [
@@ -104,7 +107,7 @@ class Cli {
         [
           'type' => 'positional',
           'name' => 'file',
-          'description' => 'Path to the CSV file. The header row must use MailPoet field names (email, first_name, last_name, subscribed_ip, created_at, confirmed_at, confirmed_ip) or existing custom field names. An "email" column is required.',
+          'description' => 'Path to the CSV file. The header row must use MailPoet field names (email, first_name, last_name, subscribed_ip, created_at, confirmed_at, confirmed_ip, tracking_consent, tracking_consent_method, tracking_consent_copy) or existing custom field names. An "email" column is required. tracking_consent accepts granted, denied or unknown; a blank cell leaves the stored value alone.',
           'optional' => false,
         ],
         [

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -48,6 +48,8 @@ class Import {
   /** @var array<string, mixed> */
   public $requiredSubscribersFields;
   const DB_QUERY_CHUNK_SIZE = 100;
+  // Matches the subscribers.tracking_consent_method column width.
+  const TRACKING_CONSENT_METHOD_MAX_LENGTH = 40;
   const STATUS_DONT_UPDATE = 'dont_update';
 
   public const ACTION_CREATE = 'create';
@@ -170,6 +172,7 @@ class Import {
         $newSubscribers = $this->setSubscriptionStatusToDefault($newSubscribers, $this->newSubscribersStatus);
         $newSubscribers = $this->setSource($newSubscribers);
         $newSubscribers = $this->setLinkToken($newSubscribers);
+        $newSubscribers = $this->applyTrackingConsentToNewSubscribers($newSubscribers);
         $createdSubscribers =
           $this->createOrUpdateSubscribers(
             self::ACTION_CREATE,
@@ -269,6 +272,22 @@ class Import {
           array_keys($data),
           $data
         );
+      }
+      if ($column === 'tracking_consent') {
+        $validStates = [
+          SubscriberEntity::TRACKING_CONSENT_GRANTED,
+          SubscriberEntity::TRACKING_CONSENT_DENIED,
+          SubscriberEntity::TRACKING_CONSENT_UNKNOWN,
+        ];
+        $data = array_map(function($value) use ($validStates) {
+          $value = trim((string)$value);
+          // A blank cell is left blank on purpose: blank means "leave the stored value alone",
+          // which is a different thing from an invalid value, and only the caller can act on it.
+          if ($value === '') {
+            return '';
+          }
+          return in_array($value, $validStates, true) ? $value : SubscriberEntity::TRACKING_CONSENT_UNKNOWN;
+        }, $data);
       }
       // if this is a custom column
       if (in_array($column, $this->subscribersCustomFields)) {
@@ -487,6 +506,55 @@ class Import {
       },
       array_fill(0, $subscribersCount, null)
     );
+    return $subscribersData;
+  }
+
+  /**
+   * Stamps consent evidence for newly created subscribers. A blank cell needs no
+   * work: the column defaults (unknown/NULL/NULL/NULL) already mean "untouched"
+   * for a row that did not exist. A non-blank cell is the collection event, so
+   * the timestamp is stamped now and never read from the CSV — it drives the
+   * tracked-at-send predicate, and a backdated value could push a rate over 100%.
+   */
+  private function applyTrackingConsentToNewSubscribers(array $subscribersData): array {
+    if (!in_array('tracking_consent', $subscribersData['fields'], true)) {
+      return $subscribersData;
+    }
+    $states = $subscribersData['data']['tracking_consent'];
+    $methods = $subscribersData['data']['tracking_consent_method'] ?? [];
+    $copies = $subscribersData['data']['tracking_consent_copy'] ?? [];
+
+    $stateValues = $updatedAtValues = $methodValues = $copyValues = [];
+    foreach ($states as $index => $state) {
+      if (trim((string)$state) === '') {
+        // The column is NOT NULL, so a blank cell has to be written as the default
+        // rather than as an empty string.
+        $stateValues[] = SubscriberEntity::TRACKING_CONSENT_UNKNOWN;
+        $updatedAtValues[] = null;
+        $methodValues[] = null;
+        $copyValues[] = null;
+        continue;
+      }
+      $stateValues[] = trim((string)$state);
+      $updatedAtValues[] = $this->createdAt;
+      $method = trim((string)($methods[$index] ?? ''));
+      $methodValues[] = $method !== '' ? mb_substr($method, 0, self::TRACKING_CONSENT_METHOD_MAX_LENGTH) : SubscriberEntity::TRACKING_CONSENT_METHOD_IMPORT;
+      $copy = trim((string)($copies[$index] ?? ''));
+      $copyValues[] = $copy !== '' ? $copy : null;
+    }
+
+    $evidence = [
+      'tracking_consent' => $stateValues,
+      'tracking_consent_updated_at' => $updatedAtValues,
+      'tracking_consent_method' => $methodValues,
+      'tracking_consent_copy' => $copyValues,
+    ];
+    foreach ($evidence as $field => $values) {
+      if (!in_array($field, $subscribersData['fields'], true)) {
+        $subscribersData['fields'][] = $field;
+      }
+      $subscribersData['data'][$field] = $values;
+    }
     return $subscribersData;
   }
 

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -199,9 +199,10 @@ class Import {
           $updatedSubscribers =
             $this->createOrUpdateSubscribers(
               self::ACTION_UPDATE,
-              $existingSubscribers,
+              $this->stripTrackingConsentColumns($existingSubscribers),
               $this->subscribersCustomFields
             );
+          $this->updateTrackingConsent($existingSubscribers);
           if ($wpUsers) {
             $this->synchronizeWPUsers($wpUsers);
           }
@@ -556,6 +557,62 @@ class Import {
       $subscribersData['data'][$field] = $values;
     }
     return $subscribersData;
+  }
+
+  /**
+   * Removes the consent columns from the standard update write. updateMultiple()
+   * writes one uniform set of columns per call, so leaving them in would let a
+   * blank CSV cell overwrite a stored value. updateTrackingConsent() below does
+   * the real write, scoped to the rows that actually supplied a state.
+   */
+  private function stripTrackingConsentColumns(array $subscribersData): array {
+    $consentFields = ['tracking_consent', 'tracking_consent_method', 'tracking_consent_copy'];
+    foreach ($consentFields as $field) {
+      unset($subscribersData['data'][$field]);
+    }
+    $subscribersData['fields'] = array_values(array_diff($subscribersData['fields'], $consentFields));
+    return $subscribersData;
+  }
+
+  /**
+   * Writes consent for existing subscribers, skipping every row whose CSV cell
+   * was blank so their stored value is left alone.
+   */
+  private function updateTrackingConsent(array $subscribersData): void {
+    if (!in_array('tracking_consent', $subscribersData['fields'], true)) {
+      return;
+    }
+    $emails = $subscribersData['data']['email'];
+    $states = $subscribersData['data']['tracking_consent'];
+    $methods = $subscribersData['data']['tracking_consent_method'] ?? [];
+    $copies = $subscribersData['data']['tracking_consent_copy'] ?? [];
+
+    $rows = [];
+    foreach ($states as $index => $state) {
+      $state = trim((string)$state);
+      if ($state === '') {
+        continue;
+      }
+      $method = trim((string)($methods[$index] ?? ''));
+      $copy = trim((string)($copies[$index] ?? ''));
+      $rows[] = [
+        $emails[$index],
+        $state,
+        $this->updatedAt,
+        $method !== '' ? mb_substr($method, 0, self::TRACKING_CONSENT_METHOD_MAX_LENGTH) : SubscriberEntity::TRACKING_CONSENT_METHOD_IMPORT,
+        $copy !== '' ? $copy : null,
+      ];
+    }
+    if (!$rows) {
+      return;
+    }
+    foreach (array_chunk($rows, self::DB_QUERY_CHUNK_SIZE) as $chunk) {
+      $this->importExportRepository->updateMultiple(
+        SubscriberEntity::class,
+        ['email', 'tracking_consent', 'tracking_consent_updated_at', 'tracking_consent_method', 'tracking_consent_copy'],
+        $chunk
+      );
+    }
   }
 
   public function getSubscribersFields(array $subscribersFields): array {

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -519,7 +519,10 @@ class Import {
    */
   private function applyTrackingConsentToNewSubscribers(array $subscribersData): array {
     if (!in_array('tracking_consent', $subscribersData['fields'], true)) {
-      return $subscribersData;
+      // Evidence with no consent behind it is not a record of anything, so a CSV that
+      // maps only the method or wording column is dropped rather than stored against
+      // the default `unknown` with no timestamp. Same rule the public API applies.
+      return $this->stripTrackingConsentEvidenceColumns($subscribersData);
     }
     $states = $subscribersData['data']['tracking_consent'];
     $methods = $subscribersData['data']['tracking_consent_method'] ?? [];
@@ -556,6 +559,16 @@ class Import {
       }
       $subscribersData['data'][$field] = $values;
     }
+    return $subscribersData;
+  }
+
+  /** Drops the evidence columns, used when no consent state came with them. */
+  private function stripTrackingConsentEvidenceColumns(array $subscribersData): array {
+    $evidenceFields = ['tracking_consent_method', 'tracking_consent_copy'];
+    foreach ($evidenceFields as $field) {
+      unset($subscribersData['data'][$field]);
+    }
+    $subscribersData['fields'] = array_values(array_diff($subscribersData['fields'], $evidenceFields));
     return $subscribersData;
   }
 

--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportFactory.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportFactory.php
@@ -64,11 +64,16 @@ class ImportExportFactory {
       'created_at' => __('Subscription time', 'mailpoet'),
       'confirmed_at' => __('Confirmation time', 'mailpoet'),
       'confirmed_ip' => __('Confirmation IP', 'mailpoet'),
+      'tracking_consent' => __('Tracking consent', 'mailpoet'),
+      'tracking_consent_method' => __('Tracking consent method', 'mailpoet'),
+      'tracking_consent_copy' => __('Tracking consent wording', 'mailpoet'),
     ];
     if ($this->action === 'export') {
       $fields = array_merge(
         $fields,
         [
+          // Export only: the plugin always stamps this itself, it is never taken from an import.
+          'tracking_consent_updated_at' => __('Tracking consent updated', 'mailpoet'),
           'last_subscribed_at' => __('Last subscribed on', 'mailpoet'),
           'list_status' => _x('List status', 'Subscription status', 'mailpoet'),
           'global_status' => _x('Global status', 'Subscription status', 'mailpoet'),
@@ -84,7 +89,7 @@ class ImportExportFactory {
         'id' => $fieldId,
         'name' => $fieldName,
         'text' => $fieldName, // Required for select2 default functionality
-        'type' => in_array($fieldId, ['confirmed_at', 'created_at', 'last_subscribed_at'], true) ? 'date' : null,
+        'type' => in_array($fieldId, ['confirmed_at', 'created_at', 'last_subscribed_at', 'tracking_consent_updated_at'], true) ? 'date' : null,
         'custom' => false,
       ];
     }, array_keys($subscriberFields), $subscriberFields);

--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
@@ -269,6 +269,10 @@ class ImportExportRepository {
         {$subscriberTable}.confirmed_ip,
         {$subscriberTable}.created_at,
         {$subscriberTable}.last_subscribed_at,
+        {$subscriberTable}.tracking_consent,
+        {$subscriberTable}.tracking_consent_updated_at,
+        {$subscriberTable}.tracking_consent_method,
+        {$subscriberTable}.tracking_consent_copy,
         {$subscriberTable}.status AS global_status,
         {$subscriberSegmentTable}.status AS list_status
       ")

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/CliTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/CliTest.php
@@ -129,6 +129,56 @@ class CliTest extends \MailPoetTest {
     $this->assertSame('Updated', $subscriber->getFirstName());
   }
 
+  public function testItImportsTrackingConsentColumns(): void {
+    $file = $this->writeCsv([
+      ['email', 'tracking_consent', 'tracking_consent_method', 'tracking_consent_copy'],
+      ['granted@example.com', 'granted', 'legacy_crm', 'Allow open and click tracking'],
+      ['bogus@example.com', 'maybe', '', ''],
+      ['silent@example.com', '', '', ''],
+    ]);
+
+    $totals = $this->cli->run($file, self::DEFAULT_OPTIONS);
+    $this->assertSame(3, $totals['created']);
+
+    $granted = $this->subscribersRepository->findOneBy(['email' => 'granted@example.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $granted);
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_GRANTED, $granted->getTrackingConsent());
+    $this->assertSame('legacy_crm', $granted->getTrackingConsentMethod());
+    $this->assertSame('Allow open and click tracking', $granted->getTrackingConsentCopy());
+    $this->assertInstanceOf(\DateTimeInterface::class, $granted->getTrackingConsentUpdatedAt());
+
+    // an unrecognised state still means "they answered", we just cannot honour the answer
+    $bogus = $this->subscribersRepository->findOneBy(['email' => 'bogus@example.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $bogus);
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_UNKNOWN, $bogus->getTrackingConsent());
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_METHOD_IMPORT, $bogus->getTrackingConsentMethod());
+
+    $silent = $this->subscribersRepository->findOneBy(['email' => 'silent@example.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $silent);
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_UNKNOWN, $silent->getTrackingConsent());
+    $this->assertNull($silent->getTrackingConsentMethod());
+    $this->assertNull($silent->getTrackingConsentUpdatedAt());
+  }
+
+  public function testItDoesNotEraseStoredTrackingConsentOnUpdate(): void {
+    $this->cli->run($this->writeCsv([
+      ['email', 'tracking_consent', 'tracking_consent_copy'],
+      ['keep@example.com', 'granted', 'Original wording'],
+    ]), self::DEFAULT_OPTIONS);
+
+    $this->cli->run($this->writeCsv([
+      ['email', 'first_name', 'tracking_consent'],
+      ['keep@example.com', 'Renamed', ''],
+    ]), ['update_existing' => true] + self::DEFAULT_OPTIONS);
+
+    $this->subscribersRepository->refreshAll();
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => 'keep@example.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->assertSame('Renamed', $subscriber->getFirstName());
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_GRANTED, $subscriber->getTrackingConsent());
+    $this->assertSame('Original wording', $subscriber->getTrackingConsentCopy());
+  }
+
   public function testDryRunDoesNotWriteAnything(): void {
     $file = $this->writeCsv([
       ['email'],

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -768,6 +768,83 @@ class ImportTest extends \MailPoetTest {
     verify($updatedSubscriber->getLastSubscribedAt())->equals(Carbon::createFromFormat('Y-m-d H:i:s', '2017-12-12 12:12:00'));
   }
 
+  public function testItLeavesTrackingConsentUntouchedWhenTheImportedCellIsBlank(): void {
+    $data = $this->testData;
+    $data['columns']['tracking_consent'] = ['index' => 8];
+    $data['subscribers'][0][] = ''; // blank: must not overwrite the stored grant below
+    $data['subscribers'][1][] = 'denied';
+
+    $existing = $this->createSubscriber('Adam', 'Smith', 'Adam@Smith.com');
+    $existing->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FORM,
+      'Original wording'
+    );
+    $this->subscriberRepository->flush();
+    $storedUpdatedAt = $existing->getTrackingConsentUpdatedAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $storedUpdatedAt);
+
+    $import = $this->createImportInstance($data);
+    $import->process();
+    $this->entityManager->clear();
+
+    $updated = $this->subscriberRepository->findOneBy(['email' => 'adam@smith.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $updated);
+    verify($updated->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    verify($updated->getTrackingConsentMethod())->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_FORM);
+    verify($updated->getTrackingConsentCopy())->equals('Original wording');
+    $currentUpdatedAt = $updated->getTrackingConsentUpdatedAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $currentUpdatedAt);
+    verify($currentUpdatedAt->getTimestamp())->equals($storedUpdatedAt->getTimestamp());
+  }
+
+  public function testItLeavesTrackingConsentUntouchedWhenTheCsvHasNoConsentColumn(): void {
+    $existing = $this->createSubscriber('Adam', 'Smith', 'Adam@Smith.com');
+    $existing->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE,
+      'Manage page wording'
+    );
+    $this->subscriberRepository->flush();
+
+    $import = $this->createImportInstance($this->testData);
+    $import->process();
+    $this->entityManager->clear();
+
+    $updated = $this->subscriberRepository->findOneBy(['email' => 'adam@smith.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $updated);
+    verify($updated->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+    verify($updated->getTrackingConsentMethod())->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE);
+    verify($updated->getTrackingConsentCopy())->equals('Manage page wording');
+  }
+
+  public function testItAppliesTrackingConsentWhenTheImportedCellIsNonBlank(): void {
+    $data = $this->testData;
+    $data['columns']['tracking_consent'] = ['index' => 8];
+    $data['subscribers'][0][] = 'denied';
+    $data['subscribers'][1][] = '';
+
+    $existing = $this->createSubscriber('Adam', 'Smith', 'Adam@Smith.com');
+    $existing->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FORM,
+      'Original wording'
+    );
+    $this->subscriberRepository->flush();
+
+    $import = $this->createImportInstance($data);
+    $import->process();
+    $this->entityManager->clear();
+
+    $updated = $this->subscriberRepository->findOneBy(['email' => 'adam@smith.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $updated);
+    verify($updated->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+    verify($updated->getTrackingConsentMethod())->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_IMPORT);
+    // the previous wording belongs to the previous answer, so it is cleared with it
+    verify($updated->getTrackingConsentCopy())->null();
+    $this->assertInstanceOf(\DateTimeInterface::class, $updated->getTrackingConsentUpdatedAt());
+  }
+
   public function testItSynchronizesWpUsers(): void {
     $this->tester->createWordPressUser('mary@jane.com', 'editor');
     $beforeImport = $this->subscriberRepository->findOneBy(['email' => 'mary@jane.com']);

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -287,6 +287,19 @@ class ImportTest extends \MailPoetTest {
     verify($result['confirmed_ip'])->equals($data['confirmed_ip']);
   }
 
+  public function testItClampsTrackingConsent(): void {
+    $data['email'] = ['adam@smith.com', 'jane@doe.com', 'blank@example.com', 'spaced@example.com'];
+    $data['tracking_consent'] = ['granted', 'not-a-real-value', '', '  denied  '];
+    $result = $this->import->validateSubscribersData($data);
+    $this->assertIsArray($result);
+    verify($result['tracking_consent'][0])->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    // invalid but non-blank: we know something was meant, we just cannot honour it
+    verify($result['tracking_consent'][1])->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    // blank stays blank so the import paths can leave the stored value alone
+    verify($result['tracking_consent'][2])->equals('');
+    verify($result['tracking_consent'][3])->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+  }
+
   public function testItThrowsErrorWhenNoValidSubscribersAreFoundDuringImport(): void {
     $data = [
       'subscribers' => [
@@ -682,6 +695,55 @@ class ImportTest extends \MailPoetTest {
     $this->assertInstanceOf(\DateTimeInterface::class, $lastSubscribed2);
     verify($lastSubscribed1->getTimestamp())->equalsWithDelta($this->testData['timestamp'], 1);
     verify($lastSubscribed2->getTimestamp())->equalsWithDelta($this->testData['timestamp'], 1);
+  }
+
+  public function testItStampsTrackingConsentEvidenceOnNewSubscribersWhenTheCellIsNonBlank(): void {
+    $data = $this->testData;
+    $data['columns']['tracking_consent'] = ['index' => 8];
+    $data['columns']['tracking_consent_copy'] = ['index' => 9];
+    $data['subscribers'][0][] = 'granted';
+    $data['subscribers'][0][] = 'Allow tracking of email opens and link clicks';
+    // blank cell: this subscriber stays at the column defaults
+    $data['subscribers'][1][] = '';
+    $data['subscribers'][1][] = '';
+    $import = $this->createImportInstance($data);
+    $import->process();
+
+    $withConsent = $this->subscriberRepository->findOneBy(['email' => 'adam@smith.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $withConsent);
+    verify($withConsent->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    verify($withConsent->getTrackingConsentMethod())->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_IMPORT);
+    verify($withConsent->getTrackingConsentCopy())->equals('Allow tracking of email opens and link clicks');
+    $this->assertInstanceOf(\DateTimeInterface::class, $withConsent->getTrackingConsentUpdatedAt());
+
+    $blankCell = $this->subscriberRepository->findOneBy(['email' => 'mary@jane.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $blankCell);
+    verify($blankCell->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    verify($blankCell->getTrackingConsentMethod())->null();
+    verify($blankCell->getTrackingConsentCopy())->null();
+    verify($blankCell->getTrackingConsentUpdatedAt())->null();
+  }
+
+  public function testItImportsTheSuppliedTrackingConsentMethodForNewSubscribers(): void {
+    $data = $this->testData;
+    $data['columns']['tracking_consent'] = ['index' => 8];
+    $data['columns']['tracking_consent_method'] = ['index' => 9];
+    $data['subscribers'][0][] = 'denied';
+    $data['subscribers'][0][] = 'legacy_crm_export';
+    $data['subscribers'][1][] = 'granted';
+    $data['subscribers'][1][] = '';
+    $import = $this->createImportInstance($data);
+    $import->process();
+
+    $withMethod = $this->subscriberRepository->findOneBy(['email' => 'adam@smith.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $withMethod);
+    verify($withMethod->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+    verify($withMethod->getTrackingConsentMethod())->equals('legacy_crm_export');
+
+    $withoutMethod = $this->subscriberRepository->findOneBy(['email' => 'mary@jane.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $withoutMethod);
+    verify($withoutMethod->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    verify($withoutMethod->getTrackingConsentMethod())->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_IMPORT);
   }
 
   public function testItDoesNotUpdateExistingSubscribersLastSubscribedAtWhenItIsPresent(): void {

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -724,6 +724,28 @@ class ImportTest extends \MailPoetTest {
     verify($blankCell->getTrackingConsentUpdatedAt())->null();
   }
 
+  public function testItDropsConsentEvidenceWhenTheCsvHasNoConsentColumn(): void {
+    // A CSV mapping only the method or wording column carries no answer, so storing that
+    // evidence against the default `unknown` would invent a proof record nobody gave.
+    $data = $this->testData;
+    $data['columns']['tracking_consent_method'] = ['index' => 8];
+    $data['columns']['tracking_consent_copy'] = ['index' => 9];
+    $data['subscribers'][0][] = 'legacy_crm';
+    $data['subscribers'][0][] = 'Wording with no consent behind it';
+    $data['subscribers'][1][] = 'legacy_crm';
+    $data['subscribers'][1][] = 'Wording with no consent behind it';
+
+    $import = $this->createImportInstance($data);
+    $import->process();
+
+    $subscriber = $this->subscriberRepository->findOneBy(['email' => 'adam@smith.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    verify($subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    verify($subscriber->getTrackingConsentMethod())->null();
+    verify($subscriber->getTrackingConsentCopy())->null();
+    verify($subscriber->getTrackingConsentUpdatedAt())->null();
+  }
+
   public function testItImportsTheSuppliedTrackingConsentMethodForNewSubscribers(): void {
     $data = $this->testData;
     $data['columns']['tracking_consent'] = ['index' => 8];

--- a/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
@@ -141,10 +141,15 @@ class ImportExportFactoryTest extends \MailPoetTest {
       'email',
       'first_name',
       'last_name',
+      'tracking_consent',
+      'tracking_consent_method',
+      'tracking_consent_copy',
     ];
     foreach ($fields as $field) {
       verify(in_array($field, array_keys($subsriberFields)))->true();
     }
+    // tracking_consent_updated_at is export-only: it is always stamped by the plugin, never imported
+    verify(in_array('tracking_consent_updated_at', array_keys($subsriberFields)))->false();
     // export fields contain extra data
     $this->importFactory->action = 'export';
     $subsriberFields = $this->importFactory->getSubscriberFields();
@@ -156,6 +161,10 @@ class ImportExportFactoryTest extends \MailPoetTest {
       'global_status',
       'subscribed_ip',
       'last_subscribed_at',
+      'tracking_consent',
+      'tracking_consent_updated_at',
+      'tracking_consent_method',
+      'tracking_consent_copy',
     ];
     foreach ($exportFields as $field) {
       verify(in_array($field, array_keys($subsriberFields)))->true();
@@ -182,13 +191,17 @@ class ImportExportFactoryTest extends \MailPoetTest {
     $formattedSubscriberFields = $this->importFactory->formatSubscriberFields(
       $this->importFactory->getSubscriberFields()
     );
+    $dateFields = ['last_subscribed_at', 'tracking_consent_updated_at'];
+    $foundDateFields = [];
     foreach ($formattedSubscriberFields as $field) {
-      if ($field['id'] === 'last_subscribed_at') {
+      if (in_array($field['id'], $dateFields, true)) {
         verify($field['type'])->equals('date');
-        return;
+        $foundDateFields[] = $field['id'];
       }
     }
-    $this->fail('Last subscribed field not found.');
+    sort($foundDateFields);
+    sort($dateFields);
+    verify($foundDateFields)->equals($dateFields);
   }
 
   public function testItCanGetSubscriberCustomFields() {
@@ -324,9 +337,10 @@ class ImportExportFactoryTest extends \MailPoetTest {
     $importMenu = $import->bootstrap();
     verify(count((array)json_decode($importMenu['segments'], true)))
       ->equals(2);
-    // email, first_name, last_name, subscribed_ip, created_at, confirmed_ip, confirmed_at + 1 custom field
+    // email, first_name, last_name, subscribed_ip, created_at, confirmed_ip, confirmed_at,
+    // tracking_consent, tracking_consent_method, tracking_consent_copy + 1 custom field
     verify(count((array)json_decode($importMenu['subscriberFields'], true)))
-      ->equals(8);
+      ->equals(11);
     // action, system fields, user fields
     verify(count((array)json_decode($importMenu['subscriberFieldsSelect2'], true)))
       ->equals(3);

--- a/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportRepositoryTest.php
@@ -279,6 +279,34 @@ class ImportExportRepositoryTest extends \MailPoetTest {
     verify($exported[1]['segment_name'])->equals('First');
   }
 
+  public function testItExportsTrackingConsentColumns(): void {
+    $user1 = $this->createSubscriber('user1@consent-export-test.com', 'One', 'User');
+    $user1->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FORM,
+      'Allow tracking of email opens and link clicks'
+    );
+    $user2 = $this->createSubscriber('user2@consent-export-test.com', 'Two', 'User');
+    $this->subscribersRepository->flush();
+    $segment1 = $this->createSegment('Export Consent', SegmentEntity::TYPE_DEFAULT);
+    $this->createSubscriberSegment($user1, $segment1, SubscriberEntity::STATUS_SUBSCRIBED);
+    $this->createSubscriberSegment($user2, $segment1, SubscriberEntity::STATUS_SUBSCRIBED);
+
+    $exported = $this->repository->getSubscribersBatchBySegment($segment1, 100);
+    verify($exported)->arrayCount(2);
+    verify($exported[0]['tracking_consent'])->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    verify($exported[0]['tracking_consent_method'])->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_FORM);
+    verify($exported[0]['tracking_consent_copy'])->equals('Allow tracking of email opens and link clicks');
+    $consentUpdatedAt = $user1->getTrackingConsentUpdatedAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $consentUpdatedAt);
+    verify($exported[0]['tracking_consent_updated_at'])->equals($consentUpdatedAt->format(DateTime::DEFAULT_DATE_TIME_FORMAT));
+    // a subscriber who never answered still exports the four columns, at their defaults
+    verify($exported[1]['tracking_consent'])->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    verify($exported[1]['tracking_consent_method'])->null();
+    verify($exported[1]['tracking_consent_copy'])->null();
+    verify($exported[1]['tracking_consent_updated_at'])->null();
+  }
+
   public function testItGetOnlyNodDeletedSubscribersByDefaultSegment(): void {
     $user1 = $this->createSubscriber('user1@export-test.com', 'One', 'User');
     $user2 = $this->createSubscriber('user2@export-test.com', 'Two', 'User');


### PR DESCRIPTION
## What this does

Tracking consent now survives subscriber import and export.

**Export** carries all four consent columns: the state, when it changed, how it was collected, and the wording the subscriber saw. That is also the "exportable proof" STOMAIL-8308 asks for.

**Import** can set `tracking_consent`, including granting it. The merchant owns their data, so someone migrating from another system can bring a real consent history across instead of losing it. `tracking_consent_method` and `tracking_consent_copy` are taken from the CSV when supplied; without a method we stamp `import`.

An invalid but non-blank state (say `maybe-later`) is clamped to `unknown`. We still stamp the evidence for those rows: the subscriber did answer, we just could not honour the answer.

## The rule this PR is careful about

**A blank cell must never erase a stored consent.**

`updateMultiple()` writes one uniform set of columns per call, so leaving consent in the standard update would let a blank cell overwrite a stored `granted` for every row in the batch. Instead the consent columns are stripped out of the main update, and written through a second `UPDATE` scoped to the rows whose CSV cell was non-blank. A CSV with no consent column at all, or a blank cell in one that exists, changes nothing.

`tracking_consent_updated_at` is always stamped by the plugin when consent is applied, never read from the CSV. It drives the tracked-at-send denominator used elsewhere in this project (#7045), and a backdated import could shrink a past denominator while a tracked open stayed in the numerator — an impossible rate over 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshots

Browser QA on a live site, all captured against the branch build.

**Consent fields available for export** — the four new columns appear in the export field picker alongside the built-in ones.

![Export page showing the tracking consent fields](https://d.pr/i/epkpMy+)

**Export completes** — four subscribers written out, consent columns included.

![Export success, four subscribers](https://d.pr/i/ODIVoa+)

**Round-trip** — the exported CSV imported back, consent state, method and wording all preserved.

![Subscribers imported, consent round-tripped](https://d.pr/i/48Hh9Y+)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8306-tracking-consent-import-export)

_The latest successful build from `fix/stomail-8306-tracking-consent-import-export` will be used. If none is available, the link won't work._
