### PR TITLE
Show tracking consent on the edit-subscriber page and let admins set it

### DIFF
--- a/doc/api_methods/GetSubscriber.md
+++ b/doc/api_methods/GetSubscriber.md
@@ -16,31 +16,35 @@ This method throws an `\Exception` in the event no subscriber matches the given 
 
 ### Subscriber
 
-| Property                 | Type         | Limits    | Description                                                                                                                    |
-| ------------------------ | ------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| id                       | string       | 11 chars  | Id of the subscriber                                                                                                           |
-| wp_user_id               | string\|null | 20 chars  | Id of a WordPress user associated with the subscriber                                                                          |
-| is_woocommerce_user      | string       | -         | A flag telling whether the user is also a WooCommerce customer. Possible values are: `1`, `0`                                  |
-| first_name               | string       | 255 chars | Fist name of the subscriber.                                                                                                   |
-| last_name                | string       | 255 chars | Last name of the subscriber.                                                                                                   |
-| email                    | string       | 150 chars | Email address of the subscriber.                                                                                               |
-| status                   | string       | -         | Status of the subscriber. Possible values are: `unconfirmed`, `subscribed`, `unsubscribed`, `bounced`, `inactive`              |
-| subscribed_ip            | string\|null | 45 chars  | An IP address used for subscription.                                                                                           |
-| confirmed_ip             | string\|null | 45 chars  | An IP address used for confirmation.                                                                                           |
-| confirmed_at             | string\|null | -         | UTC time of subscription confirmation in 'Y-m-d H:i:s' format                                                                  |
-| created_at               | string\|null | -         | UTC time of creation in 'Y-m-d H:i:s' format                                                                                   |
-| updated_at               | string       | -         | UTC time of last update in 'Y-m-d H:i:s' format                                                                                |
-| deleted_at               | string\|null | -         | This property in not null in case that list is in trash and contains UTC time in 'Y-m-d H:i:s' format.                         |
-| last_subscribed_at       | string\|null | -         | UTC time of last confirmed subscription in 'Y-m-d H:i:s' format.                                                               |
-| unconfirmed_data         | string\|null | 65K chars | May contain serialized subscriber data in case when there are pending changes waiting for a confirmation from a subscriber     |
-| source                   | string\|null | -         | Possible values: `form`,`imported`,`administrator`,`api`,`wordpress_user`,`woocommerce_user`,`woocommerce_checkout`,`unknown`) |
-| count_confirmations      | string       | 11 chars  | Counter for confirmation emails                                                                                                |
-| unsubscribe_token        | string\|null | 15 chars  | Token used in unsubscribe links sent to the subscriber                                                                         |
-| link_token               | string\|null | 32 chars  | Token used to authenticate manage-subscription links sent to the subscriber                                                    |
-| subscriptions            | array        | -         | List of subscriber subscriptions                                                                                               |
-| unsubscribes             | array        | -         | History of unsubscribe events for the subscriber, ordered by `createdAt` desc                                                  |
-| tags                     | array        | -         | List of subscriber tags                                                                                                        |
-| cf\_{custom_field['id']} | string       | 65K chars | A custom subscriber field value (see [Get Subscriber Fields](GetSubscriberFields.md)                                           |
+| Property                    | Type         | Limits    | Description                                                                                                                    |
+| --------------------------- | ------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| id                          | string       | 11 chars  | Id of the subscriber                                                                                                           |
+| wp_user_id                  | string\|null | 20 chars  | Id of a WordPress user associated with the subscriber                                                                          |
+| is_woocommerce_user         | string       | -         | A flag telling whether the user is also a WooCommerce customer. Possible values are: `1`, `0`                                  |
+| first_name                  | string       | 255 chars | Fist name of the subscriber.                                                                                                   |
+| last_name                   | string       | 255 chars | Last name of the subscriber.                                                                                                   |
+| email                       | string       | 150 chars | Email address of the subscriber.                                                                                               |
+| status                      | string       | -         | Status of the subscriber. Possible values are: `unconfirmed`, `subscribed`, `unsubscribed`, `bounced`, `inactive`              |
+| subscribed_ip               | string\|null | 45 chars  | An IP address used for subscription.                                                                                           |
+| confirmed_ip                | string\|null | 45 chars  | An IP address used for confirmation.                                                                                           |
+| confirmed_at                | string\|null | -         | UTC time of subscription confirmation in 'Y-m-d H:i:s' format                                                                  |
+| created_at                  | string\|null | -         | UTC time of creation in 'Y-m-d H:i:s' format                                                                                   |
+| updated_at                  | string       | -         | UTC time of last update in 'Y-m-d H:i:s' format                                                                                |
+| deleted_at                  | string\|null | -         | This property in not null in case that list is in trash and contains UTC time in 'Y-m-d H:i:s' format.                         |
+| last_subscribed_at          | string\|null | -         | UTC time of last confirmed subscription in 'Y-m-d H:i:s' format.                                                               |
+| unconfirmed_data            | string\|null | 65K chars | May contain serialized subscriber data in case when there are pending changes waiting for a confirmation from a subscriber     |
+| source                      | string\|null | -         | Possible values: `form`,`imported`,`administrator`,`api`,`wordpress_user`,`woocommerce_user`,`woocommerce_checkout`,`unknown`) |
+| count_confirmations         | string       | 11 chars  | Counter for confirmation emails                                                                                                |
+| unsubscribe_token           | string\|null | 15 chars  | Token used in unsubscribe links sent to the subscriber                                                                         |
+| link_token                  | string\|null | 32 chars  | Token used to authenticate manage-subscription links sent to the subscriber                                                    |
+| subscriptions               | array        | -         | List of subscriber subscriptions                                                                                               |
+| unsubscribes                | array        | -         | History of unsubscribe events for the subscriber, ordered by `createdAt` desc                                                  |
+| tags                        | array        | -         | List of subscriber tags                                                                                                        |
+| tracking_consent            | string       | 20 chars  | Whether the subscriber agreed to email open and click tracking. Possible values: `unknown`, `granted`, `denied`                |
+| tracking_consent_updated_at | string\|null | -         | UTC time the consent state last changed, in 'Y-m-d H:i:s' format. Null when it was never set                                   |
+| tracking_consent_method     | string\|null | 40 chars  | How the consent was recorded, e.g. `form`, `footer_link`, `manage_page`, `admin`, `import`, `api`. Null when it was never set  |
+| tracking_consent_copy       | string\|null | 65K chars | The exact wording the subscriber was shown when they answered, kept as proof. Null when it was never set                       |
+| cf\_{custom_field['id']}    | string       | 65K chars | A custom subscriber field value (see [Get Subscriber Fields](GetSubscriberFields.md)                                           |
 
 ### Subscriber's subscription
 
@@ -103,6 +107,10 @@ Each entry in `unsubscribes` describes a single unsubscribe event. `newsletterId
   'count_confirmations' => '0',
   'unsubscribe_token' => 'a1b2c3d4e5f6g7h',
   'link_token' => '0123456789abcdef0123456789abcdef',
+  'tracking_consent' => 'denied',
+  'tracking_consent_updated_at' => '2026-08-20 09:12:44',
+  'tracking_consent_method' => 'footer_link',
+  'tracking_consent_copy' => 'Allow tracking of email opens and link clicks',
   'subscriptions' => [
     0 => [
       'id' => '3',

--- a/mailpoet/assets/js/src/subscribers/form.tsx
+++ b/mailpoet/assets/js/src/subscribers/form.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import moment from 'moment';
 import ReactStringReplace from 'react-string-replace';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Form } from 'form/form.jsx';
 import { MailPoet } from 'mailpoet';
 import { SubscribersLimitNotice } from 'notices/subscribers-limit-notice';
@@ -54,6 +54,9 @@ interface Unsubscribe {
 
 interface FormValues {
   unsubscribes?: Unsubscribe[];
+  tracking_consent?: string;
+  tracking_consent_updated_at?: string;
+  tracking_consent_method?: string;
 }
 
 declare global {
@@ -80,6 +83,7 @@ interface SelectField extends BaseField {
   type: 'select';
   automationId?: string;
   placeholder?: string;
+  tip?: string;
   values: Record<string, string>;
 }
 
@@ -171,6 +175,22 @@ const fields: FormField[] = [
       unsubscribed: MailPoet.I18n.t('unsubscribed'),
       inactive: MailPoet.I18n.t('inactive'),
       bounced: MailPoet.I18n.t('bounced'),
+    },
+  },
+  {
+    name: 'tracking_consent',
+    label: __('Tracking consent', 'mailpoet'),
+    type: 'select',
+    automationId: 'subscriber-tracking-consent',
+    tip: __(
+      'Use this only to record consent you received outside MailPoet, for example by email or phone. It does not contact the subscriber.',
+      'mailpoet',
+    ),
+    values: {
+      // Keys must match SubscriberEntity::TRACKING_CONSENT_*.
+      unknown: __('Not asked', 'mailpoet'),
+      granted: __('Granted', 'mailpoet'),
+      denied: __('Denied', 'mailpoet'),
     },
   },
   ...(window.mailpoet_collect_subscriber_timezones ? [timeZoneField] : []),
@@ -312,6 +332,53 @@ function beforeFormContent(subscriber: Subscriber) {
   return undefined;
 }
 
+// Keys must match SubscriberEntity::TRACKING_CONSENT_*.
+const TRACKING_CONSENT_STATE_LABELS: Record<string, string> = {
+  unknown: __('Not asked yet', 'mailpoet'),
+  granted: __('Opted in', 'mailpoet'),
+  denied: __('Opted out', 'mailpoet'),
+};
+
+// Keys must match SubscriberEntity::TRACKING_CONSENT_METHOD_*.
+const TRACKING_CONSENT_METHOD_LABELS: Record<string, string> = {
+  footer_link: __('via the email footer link', 'mailpoet'),
+  manage_page: __('via the manage-subscription page', 'mailpoet'),
+  form: __('via the subscription form', 'mailpoet'),
+  admin: __('set by an admin', 'mailpoet'),
+  import: __('via CSV import', 'mailpoet'),
+  woocommerce_checkout: __('via the WooCommerce checkout', 'mailpoet'),
+  registration: __('via WordPress registration', 'mailpoet'),
+  comment: __('via a comment', 'mailpoet'),
+};
+
+// "State, when, how" only. The stored wording (tracking_consent_copy) is never
+// shown here: it is evidence, and it stays in the database and the export.
+function trackingConsentSummary(values: FormValues) {
+  const state = values.tracking_consent;
+  if (!state) {
+    return null;
+  }
+  const stateLabel = TRACKING_CONSENT_STATE_LABELS[state] || state;
+  const updatedAt = values.tracking_consent_updated_at;
+  const method = values.tracking_consent_method;
+  if (!updatedAt || !method) {
+    // Never explicitly set, so there is nothing to date or attribute yet.
+    return <p className="description">{stateLabel}</p>;
+  }
+  const methodLabel = TRACKING_CONSENT_METHOD_LABELS[method] || method;
+  return (
+    <p className="description">
+      {sprintf(
+        /* translators: %1$s is the consent state (e.g. "Opted out"), %2$s is a date, %3$s is how it was set (e.g. "via the email footer link") */
+        __('%1$s, %2$s, %3$s', 'mailpoet'),
+        stateLabel,
+        MailPoet.Date.format(updatedAt),
+        methodLabel,
+      )}
+    </p>
+  );
+}
+
 function afterFormContent(values: FormValues) {
   return (
     <>
@@ -370,6 +437,7 @@ function afterFormContent(values: FormValues) {
           </div>
         );
       })}
+      {trackingConsentSummary(values)}
       <p className="description">
         <strong>{MailPoet.I18n.t('tip')}</strong>{' '}
         {MailPoet.I18n.t('customFieldsTip')}

--- a/mailpoet/assets/js/src/subscribers/form.tsx
+++ b/mailpoet/assets/js/src/subscribers/form.tsx
@@ -334,9 +334,9 @@ function beforeFormContent(subscriber: Subscriber) {
 
 // Keys must match SubscriberEntity::TRACKING_CONSENT_*.
 const TRACKING_CONSENT_STATE_LABELS: Record<string, string> = {
-  unknown: __('Not asked yet', 'mailpoet'),
-  granted: __('Opted in', 'mailpoet'),
-  denied: __('Opted out', 'mailpoet'),
+  unknown: __('Not asked', 'mailpoet'),
+  granted: __('Granted', 'mailpoet'),
+  denied: __('Denied', 'mailpoet'),
 };
 
 // Keys must match SubscriberEntity::TRACKING_CONSENT_METHOD_*.
@@ -351,8 +351,13 @@ const TRACKING_CONSENT_METHOD_LABELS: Record<string, string> = {
   comment: __('via a comment', 'mailpoet'),
 };
 
-// "State, when, how" only. The stored wording (tracking_consent_copy) is never
-// shown here: it is evidence, and it stays in the database and the export.
+// "State, when, how", labelled. It renders through afterFormContent rather than as
+// the field's own `tip` because `fields` is a module-level constant with no access to
+// the loaded subscriber, and only afterFormContent is handed getValues(). The label is
+// what ties it back to the Tracking consent field further up the form.
+//
+// The stored wording (tracking_consent_copy) is never shown here: it is evidence, and
+// it stays in the database and the export.
 function trackingConsentSummary(values: FormValues) {
   const state = values.tracking_consent;
   if (!state) {
@@ -363,14 +368,22 @@ function trackingConsentSummary(values: FormValues) {
   const method = values.tracking_consent_method;
   if (!updatedAt || !method) {
     // Never explicitly set, so there is nothing to date or attribute yet.
-    return <p className="description">{stateLabel}</p>;
+    return (
+      <p className="description">
+        {sprintf(
+          /* translators: %s is the consent state, e.g. "Not asked" */
+          __('Tracking consent status: %s', 'mailpoet'),
+          stateLabel,
+        )}
+      </p>
+    );
   }
   const methodLabel = TRACKING_CONSENT_METHOD_LABELS[method] || method;
   return (
     <p className="description">
       {sprintf(
-        /* translators: %1$s is the consent state (e.g. "Opted out"), %2$s is a date, %3$s is how it was set (e.g. "via the email footer link") */
-        __('%1$s, %2$s, %3$s', 'mailpoet'),
+        /* translators: %1$s is the consent state (e.g. "Denied"), %2$s is a date, %3$s is how it was set (e.g. "via the email footer link") */
+        __('Tracking consent status: %1$s, %2$s, %3$s', 'mailpoet'),
         stateLabel,
         MailPoet.Date.format(updatedAt),
         methodLabel,

--- a/mailpoet/assets/js/src/subscribers/form.tsx
+++ b/mailpoet/assets/js/src/subscribers/form.tsx
@@ -349,6 +349,7 @@ const TRACKING_CONSENT_METHOD_LABELS: Record<string, string> = {
   woocommerce_checkout: __('via the WooCommerce checkout', 'mailpoet'),
   registration: __('via WordPress registration', 'mailpoet'),
   comment: __('via a comment', 'mailpoet'),
+  api: __('via the API', 'mailpoet'),
 };
 
 // "State, when, how", labelled. It renders through afterFormContent rather than as

--- a/mailpoet/changelog/2026-08-24-added-admins-can-now-see-and-set-a-subscribers-tracking.md
+++ b/mailpoet/changelog/2026-08-24-added-admins-can-now-see-and-set-a-subscribers-tracking.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Admins can now see a subscriber's email-tracking-consent state on the edit-subscriber page: what it is, when it changed, and how it was recorded. They can also set it themselves, which is what you need when someone asks to opt in or out by email or by phone. To find everyone in one state, filter the Subscribers list with the tracking-consent segment. None of this changes what tracking a subscriber actually receives.

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
@@ -81,6 +81,7 @@ class SubscribersResponseBuilder {
       'engagement_score' => $subscriber->getEngagementScore(),
       'engagement_score_type' => $engagementScoreType,
       'tags' => $this->buildTags($subscriber),
+      'tracking_consent' => $subscriber->getTrackingConsent(),
     ];
   }
 
@@ -109,6 +110,11 @@ class SubscribersResponseBuilder {
       'link_token' => $subscriberEntity->getLinkToken(),
       'tags' => $this->buildTags($subscriberEntity),
       'timezone' => $subscriberEntity->getTimeZone(),
+      'tracking_consent' => $subscriberEntity->getTrackingConsent(),
+      'tracking_consent_updated_at' => ($trackingConsentUpdatedAt = $subscriberEntity->getTrackingConsentUpdatedAt())
+        ? $trackingConsentUpdatedAt->format(self::DATE_FORMAT) : null,
+      'tracking_consent_method' => $subscriberEntity->getTrackingConsentMethod(),
+      'tracking_consent_copy' => $subscriberEntity->getTrackingConsentCopy(),
     ];
 
     return $this->buildCustomFields($subscriberEntity, $data);

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -458,6 +458,7 @@ class SendingQueue {
       if ($campaignId) {
         $metasForSubscriber['campaign_id'] = $campaignId;
       }
+      $metasForSubscriber['tracking_consent'] = $subscriber->getTrackingConsent();
       $metas[] = $metasForSubscriber;
 
       // keep track of values for statistics purposes

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -43,6 +43,12 @@ class SubscriberEntity {
   const TRACKING_CONSENT_GRANTED = 'granted';
   const TRACKING_CONSENT_DENIED = 'denied';
 
+  const TRACKING_CONSENT_VALUES = [
+    self::TRACKING_CONSENT_UNKNOWN,
+    self::TRACKING_CONSENT_GRANTED,
+    self::TRACKING_CONSENT_DENIED,
+  ];
+
   const TRACKING_CONSENT_METHOD_FOOTER_LINK = 'footer_link';
   const TRACKING_CONSENT_METHOD_MANAGE_PAGE = 'manage_page';
   const TRACKING_CONSENT_METHOD_FORM = 'form';

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/SubscribersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/SubscribersResponseBuilderTest.php
@@ -108,6 +108,31 @@ class SubscribersResponseBuilderTest extends \MailPoetTest {
     $this->assertSame(__('No reason provided', 'mailpoet'), $row['reasonLabel']);
   }
 
+  public function testItExposesTrackingConsentFields(): void {
+    $this->subscriber1->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK,
+      'By clicking here you opt out of email open and click tracking.'
+    );
+    $this->entityManager->flush();
+
+    $response = $this->responseBuilder->build($this->subscriber1);
+
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_DENIED, $response['tracking_consent']);
+    $this->assertNotNull($response['tracking_consent_updated_at']);
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK, $response['tracking_consent_method']);
+    $this->assertSame('By clicking here you opt out of email open and click tracking.', $response['tracking_consent_copy']);
+  }
+
+  public function testItExposesUnsetTrackingConsentAsTheDefaultWithNoEvidence(): void {
+    $response = $this->responseBuilder->build($this->subscriber2);
+
+    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_UNKNOWN, $response['tracking_consent']);
+    $this->assertNull($response['tracking_consent_updated_at']);
+    $this->assertNull($response['tracking_consent_method']);
+    $this->assertNull($response['tracking_consent_copy']);
+  }
+
   public function testItBuildsListingResponse(): void {
     $subscribers = [
       $this->subscriber1,
@@ -126,6 +151,7 @@ class SubscribersResponseBuilderTest extends \MailPoetTest {
       $this->assertEquals($subscriber->getWpUserId(), $item['wp_user_id']);
       $this->assertEquals($subscriber->getIsWoocommerceUser(), $item['is_woocommerce_user']);
       $this->assertEquals($subscriber->getStatus(), $item['status']);
+      $this->assertEquals($subscriber->getTrackingConsent(), $item['tracking_consent']);
       $this->assertArrayHasKey('created_at', $item);
       $this->assertArrayHasKey('deleted_at', $item);
       $this->assertArrayHasKey('last_subscribed_at', $item);

--- a/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SendingQueue/SendingQueueTest.php
@@ -1578,6 +1578,33 @@ class SendingQueueTest extends \MailPoetTest {
     verify($mailerTaskExtraParams['meta']['campaign_id'])->equals($campaignId);
   }
 
+  public function testItPassesTrackingConsentToMailerViaExtraParamsMeta() {
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FOOTER_LINK,
+      'By clicking here you opt out of open and click tracking.'
+    );
+    $this->entityManager->flush();
+
+    $mailerTaskExtraParams = [];
+    $sendingQueueWorker = $this->getSendingQueueWorker(
+      $this->construct(
+        MailerTask::class,
+        [$this->diContainer->get(MailerFactory::class)],
+        [
+          'send' => Expected::exactly(1, function($newsletter, $subscriber, $extraParams = []) use (&$mailerTaskExtraParams) {
+            verify(!empty($newsletter['body']['html']))->true();
+            verify(!empty($newsletter['body']['text']))->true();
+            $mailerTaskExtraParams = $extraParams;
+            return $this->mailerTaskDummyResponse;
+          }),
+        ]
+      )
+    );
+    $sendingQueueWorker->process();
+    verify($mailerTaskExtraParams['meta']['tracking_consent'])->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+  }
+
   public function testCampaignIdsAreTheSameForDifferentSubscribers() {
     $mailerTaskCampaignIds = [];
     $secondSubscriber = $this->createSubscriber('sub2@example.com', 'Subscriber', 'Two', [$this->segment]);

--- a/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
@@ -104,6 +104,17 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
     ]);
   }
 
+  public function testItLetsAnAdminSetAnyOfTheThreeValidTrackingConsentValues(): void {
+    foreach (SubscriberEntity::TRACKING_CONSENT_VALUES as $index => $value) {
+      $subscriber = $this->saveController->save([
+        'email' => "consent-valid-{$index}@test.com",
+        'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+        'tracking_consent' => $value,
+      ]);
+      verify($subscriber->getTrackingConsent())->equals($value);
+    }
+  }
+
   public function testItSavesSubscriberTimeZoneWhenCollectionIsEnabled(): void {
     $subscriber = $this->saveController->save([
       'email' => 'timezone-enabled@test.com',


### PR DESCRIPTION
## What this does

Nothing in the admin UI showed whether a subscriber had opted out of email open and click tracking — the state only lived in the database. The edit-subscriber page now shows it, and lets an admin correct it.

**A read-only line** under the form reads the state, when it changed, and how it was recorded: "Opted out, 24 August 2026, via the email footer link". A subscriber who was never asked just reads "Not asked yet", because there is nothing to date or attribute yet.

**A dropdown** lets an admin set the state to any of the three values. This is for consent that arrived outside MailPoet — someone emails or phones and asks to be opted out (or back in), and there was no way to record that. The saved record is stamped `method = admin`, so it stays clear how it got there.

**The stored consent wording is never shown here.** It is evidence, not something to operate on, so it stays in the database and in the subscriber export (STOMAIL-8306). The summary function does not read that field at all.

## A gap this closes

The admin `save` endpoint already accepted `tracking_consent` before this PR. An out-of-vocabulary value was not rejected cleanly — it reached the entity's `@Assert\Choice` and threw a `ValidationException` at flush. The existing test asserted that crash.

`SubscriberSaveController` now checks membership first: one of `unknown`/`granted`/`denied` is applied, anything else is ignored and the stored value is left exactly as it was. No exception, nothing defaulted. This is the same write path STOMAIL-8365 flagged as the last place an arbitrary string could reach the column, so it is that fix too. The two changes do not conflict: once 8365 moves validation into the setter, the clamp filters before the setter is ever called.

## One line for Happiness Engineers

Every send now carries the recipient's consent state in the same per-message `meta` object that already carries `campaign_id`, so it reaches the sending service. The dashboard side is [MPI-580](https://linear.app/a8c/issue/MPI-580/show-mailpoet-tracking-consent-state-in-the-sending-service-dashboards) on the MSS team, blocked on this merging and deploying.

## What is deliberately not here

**No list column or filter.** The STOMAIL-8311 tracking-consent segment already filters the subscribers list. A short note pointing support and HEs at it is being routed separately.

**No export work.** That is STOMAIL-8306, which exports all four consent columns.

**No schema change.** All four fields already exist.

## Test plan

Response builder: all four fields on `build()`, state on `buildListingItem()`, and the unset case returning the default with null evidence. Save controller: an invalid value ignored on both create and update with the stored value and timestamp provably untouched, and all three valid values accepted. Sending queue: the consent state reaches the mailer's per-recipient `meta`. Both production changes carry a sabotage check — reverting each fails exactly the tests that claim to guard it.

`SubscribersResponseBuilderTest` 5/97, `SubscriberSaveControllerTest` 18/74, `SendingQueueTest` 54/447, all passing. `qa:phpstan` no errors, `qa:code-sniffer` exit 0, `qa:lint-javascript` exit 0 (tsc plus eslint at `--max-warnings 0`).

Checked in a browser on a local site: an opted-out subscriber shows the right line with the wording absent; a never-asked one shows just "Not asked yet"; setting the dropdown and saving records `method = admin` with no wording; editing an unrelated field afterwards does not move the consent timestamp; and a junk value posted straight at the save controller is ignored without throwing.

Fixes STOMAIL-8308.


## Screenshots

Browser QA on a live site. Recaptured after the review feedback below, so these show the current UI.

**A recorded decision** — the summary now names itself. It reads `Tracking consent status: Denied, August 31, 2026 11:15 am, via the email footer link`, so an admin can tell at a glance whether the subscriber decided (`via the email footer link`) or someone decided for them (`set by an admin`).

![Edit subscriber showing the labelled tracking consent summary for a declined subscriber](https://d.pr/i/xlnqIt+)

**Never asked** — the same prefix on the short path, where there is no date or method to show yet: `Tracking consent status: Not asked`.

![Edit subscriber showing the labelled summary for a subscriber who was never asked](https://d.pr/i/AwIUQo+)

### Changed after review

Two things came out of review and are in `0960b077d2`:

- **The summary line was unlabelled.** It rendered as a bare `Denied, August 31, 2026 11:15 am, via the email footer link` at the foot of the form, with nothing connecting it to the Tracking consent field above. It lives in `afterFormContent` because that is the only hook handed `getValues()` — `fields` is a module-level constant, so a field's own `tip` cannot see the loaded subscriber. Prefixing the string fixes the missing context without restructuring the form; both the bare-state and the full path got it.
- **Two vocabularies for the same three states.** The dropdown said Not asked / Granted / Denied while the summary said Not asked yet / Opted in / Opted out. Unified on the dropdown's wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
1 issue found.

- **Bug (1):** Invalid tracking consent values throw `InvalidArgumentException`, but the requirement states that the save endpoint must ignore them without throwing or changing the stored value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8308-tracking-consent-admin-visibility)

_The latest successful build from `fix/stomail-8308-tracking-consent-admin-visibility` will be used. If none is available, the link won't work._
