### PR TITLE
Check for the tracking opt-out link and the form consent checkbox while editing

### DIFF
--- a/mailpoet/assets/js/src/form-editor/store/actions.ts
+++ b/mailpoet/assets/js/src/form-editor/store/actions.ts
@@ -354,3 +354,9 @@ export function* tutorialDismissed() {
     type: 'TUTORIAL_DISMISSED',
   };
 }
+
+export function* insertTrackingConsentBlock() {
+  yield {
+    type: 'INSERT_TRACKING_CONSENT_BLOCK',
+  };
+}

--- a/mailpoet/assets/js/src/form-editor/store/controls.tsx
+++ b/mailpoet/assets/js/src/form-editor/store/controls.tsx
@@ -234,6 +234,29 @@ export const controls = {
    * We want to ensure that email input and submit are always present.
    * @param actionData {{type: string, blocks: Block[]}} blocks property contains editor blocks
    */
+  /**
+   * Adds the tracking consent checkbox in front of the submit button, which is
+   * where the renderer already puts the captcha and the honeypot. The block is
+   * created with its defaults on purpose: unticked, optional, and with copy the
+   * merchant can edit.
+   */
+  INSERT_TRACKING_CONSENT_BLOCK() {
+    const blocks = select(blockEditorStore).getBlocks() as Array<Block>;
+    if (findBlock(blocks, 'mailpoet-form/tracking-consent')) {
+      return;
+    }
+    const submitIndex = blocks.findIndex(
+      (block) => block.name === 'mailpoet-form/submit-button',
+    );
+    const newBlocks = [...blocks];
+    newBlocks.splice(
+      submitIndex >= 0 ? submitIndex : newBlocks.length,
+      0,
+      createBlock('mailpoet-form/tracking-consent'),
+    );
+    void dispatch(blockEditorStore).resetBlocks(newBlocks);
+  },
+
   BLOCKS_CHANGED_IN_BLOCK_EDITOR(actionData) {
     const newBlocks = actionData.blocks as Array<Block>;
     // Check if both required inputs are present

--- a/mailpoet/assets/js/src/form-editor/store/form-validator.jsx
+++ b/mailpoet/assets/js/src/form-editor/store/form-validator.jsx
@@ -1,6 +1,10 @@
 import { findBlock } from './find-block';
 
-export const validateForm = (formData, formBlocks) => {
+export const validateForm = (
+  formData,
+  formBlocks,
+  isTrackingConsentCaptureEnabled = false,
+) => {
   if (
     !formData ||
     !formData.settings ||
@@ -36,6 +40,17 @@ export const validateForm = (formData, formBlocks) => {
   }
   if (!submit) {
     errors.push('missing-submit');
+  }
+  // "Required" here means the checkbox is on the form, not that the subscriber
+  // has to tick it. The block is still rendered unticked and optional.
+  if (isTrackingConsentCaptureEnabled) {
+    const trackingConsent = findBlock(
+      formBlocks,
+      'mailpoet-form/tracking-consent',
+    );
+    if (!trackingConsent) {
+      errors.push('missing-tracking-consent');
+    }
   }
   return errors;
 };

--- a/mailpoet/assets/js/src/form-editor/store/reducers/change-form-blocks.jsx
+++ b/mailpoet/assets/js/src/form-editor/store/reducers/change-form-blocks.jsx
@@ -60,6 +60,10 @@ export const changeFormBlocks = (state, action) => {
   return {
     ...newState,
     hasUnsavedChanges: true,
-    formErrors: validateForm(newState.formData, newState.formBlocks),
+    formErrors: validateForm(
+      newState.formData,
+      newState.formBlocks,
+      newState.trackingConsentCaptureEnabled,
+    ),
   };
 };

--- a/mailpoet/assets/js/src/form-editor/store/reducers/change-form-settings.jsx
+++ b/mailpoet/assets/js/src/form-editor/store/reducers/change-form-settings.jsx
@@ -11,6 +11,10 @@ export const changeFormSettings = (state, action) => {
   return {
     ...newState,
     hasUnsavedChanges: true,
-    formErrors: validateForm(newState.formData, newState.formBlocks),
+    formErrors: validateForm(
+      newState.formData,
+      newState.formBlocks,
+      newState.trackingConsentCaptureEnabled,
+    ),
   };
 };

--- a/mailpoet/assets/js/src/form-editor/store/reducers/save-form-started.ts
+++ b/mailpoet/assets/js/src/form-editor/store/reducers/save-form-started.ts
@@ -72,10 +72,11 @@ export const saveFormStartedFactory =
 
     return {
       ...state,
-      // Without excluding the new error here the Save button would sit in its
-      // busy state forever: SAVE_FORM returns early when formErrors is
-      // non-empty, and nothing else resets isFormSaving.
-      isFormSaving: !hasMissingLists && !hasMissingTrackingConsent,
+      // SAVE_FORM returns early when formErrors is non-empty and nothing else resets
+      // this, so any error at all has to stop the spinner. Naming individual errors
+      // here left the Save button stuck forever on a form missing its email or submit
+      // block, which was already true before the tracking-consent error existed.
+      isFormSaving: state.formErrors.length === 0,
       sidebar: {
         ...state.sidebar,
         activeTab: hasMissingLists ? 'form' : state.sidebar.activeTab,

--- a/mailpoet/assets/js/src/form-editor/store/reducers/save-form-started.ts
+++ b/mailpoet/assets/js/src/form-editor/store/reducers/save-form-started.ts
@@ -1,4 +1,10 @@
+import { dispatch } from '@wordpress/data';
 import { State } from '../state-types';
+
+// The literal rather than the storeName export from '../constants': that module
+// pulls in @wordpress/block-editor, which has no window in the Node test env and
+// would break every spec that touches this reducer.
+const STORE_NAME = 'mailpoet-form-editor';
 
 export const saveFormStartedFactory =
   (MailPoet) =>
@@ -11,6 +17,7 @@ export const saveFormStartedFactory =
           'save-form',
           'missing-lists',
           'missing-block',
+          'missing-tracking-consent',
         ].includes(notice.id),
     );
     const hasMissingLists =
@@ -40,9 +47,35 @@ export const saveFormStartedFactory =
       });
     }
 
+    const hasMissingTrackingConsent = state.formErrors.includes(
+      'missing-tracking-consent',
+    );
+    if (hasMissingTrackingConsent) {
+      // Deliberately not dismissible: components/notices.jsx auto-removes
+      // dismissible notices after five seconds, which is not long enough to
+      // read an error and click its action. Non-dismissible notices are
+      // cleared at the start of the next save, which is when this re-runs.
+      notices.push({
+        id: 'missing-tracking-consent',
+        content: MailPoet.I18n.t('missingTrackingConsentBlock'),
+        isDismissible: false,
+        status: 'error',
+        actions: [
+          {
+            label: MailPoet.I18n.t('addTrackingConsentBlock'),
+            onClick: () =>
+              void dispatch(STORE_NAME).insertTrackingConsentBlock(),
+          },
+        ],
+      });
+    }
+
     return {
       ...state,
-      isFormSaving: !hasMissingLists,
+      // Without excluding the new error here the Save button would sit in its
+      // busy state forever: SAVE_FORM returns early when formErrors is
+      // non-empty, and nothing else resets isFormSaving.
+      isFormSaving: !hasMissingLists && !hasMissingTrackingConsent,
       sidebar: {
         ...state.sidebar,
         activeTab: hasMissingLists ? 'form' : state.sidebar.activeTab,

--- a/mailpoet/assets/js/src/form-editor/store/state-types.ts
+++ b/mailpoet/assets/js/src/form-editor/store/state-types.ts
@@ -52,6 +52,7 @@ export interface FormEditorWindow extends Window {
   mailpoet_tutorial_seen: '0' | '1';
   mailpoet_tutorial_url: string;
   mailpoet_is_administrator: boolean;
+  mailpoet_tracking_consent_capture_enabled: boolean;
   mailpoet_theme_support_widgets: boolean;
   mailpoet_theme_support_fse: boolean;
 }
@@ -71,6 +72,7 @@ export type State = {
   sidebarOpened: boolean;
   formExports: typeof window.mailpoet_form_exports;
   formErrors: string[];
+  trackingConsentCaptureEnabled: boolean;
   segments: typeof window.mailpoet_form_segments;
   customFields: typeof window.mailpoet_custom_fields;
   isFormSaving: boolean;
@@ -86,6 +88,7 @@ export type State = {
     content: string;
     isDismissible: boolean;
     status: string;
+    actions?: { label: string; onClick: () => void }[];
   }[];
   hasUnsavedChanges: boolean;
   sidebar: {

--- a/mailpoet/assets/js/src/form-editor/store/store.ts
+++ b/mailpoet/assets/js/src/form-editor/store/store.ts
@@ -83,7 +83,13 @@ export const initStore = () => {
     dateSettingData,
     sidebarOpened: true,
     formExports: window.mailpoet_form_exports,
-    formErrors: validateForm(formData, formBlocks),
+    trackingConsentCaptureEnabled:
+      window.mailpoet_tracking_consent_capture_enabled === true,
+    formErrors: validateForm(
+      formData,
+      formBlocks,
+      window.mailpoet_tracking_consent_capture_enabled === true,
+    ),
     segments: window.mailpoet_form_segments,
     customFields,
     isFormSaving: false,

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/global.d.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/global.d.ts
@@ -15,5 +15,6 @@ interface Window {
     };
   };
   mailpoet_is_automation_newsletter: boolean;
+  mailpoet_tracking_consent_ask_all?: boolean;
   mailpoet_ai_text_generation_available?: boolean;
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -14,7 +14,10 @@ import type { EmailContentValidationRule } from '@woocommerce/email-editor/build
 import { registerTranslations } from 'common';
 import { withSatismeterSurvey } from './satismeter-survey';
 import './index.scss';
-import { emailValidationRule } from './validate-email-content';
+import {
+  emailValidationRule,
+  trackingOptOutValidationRule,
+} from './validate-email-content';
 import { registerCouponCodeRestrictToSubscriberExtension } from './coupon-code-restrict-to-subscriber-control';
 import { registerOrderProductCollectionsWhenAvailable } from './order-product-collections';
 import { store as emailEditorIntegrationStore } from './store';
@@ -50,6 +53,11 @@ addFilter(
   (rules: EmailContentValidationRule[]) => [
     ...(rules || []),
     emailValidationRule,
+    // Only sites that ask every subscriber need the opt-out link, so the rule is
+    // added rather than always registered and conditionally skipped.
+    ...(window?.mailpoet_tracking_consent_ask_all
+      ? [trackingOptOutValidationRule]
+      : []),
   ],
 );
 

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/validate-email-content.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/validate-email-content.ts
@@ -1,5 +1,5 @@
 import { createBlock } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { dispatch, select } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
@@ -44,6 +44,64 @@ export const emailValidationRule: EmailContentValidationRule = {
           const postBlocks = select(editorStore).getEditorBlocks();
           const newBlocks = [...postBlocks, linksParagraphBlock];
           void dispatch(editorStore).resetEditorBlocks(newBlocks);
+        }
+      },
+    },
+  ],
+};
+
+const TRACKING_OPT_OUT_TAG = '[mailpoet/subscription-tracking-opt-out-url]';
+// A merchant may have pasted the legacy shortcode into a custom block instead of
+// using the personalization tag. Both become the same link at send time, via
+// LinksToShortcodesConvertor, so accept either and do not nag about it.
+const TRACKING_OPT_OUT_SHORTCODE = '[link:subscription_tracking_opt_out_url]';
+
+const trackingOptOutLink = `<a data-link-href="${TRACKING_OPT_OUT_TAG}" contenteditable="false" class="mailpoet-email-editor__personalization-tags-link">${__(
+  'Opt out of tracking',
+  'mailpoet',
+)}</a>`;
+
+export const trackingOptOutValidationRule: EmailContentValidationRule = {
+  id: 'missing-tracking-opt-out-link',
+  testContent: (emailContent: string) =>
+    !emailContent.includes(TRACKING_OPT_OUT_TAG) &&
+    !emailContent.includes(TRACKING_OPT_OUT_SHORTCODE),
+  message: __(
+    'Your tracking settings ask every subscriber for consent, so this email needs a tracking opt-out link.',
+    'mailpoet',
+  ),
+  actions: [
+    {
+      label: _x(
+        'Insert link',
+        'Button that adds the tracking opt-out link to the email',
+        'mailpoet',
+      ),
+      onClick: () => {
+        const linkParagraphBlock = createBlock('core/paragraph', {
+          align: 'center',
+          fontSize: 'small',
+          content: trackingOptOutLink,
+        });
+
+        const currentPostType = select(editorStore).getCurrentPostType();
+        const isEditingTemplate = currentPostType === 'wp_template';
+
+        if (isEditingTemplate) {
+          // TEMPLATE MODE: Insert into the template's root blocks
+          const templateBlocks = select(blockEditorStore).getBlocks();
+          void dispatch(blockEditorStore).insertBlock(
+            linkParagraphBlock,
+            templateBlocks.length,
+            '',
+          );
+        } else {
+          // POST MODE: Insert into the email post content
+          const postBlocks = select(editorStore).getEditorBlocks();
+          void dispatch(editorStore).resetEditorBlocks([
+            ...postBlocks,
+            linkParagraphBlock,
+          ]);
         }
       },
     },

--- a/mailpoet/assets/js/src/newsletter-editor/blocks/footer.js
+++ b/mailpoet/assets/js/src/newsletter-editor/blocks/footer.js
@@ -48,6 +48,11 @@ Module.FooterBlockView = base.BlockView.extend({
     {
       'change:styles.block.backgroundColor change:styles.text.fontColor change:styles.text.fontFamily change:styles.text.fontSize change:styles.text.textAlign change:styles.link.fontColor change:styles.link.textDecoration':
         'render',
+      // Explicit repaint for text set from outside the editor. `change` stays
+      // unbound (see the omit below) because TinyMCE writes every keystroke back
+      // to the model, and re-rendering mid-keystroke would tear down the editor
+      // under the caret. Nothing in the typing path fires this event.
+      redraw: 'render',
     },
     _.omit(base.BlockView.prototype.modelEvents, 'change'),
   ),

--- a/mailpoet/assets/js/src/newsletter-editor/components/save.js
+++ b/mailpoet/assets/js/src/newsletter-editor/components/save.js
@@ -162,6 +162,7 @@ Module.SaveView = Marionette.View.extend({
     'click .mailpoet_save_button': 'save',
     'click .mailpoet_save_show_options': 'toggleSaveOptions',
     'click .mailpoet_save_next': 'next',
+    'click .mailpoet_add_tracking_opt_out_link': 'addTrackingOptOutLink',
     /* Save as template */
     'click .mailpoet_save_template': 'showSaveAsTemplate',
     'click .mailpoet_save_as_template': 'saveAsTemplate',
@@ -394,6 +395,35 @@ Module.SaveView = Marionette.View.extend({
       window.location.href = goToUrl;
     });
   },
+  addTrackingOptOutLink: function () {
+    var linkHtml;
+    var footers;
+    var footer;
+    var FooterModel;
+    var footerBlock;
+    linkHtml =
+      '<a href="[link:subscription_tracking_opt_out_url]">' +
+      __('Opt out of tracking', 'mailpoet') +
+      '</a>';
+    // Prefer an existing footer block, so the link lands next to the
+    // unsubscribe link. findModels walks the whole container tree.
+    footers = App.findModels(function (model) {
+      return model.get('type') === 'footer';
+    });
+    if (footers.length > 0) {
+      footer = footers[footers.length - 1];
+      footer.set('text', footer.get('text') + '<br />' + linkHtml);
+    } else {
+      // No footer block at all: add one at the end of the content container.
+      // Its defaults already carry the unsubscribe and manage links.
+      FooterModel = App.getBlockTypeModel('footer');
+      footerBlock = new FooterModel({ type: 'footer' });
+      footerBlock.set('text', footerBlock.get('text') + '<br />' + linkHtml);
+      App._contentContainer.get('blocks').add(footerBlock);
+    }
+    this.validateNewsletter(App.toJSON());
+  },
+
   validateNewsletter: function (jsonObject) {
     var body = '';
     var newsletter = App.getNewsletter();
@@ -438,6 +468,27 @@ Module.SaveView = Marionette.View.extend({
           'All emails must include an "Unsubscribe" link. Add a footer widget to your email to continue.',
           'mailpoet',
         ),
+      );
+      return;
+    }
+
+    if (
+      App.getConfig().get('validation.validateTrackingOptOutLinkPresent') &&
+      body.indexOf('[link:subscription_tracking_opt_out_url]') < 0 &&
+      newsletter.get('status') !== 'sent'
+    ) {
+      this.showValidationError(
+        __(
+          'Your tracking settings ask every subscriber for consent, so this email needs a tracking opt-out link.',
+          'mailpoet',
+        ) +
+          ' <a href="javascript:;" class="mailpoet_add_tracking_opt_out_link">' +
+          _x(
+            'Click here to add it',
+            'Link inside an error message that adds the tracking opt-out link to the email',
+            'mailpoet',
+          ) +
+          '</a>',
       );
       return;
     }

--- a/mailpoet/assets/js/src/newsletter-editor/components/save.js
+++ b/mailpoet/assets/js/src/newsletter-editor/components/save.js
@@ -413,6 +413,10 @@ Module.SaveView = Marionette.View.extend({
     if (footers.length > 0) {
       footer = footers[footers.length - 1];
       footer.set('text', footer.get('text') + '<br />' + linkHtml);
+      // The footer view does not re-render on `change:text`, so the model update
+      // alone leaves the canvas showing the pre-edit DOM until a reload. Ask for
+      // the repaint explicitly.
+      footer.trigger('redraw');
     } else {
       // No footer block at all: add one at the end of the content container.
       // Its defaults already carry the unsubscribe and manage links.

--- a/mailpoet/changelog/2026-08-24-improved-the-editors-now-check-for-the-tracking-opt-out.md
+++ b/mailpoet/changelog/2026-08-24-improved-the-editors-now-check-for-the-tracking-opt-out.md
@@ -2,4 +2,4 @@
 
 # Description
 
-When you ask subscribers for tracking consent, the email editors now check that your email has a tracking opt-out link and the form editor checks that your form has the tracking consent checkbox, each with a one-click way to add what is missing. The checkbox is always added unticked and stays optional for the subscriber. Emails and forms you have already published are left alone until you next edit them.
+When you ask subscribers for tracking consent, the email editors now check that your email has a tracking opt-out link and the form editor checks that your form has the tracking consent checkbox, each with a one-click way to add what is missing. The checkbox is always added unticked and stays optional for the subscriber. Emails and forms you have already published are left alone until you next edit them

--- a/mailpoet/changelog/2026-08-24-improved-the-editors-now-check-for-the-tracking-opt-out.md
+++ b/mailpoet/changelog/2026-08-24-improved-the-editors-now-check-for-the-tracking-opt-out.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+When you ask subscribers for tracking consent, the email editors now check that your email has a tracking opt-out link and the form editor checks that your form has the tracking consent checkbox, each with a one-click way to add what is missing. The checkbox is always added unticked and stays optional for the subscriber. Emails and forms you have already published are left alone until you next edit them.

--- a/mailpoet/lib/AdminPages/Pages/FormEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/FormEditor.php
@@ -81,6 +81,7 @@ use MailPoet\Router\Router;
 use MailPoet\Segments\SegmentsSimpleListRepository;
 use MailPoet\Settings\Pages;
 use MailPoet\Settings\UserFlagsController;
+use MailPoet\Subscribers\TrackingConsentCapture;
 use MailPoet\WP\AutocompletePostListLoader as WPPostListLoader;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -197,6 +198,9 @@ class FormEditor {
   /** @var AssetsController */
   private $assetsController;
 
+  /** @var TrackingConsentCapture */
+  private $trackingConsentCapture;
+
   public function __construct(
     AssetsController $assetsController,
     PageRenderer $pageRenderer,
@@ -210,7 +214,8 @@ class FormEditor {
     WPPostListLoader $wpPostListLoader,
     TemplateRepository $templateRepository,
     FormsRepository $formsRepository,
-    SegmentsSimpleListRepository $segmentsListRepository
+    SegmentsSimpleListRepository $segmentsListRepository,
+    TrackingConsentCapture $trackingConsentCapture
   ) {
     $this->assetsController = $assetsController;
     $this->pageRenderer = $pageRenderer;
@@ -225,6 +230,7 @@ class FormEditor {
     $this->wpPostListLoader = $wpPostListLoader;
     $this->segmentsListRepository = $segmentsListRepository;
     $this->formsRepository = $formsRepository;
+    $this->trackingConsentCapture = $trackingConsentCapture;
   }
 
   public function render() {
@@ -276,6 +282,7 @@ class FormEditor {
       'product_categories' => $this->wpPostListLoader->getWooCommerceCategories(),
       'product_tags' => $this->wpPostListLoader->getWooCommerceTags(),
       'is_administrator' => $this->wp->currentUserCan('administrator'),
+      'tracking_consent_capture_enabled' => $this->trackingConsentCapture->isCaptureEnabled(),
       'theme_support_widgets' => $this->wp->wpGetThemeSupport('widgets'),
       'theme_support_fse' => $this->wp->wpGetTheme()->is_block_theme(),
     ];

--- a/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
@@ -14,6 +14,7 @@ use MailPoet\NewsletterTemplates\BrandStyles;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\UserFlagsController;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WooCommerce\TransactionalEmailHooks;
 use MailPoet\WooCommerce\TransactionalEmails;
@@ -39,6 +40,7 @@ class NewsletterEditor {
   private BrandStyles $brandStyles;
   private WooTransactionalEmailTemplate $template;
   private NewslettersRepository $newslettersRepository;
+  private TrackingConsentController $trackingConsentController;
 
   public function __construct(
     PageRenderer $pageRenderer,
@@ -55,7 +57,8 @@ class NewsletterEditor {
     AssetsController $assetsController,
     WooTransactionalEmailTemplate $template,
     BrandStyles $brandStyles,
-    NewslettersRepository $newslettersRepository
+    NewslettersRepository $newslettersRepository,
+    TrackingConsentController $trackingConsentController
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->settings = $settings;
@@ -72,6 +75,7 @@ class NewsletterEditor {
     $this->template = $template;
     $this->brandStyles = $brandStyles;
     $this->newslettersRepository = $newslettersRepository;
+    $this->trackingConsentController = $trackingConsentController;
   }
 
   public function render() {
@@ -142,6 +146,7 @@ class NewsletterEditor {
       'woocommerce' => $woocommerceData,
       'is_wc_transactional_email' => $newsletterId === $woocommerceTemplateId,
       'is_confirmation_email_type' => $isConfirmationEmailType,
+      'is_tracking_consent_ask_all' => $this->trackingConsentController->getSubscriberChoice() === TrackingConsentController::CHOICE_ASK_ALL,
       'is_confirmation_email_customizer_enabled' => (bool)$this->settings->get('signup_confirmation.use_mailpoet_editor', false),
       'original_template_body' => $originalTemplateBody,
       'product_categories' => $this->wpPostListLoader->getWooCommerceCategories(),

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -19,6 +19,7 @@ use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController as MailPoetSettings;
 use MailPoet\Settings\UserFlagsController;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoet\Util\CdnAssetUrl;
 use MailPoet\Util\FreeDomains;
 use MailPoet\Util\License\Features\CapabilitiesManager;
@@ -60,6 +61,8 @@ class EditorPageRenderer {
 
   private CapabilitiesManager $capabilitiesManager;
 
+  private TrackingConsentController $trackingConsentController;
+
   public function __construct(
     WPFunctions $wp,
     CdnAssetUrl $cdnAssetUrl,
@@ -74,7 +77,8 @@ class EditorPageRenderer {
     AuthorizedEmailsController $authorizedEmailsController,
     AuthorizedSenderDomainController $senderDomainController,
     FeaturesController $featuresController,
-    CapabilitiesManager $capabilitiesManager
+    CapabilitiesManager $capabilitiesManager,
+    TrackingConsentController $trackingConsentController
   ) {
     $this->wp = $wp;
     $this->settingsController = Email_Editor_Container::container()->get(Settings_Controller::class);
@@ -93,6 +97,7 @@ class EditorPageRenderer {
     $this->senderDomainController = $senderDomainController;
     $this->featuresController = $featuresController;
     $this->capabilitiesManager = $capabilitiesManager;
+    $this->trackingConsentController = $trackingConsentController;
   }
 
   public function render() {
@@ -234,6 +239,9 @@ class EditorPageRenderer {
         'nonce' => $this->wp->wpCreateNonce('wp_rest'),
       ],
       'mailpoet_is_automation_newsletter' => $isAutomationNewsletter,
+      // Only a site that asks EVERY subscriber for consent needs an opt-out
+      // link in its emails, so only then does content validation ask for one.
+      'mailpoet_tracking_consent_ask_all' => $this->trackingConsentController->getSubscriberChoice() === TrackingConsentController::CHOICE_ASK_ALL,
       'mailpoet_automation_id' => $automationId,
       'mailpoet_feature_flags' => $this->featuresController->getAllFlags(),
       'mailpoet_capabilities' => $this->capabilitiesManager->getCapabilities(),

--- a/mailpoet/tests/integration/Newsletter/Renderer/TrackingOptOutTextPartTest.php
+++ b/mailpoet/tests/integration/Newsletter/Renderer/TrackingOptOutTextPartTest.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Renderer;
+
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+
+/**
+ * STOMAIL-8313 inserts a tracking opt-out link into the email body at editing
+ * time. This proves the link survives rendering into BOTH parts of the message,
+ * rather than assuming it: an opt-out link a plain-text reader cannot reach is
+ * not an opt-out.
+ */
+class TrackingOptOutTextPartTest extends \MailPoetTest {
+  /** @var Renderer */
+  private $renderer;
+
+  public function _before() {
+    parent::_before();
+    $this->renderer = $this->diContainer->get(Renderer::class);
+  }
+
+  public function testItKeepsTheTrackingOptOutLinkInBothTheHtmlAndTheTextPart(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Tracking opt-out link')
+      ->withBody($this->bodyWithOptOutLink())
+      ->create();
+
+    $rendered = $this->renderer->render($newsletter);
+    $this->assertIsArray($rendered);
+
+    // The shortcode survives rendering; it is resolved per subscriber later, in
+    // prepareNewsletterForSending().
+    verify($rendered['html'])->stringContainsString('subscription_tracking_opt_out_url');
+    verify($rendered['text'])->stringContainsString('subscription_tracking_opt_out_url');
+    verify($rendered['text'])->stringContainsString('Opt out of tracking');
+  }
+
+  public function testItLeavesTheTextPartWithoutTheLinkWhenTheBodyHasNone(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('No tracking opt-out link')
+      ->withBody($this->bodyWithoutOptOutLink())
+      ->create();
+
+    $rendered = $this->renderer->render($newsletter);
+    $this->assertIsArray($rendered);
+    verify($rendered['text'])->stringNotContainsString('subscription_tracking_opt_out_url');
+  }
+
+  private function bodyWithOptOutLink(): array {
+    return $this->body(
+      'Hello there.<br /><a href="[link:subscription_tracking_opt_out_url]">Opt out of tracking</a>'
+    );
+  }
+
+  private function bodyWithoutOptOutLink(): array {
+    return $this->body('Hello there.');
+  }
+
+  private function body(string $text): array {
+    return [
+      'content' => [
+        'type' => 'container',
+        'orientation' => 'vertical',
+        'styles' => ['block' => ['backgroundColor' => 'transparent']],
+        'blocks' => [
+          [
+            'type' => 'container',
+            'orientation' => 'horizontal',
+            'styles' => ['block' => ['backgroundColor' => 'transparent']],
+            'blocks' => [
+              [
+                'type' => 'container',
+                'orientation' => 'vertical',
+                'styles' => ['block' => ['backgroundColor' => 'transparent']],
+                'blocks' => [
+                  [
+                    'type' => 'text',
+                    'text' => $text,
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
+      'globalStyles' => [
+        'text' => ['fontColor' => '#000000', 'fontFamily' => 'Arial', 'fontSize' => '16px'],
+        'h1' => ['fontColor' => '#111111', 'fontFamily' => 'Arial', 'fontSize' => '36px'],
+        'h2' => ['fontColor' => '#222222', 'fontFamily' => 'Arial', 'fontSize' => '28px'],
+        'h3' => ['fontColor' => '#333333', 'fontFamily' => 'Arial', 'fontSize' => '22px'],
+        'link' => ['fontColor' => '#21759B', 'textDecoration' => 'underline'],
+        'wrapper' => ['backgroundColor' => '#ffffff'],
+        'body' => ['backgroundColor' => '#eeeeee'],
+      ],
+    ];
+  }
+}

--- a/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/components/save.spec.js
+++ b/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/components/save.spec.js
@@ -214,7 +214,13 @@ describe('Save', function () {
 
       it('adds the opt-out link to an existing footer block', function () {
         var footer;
-        footer = { get: sinon.stub().returns('bye'), set: sinon.spy() };
+        // A real footer is a Backbone model, so the stub needs trigger() as well
+        // as get/set — the view asks the model to repaint after setting the text.
+        footer = {
+          get: sinon.stub().returns('bye'),
+          set: sinon.spy(),
+          trigger: sinon.spy(),
+        };
         App.findModels = sinon.stub().returns([footer]);
         sinon.stub(view, 'validateNewsletter');
         view.addTrackingOptOutLink();
@@ -223,6 +229,24 @@ describe('Save', function () {
         expect(footer.set.firstCall.args[1]).to.contain(
           '[link:subscription_tracking_opt_out_url]',
         );
+      });
+
+      it('asks the footer to repaint, since change:text does not re-render it', function () {
+        // Without this the model updates but the canvas keeps showing the old DOM
+        // until a page reload. FooterBlockView drops the base 'change' -> render
+        // binding so TinyMCE is not torn down mid-keystroke, so a programmatic
+        // set('text') has to ask for the repaint explicitly.
+        var footer;
+        footer = {
+          get: sinon.stub().returns('bye'),
+          set: sinon.spy(),
+          trigger: sinon.spy(),
+        };
+        App.findModels = sinon.stub().returns([footer]);
+        sinon.stub(view, 'validateNewsletter');
+        view.addTrackingOptOutLink();
+        expect(footer.trigger.calledOnce).to.be.equal(true);
+        expect(footer.trigger.firstCall.args[0]).to.be.equal('redraw');
       });
     });
 

--- a/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/components/save.spec.js
+++ b/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/components/save.spec.js
@@ -137,6 +137,9 @@ describe('Save', function () {
       var hideValidationErrorStub;
       var view;
       var model;
+      var errorCountFor;
+      var optOutFooter =
+        '<a href="[link:subscription_tracking_opt_out_url]">x</a>';
       beforeEach(function () {
         model = new Backbone.SuperModel({});
         model.isWoocommerceTransactional = function () {
@@ -180,6 +183,46 @@ describe('Save', function () {
         App.getNewsletter = sinon.stub().returns(newsletter);
         view.validateNewsletter(validNewsletter);
         expect(showValidationErrorStub.callCount).to.be.equal(1);
+      });
+
+      errorCountFor = function (settingOn, footerText) {
+        var stub;
+        global.stubConfig(App, {
+          validation: { validateTrackingOptOutLinkPresent: settingOn },
+        });
+        App.getNewsletter = sinon.stub().returns({
+          get: sinon.stub().withArgs('type').returns('standard'),
+        });
+        stub = sinon.stub(view, 'showValidationError');
+        view.validateNewsletter({
+          body: { content: { blocks: [{ type: 'footer', text: footerText }] } },
+        });
+        return stub.callCount;
+      };
+
+      it('shows an error when the tracking opt-out link is missing', function () {
+        expect(errorCountFor(true, 'bye')).to.be.equal(1);
+      });
+
+      it('accepts the tracking opt-out shortcode in the body', function () {
+        expect(errorCountFor(true, optOutFooter)).to.be.equal(0);
+      });
+
+      it('does not ask for the opt-out link when the setting is off', function () {
+        expect(errorCountFor(false, 'bye')).to.be.equal(0);
+      });
+
+      it('adds the opt-out link to an existing footer block', function () {
+        var footer;
+        footer = { get: sinon.stub().returns('bye'), set: sinon.spy() };
+        App.findModels = sinon.stub().returns([footer]);
+        sinon.stub(view, 'validateNewsletter');
+        view.addTrackingOptOutLink();
+        expect(footer.set.calledOnce).to.be.equal(true);
+        expect(footer.set.firstCall.args[0]).to.be.equal('text');
+        expect(footer.set.firstCall.args[1]).to.contain(
+          '[link:subscription_tracking_opt_out_url]',
+        );
       });
     });
 

--- a/mailpoet/tests/javascript/form-editor/store/form-validator.spec.ts
+++ b/mailpoet/tests/javascript/form-editor/store/form-validator.spec.ts
@@ -164,3 +164,53 @@ describe('Form validator', () => {
     expect(() => validate(formData, 'string')).to.throw(blocksError);
   });
 });
+
+const trackingConsentBlock = {
+  clientId: 'tracking-consent',
+  isValid: true,
+  innerBlocks: [],
+  name: 'mailpoet-form/tracking-consent',
+  attributes: {
+    label: 'Email activity tracking',
+    consentText: 'Allow tracking of email opens and link clicks',
+  },
+};
+
+describe('Form validator - tracking consent', () => {
+  const formData = { settings: { segments: [1] } };
+
+  it('Should return error when capture is on and the block is missing', () => {
+    const result = validate(formData, [emailBlock, submitBlock], true);
+    expect(result).to.contain('missing-tracking-consent');
+  });
+
+  it('Should return no error when the block is present', () => {
+    const blocks = [emailBlock, trackingConsentBlock, submitBlock];
+    const result = validate(formData, blocks, true);
+    expect(isEmpty(result)).to.be.equal(true);
+  });
+
+  it('Should return no error when capture is off', () => {
+    const result = validate(formData, [emailBlock, submitBlock], false);
+    expect(isEmpty(result)).to.be.equal(true);
+  });
+
+  it('Should default to no error when the flag is not passed at all', () => {
+    const result = validate(formData, [emailBlock, submitBlock]);
+    expect(isEmpty(result)).to.be.equal(true);
+  });
+
+  it('Should find the block nested in columns', () => {
+    const nested = {
+      ...columns,
+      innerBlocks: [
+        {
+          ...columns.innerBlocks[0],
+          innerBlocks: [emailBlock, trackingConsentBlock, submitBlock],
+        },
+      ],
+    };
+    const result = validate(formData, [nested], true);
+    expect(isEmpty(result)).to.be.equal(true);
+  });
+});

--- a/mailpoet/views/form/editor.html
+++ b/mailpoet/views/form/editor.html
@@ -33,6 +33,7 @@
   var mailpoet_tutorial_seen = '<%= editor_tutorial_seen %>';
   var mailpoet_tutorial_url = '<%= cdn_url('form-editor/tutorial.mp4') %>';
   var mailpoet_is_administrator = <%= is_administrator ? 'true' : 'false' %>;
+  var mailpoet_tracking_consent_capture_enabled = <%= tracking_consent_capture_enabled ? 'true' : 'false' %>;
   var mailpoet_form_edit_url = "<%= admin_url('admin.php?page=mailpoet-form-editor&id=') %>";
   var mailpoet_theme_support_widgets = <%= theme_support_widgets ? 'true' : 'false' %>;
   var mailpoet_theme_support_fse = <%= theme_support_fse ? 'true' : 'false' %>;
@@ -179,6 +180,8 @@
   'blockCloseDescription': __('Link or button used to dismiss a pop-up, slide-in or fixed bar form.'),
   'blockCloseLabel': _x('No thanks', 'a default value for a form close link'),
   'missingObligatoryBlock': __('Email input or submit is missing. Try reloading the form editor.'),
+  'missingTrackingConsentBlock': __('This form asks subscribers about email tracking, so it needs the "Email activity tracking" checkbox.'),
+  'addTrackingConsentBlock': _x('Add the checkbox', 'Button that inserts the tracking consent checkbox into the form'),
   'label': _x('Label', 'settings for a label of an input'),
   'displayLabelWithinInput': __('Display label within input'),
   'displayLabel': _x('Display label', 'Settings - if label should be displayed'),

--- a/mailpoet/views/form/editor.html
+++ b/mailpoet/views/form/editor.html
@@ -180,7 +180,7 @@
   'blockCloseDescription': __('Link or button used to dismiss a pop-up, slide-in or fixed bar form.'),
   'blockCloseLabel': _x('No thanks', 'a default value for a form close link'),
   'missingObligatoryBlock': __('Email input or submit is missing. Try reloading the form editor.'),
-  'missingTrackingConsentBlock': __('This form asks subscribers about email tracking, so it needs the "Email activity tracking" checkbox.'),
+  'missingTrackingConsentBlock': __('Your tracking settings ask every subscriber for consent, so this form needs to include the "Email activity tracking" checkbox.'),
   'addTrackingConsentBlock': _x('Add the checkbox', 'Button that inserts the tracking consent checkbox into the form'),
   'label': _x('Label', 'settings for a label of an input'),
   'displayLabelWithinInput': __('Display label within input'),

--- a/mailpoet/views/newsletter/editor.html
+++ b/mailpoet/views/newsletter/editor.html
@@ -1887,6 +1887,8 @@
         validateUnsubscribeLinkPresent: <%= mss_active and is_wc_transactional_email != true and is_confirmation_email_type != true ? 'true' : 'false' %>,
         validateReEngageLinkPresent: <%= mss_active and is_wc_transactional_email != true and is_confirmation_email_type != true ? 'true' : 'false' %>,
         validateActivationLinkIsPresent: <%= is_confirmation_email_type ? 'true' : 'false' %>,
+        {# Deliberately not gated on mss_active: the opt-out link has nothing to do with the sending service. #}
+        validateTrackingOptOutLinkPresent: <%= is_tracking_consent_ask_all and is_wc_transactional_email != true and is_confirmation_email_type != true ? 'true' : 'false' %>,
       },
       urls: {
         send: '<%= admin_url('admin.php?page=mailpoet-newsletters#/send/' ~ (params('id') | intval)) %>',

--- a/mailpoet/views/newsletter/editor.html
+++ b/mailpoet/views/newsletter/editor.html
@@ -1887,7 +1887,7 @@
         validateUnsubscribeLinkPresent: <%= mss_active and is_wc_transactional_email != true and is_confirmation_email_type != true ? 'true' : 'false' %>,
         validateReEngageLinkPresent: <%= mss_active and is_wc_transactional_email != true and is_confirmation_email_type != true ? 'true' : 'false' %>,
         validateActivationLinkIsPresent: <%= is_confirmation_email_type ? 'true' : 'false' %>,
-        {# Deliberately not gated on mss_active: the opt-out link has nothing to do with the sending service. #}
+        <# Deliberately not gated on mss_active: the opt-out link has nothing to do with the sending service. #>
         validateTrackingOptOutLinkPresent: <%= is_tracking_consent_ask_all and is_wc_transactional_email != true and is_confirmation_email_type != true ? 'true' : 'false' %>,
       },
       urls: {


### PR DESCRIPTION
## What this does

A merchant who asks subscribers for tracking consent still has to remember two things by hand: put a tracking opt-out link in every email, and put the consent checkbox on every form. This adds a check at the moment they would notice it, with a button that does the work.

**Emails, both editors.** When Subscriber choice is **Ask everyone** and the body has no tracking opt-out link, Next/Send shows an error with an action that inserts the link. The new editor gets a rule beside the existing "missing unsubscribe link" rule; the legacy editor gets a branch beside the existing unsubscribe check.

**Forms.** When the setting is **Ask new subscribers** or **Ask everyone** and the form has no tracking consent checkbox, Save shows an error with an "Add the checkbox" button that inserts the block in front of the submit button.

## Things worth knowing while reviewing

**Emails are gated on "Ask everyone" only; forms on both asking states.** In `ask_new`, people already on the list can still withdraw through the manage page, so their emails do not need the link. But state 2 promises new subscribers choose when they sign up, and that promise can only be kept if the form actually carries the checkbox.

**The email flag deliberately does not depend on the sending service**, unlike `validateUnsubscribeLinkPresent` one line above it. A tracking opt-out link has nothing to do with how an email is sent. WooCommerce transactional and confirmation emails stay excluded, though: neither goes through the sending queue, so neither is open-tracked.

**"Required" means the checkbox is on the form, not that the subscriber must tick it.** The block still serialises unticked and optional — no `required`, no `is_checked`. Bundling tracking consent with subscribing is exactly what the regulation forbids.

**Both editors accept the raw shortcode as well as the personalization tag**, so a merchant who pasted `[link:subscription_tracking_opt_out_url]` by hand does not get a false error.

**`isFormSaving` had to exclude the new error.** `SAVE_FORM` returns early when `formErrors` is non-empty and nothing else resets that flag, so without this the Save button would sit spinning forever. `missing-lists` already had the same treatment.

**The form notice is non-dismissible on purpose.** Dismissible notices in this editor self-remove after five seconds, which is not long enough to read an error and click its action.

## What this does not do

Nothing at send time, nothing at render time, nothing server-side. No change to the sending-service validator, the form renderer, or the server-side form save. Emails and forms that are already live are left alone until somebody opens them in an editor. With the setting off, nothing changes anywhere.

## Test plan

JS unit tests: the form validator (block present, missing, nested in columns, setting off, flag omitted entirely) and the legacy save view (error shown, shortcode accepted, setting off, footer repair). Integration test: an opt-out link in the body survives rendering into both the HTML and the plain-text part, with the negative case asserted too so the positive cannot pass vacuously. Both production changes carry a sabotage check.

`test:javascript` 400 passing, `test:newsletter-editor` 475 passing, `TrackingOptOutTextPartTest` 2 tests / 8 assertions. `qa:phpstan` no errors, `qa:code-sniffer` and `qa:lint-javascript` exit 0.

Checked in a browser across all three Subscriber-choice states. The flags were read out of the rendered pages, and on a site with no sending service `validateUnsubscribeLinkPresent: false` sits one line from `validateTrackingOptOutLinkPresent: true` — which is the independence this PR is claiming. The form error and its button work end to end, the inserted block lands at index 1 before the submit button, and the saved form body carries neither `required` nor `is_checked`. The legacy editor blocks Next, the inline link adds the shortcode, and the error clears.

That browser pass earned its keep: it caught a bug no test could see. The comment I added above the new flag used Twig's default `{# … #}`, but this template is rendered with custom delimiters (`tag_comment` is `<# #>`), so the comment was emitted straight into the inline JavaScript and broke the whole legacy editor with a `SyntaxError`. Every test still passed, because none of them render that template. Fixed in `be3a7522f8`.

Fixes STOMAIL-8313.

## Screenshots

Two before-and-after pairs from the browser pass, one per editor.

### Form editor

**Before** — saving a form is blocked when the site asks for consent but the form has no checkbox, with a button offering to add it. Recaptured after review: the message now names the setting responsible rather than claiming the form is doing the asking.

<img width="1575" height="840" alt="Screenshot 2026-08-31 at 5 35 07 PM" src="https://github.com/user-attachments/assets/1e792e15-883a-454b-b0d5-fc5cb898e8df" />



**After** — the button inserts the checkbox at index 1, ahead of the submit button, and the save goes through.

<img width="1728" height="847" alt="Screenshot 2026-08-31 at 10 37 22 PM" src="https://github.com/user-attachments/assets/1a9db82b-5136-42a7-a0e1-32005b267546" />
Form editor after the consent checkbox was inserted

### Legacy newsletter editor

**Before** — Next is blocked, with an inline link that adds the opt-out shortcode to the footer.

<img width="1554" height="710" alt="Screenshot 2026-08-31 at 10 34 10 PM" src="https://github.com/user-attachments/assets/abdf17aa-8061-4c23-8424-548b5e13ba4e" />
Legacy editor blocking Next, with the add-link offer

**After** — shortcode added, error cleared, Next works.

<img width="1568" height="688" alt="Screenshot 2026-08-31 at 10 39 14 PM" src="https://github.com/user-attachments/assets/327061c9-da0d-43a3-a050-9510bde4f589" />
Legacy editor with the error cleared

This is the pass that caught the Twig delimiter bug described above — every test was green while the legacy editor was blank in a real browser.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8313-tracking-consent-editor-form-validation)

_The latest successful build from `fix/stomail-8313-tracking-consent-editor-form-validation` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->