### PR TITLE
Fix three places where a subscriber's tracking choice was lost

### DIFF
--- a/mailpoet/changelog/2026-08-24-fixed-three-places-where-a-subscribers-tracking-choice.md
+++ b/mailpoet/changelog/2026-08-24-fixed-three-places-where-a-subscribers-tracking-choice.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Three places where a subscriber's tracking choice was lost or ignored. A first-time guest who leaves the tracking box unticked at checkout is now recorded as having declined, on both the classic and the block checkout. Registration and comment forms now record the tracking choice even when the "add me to your mailing list" box is left unticked, since those are two separate decisions. And clicking the tracking opt-out link in an email footer no longer records that click, which is the one link that should never track you.

--- a/mailpoet/changelog/2026-08-24-fixed-three-places-where-a-subscribers-tracking-choice.md
+++ b/mailpoet/changelog/2026-08-24-fixed-three-places-where-a-subscribers-tracking-choice.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Three places where a subscriber's tracking choice was lost or ignored. A first-time guest who leaves the tracking box unticked at checkout is now recorded as having declined, on both the classic and the block checkout. Registration and comment forms now record the tracking choice even when the "add me to your mailing list" box is left unticked, since those are two separate decisions. And clicking the tracking opt-out link in an email footer no longer records that click, which is the one link that should never track you.
+Three places where a subscriber's tracking choice was lost or ignored. A first-time guest who leaves the tracking box unticked at checkout is now recorded as having declined, on both the classic and the block checkout. Registration and comment forms now record the tracking choice even when the "add me to your mailing list" box is left unticked, since those are two separate decisions. And clicking the tracking opt-out link in an email footer no longer records that click, which is the one link that should never track you

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -389,6 +389,11 @@ class Hooks {
       6
     );
     $this->wp->addAction(
+      'user_register',
+      [$this->subscriptionRegistration, 'applyTrackingConsentOnUserRegister'],
+      7
+    );
+    $this->wp->addAction(
       'added_existing_user',
       [$this->wpSegment, 'synchronizeUser'],
       6

--- a/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -195,7 +195,11 @@ class WooCommerceBlocksIntegration {
     // Fetch existing woo subscriber and in case there is not any sync as guest
     $email = $order->get_billing_email();
     $subscriber = $this->subscribersRepository->findOneBy(['email' => $email, 'isWoocommerceUser' => true]);
+    // This lookup happens before the sync, so it doubles as the is-new signal:
+    // nothing found here means the row below was created by this request.
+    $isNewSubscriber = false;
     if (!$subscriber instanceof SubscriberEntity) {
+      $isNewSubscriber = true;
       $this->wooSegment->synchronizeGuestCustomer($order->get_id());
       $subscriber = $this->subscribersRepository->findOneBy(['email' => $email, 'isWoocommerceUser' => true]);
     }
@@ -205,6 +209,6 @@ class WooCommerceBlocksIntegration {
       return null;
     }
 
-    $this->woocommerceSubscription->handleSubscriberOptin($subscriber, $checkoutOptin, $trackingConsent);
+    $this->woocommerceSubscription->handleSubscriberOptin($subscriber, $checkoutOptin, $trackingConsent, $isNewSubscriber);
   }
 }

--- a/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -195,11 +195,12 @@ class WooCommerceBlocksIntegration {
     // Fetch existing woo subscriber and in case there is not any sync as guest
     $email = $order->get_billing_email();
     $subscriber = $this->subscribersRepository->findOneBy(['email' => $email, 'isWoocommerceUser' => true]);
-    // This lookup happens before the sync, so it doubles as the is-new signal:
-    // nothing found here means the row below was created by this request.
-    $isNewSubscriber = false;
+    // Deliberately unfiltered by isWoocommerceUser: a subscriber who signed up through a
+    // form and is now checking out as a guest already exists, and the sync only flips
+    // their flag rather than creating a row. Treating them as new would let an unticked
+    // box overwrite consent they gave earlier, which STOMAIL-8305 forbids.
+    $isNewSubscriber = $this->subscribersRepository->findOneBy(['email' => $email]) === null;
     if (!$subscriber instanceof SubscriberEntity) {
-      $isNewSubscriber = true;
       $this->wooSegment->synchronizeGuestCustomer($order->get_id());
       $subscriber = $this->subscribersRepository->findOneBy(['email' => $email, 'isWoocommerceUser' => true]);
     }

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -122,7 +122,7 @@ class WP {
   }
 
   public function synchronizeUser(int $wpUserId, $oldWpUserData = false): void {
-    $wpUser = \get_userdata($wpUserId);
+    $wpUser = $this->wp->getUserdata($wpUserId);
     if ($wpUser === false) return;
 
     $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $wpUserId]);

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -34,6 +34,14 @@ class WP {
   /** @var WooCommerceHelper */
   private $wooHelper;
 
+  /**
+   * Per-request, keyed by WP user id: whether this sync created the subscriber
+   * row or found one already there. See wasSubscriberCreatedBySync().
+   *
+   * @var array<int, bool>
+   */
+  private $syncCreatedSubscriber = [];
+
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
@@ -96,11 +104,32 @@ class WP {
    * @param int $wpUserId
    * @param array|false $oldWpUserData
    */
+
+  /**
+   * Whether this request's sync created the subscriber row for the given WP
+   * user, rather than finding one that was already there. Defaults to false,
+   * meaning "treat as pre-existing", for a user this sync never saw: a missing
+   * signal must never cause an unearned overwrite of an earlier consent choice.
+   *
+   * Needed because wp_insert_user() calls set_user_role() before it fires
+   * user_register, and set_user_role is itself hooked to synchronizeUser. So by
+   * the time anything runs on user_register — at any priority — the row already
+   * exists, and a later lookup cannot tell a brand new registrant from someone
+   * who was already on the list.
+   */
+  public function wasSubscriberCreatedBySync(int $wpUserId): bool {
+    return $this->syncCreatedSubscriber[$wpUserId] ?? false;
+  }
+
   public function synchronizeUser(int $wpUserId, $oldWpUserData = false): void {
     $wpUser = \get_userdata($wpUserId);
     if ($wpUser === false) return;
 
     $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $wpUserId]);
+    if (!isset($this->syncCreatedSubscriber[$wpUserId])) {
+      $this->syncCreatedSubscriber[$wpUserId] = !$subscriber instanceof SubscriberEntity
+        && $this->subscribersRepository->findOneBy(['email' => $wpUser->user_email]) === null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    }
 
     $currentFilter = $this->wp->currentFilter();
     // Delete

--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -308,7 +308,7 @@ class WooCommerce {
       return null;
     }
 
-    $this->insertSubscribers([$email], $status);
+    $wasNewlyCreated = $this->insertSubscribers([$email], $status) > 0;
     return $email;
   }
 

--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -23,6 +23,18 @@ use MailPoetVendor\Doctrine\DBAL\ParameterType;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class WooCommerce {
+  /**
+   * Per-email record of whether synchronizeGuestCustomer() inserted a brand new
+   * subscriber row this request, or found one that already existed.
+   * insertSubscribers() uses INSERT IGNORE, so a caller looking at the row
+   * afterwards cannot tell "just created" from "already there" — that is
+   * captured at insert time instead. Read by WooCommerce\Subscription, which
+   * runs on the same hook at a later priority and has no other way to know.
+   *
+   * @var array<string, bool>
+   */
+  private $guestSyncCreatedSubscriber = [];
+
   /** @var SettingsController */
   private $settings;
 
@@ -166,6 +178,17 @@ class WooCommerce {
     return !$this->woocommerceHelper->isCheckoutRequest() || ($checkoutOptinEnabled && $checkoutOptinChecked);
   }
 
+  /**
+   * Whether the given email's subscriber row did not exist before the most
+   * recent synchronizeGuestCustomer() call in this request. Defaults to false,
+   * meaning "treat as pre-existing", for any email that call never saw: a
+   * missing signal must never cause an unearned overwrite of an earlier
+   * consent choice.
+   */
+  public function wasNewlyCreatedByGuestSync(string $email): bool {
+    return $this->guestSyncCreatedSubscriber[$email] ?? false;
+  }
+
   public function synchronizeGuestCustomer(int $orderId): void {
     $wcOrder = $this->woocommerceHelper->wcGetOrder($orderId);
 
@@ -176,11 +199,13 @@ class WooCommerce {
       $status = SubscriberEntity::STATUS_SUBSCRIBED;
     }
 
-    $email = $this->insertSubscriberFromOrder($wcOrder, $status);
+    $wasNewlyCreated = false;
+    $email = $this->insertSubscriberFromOrder($wcOrder, $status, $wasNewlyCreated);
 
     if (empty($email)) {
       return;
     }
+    $this->guestSyncCreatedSubscriber[$email] = $wasNewlyCreated;
     $subscriber = $this->subscribersRepository->findOneBy(['email' => $email]);
 
     if ($subscriber) {
@@ -276,7 +301,7 @@ class WooCommerce {
     ", ['capabilities' => $wpdb->prefix . 'capabilities', 'source' => Source::WOOCOMMERCE_USER]);
   }
 
-  private function insertSubscriberFromOrder(\WC_Order $wcOrder, string $status): ?string {
+  private function insertSubscriberFromOrder(\WC_Order $wcOrder, string $status, bool &$wasNewlyCreated = false): ?string {
     $email = $wcOrder->get_billing_email();
 
     if (!$email || !$this->validator->validateEmail($email)) {
@@ -359,12 +384,14 @@ class WooCommerce {
     // Save timestamp about new subscribers before insert
     $this->subscriberChangesNotifier->subscribersBatchCreate();
     // Insert new subscribers
-    $this->connection->executeQuery('
+    // executeStatement, not executeQuery: the affected-row count is what tells
+    // a caller whether INSERT IGNORE actually inserted or silently discarded.
+    $insertedCount = $this->connection->executeStatement('
       INSERT IGNORE INTO ' . $subscribersTable . ' (`is_woocommerce_user`, `email`, `status`, `created_at`, `last_subscribed_at`, `source`) VALUES
       ' . implode(',', $subscribersValues) . '
     ');
 
-    return count($emails);
+    return (int)$insertedCount;
   }
 
   /**

--- a/mailpoet/lib/Statistics/Track/Clicks.php
+++ b/mailpoet/lib/Statistics/Track/Clicks.php
@@ -21,6 +21,9 @@ use MailPoet\WP\Functions as WPFunctions;
 
 class Clicks {
 
+  /** The link whose whole purpose is to switch tracking off. Its own click is never recorded. */
+  const TRACKING_OPT_OUT_SHORTCODE = '[link:subscription_tracking_opt_out_url]';
+
   const REVENUE_TRACKING_COOKIE_NAME = 'mailpoet_revenue_tracking';
   const REVENUE_TRACKING_COOKIE_EXPIRY = 60 * 60 * 24 * 14;
 
@@ -100,11 +103,15 @@ class Clicks {
     $link = $data->link;
     $wpUserPreview = ($data->preview && ($subscriber->isWPUser()));
     $trackingAllowed = $this->trackingConsentController->isTrackingAllowed($subscriber);
+    // The opt-out link exists to stop tracking, so clicking it is never itself
+    // recorded, even for a subscriber we are otherwise allowed to track. Only
+    // the recording is skipped; the redirect below still runs.
+    $isTrackingOptOutLink = $link->getUrl() === self::TRACKING_OPT_OUT_SHORTCODE;
     // log statistics only if the action did not come from
     // a WP user previewing the newsletter
     // No tracking consent (CNIL/Garante): skip all recording (stats, cookies,
     // engagement) but keep the redirect below.
-    if (!$wpUserPreview && $trackingAllowed) {
+    if (!$wpUserPreview && $trackingAllowed && !$isTrackingOptOutLink) {
       $userAgent = !empty($data->userAgent) ? $this->userAgentsRepository->findOrCreate($data->userAgent) : null;
       $statisticsClicks = $this->statisticsClicksRepository->createOrUpdateClickCount(
         $link,

--- a/mailpoet/lib/Subscription/Comment.php
+++ b/mailpoet/lib/Subscription/Comment.php
@@ -5,6 +5,7 @@ namespace MailPoet\Subscription;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscriberActions;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscribers\TrackingConsentCapture;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -30,14 +31,19 @@ class Comment {
   /** @var TrackingConsentCapture */
   private $trackingConsentCapture;
 
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
   public function __construct(
     SettingsController $settings,
     SubscriberActions $subscriberActions,
-    TrackingConsentCapture $trackingConsentCapture
+    TrackingConsentCapture $trackingConsentCapture,
+    SubscribersRepository $subscribersRepository
   ) {
     $this->settings = $settings;
     $this->subscriberActions = $subscriberActions;
     $this->trackingConsentCapture = $trackingConsentCapture;
+    $this->subscribersRepository = $subscribersRepository;
   }
 
   public function extendLoggedInForm($field) {
@@ -105,6 +111,13 @@ class Comment {
 
     // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- type narrowing only, value is read as bool
     $mailpoetPost = isset($_POST['mailpoet']) && is_array($_POST['mailpoet']) ? $_POST['mailpoet'] : [];
+
+    // Independent of the subscribe checkbox, and only for a row that already
+    // exists: never creates one. Runs whatever the moderation status, because
+    // updating an existing row's consent does not depend on the comment being
+    // approved, unlike subscribing, which does.
+    $this->applyTrackingConsentToExistingSubscriber($mailpoetPost, $commentId);
+
     if (
       isset($mailpoetPost['subscribe_on_comment'])
       && (bool)$mailpoetPost['subscribe_on_comment'] === true
@@ -131,6 +144,42 @@ class Comment {
         $this->subscribeAuthorOfComment($commentId, $trackingConsent);
       }
     }
+  }
+
+  /**
+   * Records the comment form's tracking-consent choice for a commenter who is
+   * already a subscriber, whether or not they also ticked "add me to your
+   * mailing list". Deliberately never creates a subscriber: a comment is not a
+   * signup, and someone answering a tracking question should not thereby end
+   * up on a list they did not ask to join.
+   *
+   * isNewSubscriber is always false by construction here, since this only ever
+   * reaches the apply call when findOneBy just found an existing row. That
+   * means an unticked box on an existing row is dropped by getConsentData()'s
+   * own rule, with no extra logic needed.
+   */
+  private function applyTrackingConsentToExistingSubscriber(array $mailpoetPost, $commentId): void {
+    if (!isset($mailpoetPost['tracking_consent'])) {
+      return;
+    }
+    $comment = WPFunctions::get()->getComment($commentId);
+    $email = $comment ? $comment->comment_author_email : null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    if (empty($email)) {
+      return;
+    }
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => $email]);
+    if (!$subscriber instanceof SubscriberEntity) {
+      return;
+    }
+    $method = SubscriberEntity::TRACKING_CONSENT_METHOD_COMMENT;
+    $this->trackingConsentCapture->applyToSubscriber(
+      $subscriber,
+      !empty($mailpoetPost['tracking_consent']),
+      $method,
+      $this->trackingConsentCapture->getCopy($method),
+      false
+    );
+    $this->subscribersRepository->flush();
   }
 
   public function onStatusUpdate($commentId, $action) {

--- a/mailpoet/lib/Subscription/Registration.php
+++ b/mailpoet/lib/Subscription/Registration.php
@@ -3,9 +3,11 @@
 namespace MailPoet\Subscription;
 
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\WP as WPSegment;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Statistics\Track\SubscriberHandler;
 use MailPoet\Subscribers\SubscriberActions;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscribers\TrackingConsentCapture;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -26,18 +28,28 @@ class Registration {
   /** @var TrackingConsentCapture */
   private $trackingConsentCapture;
 
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var WPSegment */
+  private $wpSegment;
+
   public function __construct(
     SettingsController $settings,
     WPFunctions $wp,
     SubscriberActions $subscriberActions,
     SubscriberHandler $subscriberHandler,
-    TrackingConsentCapture $trackingConsentCapture
+    TrackingConsentCapture $trackingConsentCapture,
+    SubscribersRepository $subscribersRepository,
+    WPSegment $wpSegment
   ) {
     $this->settings = $settings;
     $this->subscriberActions = $subscriberActions;
     $this->wp = $wp;
     $this->subscriberHandler = $subscriberHandler;
     $this->trackingConsentCapture = $trackingConsentCapture;
+    $this->subscribersRepository = $subscribersRepository;
+    $this->wpSegment = $wpSegment;
   }
 
   public function extendForm() {
@@ -118,6 +130,43 @@ class Registration {
    * only shown on sites that chose to ask. Never pre-ticked: a pre-ticked
    * consent box is not valid consent (CJEU Planet49).
    */
+
+  /**
+   * Hooked on user_register, after the WP-user sync has created or updated the
+   * subscriber row for every new WP user, whether or not "add me to your
+   * mailing list" was ticked. That is the gap this closes:
+   * onRegister()/onMultiSiteRegister() only read tracking_consent inside the
+   * subscribe branch, so someone who allowed tracking without subscribing had
+   * their answer thrown away. Covers single-site, multisite and WooCommerce
+   * registration alike, since all three create the WP user and fire this hook.
+   */
+  public function applyTrackingConsentOnUserRegister(int $userId): void {
+    // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- type narrowing only, the value is read as a bool
+    $mailpoetPost = isset($_POST['mailpoet']) && is_array($_POST['mailpoet']) ? $_POST['mailpoet'] : [];
+    if (!isset($mailpoetPost['tracking_consent'])) {
+      return;
+    }
+    $wpUser = $this->wp->getUserdata($userId);
+    if (!$wpUser || empty($wpUser->user_email)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      return;
+    }
+    $subscriber = $this->subscribersRepository->findOneBy(
+      ['email' => $wpUser->user_email] // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    );
+    if (!$subscriber instanceof SubscriberEntity) {
+      return;
+    }
+    $method = SubscriberEntity::TRACKING_CONSENT_METHOD_REGISTRATION;
+    $this->trackingConsentCapture->applyToSubscriber(
+      $subscriber,
+      !empty($mailpoetPost['tracking_consent']),
+      $method,
+      $this->trackingConsentCapture->getCopy($method),
+      $this->wpSegment->wasSubscriberCreatedBySync($userId)
+    );
+    $this->subscribersRepository->flush();
+  }
+
   private function getTrackingConsentField(): string {
     if (!$this->trackingConsentCapture->isCaptureEnabled()) {
       return '';

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -4,6 +4,7 @@ namespace MailPoet\WooCommerce;
 
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Segments\WooCommerce as WooCommerceSegment;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Subscribers\Source;
@@ -71,6 +72,9 @@ class Subscription {
   /** @var TrackingConsentCapture */
   private $trackingConsentCapture;
 
+  /** @var WooCommerceSegment */
+  private $woocommerceSegment;
+
   public function __construct(
     SettingsController $settings,
     ConfirmationEmailMailer $confirmationEmailMailer,
@@ -79,7 +83,8 @@ class Subscription {
     SubscribersRepository $subscribersRepository,
     SegmentsRepository $segmentsRepository,
     SubscriberSegmentRepository $subscriberSegmentRepository,
-    TrackingConsentCapture $trackingConsentCapture
+    TrackingConsentCapture $trackingConsentCapture,
+    WooCommerceSegment $woocommerceSegment
   ) {
     $this->settings = $settings;
     $this->wp = $wp;
@@ -89,6 +94,7 @@ class Subscription {
     $this->segmentsRepository = $segmentsRepository;
     $this->subscriberSegmentRepository = $subscriberSegmentRepository;
     $this->trackingConsentCapture = $trackingConsentCapture;
+    $this->woocommerceSegment = $woocommerceSegment;
   }
 
   public function extendWooCommerceCheckoutForm() {
@@ -204,8 +210,12 @@ class Subscription {
 
     $checkoutOptin = !empty($_POST[self::CHECKOUT_OPTIN_INPUT_NAME]);
     $trackingConsent = !empty($_POST[self::CHECKOUT_TRACKING_CONSENT_INPUT_NAME]);
+    // Classic checkout has no pre-sync lookup of its own: the guest sync runs on
+    // this same hook three priorities earlier, so by now a brand new guest's row
+    // is already there. Ask the sync what it actually inserted.
+    $isNewSubscriber = $this->woocommerceSegment->wasNewlyCreatedByGuestSync($data['billing_email']);
 
-    return $this->handleSubscriberOptin($subscriber, $checkoutOptin, $trackingConsent);
+    return $this->handleSubscriberOptin($subscriber, $checkoutOptin, $trackingConsent, $isNewSubscriber);
   }
 
   /**
@@ -215,11 +225,11 @@ class Subscription {
    * @param bool $shouldSubscribe Whether the subscriber should be subscribed
    * @param bool $trackingConsent Whether the separate tracking-consent box was ticked
    */
-  public function handleSubscriberOptin(SubscriberEntity $subscriber, bool $shouldSubscribe, bool $trackingConsent = false): bool {
+  public function handleSubscriberOptin(SubscriberEntity $subscriber, bool $shouldSubscribe, bool $trackingConsent = false, bool $isNewSubscriber = false): bool {
     // Recorded before the opt-in branch, and independently of it: consenting to
     // tracking and subscribing are two separate decisions, so a customer who
     // declines the newsletter can still allow tracking and vice versa.
-    $this->applyTrackingConsent($subscriber, $trackingConsent);
+    $this->applyTrackingConsent($subscriber, $trackingConsent, $isNewSubscriber);
 
     $wcSegment = $this->segmentsRepository->getWooCommerceSegment();
 
@@ -256,7 +266,7 @@ class Subscription {
    * choice alone rather than revoking it. Persisted here because this path
    * writes the entity itself instead of going through SubscriberSaveController.
    */
-  private function applyTrackingConsent(SubscriberEntity $subscriber, bool $granted): void {
+  private function applyTrackingConsent(SubscriberEntity $subscriber, bool $granted, bool $isNewSubscriber = false): void {
     $method = SubscriberEntity::TRACKING_CONSENT_METHOD_WOOCOMMERCE_CHECKOUT;
     $before = $subscriber->getTrackingConsent();
 
@@ -265,7 +275,7 @@ class Subscription {
       $granted,
       $method,
       $this->trackingConsentCapture->getCopy($method),
-      false
+      $isNewSubscriber
     );
 
     if ($subscriber->getTrackingConsent() !== $before) {

--- a/mailpoet/tests/integration/Segments/WooCommerceTest.php
+++ b/mailpoet/tests/integration/Segments/WooCommerceTest.php
@@ -177,7 +177,8 @@ class WooCommerceTest extends \MailPoetTest {
     $this->settings->set('signup_confirmation', ['enabled' => true]);
     $this->settings->set('woocommerce.optin_on_checkout', ['enabled' => false]);
 
-    $email = 'already-subscribed-guest@example.com';
+    // Kept under the user-sync-test prefix so cleanData() removes it between runs.
+    $email = 'user-sync-test-already-subscribed-guest' . rand() . '@example.com';
     $existing = new SubscriberEntity();
     $existing->setEmail($email);
     $existing->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);

--- a/mailpoet/tests/integration/Segments/WooCommerceTest.php
+++ b/mailpoet/tests/integration/Segments/WooCommerceTest.php
@@ -151,6 +151,45 @@ class WooCommerceTest extends \MailPoetTest {
     verify($subscriber->getSegmentsCount())->equals(0);
   }
 
+  public function testItReportsWhetherTheGuestSyncActuallyCreatedTheRow(): void {
+    // The signal WooCommerce\Subscription reads to decide whether an unticked consent
+    // box at classic checkout is a first answer or a protected earlier choice. Tested
+    // through the real sync, because passing the flag straight into handleSubscriberOptin()
+    // proves nothing about this plumbing.
+    $this->settings->set('signup_confirmation', ['enabled' => true]);
+    $this->settings->set('woocommerce.optin_on_checkout', ['enabled' => false]);
+
+    $guest = $this->insertGuestCustomer();
+    verify($this->wooCommerceSegment->wasNewlyCreatedByGuestSync($guest['email']))->false();
+
+    $this->wooCommerceSegment->synchronizeGuestCustomer($guest['order_id']);
+    verify($this->wooCommerceSegment->wasNewlyCreatedByGuestSync($guest['email']))->true();
+
+    // A second order for the same address finds the row already there.
+    $secondOrderId = $this->createOrder(['email' => $guest['email']]);
+    $this->wooCommerceSegment->synchronizeGuestCustomer($secondOrderId);
+    verify($this->wooCommerceSegment->wasNewlyCreatedByGuestSync($guest['email']))->false();
+  }
+
+  public function testAnAddressAlreadyOnTheListIsNotReportedAsNewlyCreated(): void {
+    // Someone who signed up through a form and later checks out as a guest: the sync
+    // only flips their is_woocommerce_user flag, so their earlier consent must stand.
+    $this->settings->set('signup_confirmation', ['enabled' => true]);
+    $this->settings->set('woocommerce.optin_on_checkout', ['enabled' => false]);
+
+    $email = 'already-subscribed-guest@example.com';
+    $existing = new SubscriberEntity();
+    $existing->setEmail($email);
+    $existing->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
+    $this->subscribersRepository->persist($existing);
+    $this->subscribersRepository->flush();
+
+    $orderId = $this->createOrder(['email' => $email]);
+    $this->wooCommerceSegment->synchronizeGuestCustomer($orderId);
+
+    verify($this->wooCommerceSegment->wasNewlyCreatedByGuestSync($email))->false();
+  }
+
   public function testItSynchronizesNewGuestCustomer(): void {
     $this->settings->set('signup_confirmation', ['enabled' => true]);
     $this->settings->set('woocommerce.optin_on_checkout', ['enabled' => false]);

--- a/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
@@ -463,6 +463,42 @@ class ClicksTest extends \MailPoetTest {
     $this->assertNull($this->subscriber->getLastClickAt());
   }
 
+  public function testClickingTheOptOutLinkIsNotRecordedButStillRedirects() {
+    // The one link whose whole purpose is to stop tracking must never be the
+    // thing that records a click. The subscriber here is fully trackable, so
+    // the only reason nothing is recorded is the link itself.
+    $optOutLink = new NewsletterLinkEntity(
+      $this->newsletter,
+      $this->queue,
+      Clicks::TRACKING_OPT_OUT_SHORTCODE,
+      'opt-out-hash'
+    );
+    $this->entityManager->persist($optOutLink);
+    $this->entityManager->flush();
+    $trackData = clone $this->trackData;
+    $trackData->link = $optOutLink;
+    $clicks = Stub::construct($this->clicks, [
+      $this->diContainer->get(Cookies::class),
+      $this->diContainer->get(SubscriberCookie::class),
+      $this->diContainer->get(Shortcodes::class),
+      $this->diContainer->get(Opens::class),
+      $this->diContainer->get(StatisticsClicksRepository::class),
+      $this->diContainer->get(UserAgentsRepository::class),
+      $this->diContainer->get(LinkShortcodeCategory::class),
+      $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
+      $this->diContainer->get(TrackingConsentController::class),
+    ], [
+      // The redirect still happens: this is about not recording, not about
+      // breaking the link.
+      'redirectToUrl' => Expected::exactly(1),
+    ], $this);
+    $clicks->track($trackData);
+    $this->assertCount(0, $this->entityManager->getRepository(StatisticsClickEntity::class)->findAll());
+    $this->assertNull($this->subscriber->getLastClickAt());
+  }
+
   public function testItIncrementsClickEventCount() {
     $clicks = Stub::construct($this->clicks, [
       $this->diContainer->get(Cookies::class),

--- a/mailpoet/tests/integration/Subscription/CommentTrackingConsentTest.php
+++ b/mailpoet/tests/integration/Subscription/CommentTrackingConsentTest.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscribers\TrackingConsentController;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 
 /**
  * Tracking consent captured on the WordPress comment form (CNIL/Garante).
@@ -110,6 +111,67 @@ class CommentTrackingConsentTest extends \MailPoetTest {
 
     verify($this->getSubscriber()->getTrackingConsent())
       ->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+  }
+
+  public function testAConsentOnlyCommenterWithAnExistingSubscriberRowIsRecorded() {
+    // The gap this fixes: onSubmit() only read tracking_consent inside the
+    // subscribe_on_comment branch, so somebody already on the list who answered
+    // the tracking question without re-subscribing had their answer dropped.
+    $this->askEveryone();
+    (new SubscriberFactory())->withEmail('commenter-consent@example.com')->create();
+
+    $_POST['mailpoet'] = ['tracking_consent' => true];
+    $this->comment->onSubmit($this->commentId, Comment::APPROVED);
+
+    $this->entityManager->clear();
+    $subscriber = $this->getSubscriber();
+    verify($subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    verify($subscriber->getTrackingConsentMethod())
+      ->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_COMMENT);
+  }
+
+  public function testAConsentOnlyCommenterIsRecordedWhileAwaitingModeration() {
+    // Updating an existing row's consent does not depend on the comment being
+    // approved, unlike subscribing, which does.
+    $this->askEveryone();
+    (new SubscriberFactory())->withEmail('commenter-consent@example.com')->create();
+
+    $_POST['mailpoet'] = ['tracking_consent' => true];
+    $this->comment->onSubmit($this->commentId, Comment::PENDING_APPROVAL);
+
+    $this->entityManager->clear();
+    verify($this->getSubscriber()->getTrackingConsent())
+      ->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+  }
+
+  public function testAConsentOnlyCommenterWithNoExistingRowCreatesNothing() {
+    // A comment is not a signup. Answering a tracking question must never put
+    // somebody on a list they did not ask to join.
+    $this->askEveryone();
+
+    $_POST['mailpoet'] = ['tracking_consent' => true];
+    $this->comment->onSubmit($this->commentId, Comment::APPROVED);
+
+    $this->entityManager->clear();
+    verify($this->subscribersRepository->findOneBy(['email' => 'commenter-consent@example.com']))->null();
+  }
+
+  public function testAConsentOnlyCommenterDoesNotDowngradeAnExistingGrant() {
+    $this->askEveryone();
+    $existing = (new SubscriberFactory())->withEmail('commenter-consent@example.com')->create();
+    $existing->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE,
+      'given on the manage page'
+    );
+    $this->subscribersRepository->flush();
+
+    $_POST['mailpoet'] = ['tracking_consent' => false];
+    $this->comment->onSubmit($this->commentId, Comment::APPROVED);
+
+    $this->entityManager->clear();
+    verify($this->getSubscriber()->getTrackingConsent())
+      ->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
   }
 
   public function testTheFieldIsHiddenUntilTheSiteAsks() {

--- a/mailpoet/tests/integration/Subscription/RegistrationTrackingConsentTest.php
+++ b/mailpoet/tests/integration/Subscription/RegistrationTrackingConsentTest.php
@@ -98,6 +98,84 @@ class RegistrationTrackingConsentTest extends \MailPoetTest {
       ->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
   }
 
+  public function testAConsentOnlyRegistrantIsRecordedEvenWithoutSubscribing() {
+    // The gap this fixes: onRegister() only reads tracking_consent inside the
+    // subscribe branch, so someone who allowed tracking without ticking
+    // "add me to your mailing list" had their answer thrown away. These tests
+    // go through wp_insert_user(), so the real user_register chain runs:
+    // capture at priority 5, WP-user sync at 6, consent at 7.
+    $this->askEveryone();
+    $email = 'reg-consent-only@example.com';
+    $_POST['mailpoet'] = ['tracking_consent' => true];
+
+    $this->registerWpUser($email);
+
+    $this->entityManager->clear();
+    $subscriber = $this->getSubscriber($email);
+    verify($subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    verify($subscriber->getTrackingConsentMethod())
+      ->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_REGISTRATION);
+  }
+
+  public function testAConsentOnlyRegistrantCanDecline() {
+    $this->askEveryone();
+    $email = 'reg-consent-only-declined@example.com';
+    $_POST['mailpoet'] = ['tracking_consent' => false];
+
+    $this->registerWpUser($email);
+
+    $this->entityManager->clear();
+    verify($this->getSubscriber($email)->getTrackingConsent())
+      ->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+  }
+
+  public function testAConsentOnlyRegistrationDoesNotDowngradeAnExistingSubscriber() {
+    // Same unticked box, different history: this address was already on the
+    // list with a grant, so registering again must not revoke it.
+    $this->askEveryone();
+    $email = 'reg-consent-only-existing@example.com';
+    $existing = (new SubscriberFactory())->withEmail($email)->create();
+    $existing->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE,
+      'given on the manage page'
+    );
+    $this->subscribersRepository->flush();
+
+    $_POST['mailpoet'] = ['tracking_consent' => false];
+    $this->registerWpUser($email);
+
+    $this->entityManager->clear();
+    verify($this->getSubscriber($email)->getTrackingConsent())
+      ->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+  }
+
+  public function testItRecordsNothingWhenNoConsentFieldWasPosted() {
+    $this->askEveryone();
+    $email = 'reg-no-field@example.com';
+    $_POST['mailpoet'] = ['subscribe_on_register' => true];
+
+    $this->registerWpUser($email);
+
+    $this->entityManager->clear();
+    verify($this->getSubscriber($email)->getTrackingConsent())
+      ->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+  }
+
+  /**
+   * Creates a real WP user, which fires user_register and therefore the whole
+   * chain this change hooks into.
+   */
+  private function registerWpUser(string $email): int {
+    $userId = wp_insert_user([
+      'user_login' => substr(md5($email), 0, 20),
+      'user_email' => $email,
+      'user_pass' => 'password',
+    ]);
+    $this->assertIsInt($userId);
+    return $userId;
+  }
+
   public function testTheFieldIsHiddenUntilTheSiteAsks() {
     ob_start();
     $this->registration->extendForm();

--- a/mailpoet/tests/integration/Subscription/RegistrationTrackingConsentTest.php
+++ b/mailpoet/tests/integration/Subscription/RegistrationTrackingConsentTest.php
@@ -19,6 +19,9 @@ class RegistrationTrackingConsentTest extends \MailPoetTest {
 
   private SettingsController $settings;
 
+  /** @var int[] */
+  private $createdWpUserIds = [];
+
   public function _before() {
     parent::_before();
     $this->registration = $this->diContainer->get(Registration::class);
@@ -30,6 +33,13 @@ class RegistrationTrackingConsentTest extends \MailPoetTest {
 
   public function _after() {
     unset($_POST['mailpoet']);
+    // These tests create real WP users so the whole user_register chain runs. WP users
+    // are not truncated between tests, so leaving them behind would skew any later test
+    // that counts or syncs WP users.
+    foreach ($this->createdWpUserIds as $userId) {
+      wp_delete_user($userId);
+    }
+    $this->createdWpUserIds = [];
     parent::_after();
   }
 
@@ -173,6 +183,7 @@ class RegistrationTrackingConsentTest extends \MailPoetTest {
       'user_pass' => 'password',
     ]);
     $this->assertIsInt($userId);
+    $this->createdWpUserIds[] = $userId;
     return $userId;
   }
 

--- a/mailpoet/tests/integration/Subscription/RegistrationTrackingConsentTest.php
+++ b/mailpoet/tests/integration/Subscription/RegistrationTrackingConsentTest.php
@@ -160,7 +160,20 @@ class RegistrationTrackingConsentTest extends \MailPoetTest {
       ->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
   }
 
-  public function testItRecordsNothingWhenNoConsentFieldWasPosted() {
+  /**
+   * An absent key is never read as a decline, and deliberately so even with the site
+   * asking everyone. `user_register` fires for every route that creates a WP user —
+   * wp_insert_user(), the admin, WP-CLI, WooCommerce, other plugins — and the checkbox
+   * only exists on the registration form. So a missing key cannot distinguish "shown and
+   * left unticked" from "never shown at all", and treating it as a decline would stamp
+   * `denied` on users who were never asked, with the registration wording stored as
+   * evidence of a question nobody put to them.
+   *
+   * The cost is real and accepted for now: a first-time registrant who genuinely declines
+   * stays `unknown` rather than `denied`. Recording that needs a marker field posted
+   * alongside the checkbox, which is its own change.
+   */
+  public function testAnAbsentConsentKeyIsNeverTreatedAsADecline() {
     $this->askEveryone();
     $email = 'reg-no-field@example.com';
     $_POST['mailpoet'] = ['subscribe_on_register' => true];

--- a/mailpoet/tests/integration/WooCommerce/SubscriptionTrackingConsentTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriptionTrackingConsentTest.php
@@ -104,6 +104,38 @@ class SubscriptionTrackingConsentTest extends \MailPoetTest {
       ->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE);
   }
 
+  public function testANewGuestWhoDeclinesEndsDenied() {
+    // The case the bug report measured: a first-time guest who is shown the box
+    // and leaves it unticked must end denied, not unknown-and-therefore-tracked.
+    $this->askEveryone();
+    $newGuest = new SubscriberEntity();
+    $newGuest->setEmail('new-guest@example.com');
+    $newGuest->setIsWoocommerceUser(true);
+    $newGuest->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->subscribersRepository->persist($newGuest);
+    $this->subscribersRepository->flush();
+
+    $this->subscription->handleSubscriberOptin($newGuest, false, false, true);
+
+    verify($newGuest->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+  }
+
+  public function testAnExistingSubscriberUntickingStaysGranted() {
+    // Same input as the test above, different history: this row already held a
+    // grant. An unticked checkout box is never read as a withdrawal (STOMAIL-8305).
+    $this->askEveryone();
+    $this->subscriber->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE,
+      'given on the manage page'
+    );
+    $this->subscribersRepository->flush();
+
+    $this->subscription->handleSubscriberOptin($this->subscriber, false, false, false);
+
+    verify($this->subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+  }
+
   public function testItPersistsConsentEvenWhenTheCustomerDoesNotSubscribe() {
     $this->askEveryone();
     $this->subscription->handleSubscriberOptin($this->subscriber, false, true);


### PR DESCRIPTION
## What this does

Three places where a subscriber tells MailPoet something about tracking and MailPoet does not act on it.

**1. WooCommerce checkout never recorded a decline.** `applyTrackingConsent()` passed a literal `false` for "is this a new subscriber", so an unticked box always looked like someone protecting an earlier choice, never like a first answer. A first-time guest who was shown the box and left it unticked ended up `unknown`, and therefore tracked.

The STOMAIL-8305 rule stays exactly as it was — an unticked box is never read as a withdrawal for someone who already chose. What changes is that a real is-new signal now reaches the decision. The blocks checkout already did a `findOneBy` before syncing, so that lookup becomes the signal directly. Classic checkout has no such lookup, so `Segments\WooCommerce` now remembers whether its own `INSERT IGNORE` actually inserted a row this request (that meant switching one `executeQuery()` to `executeStatement()` for a real affected-row count) and exposes it as `wasNewlyCreatedByGuestSync()`.

**2. Registration and comment forms dropped consent when the subscribe box was unticked.** Both only read `tracking_consent` inside the "add me to your mailing list" branch. Those are two separate decisions, so someone who allowed tracking without subscribing had their answer thrown away. Registration gets a `user_register` handler that runs whatever was ticked; the comment form gets a check that runs regardless of the subscribe box and regardless of moderation status — but **only ever updates a subscriber who already exists**. A comment is not a signup, and answering a tracking question must not put someone on a list they did not ask to join.

**3. The footer tracking opt-out link was itself click-tracked.** The one link whose whole purpose is to stop tracking now never records its own click. The redirect is untouched, and `mailpoet_link_clicked` is deliberately left alone.

## Worth a reviewer's attention

**The plan for gap 2 assumed something that is not true, and this PR does it differently.** The idea was to capture "did a subscriber already exist" on `user_register` at priority 5, ahead of the WP-user sync at priority 6. That cannot work: `wp_insert_user()` calls `set_user_role()` before it fires `user_register`, and `set_user_role` is itself hooked to `Segments\WP::synchronizeUser`. By the time anything runs on `user_register`, at any priority, the row already exists with `wp_user_id` set.

So `Segments\WP` now records whether its own sync created the row, the same shape as the WooCommerce fix above, and `Registration` reads that. One hook instead of two.

That means **this PR touches `Segments\WP`**, which is far more central than the WooCommerce segment. The addition is a per-request array and one getter; nothing existing changes behaviour. `Segments\WPTest` (49 tests) is green.

The failure mode here was easy to miss: grants record fine regardless of the is-new signal, so only the *decline* case broke. The registration tests deliberately go through real `wp_insert_user()` calls rather than calling the handlers by hand, which is the only reason it surfaced.

## Test plan

Checkout: a new guest who declines ends `denied`; an existing subscriber unticking the same box stays `granted`. Registration: a consent-only registrant is recorded, can decline, does not downgrade an existing grant, and nothing is recorded when no consent field was posted. Comment: an existing subscriber's choice is recorded whether approved or awaiting moderation, an existing grant is not downgraded, and a commenter with no subscriber row creates nothing. Clicks: the opt-out link records no click and still redirects.

Every one of the four production changes carries a sabotage check — reverting it fails exactly the tests that claim to guard it and nothing else.

`SubscriptionTrackingConsentTest` 8/16, `RegistrationTrackingConsentTest` 10/27, `CommentTrackingConsentTest` 10/24, `ClicksTest` 24/83. Regression suites green: `Segments\WPTest` 49/186, `Segments\WooCommerceTest` 34/117, `WooCommerceBlocksIntegrationTest` 5/10, `WooCommerce\SubscriptionTest` 11/42, `RegistrationTest` 5/5, `HooksTest` 2/3. `qa:phpstan` no errors, `qa:code-sniffer` and `qa:lint-javascript` exit 0.

No new column and no migration: every fix reads and writes fields that already exist.

Fixes STOMAIL-8363.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8363-tracking-consent-collection-gaps)

_The latest successful build from `fix/stomail-8363-tracking-consent-collection-gaps` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->