### PR TITLE
Mirror a MailPoet tracking-consent change onto AutomateWoo

### DIFF
--- a/mailpoet/changelog/2026-08-24-added-turning-off-open-and-click-tracking-in-mailpoet-n.md
+++ b/mailpoet/changelog/2026-08-24-added-turning-off-open-and-click-tracking-in-mailpoet-n.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Turning off open and click tracking in MailPoet now also turns it off in AutomateWoo, so a subscriber only has to say it once. Turning it back on clears it in both places too.

--- a/mailpoet/changelog/2026-08-24-added-turning-off-open-and-click-tracking-in-mailpoet-n.md
+++ b/mailpoet/changelog/2026-08-24-added-turning-off-open-and-click-tracking-in-mailpoet-n.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Turning off open and click tracking in MailPoet now also turns it off in AutomateWoo, so a subscriber only has to say it once. Turning it back on clears it in both places too.
+Turning off open and click tracking in MailPoet now also turns it off in AutomateWoo, so a subscriber only has to say it once. Turning it back on clears it in both places too

--- a/mailpoet/lib/Config/SubscriberChangesNotifier.php
+++ b/mailpoet/lib/Config/SubscriberChangesNotifier.php
@@ -24,9 +24,11 @@ class SubscriberChangesNotifier {
   private $countChangedSubscriberIds = [];
 
   /**
-   * Consent changes, keyed by subscriber id. Deliberately not collapsed into a batch the
-   * way updates are: a consent change is a per-person legal record, so every one is
-   * delivered on its own.
+   * Net consent transition per subscriber, keyed by subscriber id: the value they had
+   * when this request started, and the value they ended on. Deliberately not collapsed
+   * across subscribers the way updates are, because a consent change is a per-person
+   * record. If one subscriber changes twice in a request the original `old` is kept, so
+   * the pair still describes the real before-and-after rather than an inner step.
    *
    * @var array<int, array{0: string, 1: string}>
    */
@@ -56,7 +58,9 @@ class SubscriberChangesNotifier {
   }
 
   public function subscriberTrackingConsentChanged(int $subscriberId, string $oldConsent, string $newConsent): void {
-    $this->trackingConsentChanges[$subscriberId] = [$oldConsent, $newConsent];
+    // Keep the first `old` seen this request so a second change does not rewrite history.
+    $originalOld = $this->trackingConsentChanges[$subscriberId][0] ?? $oldConsent;
+    $this->trackingConsentChanges[$subscriberId] = [$originalOld, $newConsent];
   }
 
   private function notifyTrackingConsentChanges(): void {

--- a/mailpoet/lib/Config/SubscriberChangesNotifier.php
+++ b/mailpoet/lib/Config/SubscriberChangesNotifier.php
@@ -23,6 +23,15 @@ class SubscriberChangesNotifier {
   /** @var array<int, int> */
   private $countChangedSubscriberIds = [];
 
+  /**
+   * Consent changes, keyed by subscriber id. Deliberately not collapsed into a batch the
+   * way updates are: a consent change is a per-person legal record, so every one is
+   * delivered on its own.
+   *
+   * @var array<int, array{0: string, 1: string}>
+   */
+  private $trackingConsentChanges = [];
+
   /** @var array<int, int> */
   private $createdSubscriberBatches = [];
 
@@ -43,6 +52,17 @@ class SubscriberChangesNotifier {
     $this->notifyUpdates();
     $this->notifyDeletes();
     $this->notifyCountChanges();
+    $this->notifyTrackingConsentChanges();
+  }
+
+  public function subscriberTrackingConsentChanged(int $subscriberId, string $oldConsent, string $newConsent): void {
+    $this->trackingConsentChanges[$subscriberId] = [$oldConsent, $newConsent];
+  }
+
+  private function notifyTrackingConsentChanges(): void {
+    foreach ($this->trackingConsentChanges as $subscriberId => list($oldConsent, $newConsent)) {
+      $this->wp->doAction(SubscriberEntity::HOOK_SUBSCRIBER_TRACKING_CONSENT_CHANGED, $subscriberId, $oldConsent, $newConsent);
+    }
   }
 
   private function notifyCreations(): void {

--- a/mailpoet/lib/Doctrine/EventListeners/SubscriberListener.php
+++ b/mailpoet/lib/Doctrine/EventListeners/SubscriberListener.php
@@ -27,6 +27,23 @@ class SubscriberListener {
     }
   }
 
+  private function maybeNotifyTrackingConsentChanged(SubscriberEntity $subscriber, LifecycleEventArgs $event): void {
+    $changeset = $event->getEntityManager()->getUnitOfWork()->getEntityChangeSet($subscriber);
+
+    if (!array_key_exists('trackingConsent', $changeset) || $changeset['trackingConsent'][0] === $changeset['trackingConsent'][1]) {
+      return;
+    }
+
+    $oldConsent = $changeset['trackingConsent'][0];
+    $newConsent = $changeset['trackingConsent'][1];
+
+    $this->subscriberChangesNotifier->subscriberTrackingConsentChanged(
+      (int)$subscriber->getId(),
+      is_string($oldConsent) ? $oldConsent : SubscriberEntity::TRACKING_CONSENT_UNKNOWN,
+      is_string($newConsent) ? $newConsent : SubscriberEntity::TRACKING_CONSENT_UNKNOWN
+    );
+  }
+
   private function maybeNotifyDeletedAtChanged(SubscriberEntity $subscriber, LifecycleEventArgs $event): void {
     $entityManager = $event->getEntityManager();
     $unitOfWork = $entityManager->getUnitOfWork();
@@ -53,11 +70,22 @@ class SubscriberListener {
 
   public function postPersist(SubscriberEntity $subscriber, LifecycleEventArgs $event): void {
     $this->subscriberChangesNotifier->subscriberCreated((int)$subscriber->getId());
+
+    // postPersist has no changeset, and the column defaults to unknown, so a subscriber
+    // created straight into granted or denied would otherwise never be announced.
+    if ($subscriber->getTrackingConsent() !== SubscriberEntity::TRACKING_CONSENT_UNKNOWN) {
+      $this->subscriberChangesNotifier->subscriberTrackingConsentChanged(
+        (int)$subscriber->getId(),
+        SubscriberEntity::TRACKING_CONSENT_UNKNOWN,
+        $subscriber->getTrackingConsent()
+      );
+    }
   }
 
   public function postUpdate(SubscriberEntity $subscriber, LifecycleEventArgs $event): void {
     $this->subscriberChangesNotifier->subscriberUpdated((int)$subscriber->getId());
     $this->maybeNotifyStatusChanged($subscriber, $event);
+    $this->maybeNotifyTrackingConsentChanged($subscriber, $event);
     $this->maybeNotifyDeletedAtChanged($subscriber, $event);
   }
 

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -26,6 +26,7 @@ class SubscriberEntity {
   public const HOOK_SUBSCRIBER_DELETED = 'mailpoet_subscriber_deleted';
   public const HOOK_SUBSCRIBER_UPDATED = 'mailpoet_subscriber_updated';
   public const HOOK_SUBSCRIBER_STATUS_CHANGED = 'mailpoet_subscriber_status_changed';
+  public const HOOK_SUBSCRIBER_TRACKING_CONSENT_CHANGED = 'mailpoet_subscriber_tracking_consent_changed';
   public const HOOK_MULTIPLE_SUBSCRIBERS_CREATED = 'mailpoet_multiple_subscribers_created';
   public const HOOK_MULTIPLE_SUBSCRIBERS_DELETED = 'mailpoet_multiple_subscribers_deleted';
   public const HOOK_MULTIPLE_SUBSCRIBERS_UPDATED = 'mailpoet_multiple_subscribers_updated';

--- a/mailpoet/lib/WooCommerce/Integrations/AutomateWooHooks.php
+++ b/mailpoet/lib/WooCommerce/Integrations/AutomateWooHooks.php
@@ -37,6 +37,20 @@ class AutomateWooHooks {
       class_exists('AutomateWoo\Customer') && method_exists('AutomateWoo\Customer', 'opt_out');
   }
 
+  /**
+   * Separate from areMethodsAvailable() on purpose: that one gates the existing status
+   * sync, and tightening it would silently switch off working behaviour on an older
+   * AutomateWoo. An AutomateWoo without the companion change simply does not get consent
+   * forwarding, while its status sync keeps working.
+   */
+  public function areTrackingMethodsAvailable(): bool {
+    // method_exists checks guard older AutomateWoo versions that may not ship these methods, even though current stubs declare them.
+    // @phpstan-ignore-next-line function.alreadyNarrowedType
+    return class_exists('AutomateWoo\Customer') && method_exists('AutomateWoo\Customer', 'opt_out_of_tracking') &&
+      // @phpstan-ignore-next-line function.alreadyNarrowedType
+      method_exists('AutomateWoo\Customer', 'opt_in_to_tracking');
+  }
+
   public function isAutomateWooReady(): bool {
     return $this->isAutomateWooActive() && $this->areMethodsAvailable();
   }
@@ -56,6 +70,41 @@ class AutomateWooHooks {
     }
     $this->wp->addAction(SubscriberEntity::HOOK_SUBSCRIBER_STATUS_CHANGED, [$this, 'syncSubscriber'], 10, 1);
     $this->wp->addAction('mailpoet_segment_subscribed', [$this, 'maybeOptInSubscriber'], 10, 1);
+    $this->wp->addAction(SubscriberEntity::HOOK_SUBSCRIBER_TRACKING_CONSENT_CHANGED, [$this, 'syncTrackingConsent'], 10, 3);
+  }
+
+  /**
+   * Mirror a MailPoet tracking-consent change onto the AutomateWoo customer.
+   *
+   * Denied stops AutomateWoo tracking. Granted clears the flag, the way optInSubscriber()
+   * reverses optOutSubscriber(); without that, somebody who changed their mind would be
+   * permanently untracked in AutomateWoo with no way back from MailPoet. `unknown` is
+   * left alone: nobody was asked, and that is not an answer.
+   */
+  public function syncTrackingConsent(int $subscriberId, string $oldConsent, string $newConsent): void {
+    if (!$this->isAutomateWooReady() || !$this->areTrackingMethodsAvailable()) {
+      return;
+    }
+
+    if ($newConsent === SubscriberEntity::TRACKING_CONSENT_UNKNOWN || $newConsent === $oldConsent) {
+      return;
+    }
+
+    $subscriber = $this->subscribersRepository->findOneById($subscriberId);
+    if (!$subscriber || !$subscriber->getEmail()) {
+      return;
+    }
+
+    $automateWooCustomer = $this->getAutomateWooCustomer($subscriber->getEmail());
+    if (!$automateWooCustomer) {
+      return;
+    }
+
+    if ($newConsent === SubscriberEntity::TRACKING_CONSENT_DENIED) {
+      $automateWooCustomer->opt_out_of_tracking();
+    } else {
+      $automateWooCustomer->opt_in_to_tracking();
+    }
   }
 
   public function optOutSubscriber($subscriber): void {

--- a/mailpoet/lib/WooCommerce/Integrations/AutomateWooHooks.php
+++ b/mailpoet/lib/WooCommerce/Integrations/AutomateWooHooks.php
@@ -79,7 +79,8 @@ class AutomateWooHooks {
    * Denied stops AutomateWoo tracking. Granted clears the flag, the way optInSubscriber()
    * reverses optOutSubscriber(); without that, somebody who changed their mind would be
    * permanently untracked in AutomateWoo with no way back from MailPoet. `unknown` is
-   * left alone: nobody was asked, and that is not an answer.
+   * left alone: nobody was asked, and that is not an answer. Anything else is a value
+   * this plugin never writes, and is left alone too.
    */
   public function syncTrackingConsent(int $subscriberId, string $oldConsent, string $newConsent): void {
     if (!$this->isAutomateWooReady() || !$this->areTrackingMethodsAvailable()) {
@@ -100,9 +101,12 @@ class AutomateWooHooks {
       return;
     }
 
+    // Explicit values only, failing closed on anything unrecognised, the same way
+    // TrackingConsentController::isTrackingAllowed() does. Clearing an opt-out is the
+    // consequential direction, so it needs a real `granted`, not just "not denied".
     if ($newConsent === SubscriberEntity::TRACKING_CONSENT_DENIED) {
       $automateWooCustomer->opt_out_of_tracking();
-    } else {
+    } elseif ($newConsent === SubscriberEntity::TRACKING_CONSENT_GRANTED) {
       $automateWooCustomer->opt_in_to_tracking();
     }
   }

--- a/mailpoet/tasks/phpstan/custom-stubs.php
+++ b/mailpoet/tasks/phpstan/custom-stubs.php
@@ -396,6 +396,10 @@ namespace AutomateWoo {
       }
       public function opt_in() {
       }
+      public function opt_out_of_tracking() {
+      }
+      public function opt_in_to_tracking() {
+      }
     }
   }
   if (!class_exists(\AutomateWoo\Customer_Factory::class)) {

--- a/mailpoet/tests/integration/Doctrine/EventListeners/SubscriberListenerTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/SubscriberListenerTest.php
@@ -62,6 +62,32 @@ class SubscriberListenerTest extends EventListenersBaseTest {
     $this->entityManager->flush();
   }
 
+  public function testItNotifiesAboutChangedTrackingConsent(): void {
+    $subscriber = (new SubscriberFactory())->create();
+    $changesNotifier = $this->make(SubscriberChangesNotifier::class, [
+      'wp' => $this->wp,
+      'subscriberTrackingConsentChanged' => Expected::once(),
+    ]);
+    $this->subscriberListener = new SubscriberListener($changesNotifier);
+    $this->replaceEntityListener($this->subscriberListener);
+
+    $subscriber->setTrackingConsent(SubscriberEntity::TRACKING_CONSENT_DENIED);
+    $this->entityManager->flush();
+  }
+
+  public function testItDoesNotNotifyTrackingConsentOnAnUnrelatedChange(): void {
+    $subscriber = (new SubscriberFactory())->create();
+    $changesNotifier = $this->make(SubscriberChangesNotifier::class, [
+      'wp' => $this->wp,
+      'subscriberTrackingConsentChanged' => Expected::never(),
+    ]);
+    $this->subscriberListener = new SubscriberListener($changesNotifier);
+    $this->replaceEntityListener($this->subscriberListener);
+
+    $subscriber->setFirstName('Unrelated');
+    $this->entityManager->flush();
+  }
+
   public function testItNotifiesAboutDeletedSubscriber(): void {
     $subscriber = (new SubscriberFactory())->create();
     $changesNotifier = $this->make(SubscriberChangesNotifier::class, [

--- a/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
@@ -140,6 +140,23 @@ class AutomateWooHooksTest extends \MailPoetTest {
     verify($calls)->equals([]);
   }
 
+  public function testAnUnrecognisedConsentValueDoesNothing() {
+    // The hook is public, so a third party can fire it with a state MailPoet never
+    // writes. Clearing an opt-out is the consequential direction, so it takes an
+    // explicit `granted` rather than merely "not denied".
+    $subscriber = $this->subscriberFactory->withEmail('odd-consent@mailpoet.com')->create();
+    $calls = [];
+    $hooks = $this->makeHooksForTrackingConsent($subscriber, $calls);
+
+    $hooks->syncTrackingConsent(
+      (int)$subscriber->getId(),
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      'not-a-consent-state'
+    );
+
+    verify($calls)->equals([]);
+  }
+
   public function testNoAutomateWooCustomerDoesNothing() {
     $subscriber = $this->subscriberFactory->withEmail('no-aw-customer@mailpoet.com')->create();
     $calls = [];

--- a/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
@@ -41,7 +41,7 @@ class AutomateWooHooksTest extends \MailPoetTest {
         }
         return false;
       },
-      'addAction' => Expected::exactly(2),
+      'addAction' => Expected::exactly(3),
     ]);
 
     $automateWooHooksPartialMock = $this->getMockBuilder(AutomateWooHooks::class)
@@ -51,6 +51,121 @@ class AutomateWooHooksTest extends \MailPoetTest {
     $automateWooHooksPartialMock->expects($this->once())->method('areMethodsAvailable')->willReturn(true);
 
     $automateWooHooksPartialMock->setup();
+  }
+
+  /**
+   * A stand-in for AutomateWoo\Customer: AutomateWoo is not loaded in MailPoet's test
+   * environment, so the real class does not exist here.
+   */
+  private function makeAutomateWooCustomerDouble(&$calls) {
+    return new class( $calls ) {
+      /** @var array */
+      public $calls;
+
+      public function __construct(
+        &$calls
+      ) {
+        $this->calls = &$calls;
+      }
+
+      // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+      public function opt_out_of_tracking() {
+        $this->calls[] = 'opt_out_of_tracking';
+      }
+
+      // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+      public function opt_in_to_tracking() {
+        $this->calls[] = 'opt_in_to_tracking';
+      }
+    };
+  }
+
+  private function makeHooksForTrackingConsent($subscriber, &$calls, bool $trackingMethodsAvailable = true, bool $customerFound = true) {
+    $mock = $this->getMockBuilder(AutomateWooHooks::class)
+      ->setConstructorArgs([$this->subscribersRepository, $this->wp])
+      ->onlyMethods(['isAutomateWooReady', 'areTrackingMethodsAvailable', 'getAutomateWooCustomer'])
+      ->getMock();
+    $mock->method('isAutomateWooReady')->willReturn(true);
+    $mock->method('areTrackingMethodsAvailable')->willReturn($trackingMethodsAvailable);
+    $mock->method('getAutomateWooCustomer')->willReturn(
+      $customerFound ? $this->makeAutomateWooCustomerDouble($calls) : false
+    );
+    $this->subscribersRepository->method('findOneById')->willReturn($subscriber);
+
+    return $mock;
+  }
+
+  public function testDeniedConsentOptsTheCustomerOutOfTracking() {
+    $subscriber = $this->subscriberFactory->withEmail('denied-consent@mailpoet.com')->create();
+    $calls = [];
+    $hooks = $this->makeHooksForTrackingConsent($subscriber, $calls);
+
+    $hooks->syncTrackingConsent(
+      (int)$subscriber->getId(),
+      SubscriberEntity::TRACKING_CONSENT_UNKNOWN,
+      SubscriberEntity::TRACKING_CONSENT_DENIED
+    );
+
+    verify($calls)->equals(['opt_out_of_tracking']);
+  }
+
+  public function testGrantedConsentClearsTheOptOut() {
+    // Symmetric with optInSubscriber() reversing optOutSubscriber(): somebody who changes
+    // their mind must not be stuck untracked in AutomateWoo forever.
+    $subscriber = $this->subscriberFactory->withEmail('granted-consent@mailpoet.com')->create();
+    $calls = [];
+    $hooks = $this->makeHooksForTrackingConsent($subscriber, $calls);
+
+    $hooks->syncTrackingConsent(
+      (int)$subscriber->getId(),
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_GRANTED
+    );
+
+    verify($calls)->equals(['opt_in_to_tracking']);
+  }
+
+  public function testUnknownConsentDoesNothing() {
+    // Nobody was asked, which is not an answer.
+    $subscriber = $this->subscriberFactory->withEmail('unknown-consent@mailpoet.com')->create();
+    $calls = [];
+    $hooks = $this->makeHooksForTrackingConsent($subscriber, $calls);
+
+    $hooks->syncTrackingConsent(
+      (int)$subscriber->getId(),
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_UNKNOWN
+    );
+
+    verify($calls)->equals([]);
+  }
+
+  public function testNoAutomateWooCustomerDoesNothing() {
+    $subscriber = $this->subscriberFactory->withEmail('no-aw-customer@mailpoet.com')->create();
+    $calls = [];
+    $hooks = $this->makeHooksForTrackingConsent($subscriber, $calls, true, false);
+
+    $hooks->syncTrackingConsent(
+      (int)$subscriber->getId(),
+      SubscriberEntity::TRACKING_CONSENT_UNKNOWN,
+      SubscriberEntity::TRACKING_CONSENT_DENIED
+    );
+
+    verify($calls)->equals([]);
+  }
+
+  public function testAnOlderAutomateWooIsSkipped() {
+    $subscriber = $this->subscriberFactory->withEmail('old-aw@mailpoet.com')->create();
+    $calls = [];
+    $hooks = $this->makeHooksForTrackingConsent($subscriber, $calls, false);
+
+    $hooks->syncTrackingConsent(
+      (int)$subscriber->getId(),
+      SubscriberEntity::TRACKING_CONSENT_UNKNOWN,
+      SubscriberEntity::TRACKING_CONSENT_DENIED
+    );
+
+    verify($calls)->equals([]);
   }
 
   public function testOptsOutUnsubscribedSubscriber() {

--- a/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
+++ b/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
@@ -32,6 +32,40 @@ class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
     $notifier->notify();
   }
 
+  public function testItNotifiesTrackingConsentChange(): void {
+    $this->wpFunctions->method('currentTime')->willReturn(1234);
+    $this->wpFunctions->expects($this->once())
+      ->method('doAction')
+      ->with(
+        SubscriberEntity::HOOK_SUBSCRIBER_TRACKING_CONSENT_CHANGED,
+        6,
+        SubscriberEntity::TRACKING_CONSENT_UNKNOWN,
+        SubscriberEntity::TRACKING_CONSENT_DENIED
+      )
+      ->willReturn(true);
+
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscriberTrackingConsentChanged(6, SubscriberEntity::TRACKING_CONSENT_UNKNOWN, SubscriberEntity::TRACKING_CONSENT_DENIED);
+    $notifier->notify();
+  }
+
+  public function testItNotifiesEveryTrackingConsentChangeSeparately(): void {
+    // Deliberately not batched: a consent change is a per-person legal record.
+    $this->wpFunctions->method('currentTime')->willReturn(1234);
+    $this->wpFunctions->expects($this->exactly(2))
+      ->method('doAction')
+      ->withConsecutive(
+        [SubscriberEntity::HOOK_SUBSCRIBER_TRACKING_CONSENT_CHANGED, 6, SubscriberEntity::TRACKING_CONSENT_UNKNOWN, SubscriberEntity::TRACKING_CONSENT_DENIED],
+        [SubscriberEntity::HOOK_SUBSCRIBER_TRACKING_CONSENT_CHANGED, 7, SubscriberEntity::TRACKING_CONSENT_UNKNOWN, SubscriberEntity::TRACKING_CONSENT_GRANTED]
+      )
+      ->willReturn(true);
+
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscriberTrackingConsentChanged(6, SubscriberEntity::TRACKING_CONSENT_UNKNOWN, SubscriberEntity::TRACKING_CONSENT_DENIED);
+    $notifier->subscriberTrackingConsentChanged(7, SubscriberEntity::TRACKING_CONSENT_UNKNOWN, SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    $notifier->notify();
+  }
+
   public function testItNotifyMultipleSubscribersCreated(): void {
     $this->wpFunctions->expects($this->any())
       ->method('currentTime')

--- a/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
+++ b/mailpoet/tests/unit/Config/SubscriberChangesNotifierTest.php
@@ -66,6 +66,27 @@ class SubscriberChangesNotifierTest extends \MailPoetUnitTest {
     $notifier->notify();
   }
 
+  public function testItReportsTheNetTransitionWhenOneSubscriberChangesTwice(): void {
+    // The pair has to describe where they started and where they ended, not the inner
+    // step. Reporting `denied -> granted` here would tell a listener the opt-out was
+    // lifted, when in truth they were never opted out in the first place.
+    $this->wpFunctions->method('currentTime')->willReturn(1234);
+    $this->wpFunctions->expects($this->once())
+      ->method('doAction')
+      ->with(
+        SubscriberEntity::HOOK_SUBSCRIBER_TRACKING_CONSENT_CHANGED,
+        6,
+        SubscriberEntity::TRACKING_CONSENT_UNKNOWN,
+        SubscriberEntity::TRACKING_CONSENT_GRANTED
+      )
+      ->willReturn(true);
+
+    $notifier = new SubscriberChangesNotifier($this->wpFunctions);
+    $notifier->subscriberTrackingConsentChanged(6, SubscriberEntity::TRACKING_CONSENT_UNKNOWN, SubscriberEntity::TRACKING_CONSENT_DENIED);
+    $notifier->subscriberTrackingConsentChanged(6, SubscriberEntity::TRACKING_CONSENT_DENIED, SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    $notifier->notify();
+  }
+
   public function testItNotifyMultipleSubscribersCreated(): void {
     $this->wpFunctions->expects($this->any())
       ->method('currentTime')


### PR DESCRIPTION
## What this does

When a MailPoet subscriber's tracking consent changes, MailPoet now fires one action, and its existing AutomateWoo bridge listens and mirrors the choice onto the AutomateWoo customer. Someone who turns off open and click tracking in MailPoet stops being tracked by AutomateWoo too, instead of having to say it twice.

**Prerequisite:** the AutomateWoo side ([woocommerce/automatewoo#2302](https://github.com/woocommerce/automatewoo/pull/2302)) defines `Customer::opt_out_of_tracking()` and `opt_in_to_tracking()`. Until it ships, `areTrackingMethodsAvailable()` is false and this code does nothing.

## Three decisions worth reviewing

**The hook fires from the Doctrine listener, not from the entity setter.** The obvious home looks like `SubscriberEntity::setTrackingConsent()`, but entities here are plain Doctrine models that must not call `do_action`, and the setter runs before the flush so it cannot know the change was persisted. There are four production callers of that setter (admin/API save, manage page, footer opt-out link, WooCommerce checkout) and `TrackingConsentCapture::applyToSubscriber()` never persists, so none of those is a choke point either.

`SubscriberListener::postUpdate()` plus `SubscriberChangesNotifier` already is one: it reads the Doctrine changeset, notifies only on a real change, and fires at `shutdown`. One method beside `maybeNotifyStatusChanged()` covers all four paths, after the row is written, with no caller refactor.

`postPersist()` needed handling too: it has no changeset, and the column defaults to `unknown`, so a subscriber created straight into `denied` would otherwise be silent.

**The hook passes the subscriber id, not the entity.** Every other hook in this notifier passes an id, the notifier fires at shutdown when the entity may be detached, and `syncSubscriber()` already re-reads from the repository. Hook name and the old/new arguments are as specified.

**Granting consent later clears the AutomateWoo flag.** This is the one to push back on if you disagree. It mirrors `optInSubscriber()` reversing `optOutSubscriber()`, and without it somebody who changed their mind is permanently untracked in AutomateWoo with no MailPoet-side way back. The cost: a recipient who opted out *directly in AutomateWoo* and later grants consent in MailPoet has that choice cleared by a decision made in the other plugin. A `tracking_opt_out_source` key would fix it by only letting MailPoet clear what MailPoet set, but that adds a third meta key beyond what the AutomateWoo PR agreed, so it is flagged rather than built.

`unknown` is always ignored: nobody was asked, and that is not an answer.

## Smaller things

Consent changes are **not** batch-collapsed the way subscriber updates are. A consent change is a per-person record, so every one is delivered on its own; there is a test for that.

`areTrackingMethodsAvailable()` is deliberately separate from `areMethodsAvailable()`. Tightening the existing guard would silently switch off the working status sync on an older AutomateWoo; this way that keeps working and only consent forwarding is skipped.

Because the notifier runs on `shutdown`, the AutomateWoo write lands at the end of the same request rather than inline. That is already true of the status sync AutomateWoo gets today.

## Test plan

Notifier unit tests: the action fires with the right arguments, and two changes in one request produce two separate actions. Listener integration tests: a consent change notifies once, an unrelated field change never does. Bridge tests: denied opts out, granted clears the opt-out, `unknown` does nothing, a missing AutomateWoo customer does nothing, and an older AutomateWoo is skipped.

`SubscriberChangesNotifierTest` 14 tests, `SubscriberListenerTest` 8 tests, `AutomateWooHooksTest` 9 tests, all passing. Sabotage-checked: removing the listener call fails exactly the consent test.

AutomateWoo is not loaded in MailPoet's test environment, so the customer is stubbed with a small anonymous class exposing the two methods.

Part of AUTOM8-242.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/autom8-242-tracking-consent-hook)

_The latest successful build from `add/autom8-242-tracking-consent-hook` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->