### PR TITLE
Fix regressions in the Latest Posts block

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -250,6 +250,7 @@ interface Window {
     name: string;
   }[];
   mailpoet_cdn_url: string;
+  mailpoet_is_email_editor: boolean;
   mailpoet_main_page_slug: string;
   finish_wizard_url: string;
   admin_email: string;

--- a/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/index.tsx
+++ b/mailpoet/assets/js/src/mailpoet-custom-email-editor-blocks/latest-posts/index.tsx
@@ -12,12 +12,17 @@ import { Edit as PostContentEdit } from './post-content/edit';
 
 const saveInnerBlocks = (): JSX.Element => <InnerBlocks.Content />;
 
+// The script is loaded in every block editor, because WordPress loads the editor
+// script of every registered block. Only the email editor may offer the block.
+const isEmailEditor = window.mailpoet_is_email_editor === true;
+
 registerBlockType(latestPostsMetadata, {
   icon: { src: postList },
   edit: LatestPostsEdit as React.ComponentType<
     BlockEditProps<Record<string, unknown>>
   >,
   save: saveInnerBlocks,
+  supports: { ...latestPostsMetadata.supports, inserter: isEmailEditor },
 });
 
 registerBlockType(postTemplateMetadata, {

--- a/mailpoet/changelog/2026-08-24-14-57-41-fixed-blocks-from-other-plugins-missing-in-the-wordpress.md
+++ b/mailpoet/changelog/2026-08-24-14-57-41-fixed-blocks-from-other-plugins-missing-in-the-wordpress.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Blocks from other plugins missing in the WordPress post editor when MailPoet is active

--- a/mailpoet/changelog/2026-08-24-14-57-42-fixed-shortcodes-showing-as-raw-text-in-emails-that-use-.md
+++ b/mailpoet/changelog/2026-08-24-14-57-42-fixed-shortcodes-showing-as-raw-text-in-emails-that-use-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Shortcodes showing as raw text in emails that use the Post Content block

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/AbstractBlock.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/AbstractBlock.php
@@ -13,25 +13,27 @@ abstract class AbstractBlock {
   public function initialize() {
     $this->registerAssets();
     $this->registerBlockType();
-    add_action('enqueue_block_editor_assets', [$this, 'enqueueEditorAssets']);
+    add_action('enqueue_block_editor_assets', [$this, 'markEmailEditorScreen']);
   }
 
   /**
-   * The blocks stay registered everywhere so emails can render. Their editor
-   * script is what adds them to an inserter, and WordPress loads it in every
-   * editor, so we load it here instead - only on the email editor page.
+   * WordPress loads the editor script of every registered block in every editor,
+   * and the blocks must stay registered so emails can render when they are sent.
+   * The script therefore runs everywhere and decides for itself whether to offer
+   * the block in the inserter, so it needs to know which editor it is in.
    */
-  public function enqueueEditorAssets(): void {
-    $screen = function_exists('get_current_screen') ? get_current_screen() : null;
-    if (!$screen || $screen->post_type !== EmailEditor::MAILPOET_EMAIL_POST_TYPE) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  public function markEmailEditorScreen(): void {
+    $handle = $this->getEditorScript('handle');
+    if ($handle === null) {
       return;
     }
-    if (null !== $this->getEditorScript()) {
-      wp_enqueue_script($this->getEditorScript('handle'));
-    }
-    if (null !== $this->getEditorStyle()) {
-      wp_enqueue_style($this->getEditorStyle('handle'));
-    }
+    $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+    $isEmailEditor = $screen && $screen->post_type === EmailEditor::MAILPOET_EMAIL_POST_TYPE; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    wp_add_inline_script(
+      $handle,
+      'window.mailpoet_is_email_editor = ' . ($isEmailEditor ? 'true' : 'false') . ';',
+      'before'
+    );
   }
 
   protected function getBlockType(): string {
@@ -71,6 +73,8 @@ abstract class AbstractBlock {
     $metadata_path = Env::$assetsPath . '/dist/js/email-editor-blocks/' . $this->blockName . '/block.json';
     $block_settings = [
         'render_callback' => [$this, 'render'],
+        'editor_script' => $this->getEditorScript('handle'),
+        'editor_style' => $this->getEditorStyle('handle'),
     ];
     register_block_type_from_metadata(
       $metadata_path,

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/AbstractBlock.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/AbstractBlock.php
@@ -3,6 +3,7 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes;
 
 use MailPoet\Config\Env;
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use WP_Style_Engine;
 
 abstract class AbstractBlock {
@@ -12,6 +13,25 @@ abstract class AbstractBlock {
   public function initialize() {
     $this->registerAssets();
     $this->registerBlockType();
+    add_action('enqueue_block_editor_assets', [$this, 'enqueueEditorAssets']);
+  }
+
+  /**
+   * The blocks stay registered everywhere so emails can render. Their editor
+   * script is what adds them to an inserter, and WordPress loads it in every
+   * editor, so we load it here instead - only on the email editor page.
+   */
+  public function enqueueEditorAssets(): void {
+    $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+    if (!$screen || $screen->post_type !== EmailEditor::MAILPOET_EMAIL_POST_TYPE) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      return;
+    }
+    if (null !== $this->getEditorScript()) {
+      wp_enqueue_script($this->getEditorScript('handle'));
+    }
+    if (null !== $this->getEditorStyle()) {
+      wp_enqueue_style($this->getEditorStyle('handle'));
+    }
   }
 
   protected function getBlockType(): string {
@@ -51,8 +71,6 @@ abstract class AbstractBlock {
     $metadata_path = Env::$assetsPath . '/dist/js/email-editor-blocks/' . $this->blockName . '/block.json';
     $block_settings = [
         'render_callback' => [$this, 'render'],
-        'editor_script' => $this->getEditorScript('handle'),
-        'editor_style' => $this->getEditorStyle('handle'),
     ];
     register_block_type_from_metadata(
       $metadata_path,

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -338,7 +338,7 @@ class LatestPosts extends AbstractBlock {
         $html .= render_block($this->normalizeBlock($contentBlock));
       }
     }
-    return $html;
+    return $this->wp->stripShortcodes($html);
   }
 
   private function renderClassicPostContent(\WP_Post $post): string {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -10,7 +10,6 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Column 
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Columns as ColumnsRenderer;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Image as ImageRenderer;
 use MailPoet\Config\Env;
-use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterPostEntity;
 use MailPoet\Newsletter\AutomatedLatestContent;
@@ -132,7 +131,6 @@ class LatestPosts extends AbstractBlock {
     $this->registerTemplateBlock();
     $this->registerPostContentBlock();
     $this->wp->addFilter('block_categories_all', [$this, 'addBlockCategory']);
-    $this->wp->addFilter('allowed_block_types_all', [$this, 'restrictBlocksToEmailEditor'], 10, 2);
     $this->wp->addFilter('block_type_metadata_settings', [$this, 'enableEmailSupportForCoreBlocks']);
     $this->wp->addFilter('woocommerce_email_content_renderer_styles', [$this, 'makeLinkColorStylesInlineable']);
     $this->enableEmailSupportForRegisteredCoreBlocks();
@@ -164,39 +162,6 @@ class LatestPosts extends AbstractBlock {
       'title' => __('MailPoet', 'mailpoet'),
     ];
     return $categories;
-  }
-
-  /**
-   * The block is registered globally so it can render when emails are sent, but
-   * it is only meant to be used inside the MailPoet email editor. Hide it (and
-   * its template block) from the inserter of every other editor.
-   *
-   * @param bool|string[] $allowedBlocks
-   * @param \WP_Block_Editor_Context $editorContext
-   * @return bool|string[]
-   */
-  public function restrictBlocksToEmailEditor($allowedBlocks, $editorContext) {
-    $post = $editorContext->post ?? null;
-    $postType = $post instanceof \WP_Post ? $post->post_type : null; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-    if ($postType === EmailEditor::MAILPOET_EMAIL_POST_TYPE) {
-      return $allowedBlocks;
-    }
-
-    // Another integration may have disallowed every block
-    if ($allowedBlocks === false) {
-      return $allowedBlocks;
-    }
-
-    // When every block is allowed the value is `true` rather than a list. Build
-    // the full list of block names first so we have something to remove ours from.
-    if (!is_array($allowedBlocks)) {
-      $allowedBlocks = array_keys(\WP_Block_Type_Registry::get_instance()->get_all_registered());
-    }
-
-    $ownBlocks = [$this->getBlockType(), self::TEMPLATE_BLOCK, self::POST_CONTENT_BLOCK];
-    return array_values(array_filter($allowedBlocks, static function ($blockName) use ($ownBlocks) {
-      return !in_array($blockName, $ownBlocks, true);
-    }));
   }
 
   /**
@@ -484,8 +449,6 @@ class LatestPosts extends AbstractBlock {
       'render_callback' => static function (): string {
         return '';
       },
-      'editor_script' => $this->getEditorScript('handle'),
-      'editor_style' => $this->getEditorStyle('handle'),
     ]);
   }
 
@@ -499,8 +462,6 @@ class LatestPosts extends AbstractBlock {
     }
     $blockType = register_block_type_from_metadata($metadataPath, [
       'render_callback' => [$this, 'renderPostContent'],
-      'editor_script' => $this->getEditorScript('handle'),
-      'editor_style' => $this->getEditorStyle('handle'),
     ]);
     if ($blockType instanceof \WP_Block_Type) {
       // The render callback already produces email-ready markup; without an

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/LatestPosts.php
@@ -449,6 +449,8 @@ class LatestPosts extends AbstractBlock {
       'render_callback' => static function (): string {
         return '';
       },
+      'editor_script' => $this->getEditorScript('handle'),
+      'editor_style' => $this->getEditorStyle('handle'),
     ]);
   }
 
@@ -462,6 +464,8 @@ class LatestPosts extends AbstractBlock {
     }
     $blockType = register_block_type_from_metadata($metadataPath, [
       'render_callback' => [$this, 'renderPostContent'],
+      'editor_script' => $this->getEditorScript('handle'),
+      'editor_style' => $this->getEditorStyle('handle'),
     ]);
     if ($blockType instanceof \WP_Block_Type) {
       // The render callback already produces email-ready markup; without an

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -49,6 +49,11 @@ class LatestPostsTest extends \MailPoetTest {
   }
 
   public function _after(): void {
+    // Both are process-wide, so a failing test must not leak them into the next one.
+    if (function_exists('set_current_screen')) {
+      set_current_screen('front');
+    }
+    $this->clearInlineScript('mailpoet-latest-posts-block');
     foreach ($this->attachmentIds as $attachmentId) {
       $this->wp->wpDeletePost($attachmentId, true);
     }
@@ -468,6 +473,14 @@ class LatestPostsTest extends \MailPoetTest {
 
   }
 
+  public function testItLeavesTheAllowedBlockTypesFilterAlone(): void {
+    // Turning `true` into a list makes it a hard allow-list, which hides blocks
+    // that other plugins register in JavaScript only.
+    $context = new \WP_Block_Editor_Context(['post' => $this->wp->getPost($this->postIds[0])]);
+
+    verify($this->wp->applyFilters('allowed_block_types_all', true, $context))->equals(true);
+  }
+
   public function testItKeepsItsEditorScriptRegisteredForEveryEditor(): void {
     // The script must keep loading everywhere: it is what registers the blocks
     // on the client, and dropping it from other editors breaks the site editor.
@@ -491,13 +504,10 @@ class LatestPostsTest extends \MailPoetTest {
     $this->block->markEmailEditorScreen();
     verify($this->grabInlineScript($scriptHandle))->stringContainsString('window.mailpoet_is_email_editor = false;');
 
-    wp_scripts()->add_data($scriptHandle, 'before', []);
+    $this->clearInlineScript($scriptHandle);
     $this->setCurrentScreen(EmailEditor::MAILPOET_EMAIL_POST_TYPE);
     $this->block->markEmailEditorScreen();
     verify($this->grabInlineScript($scriptHandle))->stringContainsString('window.mailpoet_is_email_editor = true;');
-
-    wp_scripts()->add_data($scriptHandle, 'before', []);
-    $this->setCurrentScreen('front');
   }
 
   public function testItCapsTheNumberOfManuallySelectedPosts(): void {
@@ -752,6 +762,10 @@ class LatestPostsTest extends \MailPoetTest {
     }
     $this->assertIsArray($term);
     return (int)$term['term_id'];
+  }
+
+  private function clearInlineScript(string $handle): void {
+    wp_scripts()->add_data($handle, 'before', []);
   }
 
   private function grabInlineScript(string $handle): string {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -12,6 +12,12 @@ use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\WP\Functions as WPFunctions;
 
 class LatestPostsTest extends \MailPoetTest {
+  private const OWN_BLOCKS = [
+    'mailpoet/latest-posts',
+    'mailpoet/latest-posts-template',
+    'mailpoet/post-content',
+  ];
+
   private LatestPosts $block;
   private WPFunctions $wp;
   private NewsletterPostsRepository $newsletterPostsRepository;
@@ -462,38 +468,35 @@ class LatestPostsTest extends \MailPoetTest {
 
   }
 
-  public function testItKeepsTheBlockAvailableInsideTheEmailEditor(): void {
-    $newsletter = $this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD);
-    $wpPostId = $newsletter->getWpPostId();
-    $this->assertIsInt($wpPostId);
-    $emailPost = $this->wp->getPost($wpPostId);
-    $context = new \WP_Block_Editor_Context(['post' => $emailPost]);
+  public function testItKeepsItsEditorScriptsOffTheGlobalBlockEditorEnqueue(): void {
+    // WordPress loads the editor script of every registered block in every
+    // editor. If ours were on that list, the blocks would show up in the post,
+    // page, site and widget inserters too.
+    $this->ensurePostContentBlockRegistered();
+    $registry = \WP_Block_Type_Registry::get_instance();
 
-    // The email editor leaves the allow-list untouched (blocks stay available).
-    verify($this->block->restrictBlocksToEmailEditor(true, $context))->equals(true);
+    foreach (self::OWN_BLOCKS as $blockName) {
+      $blockType = $registry->get_registered($blockName);
+      $this->assertInstanceOf(\WP_Block_Type::class, $blockType);
+      verify($blockType->editor_script_handles)->equals([]); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      verify($blockType->editor_style_handles)->equals([]); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    }
   }
 
-  public function testItHidesTheBlockOutsideTheEmailEditor(): void {
-    $regularPost = $this->wp->getPost($this->postIds[0]);
-    $context = new \WP_Block_Editor_Context(['post' => $regularPost]);
+  public function testItEnqueuesItsEditorAssetsOnlyOnTheEmailEditorPage(): void {
+    $this->ensurePostContentBlockRegistered();
+    $scriptHandle = 'mailpoet-latest-posts-block';
 
-    $allowed = $this->block->restrictBlocksToEmailEditor(true, $context);
+    $this->setCurrentScreen('post');
+    $this->block->enqueueEditorAssets();
+    verify(wp_script_is($scriptHandle, 'enqueued'))->false();
 
-    $this->assertIsArray($allowed);
-    verify(in_array('mailpoet/latest-posts', $allowed, true))->false();
-    verify(in_array('mailpoet/latest-posts-template', $allowed, true))->false();
-    verify(in_array('mailpoet/post-content', $allowed, true))->false();
-    // Other blocks remain available.
-    verify(in_array('core/paragraph', $allowed, true))->true();
-  }
+    $this->setCurrentScreen(EmailEditor::MAILPOET_EMAIL_POST_TYPE);
+    $this->block->enqueueEditorAssets();
+    verify(wp_script_is($scriptHandle, 'enqueued'))->true();
 
-  public function testItKeepsAnEmptyAllowListFromAnotherIntegration(): void {
-    $regularPost = $this->wp->getPost($this->postIds[0]);
-    $context = new \WP_Block_Editor_Context(['post' => $regularPost]);
-
-    // `false` means another integration disallowed every block; we must not
-    // turn that back into the full block list.
-    verify($this->block->restrictBlocksToEmailEditor(false, $context))->equals(false);
+    wp_dequeue_script($scriptHandle);
+    $this->setCurrentScreen('front');
   }
 
   public function testItCapsTheNumberOfManuallySelectedPosts(): void {
@@ -716,6 +719,14 @@ class LatestPostsTest extends \MailPoetTest {
     }
     $this->assertIsArray($term);
     return (int)$term['term_id'];
+  }
+
+  private function setCurrentScreen(string $hookName): void {
+    if (!function_exists('set_current_screen')) {
+      require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
+      require_once ABSPATH . 'wp-admin/includes/screen.php';
+    }
+    set_current_screen($hookName);
   }
 
   private function ensurePostContentBlockRegistered(): void {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -468,34 +468,35 @@ class LatestPostsTest extends \MailPoetTest {
 
   }
 
-  public function testItKeepsItsEditorScriptsOffTheGlobalBlockEditorEnqueue(): void {
-    // WordPress loads the editor script of every registered block in every
-    // editor. If ours were on that list, the blocks would show up in the post,
-    // page, site and widget inserters too.
+  public function testItKeepsItsEditorScriptRegisteredForEveryEditor(): void {
+    // The script must keep loading everywhere: it is what registers the blocks
+    // on the client, and dropping it from other editors breaks the site editor.
     $this->ensurePostContentBlockRegistered();
     $registry = \WP_Block_Type_Registry::get_instance();
 
     foreach (self::OWN_BLOCKS as $blockName) {
       $blockType = $registry->get_registered($blockName);
       $this->assertInstanceOf(\WP_Block_Type::class, $blockType);
-      verify($blockType->editor_script_handles)->equals([]); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      verify($blockType->editor_style_handles)->equals([]); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      verify($blockType->editor_script_handles)->equals(['mailpoet-latest-posts-block']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     }
   }
 
-  public function testItEnqueuesItsEditorAssetsOnlyOnTheEmailEditorPage(): void {
+  public function testItTellsTheEditorScriptWhichScreenItIsOn(): void {
+    // The script is loaded in every editor and hides the block from the inserter
+    // unless this flag says it is the email editor.
     $this->ensurePostContentBlockRegistered();
     $scriptHandle = 'mailpoet-latest-posts-block';
 
     $this->setCurrentScreen('post');
-    $this->block->enqueueEditorAssets();
-    verify(wp_script_is($scriptHandle, 'enqueued'))->false();
+    $this->block->markEmailEditorScreen();
+    verify($this->grabInlineScript($scriptHandle))->stringContainsString('window.mailpoet_is_email_editor = false;');
 
+    wp_scripts()->add_data($scriptHandle, 'before', []);
     $this->setCurrentScreen(EmailEditor::MAILPOET_EMAIL_POST_TYPE);
-    $this->block->enqueueEditorAssets();
-    verify(wp_script_is($scriptHandle, 'enqueued'))->true();
+    $this->block->markEmailEditorScreen();
+    verify($this->grabInlineScript($scriptHandle))->stringContainsString('window.mailpoet_is_email_editor = true;');
 
-    wp_dequeue_script($scriptHandle);
+    wp_scripts()->add_data($scriptHandle, 'before', []);
     $this->setCurrentScreen('front');
   }
 
@@ -719,6 +720,11 @@ class LatestPostsTest extends \MailPoetTest {
     }
     $this->assertIsArray($term);
     return (int)$term['term_id'];
+  }
+
+  private function grabInlineScript(string $handle): string {
+    $data = wp_scripts()->get_data($handle, 'before');
+    return is_array($data) ? implode("\n", array_filter($data, 'is_string')) : '';
   }
 
   private function setCurrentScreen(string $hookName): void {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Blocks/LatestPostsTest.php
@@ -606,6 +606,38 @@ class LatestPostsTest extends \MailPoetTest {
     verify($html)->stringNotContainsString('[gallery]');
   }
 
+  public function testItKeepsSquareBracketsThatAreNotShortcodes(): void {
+    // Nothing strips post content by syntax, so brackets that only look like a
+    // tag must survive: an array query parameter, a footnote.
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts bracket link',
+      'Read <a href="https://example.com/?tag[]=draft">the list</a> and note [1]'
+    );
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1], [], [$this->block('mailpoet/post-content')]);
+
+    verify($html)->stringContainsString('?tag[]=draft');
+    verify($html)->stringContainsString('[1]');
+  }
+
+  public function testItStripsRegisteredShortcodesFromBlockContent(): void {
+    // Block content renders as HTML, so only the registered tags are removed
+    // there. Guessing by syntax would damage attribute values and comments.
+    $this->ensurePostContentBlockRegistered();
+    $this->postIds[] = $this->createPostWithContent(
+      'Latest posts block shortcode',
+      '<!-- wp:paragraph --><p>Block intro text [gallery ids="1,2"]</p><!-- /wp:paragraph -->'
+    );
+    $this->setCurrentEmailPostForNewsletter($this->createBlockEmailNewsletter(NewsletterEntity::TYPE_STANDARD));
+
+    $html = $this->render(['perPage' => 1], [], [$this->block('mailpoet/post-content')]);
+
+    verify($html)->stringContainsString('Block intro text');
+    verify($html)->stringNotContainsString('[gallery');
+  }
+
   public function testItSkipsContentOfPasswordProtectedPosts(): void {
     $this->ensurePostContentBlockRegistered();
     $this->postIds[] = $this->createPostWithContent(


### PR DESCRIPTION
## Description

Two fixes in the Latest Posts block, both found by the AI regression review of #6917.

**1. Third-party blocks disappearing from the post editor.** `restrictBlocksToEmailEditor()` ran on `allowed_block_types_all` on every request. When the value was `true`, it replaced it with the PHP block registry, which turns the filter into a hard allow-list. Blocks that other plugins register in JavaScript only were dropped from the post, page, site and widget inserters on every site with MailPoet active.

A block only shows in the inserter if it is registered in JavaScript, and ours is registered by its editor script, which WordPress loads in every editor. So the filter is gone. The script still loads everywhere, as before. PHP now tells it which screen it is on through `window.mailpoet_is_email_editor`, and the block sets `supports.inserter` from that flag.

**2. Shortcodes sent as raw text.** `renderPostContentBlocks()` did not strip shortcodes at all, so a shortcode in a post reached the subscriber as literal `[tag]` text. It now calls `strip_shortcodes()`, which is what the classic editor already does with post content.

## Code review notes

_N/A_

## QA notes

1. Activate a plugin that registers a block in JavaScript only.
2. Register a JS only block from the console:
```
wp.blocks.registerBlockType('test/js-only', {
     title: 'JS Only Test',
     category: 'text',
     edit: () => wp.element.createElement('p', null, 'JS only block'),
     save: () => wp.element.createElement('p', null, 'JS only block'),
});
```
3. Open a MailPoet email - Latest Posts is still there, with its styles.
4. Back in a normal post, Latest Posts and Post Content are not in the inserter.

Shortcodes:

1. Add a mu-plugin that registers a shortcode:
```php
add_action('init', function () {
    add_shortcode('qa_shortcode', fn() => '<em>rendered</em>');
});
```
2. Write a post in the block editor that uses `[qa_shortcode]` in a paragraph.
3. Create a standard newsletter in the block editor, add a Latest Posts block, and put a Post Content block inside its template.
4. Send it to a test subscriber and read the email in Mailpit.
5. On trunk the email contains `[qa_shortcode]`. On this branch the tag is gone.

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-8377/ai-regression-reviewtrunk-restrictblockstoemaileditor-expands-allowed

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8377-ai-regression-reviewtrunk-restrictblockstoemaileditor)

_The latest successful build from `stomail-8377-ai-regression-reviewtrunk-restrictblockstoemaileditor` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->