### PR TITLE
Backfill missed changelog entries in changelog.txt

### DIFF
--- a/mailpoet/changelog.txt
+++ b/mailpoet/changelog.txt
@@ -261,6 +261,7 @@
 * Fixed: Default scheduled send time now shows 8:00 AM in the site's local timezone instead of 8:00 AM UTC;
 * Fixed: Newly created tags are now available for autocomplete when importing subscribers multiple times without reloading the page;
 * Fixed: Missing translations in the new email editor;
+* Fixed: Unique constraint violation when a WordPress user changes their email to one already used by another subscriber;
 * Removed: Removed deprecated \_\_get magic getter methods from NewsletterEntity, SendingQueueEntity, and SubscriberEntity.
 
 = 5.23.2 - 2026-04-15 =
@@ -301,6 +302,7 @@
 * Fixed: Fix subscription form block breaking the Site Editor when submit button is clicked.
 
 = 5.22.0 - 2026-03-03 =
+* Updated: Placeholder images for the Newsletter, Sale Announcement, Educational Campaign, and Event Invitation email patterns;
 * Improved: Switched to classmap-only autoloading to improve performance by eliminating redundant PSR-4 lookups in the Jetpack autoloader;
 * Improved: Neutralize MailPoet branding in stats and subscriber notification emails for Garden environments;
 * Improved: Reduce unnecessary database queries on every page load;
@@ -427,7 +429,8 @@
 * Fixed: Invalid product attributes may break the Segments page.
 
 = 5.14.1 - 2025-09-01 =
-* Improved: Use specific version when downloading premium plugin.
+* Improved: Use specific version when downloading premium plugin;
+* Fixed: Error handling for invalid segment statistics results.
 
 = 5.14.0 - 2025-08-25 =
 * Updated: Update the email editor version;

--- a/mailpoet/changelog/2025-08-27-18-33-54-improved-error-handling-statistics-queries
+++ b/mailpoet/changelog/2025-08-27-18-33-54-improved-error-handling-statistics-queries
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-Improved error handling for invalid segment statistics results.

--- a/mailpoet/changelog/2026-02-24-13-52-11-add-placeholder-images-to-email-patterns
+++ b/mailpoet/changelog/2026-02-24-13-52-11-add-placeholder-images-to-email-patterns
@@ -1,5 +1,0 @@
-# Type: Updated
-
-# Description
-
-Add placeholder images to email campaign patterns: Newsletter, Sale Announcement, Educational Campaign, and Event Invitation.

--- a/mailpoet/changelog/2026-04-02-18-55-42-fix-duplicate-email-constraint-violation
+++ b/mailpoet/changelog/2026-04-02-18-55-42-fix-duplicate-email-constraint-violation
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-Fix unique constraint violation when a WordPress user changes their email to one already used by another subscriber.


### PR DESCRIPTION
## Description

Three entry files in `mailpoet/changelog/` have no `.md` extension (and no `<type>` segment in the filename), so `MailPoetTasks\Release\Changelogger` never picked them up: both `compileChangelog()` and `clearChangelogEntries()` only look at `changelog/*.md`. Every release since then skipped these entries and left the files in place, while the changes themselves already shipped.

This PR adds the three lines to `changelog.txt` under the versions that first contained the corresponding commits, and deletes the stale files. Attribution was checked with `git merge-base --is-ancestor` against the release commits and against the previous release of each:

| Entry file | PR | First release containing it |
| --- | --- | --- |
| `2025-08-27-18-33-54-improved-error-handling-statistics-queries` | #6307 | 5.14.1 (2025-09-01) |
| `2026-02-24-13-52-11-add-placeholder-images-to-email-patterns` | #6537 | 5.22.0 (2026-03-03) |
| `2026-04-02-18-55-42-fix-duplicate-email-constraint-violation` | #6601 | 5.24.0 (2026-04-27) |

## Code review notes

The descriptions are reworded from the entry files so they read naturally after the type prefix (the originals repeated the type verb, e.g. "Fixed: Fix ...", and one said "Fixed: Improved ..."). The meaning is unchanged; the original wording is in the deleted files in this diff if a comparison is needed.

## Linked PRs

- #6307
- #6537
- #6601

## Linked tickets

[STOMAIL-8417](https://linear.app/a8c/issue/STOMAIL-8417)

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8417-backfill-missing-changelog-entries)

_The latest successful build from `fix/stomail-8417-backfill-missing-changelog-entries` will be used. If none is available, the link won't work._