### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -38,4 +38,4 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4

--- a/.github/workflows/create-trunk-snapshot-build.yml
+++ b/.github/workflows/create-trunk-snapshot-build.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: 'Update trunk-snapshot tag'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -62,22 +62,22 @@ jobs:
             }
 
       - name: 'Checkout ref'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ env.TARGET_REF }}
 
       - name: 'Setup PHP'
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.3'
           extensions: mbstring, xml, mysql, gd, zip, intl
           tools: wp-cli
 
       - name: 'Setup pnpm'
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
       - name: 'Setup Node.js'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
@@ -120,7 +120,7 @@ jobs:
           echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: 'Upload trunk snapshot build'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ env.MAX_PHP_VERSION }}
 
@@ -142,7 +142,7 @@ jobs:
       # Create a pull request if there are changes
       - name: Create Pull Request
         if: env.CHANGES_DETECTED == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GH_TOKEN }}
           branch: update-plugins-and-wordpress

--- a/.github/workflows/wordpress-playground-preview.yml
+++ b/.github/workflows/wordpress-playground-preview.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Check and append description
         shell: bash


### PR DESCRIPTION
## Description

Every external GitHub Action used by this repo is now pinned to a full 40-character commit SHA. The old tag stays in a trailing comment so the pin is still readable, and so tooling can bump it later.

A tag or branch can be moved. If someone takes over an upstream Action repo, or an existing maintainer is compromised, a moved tag runs their code in our CI with our secrets. A commit SHA cannot be moved, so this closes that route.

Darren is doing the same sweep across the WooCommerce org and will then turn on the org-level "require actions to be pinned to a full-length commit SHA" setting. See [the P2](https://wp.me/pcShBQ-41r) and the two merged examples: [woocommerce/automatewoo#2301](https://github.com/woocommerce/automatewoo/pull/2301), [woocommerce/woocommerce-google-analytics-integration#654](https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/654). This PR brings the MailPoet org in line.

Local actions and external reusable workflows are left alone, matching what the two Woo PRs above actually did.

## Code review notes

Actions pinned:

- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7`
- `actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9`
- `actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6`
- `github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4`
- `github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4`
- `peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8`
- `pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6`
- `shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2`

How this was checked:

- Resolved every distinct tag twice, by two different methods (`gh api repos/OWNER/REPO/commits/REF` and `git ls-remote`), and confirmed both gave the same SHA. All 8 matched.
- Parsed every changed workflow file as YAML. No failures.
- Re-scanned the repo afterwards: zero mutable external Action references left.
- `git diff --check` is clean, and the diff touches `uses:` lines only, nothing else.

## QA notes

No product code changes. This is CI and automation config only, so there is nothing to QA in the plugin.

To check the change itself: confirm each `uses:` line ends in a 40-character SHA with the old ref in the trailing comment, and confirm the affected workflows (CodeQL, trunk snapshot build, WordPress/plugin updater, Playground preview) still run.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry — **N/A**, no user-facing change. CI config only.
- [ ] I followed best practices for translations — **N/A**
- [ ] I added sufficient test coverage — **N/A**
- [ ] I embraced TypeScript — **N/A**

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:pin-github-actions-to-sha)

_The latest successful build from `pin-github-actions-to-sha` will be used. If none is available, the link won't work._