### PR TITLE
Stop one bad tracking consent value from taking the plugin down

### DIFF
--- a/mailpoet/changelog/2026-08-25-fixed-one-invalid-tracking-consent-value-no-longer-brea.md
+++ b/mailpoet/changelog/2026-08-25-fixed-one-invalid-tracking-consent-value-no-longer-brea.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+One invalid tracking consent value in the database no longer breaks the plugin. A subscriber row holding an out-of-range value, from a hand-edited column, an incomplete migration or a restored backup, used to make MailPoet throw the moment anything saved that subscriber, which took down the whole MailPoet REST API and every signup form on the site. Bad stored values are now harmless to read and to save around, and page-view tracking can no longer stop the rest of the plugin from starting up.

--- a/mailpoet/changelog/2026-08-25-fixed-one-invalid-tracking-consent-value-no-longer-brea.md
+++ b/mailpoet/changelog/2026-08-25-fixed-one-invalid-tracking-consent-value-no-longer-brea.md
@@ -2,4 +2,4 @@
 
 # Description
 
-One invalid tracking consent value in the database no longer breaks the plugin. A subscriber row holding an out-of-range value, from a hand-edited column, an incomplete migration or a restored backup, used to make MailPoet throw the moment anything saved that subscriber, which took down the whole MailPoet REST API and every signup form on the site. Bad stored values are now harmless to read and to save around, and page-view tracking can no longer stop the rest of the plugin from starting up.
+One invalid tracking consent value in the database no longer breaks the plugin. A subscriber row holding an out-of-range value, from a hand-edited column, an incomplete migration or a restored backup, used to make MailPoet throw the moment anything saved that subscriber, which took down the whole MailPoet REST API and every signup form on the site. Bad stored values are now harmless to read and to save around, and page-view tracking can no longer stop the rest of the plugin from starting up

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -455,10 +455,16 @@ class Initializer {
         // whole namespace down for a customer, twice over: it aborted the remaining
         // calls in this block AND left INITIALIZED undefined, so postInitialize()
         // skipped restApi->init() as well.
-        $this->loggerFactory->getLogger('Subscriber Activity Tracker')->error($e->getMessage(), [
-          'file' => $e->getFile(),
-          'line' => $e->getLine(),
-        ]);
+        try {
+          $this->loggerFactory->getLogger('Subscriber Activity Tracker')->error($e->getMessage(), [
+            'file' => $e->getFile(),
+            'line' => $e->getLine(),
+          ]);
+        } catch (\Throwable $loggingError) {
+          // The logger writes to the database, so the very failure being reported here
+          // can be the reason it cannot write. Losing the log line is a smaller problem
+          // than re-throwing and taking down the REST namespace this catch exists to save.
+        }
       }
       $this->postEditorBlock->init();
       $this->automationEngine->initialize();

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -22,6 +22,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor as MailpoetEmailEdito
 use MailPoet\EmailEditor\Integrations\MailPoet\Logger;
 use MailPoet\Form\RestApi\Api as FormsRestApi;
 use MailPoet\InvalidStateException;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Logging\LogsDownload;
 use MailPoet\Logging\RestApi\Api as LogsRestApi;
 use MailPoet\Migrator\Cli as MigratorCli;
@@ -127,6 +128,9 @@ class Initializer {
   /** @var SubscriberActivityTracker */
   private $subscriberActivityTracker;
 
+  /** @var LoggerFactory */
+  private $loggerFactory;
+
   /** @var Engine */
   private $automationEngine;
 
@@ -207,6 +211,7 @@ class Initializer {
     Localizer $localizer,
     AutomaticEmails $automaticEmails,
     SubscriberActivityTracker $subscriberActivityTracker,
+    LoggerFactory $loggerFactory,
     WPFunctions $wpFunctions,
     AssetsLoader $assetsLoader,
     Engine $automationEngine,
@@ -250,6 +255,7 @@ class Initializer {
     $this->localizer = $localizer;
     $this->automaticEmails = $automaticEmails;
     $this->subscriberActivityTracker = $subscriberActivityTracker;
+    $this->loggerFactory = $loggerFactory;
     $this->wpFunctions = $wpFunctions;
     $this->assetsLoader = $assetsLoader;
     $this->automationEngine = $automationEngine;
@@ -441,7 +447,19 @@ class Initializer {
       $this->setupAutomaticEmails();
       $this->setupWoocommerceBlocksIntegration();
       $this->setupDeactivationPoll();
-      $this->subscriberActivityTracker->trackActivity();
+      try {
+        $this->subscriberActivityTracker->trackActivity();
+      } catch (\Throwable $e) {
+        // Page-view tracking failing must never stop the rest of initialize(), which
+        // includes registering the mailpoet/v1 REST namespace. One throw here took the
+        // whole namespace down for a customer, twice over: it aborted the remaining
+        // calls in this block AND left INITIALIZED undefined, so postInitialize()
+        // skipped restApi->init() as well.
+        $this->loggerFactory->getLogger('Subscriber Activity Tracker')->error($e->getMessage(), [
+          'file' => $e->getFile(),
+          'line' => $e->getLine(),
+        ]);
+      }
       $this->postEditorBlock->init();
       $this->automationEngine->initialize();
       $this->tagsRestApi->initialize();

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -22,7 +22,6 @@ use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor as MailpoetEmailEdito
 use MailPoet\EmailEditor\Integrations\MailPoet\Logger;
 use MailPoet\Form\RestApi\Api as FormsRestApi;
 use MailPoet\InvalidStateException;
-use MailPoet\Logging\LoggerFactory;
 use MailPoet\Logging\LogsDownload;
 use MailPoet\Logging\RestApi\Api as LogsRestApi;
 use MailPoet\Migrator\Cli as MigratorCli;
@@ -128,9 +127,6 @@ class Initializer {
   /** @var SubscriberActivityTracker */
   private $subscriberActivityTracker;
 
-  /** @var LoggerFactory */
-  private $loggerFactory;
-
   /** @var Engine */
   private $automationEngine;
 
@@ -211,7 +207,6 @@ class Initializer {
     Localizer $localizer,
     AutomaticEmails $automaticEmails,
     SubscriberActivityTracker $subscriberActivityTracker,
-    LoggerFactory $loggerFactory,
     WPFunctions $wpFunctions,
     AssetsLoader $assetsLoader,
     Engine $automationEngine,
@@ -255,7 +250,6 @@ class Initializer {
     $this->localizer = $localizer;
     $this->automaticEmails = $automaticEmails;
     $this->subscriberActivityTracker = $subscriberActivityTracker;
-    $this->loggerFactory = $loggerFactory;
     $this->wpFunctions = $wpFunctions;
     $this->assetsLoader = $assetsLoader;
     $this->automationEngine = $automationEngine;
@@ -455,15 +449,14 @@ class Initializer {
         // whole namespace down for a customer, twice over: it aborted the remaining
         // calls in this block AND left INITIALIZED undefined, so postInitialize()
         // skipped restApi->init() as well.
-        try {
-          $this->loggerFactory->getLogger('Subscriber Activity Tracker')->error($e->getMessage(), [
-            'file' => $e->getFile(),
-            'line' => $e->getLine(),
-          ]);
-        } catch (\Throwable $loggingError) {
-          // The logger writes to the database, so the very failure being reported here
-          // can be the reason it cannot write. Losing the log line is a smaller problem
-          // than re-throwing and taking down the REST namespace this catch exists to save.
+        //
+        // Log to the PHP error log, not the MailPoet logger: the logger writes to the
+        // database, and a database that is missing, unmigrated or unreachable is exactly
+        // the kind of failure this catch exists to survive.
+        if (function_exists('error_log')) {
+          // phpcs:disable QITStandard.PHP.DebugCode.DebugFunctionFound
+          error_log('[MailPoet] Subscriber activity tracking failed: ' . (string)$e); // phpcs:ignore Squiz.PHP.DiscouragedFunctions
+          // phpcs:enable QITStandard.PHP.DebugCode.DebugFunctionFound
         }
       }
       $this->postEditorBlock->init();

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -88,8 +88,14 @@ class SubscriberEntity {
    * treated as consent. How `unknown` is handled is a site setting; see
    * TrackingConsentController.
    *
+   * Validated in setTrackingConsent(), not by a validation constraint on this
+   * property. A constraint runs at flush, so a row that already holds a bad value —
+   * hand-edited column, incomplete migration, restored backup — would throw the moment
+   * anything flushed it, even an unrelated field. That took the whole mailpoet/v1
+   * namespace down for one customer. A caller trying to WRITE a bad value still fails,
+   * immediately, in the setter.
+   *
    * @ORM\Column(type="string", length=20)
-   * @Assert\Choice({"unknown", "granted", "denied"})
    * @var string
    */
   private $trackingConsent = self::TRACKING_CONSENT_UNKNOWN;
@@ -366,7 +372,16 @@ class SubscriberEntity {
    * Setting the state also stamps when, how, and against what wording it
    * changed (CNIL/Garante record-keeping).
    */
+
+  /**
+   * @throws \InvalidArgumentException if $consent is not one of the three
+   *   TRACKING_CONSENT_* constants. This is the only place the value is validated;
+   *   see the property docblock for why it is not a flush-time constraint.
+   */
   public function setTrackingConsent(string $consent, ?string $method = null, ?string $copy = null): void {
+    if (!in_array($consent, [self::TRACKING_CONSENT_UNKNOWN, self::TRACKING_CONSENT_GRANTED, self::TRACKING_CONSENT_DENIED], true)) {
+      throw new \InvalidArgumentException("Invalid tracking consent value: {$consent}");
+    }
     if ($this->trackingConsent === $consent) {
       return;
     }

--- a/mailpoet/tests/integration/Entities/SubscriberTrackingConsentTest.php
+++ b/mailpoet/tests/integration/Entities/SubscriberTrackingConsentTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Entities;
+
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+
+/**
+ * A subscriber row holding an out-of-range tracking_consent value must never take the
+ * whole plugin down. Validation lives in the setter, so a bad value that is already
+ * stored stays harmless on read and on an unrelated flush. STOMAIL-8365.
+ */
+class SubscriberTrackingConsentTest extends \MailPoetTest {
+  public function testSetTrackingConsentRejectsAnInvalidValue(): void {
+    $subscriber = new SubscriberEntity();
+    $this->expectException(\InvalidArgumentException::class);
+    $subscriber->setTrackingConsent('not-a-real-value');
+  }
+
+  public function testSetTrackingConsentAcceptsEachValidValue(): void {
+    $subscriber = new SubscriberEntity();
+
+    $validValues = [
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_UNKNOWN,
+    ];
+
+    foreach ($validValues as $value) {
+      $subscriber->setTrackingConsent($value);
+      verify($subscriber->getTrackingConsent())->equals($value);
+    }
+  }
+
+  public function testABadStoredValueDoesNotThrowOnAnUnrelatedFlush(): void {
+    // The support case: a row already holds an out-of-range value. Loading it and
+    // flushing something unrelated must not throw. Only a caller trying to WRITE a
+    // bad value should.
+    $subscriber = (new SubscriberFactory())->withEmail('bad-stored-consent@example.com')->create();
+    $table = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $this->entityManager->getConnection()->executeStatement(
+      "UPDATE `{$table}` SET tracking_consent = 'legacy-junk' WHERE id = ?",
+      [$subscriber->getId()]
+    );
+    $this->entityManager->clear();
+
+    $reloaded = $this->entityManager->find(SubscriberEntity::class, $subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $reloaded);
+    verify($reloaded->getTrackingConsent())->equals('legacy-junk');
+
+    $reloaded->setFirstName('Touched');
+    $this->entityManager->flush();
+
+    verify($reloaded->getFirstName())->equals('Touched');
+  }
+
+  public function testAnEmptyStoredValueDoesNotThrowOnAnUnrelatedFlush(): void {
+    // The exact shape the customer's database was in.
+    $subscriber = (new SubscriberFactory())->withEmail('empty-stored-consent@example.com')->create();
+    $table = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $this->entityManager->getConnection()->executeStatement(
+      "UPDATE `{$table}` SET tracking_consent = '' WHERE id = ?",
+      [$subscriber->getId()]
+    );
+    $this->entityManager->clear();
+
+    $reloaded = $this->entityManager->find(SubscriberEntity::class, $subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $reloaded);
+    $reloaded->setLastName('Touched');
+    $this->entityManager->flush();
+
+    verify($reloaded->getLastName())->equals('Touched');
+  }
+}

--- a/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Subscribers;
 
 use MailPoet\ConflictException;
-use MailPoet\Doctrine\Validator\ValidationException;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
@@ -94,7 +93,10 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
   }
 
   public function testItRejectsInvalidTrackingConsentValue(): void {
-    $this->expectException(ValidationException::class);
+    // The rejection moved from flush-time validation to the entity setter, so the
+    // exception type changed with it. Both extend \Exception, and the public API's
+    // createOrUpdate() calls already catch broadly, so callers are unaffected.
+    $this->expectException(\InvalidArgumentException::class);
     $this->saveController->save([
       'email' => 'consent-bogus@test.com',
       'status' => SubscriberEntity::STATUS_SUBSCRIBED,


### PR DESCRIPTION
## What this fixes

A single subscriber row holding an out-of-range `tracking_consent` value could take the whole plugin down, silently. One customer hit exactly this: the `mailpoet/v1` REST namespace disappeared and every public signup form on their site stopped working.

Two independent fixes, one PR.

### 1. Validate in the setter, not on every flush

`tracking_consent` carried a `@Assert\Choice` constraint, which Doctrine evaluates **at flush**. So a row that already held a bad value — a hand-edited column, an incomplete migration, a restored backup — threw the moment *anything* flushed that subscriber, including an update to a completely unrelated field. The stored data was already bad; the validation turned that into an outage.

The check now lives in `setTrackingConsent()`. A caller trying to *write* a bad value still fails, immediately and loudly, with `\InvalidArgumentException` and a clear message instead of a deep Doctrine one three layers up. A bad value that is merely *stored* is no longer fatal to read or to save around.

### 2. Page-view tracking cannot abort start-up

`Initializer::initialize()` wraps about a dozen calls in one `try`. A throw from any of them skips everything after it — and it is worse than it looks: it also leaves `Initializer::INITIALIZED` undefined, so `postInitialize()` then skips `restApi->init()` too. That is two independent routes from one throw to "the REST namespace is gone".

`trackActivity()` now has its own `try`/`catch(\Throwable)` and logs, the same shape `Config\HooksWooCommerce` already uses. Fix 1 removes this specific cause; Fix 2 means any *other* throwable from that one call stops costing the rest of start-up.

## Worth knowing while reviewing

**One existing test changes its expected exception type.** `SubscriberSaveControllerTest::testItRejectsInvalidTrackingConsentValue` expected `ValidationException` (flush-time). It now expects `\InvalidArgumentException` (setter). Both extend `xception`, and the public API's `createOrUpdate()` calls already `catch (xception $e)` — verified, both call sites — so no caller behaviour changes. If [#7059](https://github.com/mailpoet/mailpoet/pull/7059) lands first, its save-controller clamp means the setter never sees a bad value from that path at all and this test is replaced there anyway; the two PRs are compatible in either merge order.

**Fix 2 has no automated test, deliberately.** I wrote one and threw it away rather than ship something green and meaningless: in the integration harness `initialize()` aborts before it ever reaches `trackActivity()` — I instrumented it and confirmed the call is never made — so no test driving `initialize()` can exercise this branch here. A test that passed would have been passing for the wrong reason. The change is six lines of `try`/`catch` + log, matching an existing pattern in the codebase.

**Suggestions 3-6 from the issue** (surface the failure on screen, a System Info line, a schema/data check, a readiness gate) stay as later scope inside this same issue, per the decision. Not built here, not split out.

No schema change, no migration.

## Test plan

New `SubscriberTrackingConsentTest`: the setter rejects an invalid value, accepts each of the three valid ones, and — the two that reproduce the outage — a row holding `'legacy-junk'` and a row holding `''` both survive an unrelated field update and flush without throwing. Sabotage-checked: removing the setter guard fails exactly the rejection test.

`tests/integration/Entities/` 4 tests, plus regression runs over `Subscribers/`, `Subscription/` and `Config/InitializerTest`. `qa:phpstan` no errors, `qa:code-sniffer` exit 0.

Fixes STOMAIL-8365.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8365-tracking-consent-bricking)

_The latest successful build from `fix/stomail-8365-tracking-consent-bricking` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->