### PR TITLE
Stop logging sending frequency limit as cron error

### DIFF
--- a/mailpoet/assets/js/src/help/queue-status.tsx
+++ b/mailpoet/assets/js/src/help/queue-status.tsx
@@ -6,6 +6,7 @@ import { Props as TasksListDataRowProps } from './tasks-list/tasks-list-data-row
 type Props = {
   statusData: {
     status?: string;
+    sendingLimitReached?: boolean;
     started?: number;
     sent?: number;
     retryAttempt?: number;
@@ -25,6 +26,16 @@ type Props = {
   };
 };
 
+function getQueueStatusText(status: Props['statusData']): string {
+  if (status.status === 'paused') {
+    return MailPoet.I18n.t('paused');
+  }
+  if (status.sendingLimitReached) {
+    return MailPoet.I18n.t('sendingLimitReached');
+  }
+  return MailPoet.I18n.t('running');
+}
+
 function QueueStatus({ statusData }: Props): JSX.Element {
   const status = statusData;
   return (
@@ -35,10 +46,7 @@ function QueueStatus({ statusData }: Props): JSX.Element {
         rows={[
           {
             key: MailPoet.I18n.t('status'),
-            value:
-              status.status === 'paused'
-                ? MailPoet.I18n.t('paused')
-                : MailPoet.I18n.t('running'),
+            value: getQueueStatusText(status),
           },
           {
             key: MailPoet.I18n.t('startedAt'),

--- a/mailpoet/assets/js/src/help/system-status.jsx
+++ b/mailpoet/assets/js/src/help/system-status.jsx
@@ -191,6 +191,8 @@ function buildSystemStatusReport(
   let queueStatusText = MailPoet.I18n.t('unknown');
   if (queueStatus.status === 'paused')
     queueStatusText = MailPoet.I18n.t('paused');
+  else if (queueStatus.sendingLimitReached)
+    queueStatusText = MailPoet.I18n.t('sendingLimitReached');
   else if (queueStatus.status !== undefined)
     queueStatusText = MailPoet.I18n.t('running');
   const queueRetryAttempt =

--- a/mailpoet/changelog/2026-08-24-14-33-44-fixed-stopped-logging-sending-frequency-limit-as-cron-error.md
+++ b/mailpoet/changelog/2026-08-24-14-33-44-fixed-stopped-logging-sending-frequency-limit-as-cron-error.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Stopped logging the expected "Sending frequency limit has been reached" state as a cron error

--- a/mailpoet/changelog/2026-08-26-12-25-33-improved-sending-queue-status-on-the-help-page-now-shows-wh.md
+++ b/mailpoet/changelog/2026-08-26-12-25-33-improved-sending-queue-status-on-the-help-page-now-shows-wh.md
@@ -1,5 +1,0 @@
-# Type: Improved
-
-# Description
-
-Sending queue status on the Help page now shows when the sending frequency limit is active

--- a/mailpoet/changelog/2026-08-26-12-25-33-improved-sending-queue-status-on-the-help-page-now-shows-wh.md
+++ b/mailpoet/changelog/2026-08-26-12-25-33-improved-sending-queue-status-on-the-help-page-now-shows-wh.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Sending queue status on the Help page now shows when the sending frequency limit is active

--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -80,6 +80,7 @@ class Help {
     ];
 
     $systemStatusData['cronStatus']['accessible'] = $this->cronHelper->isDaemonAccessible();
+    $systemStatusData['queueStatus']['sendingLimitReached'] = MailerLog::isSendingLimitReached();
     $systemStatusData['queueStatus']['tasksStatusCounts'] = $this->scheduledTasksRepository->getCountsPerStatus();
 
     $scheduledTasks = $this->scheduledTasksRepository->getLatestTasks(SendingQueue::TASK_TYPE);

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -4,6 +4,7 @@ namespace MailPoet\Cron;
 
 use MailPoet\Cron\Workers\WorkersFactory;
 use MailPoet\Logging\LoggerFactory;
+use MailPoet\Mailer\MailerLog;
 use MailPoet\Util\Helpers;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -67,10 +68,18 @@ class Daemon {
         $workerClass = is_object($worker) ? get_class($worker) : '';
         $workerClassNameParts = explode('\\', $workerClass);
         $workerName = end($workerClassNameParts);
+
         $errors[] = [
           'worker' => $workerName,
           'message' => $e->getMessage(),
         ];
+
+        // Expected sending state, not an error — sending resumes once the frequency interval passes.
+        // Still saved to the daemon's last error so the help page shows why sending appears stuck.
+        if ($e->getCode() === MailerLog::SENDING_LIMIT_REACHED) {
+          $this->loggerFactory->getLogger(LoggerFactory::TOPIC_CRON)->info($e->getMessage(), ['worker' => $workerName]);
+          continue;
+        }
 
         if ($e->getCode() === CronHelper::DAEMON_EXECUTION_LIMIT_REACHED) {
           break;

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -70,7 +70,6 @@ class Daemon {
         $workerName = end($workerClassNameParts);
 
         // Expected sending state, not an error — sending resumes once the frequency interval passes.
-        // The Help page shows the state in the sending queue status, derived live from the mailer log.
         if ($e instanceof SendingLimitReachedException) {
           $this->loggerFactory->getLogger(LoggerFactory::TOPIC_CRON)->info($e->getMessage(), ['worker' => $workerName]);
           continue;

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -4,7 +4,7 @@ namespace MailPoet\Cron;
 
 use MailPoet\Cron\Workers\WorkersFactory;
 use MailPoet\Logging\LoggerFactory;
-use MailPoet\Mailer\MailerLog;
+use MailPoet\Mailer\SendingLimitReachedException;
 use MailPoet\Util\Helpers;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -69,17 +69,17 @@ class Daemon {
         $workerClassNameParts = explode('\\', $workerClass);
         $workerName = end($workerClassNameParts);
 
+        // Expected sending state, not an error — sending resumes once the frequency interval passes.
+        // The Help page shows the state in the sending queue status, derived live from the mailer log.
+        if ($e instanceof SendingLimitReachedException) {
+          $this->loggerFactory->getLogger(LoggerFactory::TOPIC_CRON)->info($e->getMessage(), ['worker' => $workerName]);
+          continue;
+        }
+
         $errors[] = [
           'worker' => $workerName,
           'message' => $e->getMessage(),
         ];
-
-        // Expected sending state, not an error — sending resumes once the frequency interval passes.
-        // Still saved to the daemon's last error so the help page shows why sending appears stuck.
-        if ($e->getCode() === MailerLog::SENDING_LIMIT_REACHED) {
-          $this->loggerFactory->getLogger(LoggerFactory::TOPIC_CRON)->info($e->getMessage(), ['worker' => $workerName]);
-          continue;
-        }
 
         if ($e->getCode() === CronHelper::DAEMON_EXECUTION_LIMIT_REACHED) {
           break;

--- a/mailpoet/lib/Mailer/MailerLog.php
+++ b/mailpoet/lib/Mailer/MailerLog.php
@@ -28,8 +28,6 @@ class MailerLog {
   const STATUS_PAUSED = 'paused';
   const RETRY_ATTEMPTS_LIMIT = 3;
   const RETRY_INTERVAL = 120; // seconds
-  // Exception code for an expected sending state (not an error); must not collide with CronHelper::DAEMON_EXECUTION_LIMIT_REACHED
-  const SENDING_LIMIT_REACHED = 1002;
 
   /**
    * @param MailerLogData|null $mailerLog
@@ -109,7 +107,7 @@ class MailerLog {
 
     // ensure that sending frequency has not been reached
     if (self::isSendingLimitReached($mailerLog)) {
-      throw new \Exception(__('Sending frequency limit has been reached.', 'mailpoet'), self::SENDING_LIMIT_REACHED);
+      throw new SendingLimitReachedException(__('Sending frequency limit has been reached.', 'mailpoet'));
     }
     return null;
   }

--- a/mailpoet/lib/Mailer/MailerLog.php
+++ b/mailpoet/lib/Mailer/MailerLog.php
@@ -28,6 +28,8 @@ class MailerLog {
   const STATUS_PAUSED = 'paused';
   const RETRY_ATTEMPTS_LIMIT = 3;
   const RETRY_INTERVAL = 120; // seconds
+  // Exception code for an expected sending state (not an error); 1001 is CronHelper::DAEMON_EXECUTION_LIMIT_REACHED
+  const SENDING_LIMIT_REACHED = 1002;
 
   /**
    * @param MailerLogData|null $mailerLog
@@ -107,7 +109,7 @@ class MailerLog {
 
     // ensure that sending frequency has not been reached
     if (self::isSendingLimitReached($mailerLog)) {
-      throw new \Exception(__('Sending frequency limit has been reached.', 'mailpoet'));
+      throw new \Exception(__('Sending frequency limit has been reached.', 'mailpoet'), self::SENDING_LIMIT_REACHED);
     }
     return null;
   }

--- a/mailpoet/lib/Mailer/MailerLog.php
+++ b/mailpoet/lib/Mailer/MailerLog.php
@@ -28,7 +28,7 @@ class MailerLog {
   const STATUS_PAUSED = 'paused';
   const RETRY_ATTEMPTS_LIMIT = 3;
   const RETRY_INTERVAL = 120; // seconds
-  // Exception code for an expected sending state (not an error); 1001 is CronHelper::DAEMON_EXECUTION_LIMIT_REACHED
+  // Exception code for an expected sending state (not an error); must not collide with CronHelper::DAEMON_EXECUTION_LIMIT_REACHED
   const SENDING_LIMIT_REACHED = 1002;
 
   /**

--- a/mailpoet/lib/Mailer/SendingLimitReachedException.php
+++ b/mailpoet/lib/Mailer/SendingLimitReachedException.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Mailer;
+
+use MailPoet\RuntimeException;
+
+/**
+ * Thrown when the configured sending frequency limit is reached. An expected
+ * sending state, not an error — sending resumes once the interval passes.
+ */
+class SendingLimitReachedException extends RuntimeException {
+}

--- a/mailpoet/lib/SystemReport/SystemReportCollector.php
+++ b/mailpoet/lib/SystemReport/SystemReportCollector.php
@@ -175,7 +175,7 @@ class SystemReportCollector {
       'Plugin installed at' => $this->settings->get('installed_at'),
       'Installed via WooCommerce onboarding wizard' => $this->wooCommerceHelper->wasMailPoetInstalledViaWooCommerceOnboardingWizard(),
       'Sending queue status' => $this->formatCompositeField([
-        'Status' => $mailerLog['status'] ?? 'Unknown',
+        'Status' => $mailerLog['status'] ?? (MailerLog::isSendingLimitReached() ? 'Sending frequency limit reached' : 'Unknown'),
         'Started at' => isset($mailerLog['started']) ? $this->formatTimestamp((int)$mailerLog['started']) : 'Unknown',
         'Emails sent' => $mailerLog['sent'],
         'Retry attempts' => $mailerLog['retry_attempt'] ?? 0,

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -9,7 +9,9 @@ use MailPoet\Cron\Daemon;
 use MailPoet\Cron\Workers\SimpleWorker;
 use MailPoet\Cron\Workers\WorkersFactory;
 use MailPoet\Entities\LogEntity;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Logging\LogRepository;
+use MailPoet\Mailer\MailerLog;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WpFunctions;
 
@@ -28,6 +30,12 @@ class DaemonTest extends \MailPoetTest {
     $this->settings = SettingsController::getInstance();
     $this->logRepository = $this->diContainer->get(LogRepository::class);
     $this->wp = $this->diContainer->get(WpFunctions::class);
+  }
+
+  public function _after() {
+    parent::_after();
+    // drop logger instances cached with the DEBUG level enabled via the 'logging' setting in tests below
+    $this->diContainer->get(LoggerFactory::class)->clearLoggerInstances();
   }
 
   public function testItCanRun() {
@@ -63,6 +71,33 @@ class DaemonTest extends \MailPoetTest {
     $log = $this->logRepository->findOneBy(['name' => 'cron', 'level' => 400]);
     $this->assertInstanceOf(LogEntity::class, $log);
     verify($log->getMessage())->stringContainsString('Worker error!');
+  }
+
+  public function testItLogsSendingLimitReachedAsInfoAndKeepsLastError() {
+    $this->settings->set('logging', 'everything');
+    // loggers cache their handler's minimum level at creation, so drop instances created before the setting change
+    $this->diContainer->get(LoggerFactory::class)->clearLoggerInstances();
+    $message = 'Sending frequency limit has been reached.';
+    $cronWorkerRunner = $this->make(CronWorkerRunner::class, [
+      'run' => function () use ($message) {
+        throw new \Exception($message, MailerLog::SENDING_LIMIT_REACHED);
+      },
+    ]);
+    $data = [
+      'token' => 123,
+    ];
+    $this->settings->set(CronHelper::DAEMON_SETTING, $data);
+    $daemon = $this->getServiceWithOverrides(Daemon::class, [
+      'cronWorkerRunner' => $cronWorkerRunner,
+      'workersFactory' => $this->createWorkersFactoryMock(),
+    ]);
+    $daemon->run($data);
+    verify($this->logRepository->findOneBy(['name' => 'cron', 'level' => 400]))->null();
+    $infoLog = $this->logRepository->findOneBy(['name' => 'cron', 'level' => 200]);
+    $this->assertInstanceOf(LogEntity::class, $infoLog);
+    verify($infoLog->getMessage())->stringContainsString($message);
+    $daemonSetting = $this->settings->get(CronHelper::DAEMON_SETTING);
+    verify($daemonSetting['last_error'][0]['message'])->equals($message);
   }
 
   public function testItTerminatesWhenExecutionLimitIsReached() {

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -11,7 +11,7 @@ use MailPoet\Cron\Workers\WorkersFactory;
 use MailPoet\Entities\LogEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Logging\LogRepository;
-use MailPoet\Mailer\MailerLog;
+use MailPoet\Mailer\SendingLimitReachedException;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WpFunctions;
 
@@ -73,14 +73,14 @@ class DaemonTest extends \MailPoetTest {
     verify($log->getMessage())->stringContainsString('Worker error!');
   }
 
-  public function testItLogsSendingLimitReachedAsInfoAndKeepsLastError() {
+  public function testItLogsSendingLimitReachedAsInfoAndNotAsError() {
     $this->settings->set('logging', 'everything');
     // loggers cache their handler's minimum level at creation, so drop instances created before the setting change
     $this->diContainer->get(LoggerFactory::class)->clearLoggerInstances();
     $message = 'Sending frequency limit has been reached.';
     $cronWorkerRunner = $this->make(CronWorkerRunner::class, [
       'run' => function () use ($message) {
-        throw new \Exception($message, MailerLog::SENDING_LIMIT_REACHED);
+        throw new SendingLimitReachedException($message);
       },
     ]);
     $data = [
@@ -97,7 +97,7 @@ class DaemonTest extends \MailPoetTest {
     $this->assertInstanceOf(LogEntity::class, $infoLog);
     verify($infoLog->getMessage())->stringContainsString($message);
     $daemonSetting = $this->settings->get(CronHelper::DAEMON_SETTING);
-    verify($daemonSetting['last_error'][0]['message'])->equals($message);
+    verify($daemonSetting['last_error'] ?? null)->null();
   }
 
   public function testItTerminatesWhenExecutionLimitIsReached() {

--- a/mailpoet/tests/integration/Mailer/MailerLogTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerLogTest.php
@@ -346,6 +346,7 @@ class MailerLogTest extends \MailPoetTest {
       self::fail('Sending frequency exception was not thrown.');
     } catch (\Exception $e) {
       verify($e->getMessage())->equals('Sending frequency limit has been reached.');
+      verify($e->getCode())->equals(MailerLog::SENDING_LIMIT_REACHED);
     }
   }
 

--- a/mailpoet/tests/integration/Mailer/MailerLogTest.php
+++ b/mailpoet/tests/integration/Mailer/MailerLogTest.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\LogEntity;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
+use MailPoet\Mailer\SendingLimitReachedException;
 use MailPoet\Settings\SettingsController;
 
 class MailerLogTest extends \MailPoetTest {
@@ -346,7 +347,7 @@ class MailerLogTest extends \MailPoetTest {
       self::fail('Sending frequency exception was not thrown.');
     } catch (\Exception $e) {
       verify($e->getMessage())->equals('Sending frequency limit has been reached.');
-      verify($e->getCode())->equals(MailerLog::SENDING_LIMIT_REACHED);
+      $this->assertInstanceOf(SendingLimitReachedException::class, $e);
     }
   }
 

--- a/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
+++ b/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
@@ -280,6 +280,7 @@ class SystemReportCollectorTest extends \MailPoetTest {
 
     $systemInfoData = $this->diContainer->get(SystemReportCollector::class)->getData();
     $subjectField = $systemInfoData['Sending queue status'];
+    verify($subjectField)->stringContainsString('Status: Unknown');
     verify($subjectField)->stringContainsString('Started at: 1970-01-01 09:00:00');
     verify($subjectField)->stringContainsString('Retry attempts: 1');
     verify($subjectField)->stringContainsString("Last seen error: $error ($operation)");
@@ -288,6 +289,19 @@ class SystemReportCollectorTest extends \MailPoetTest {
     $systemInfoData = $this->diContainer->get(SystemReportCollector::class)->getData();
     $subjectField = $systemInfoData['Sending queue status'];
     verify($subjectField)->stringContainsString('Status: ' . MailerLog::STATUS_PAUSED);
+  }
+
+  public function testItReportsSendingFrequencyLimitReachedInQueueStatus() {
+    $this->settings->set(Mailer::MAILER_CONFIG_SETTING_NAME, [
+      'method' => 'SMTP',
+      'frequency' => ['emails' => 1, 'interval' => 30],
+    ]);
+    $mailerLog = MailerLog::createMailerLog();
+    $mailerLog['sent'] = [date('Y-m-d H:i:s') => 1];
+    MailerLog::updateMailerLog($mailerLog);
+
+    $systemInfoData = $this->diContainer->get(SystemReportCollector::class)->getData();
+    verify($systemInfoData['Sending queue status'])->stringContainsString('Status: Sending frequency limit reached');
   }
 
   public function testItReturnsDataInconsistencyStatus() {

--- a/mailpoet/views/help.html
+++ b/mailpoet/views/help.html
@@ -55,6 +55,7 @@
     'none': _x('none', 'An empty state is a status table e.g. Error: none'),
     'running': _x('running', 'A state of a process.'),
     'paused': _x('paused', 'A state of a process.'),
+    'sendingLimitReached': _x('Sending frequency limit reached — sending will resume once the interval passes', 'A state of the sending queue shown while the configured sending frequency limit is active.'),
     'cronWaiting': _x('waiting for the next run', 'A state of a process.'),
     'startedAt': _x('Started at', 'A label in a status table e.g. Started at: 2018-10-18 18:50'),
     'sentEmails': _x('Sent emails', 'A label in a status table e.g. Sent emails: 50'),


### PR DESCRIPTION
## Description

When a background sending job reaches the configured sending frequency limit, MailPoet logged `Sending frequency limit has been reached.` as an error on every cron run while the limit was active. That is confusing for users — it is not an error: the job just waits and resumes sending once the frequency interval passes.

The state is now logged at info level, so with the default logging setting ("Errors only") it no longer produces log entries. It also no longer appears in the cron daemon's last seen error. Instead, the Help page shows it directly in the sending queue status, next to "running" and "paused". 

## Code review notes

`Sending is waiting to be retried.` was considered for the same treatment but deliberately left at error level: it also fires immediately after a genuine send failure (soft errors via `SendingErrorHandler` → `MailerLog::processError()` do not write their own error log entry), so demoting it would hide real delivery failures from the error log until sending pauses after three retries.

## QA notes

1. Set the sending method to "Other" with a low frequency (e.g. 1 email per 30 minutes) and send a newsletter to a few subscribers.
2. Previously: MailPoet > Help > Logs showed repeated `Sending frequency limit has been reached.` error entries while the limit was active, and System Info showed it as the cron daemon's last seen error.
3. Now: no error entries in the Logs (with logging set to "everything", info entries appear instead), the last seen error stays empty, and the sending queue status on Help > System Status shows "Sending frequency limit reached — sending will resume once the interval passes". The status returns to "running" and sending resumes once the interval passes.

## Linked PRs

_N/A_

## Linked tickets

- [STOMAIL-8418](https://linear.app/a8c/issue/STOMAIL-8418/stop-logging-the-sending-frequency-limit-state-as-a-cron-error)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

### Before 
<img width="1283" height="556" alt="Screenshot 2026-08-25 at 8 45 10" src="https://github.com/user-attachments/assets/9132658f-0b6b-4020-aab8-346234306513" />


### After
<img width="1272" height="311" alt="Screenshot 2026-08-25 at 8 30 09" src="https://github.com/user-attachments/assets/ae5e789c-aaa0-4233-8f68-de7d6363b5aa" />

<img width="430" height="535" alt="Screenshot 2026-08-26 at 16 21 06" src="https://github.com/user-attachments/assets/228f6cc4-802a-4850-b024-921c2e4b5995" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-frequency-limit-loggi)

_The latest successful build from `fix-frequency-limit-loggi` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->