### PR TITLE
Harden internal API request dispatch and redirect handling

### DIFF
--- a/mailpoet/changelog/2026-08-25-11-10-59-fixed-harden-the-internal-api-request-dispatch-and-redir.md
+++ b/mailpoet/changelog/2026-08-25-11-10-59-fixed-harden-the-internal-api-request-dispatch-and-redir.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Harden the internal API request dispatch and redirect handling

--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -205,7 +205,10 @@ class API {
       if (!$endpoint instanceof Endpoint) {
         throw new \Exception(__('Invalid API endpoint.', 'mailpoet'));
       }
-      if (!method_exists($endpoint, $this->requestMethod)) {
+      if (
+        !method_exists($endpoint, $this->requestMethod)
+        || $this->isReservedEndpointMethod($endpoint, $this->requestMethod)
+      ) {
         throw new \Exception(__('Invalid API endpoint method.', 'mailpoet'));
       }
 
@@ -243,6 +246,17 @@ class API {
       $errorResponse = $this->createErrorResponse(Error::BAD_REQUEST, $errorMessage, Response::STATUS_BAD_REQUEST);
       return $errorResponse;
     }
+  }
+
+  /**
+   * Only genuine endpoint actions may be dispatched. The response-builder helpers
+   * declared on the Endpoint base class (redirectResponse, successResponse, etc.)
+   * are framework plumbing, not callable actions.
+   */
+  private function isReservedEndpointMethod($endpoint, $requestMethod): bool {
+    return (new \ReflectionMethod($endpoint, $requestMethod))
+      ->getDeclaringClass()
+      ->getName() === Endpoint::class;
   }
 
   public function validatePermissions($requestMethod, $permissions) {

--- a/mailpoet/lib/API/JSON/Endpoint.php
+++ b/mailpoet/lib/API/JSON/Endpoint.php
@@ -4,6 +4,7 @@ namespace MailPoet\API\JSON;
 
 use MailPoet\API\JSON\v1\RedirectResponse;
 use MailPoet\Config\AccessControl;
+use MailPoet\WP\Functions as WPFunctions;
 
 abstract class Endpoint {
   const TYPE_POST = 'POST';
@@ -43,6 +44,10 @@ abstract class Endpoint {
   }
 
   public function redirectResponse($url) {
+    $wp = WPFunctions::get();
+    // Keep redirects on-site: fall back to the home URL for any off-site target,
+    // mirroring WordPress' own wp_safe_redirect() handling.
+    $url = $wp->wpValidateRedirect($url, $wp->homeUrl());
     return new RedirectResponse($url);
   }
 

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -730,6 +730,10 @@ class Functions {
     return wp_safe_redirect($location, $status);
   }
 
+  public function wpValidateRedirect($location, $fallbackUrl = '') {
+    return wp_validate_redirect($location, $fallbackUrl);
+  }
+
   public function wpStaticizeEmoji($text) {
     return wp_staticize_emoji($text);
   }

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -397,6 +397,50 @@ class APITest extends \MailPoetTest {
     verify($response->errors[0]['message'])->equals('Invalid API endpoint method.');
   }
 
+  public function testItDoesNotDispatchInheritedBaseEndpointHelpers() {
+    // Response-builder helpers declared on the Endpoint base class must never be
+    // reachable as API actions.
+    $namespace = [
+      'name' => 'MailPoet\API\JSON\v1',
+      'version' => 'v1',
+    ];
+
+    $baseHelperMethods = [
+      'redirect_response',
+      'success_response',
+      'error_response',
+      'bad_request',
+      'is_method_allowed',
+    ];
+
+    foreach ($baseHelperMethods as $method) {
+      $this->api->addEndpointNamespace($namespace['name'], $namespace['version']);
+      $this->api->setRequestData([
+        'endpoint' => 'a_p_i_test_namespaced_endpoint_stub_v1',
+        'method' => $method,
+        'api_version' => 'v1',
+        'data' => 'https://evil.example.com/phish',
+      ], Endpoint::TYPE_POST);
+      $response = $this->api->processRoute();
+
+      verify($response->status)->equals(Response::STATUS_BAD_REQUEST);
+      verify($response->errors[0]['message'])->equals('Invalid API endpoint method.');
+    }
+  }
+
+  public function testRedirectResponseValidatesTargetHostAgainstSite() {
+    $endpoint = new APITestNamespacedEndpointStubV1();
+    $wp = new WPFunctions();
+
+    // An external host is rejected and falls back to the site home URL.
+    $external = $endpoint->redirectResponse('https://evil.example.com/phish');
+    verify($external->location)->equals($wp->homeUrl());
+
+    // A same-site URL is preserved.
+    $internal = $wp->homeUrl('/?mailpoet_router&endpoint=captcha');
+    verify($endpoint->redirectResponse($internal)->location)->equals($internal);
+  }
+
   public function testItLogsExceptionToLogTable() {
     $this->settings->set('logging', 'everything');
     $namespace = [


### PR DESCRIPTION
## Description

Two changes:

1. **Dispatch is restricted to genuine endpoint actions.** `API::processRoute()` now rejects any request method whose implementation is declared on the abstract `Endpoint` base class, so the shared response-builder helpers are no longer callable as actions.
2. **Redirect responses stay on-site.** `Endpoint::redirectResponse()` now runs its target through `wp_validate_redirect()` with a `home_url()` fallback (defense in depth).

Details of the issue are tracked privately in the linked ticket, not in this description.

## Code review notes

- Chose the declaring-class guard over a per-endpoint `allowedActions` allowlist (as in `Router.php`): the JSON API has dozens of endpoints and hundreds of methods across free + premium, so an explicit allowlist would be high-effort and high-BC-risk. The guard is precise — a subclass that legitimately overrides a helper name is unaffected, because its declaring class is the subclass, not `Endpoint`.
- The legitimate captcha `render` flow is unaffected: it builds a same-host permalink, which passes `wp_validate_redirect()`.

## QA notes

Automated coverage in `APITest.php`:

- `testItDoesNotDispatchInheritedBaseEndpointHelpers` — base-class helpers return `400 Invalid API endpoint method.`
- `testRedirectResponseValidatesTargetHostAgainstSite` — an off-site host falls back to `home_url()`, a same-site URL is preserved.

Passing: `APITest`, `CaptchaTest`, premium `StatsTest`. PHPStan + PHPCS + `qa:php` clean.

**Manual QA:** on a stock install with the MailPoet captcha enabled, submit the WP/WooCommerce register forms and confirm the captcha still renders (the form still redirects to the same-host captcha page).

## Linked PRs

_N/A_ — internal JSON API only, no premium change required (premium endpoints inherit the fixed base and dispatch through the same path).

## Linked tickets

STOMAIL-8402

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
