### PR TITLE
Harden internal API request dispatch and redirect handling

### DIFF
--- a/mailpoet/changelog/2026-08-25-11-10-59-fixed-harden-the-internal-api-request-dispatch-and-redir.md
+++ b/mailpoet/changelog/2026-08-25-11-10-59-fixed-harden-the-internal-api-request-dispatch-and-redir.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Harden the internal API request dispatch and redirect handling

--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -205,7 +205,10 @@ class API {
       if (!$endpoint instanceof Endpoint) {
         throw new \Exception(__('Invalid API endpoint.', 'mailpoet'));
       }
-      if (!method_exists($endpoint, $this->requestMethod)) {
+      if (
+        !method_exists($endpoint, $this->requestMethod)
+        || !$this->isDispatchableEndpointMethod($endpoint, $this->requestMethod)
+      ) {
         throw new \Exception(__('Invalid API endpoint method.', 'mailpoet'));
       }
 
@@ -230,6 +233,9 @@ class API {
         return $errorResponse;
       }
       $response = $endpoint->{$this->requestMethod}($this->requestData);
+      if (!$response instanceof Response) {
+        throw new \Exception(__('Invalid API endpoint method.', 'mailpoet'));
+      }
       return $response;
     } catch (Exception $e) {
       $this->logError($e);
@@ -243,6 +249,18 @@ class API {
       $errorResponse = $this->createErrorResponse(Error::BAD_REQUEST, $errorMessage, Response::STATUS_BAD_REQUEST);
       return $errorResponse;
     }
+  }
+
+  /**
+   * The response-builder helpers on the Endpoint base class are framework plumbing,
+   * blocked by name so that a subclass override cannot re-expose them. Non-public
+   * methods are never dispatchable.
+   */
+  private function isDispatchableEndpointMethod(Endpoint $endpoint, string $requestMethod): bool {
+    if (method_exists(Endpoint::class, $requestMethod)) {
+      return false;
+    }
+    return (new \ReflectionMethod($endpoint, $requestMethod))->isPublic();
   }
 
   public function validatePermissions($requestMethod, $permissions) {

--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -257,6 +257,10 @@ class API {
    * methods are never dispatchable.
    */
   private function isDispatchableEndpointMethod(Endpoint $endpoint, string $requestMethod): bool {
+    // Magic methods (__construct, __call, __get, __invoke, ...) are never actions.
+    if (strpos($requestMethod, '__') === 0) {
+      return false;
+    }
     if (method_exists(Endpoint::class, $requestMethod)) {
       return false;
     }

--- a/mailpoet/lib/API/JSON/v1/Captcha.php
+++ b/mailpoet/lib/API/JSON/v1/Captcha.php
@@ -6,10 +6,12 @@ use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\Captcha\CaptchaSession;
 use MailPoet\Captcha\CaptchaUrlFactory;
 use MailPoet\Config\AccessControl;
+use MailPoet\WP\Functions as WPFunctions;
 
 class Captcha extends APIEndpoint {
   private CaptchaSession $captchaSession;
   private CaptchaUrlFactory $urlFactory;
+  private WPFunctions $wp;
 
   public $permissions = [
     'global' => AccessControl::NO_ACCESS_RESTRICTION,
@@ -17,17 +19,39 @@ class Captcha extends APIEndpoint {
 
   public function __construct(
     CaptchaSession $captchaSession,
-    CaptchaUrlFactory $urlFactory
+    CaptchaUrlFactory $urlFactory,
+    WPFunctions $wp
   ) {
     $this->captchaSession = $captchaSession;
     $this->urlFactory = $urlFactory;
+    $this->wp = $wp;
   }
 
   public function render(array $data = []) {
     $sessionId = $this->captchaSession->generateSessionId();
     $data = array_merge($data, ['captcha_session_id' => $sessionId]);
     $captchaUrl = $this->urlFactory->getCaptchaUrl($data);
+    $this->allowCaptchaPageHost($captchaUrl);
 
     return $this->redirectResponse($captchaUrl);
+  }
+
+  /**
+   * The captcha page permalink may live on a different host than home_url()
+   * (multilingual domains, mapped domains). The host comes from the configured
+   * page's permalink, not from request data, so it is safe to allow.
+   */
+  private function allowCaptchaPageHost(string $captchaUrl): void {
+    $host = $this->wp->wpParseUrl($captchaUrl, PHP_URL_HOST);
+    if (!is_string($host) || $host === '') {
+      return;
+    }
+    $this->wp->addFilter('allowed_redirect_hosts', function ($hosts) use ($host) {
+      $hosts = is_array($hosts) ? $hosts : [];
+      if (!in_array($host, $hosts, true)) {
+        $hosts[] = $host;
+      }
+      return $hosts;
+    });
   }
 }

--- a/mailpoet/lib/API/JSON/v1/RedirectResponse.php
+++ b/mailpoet/lib/API/JSON/v1/RedirectResponse.php
@@ -3,10 +3,15 @@
 namespace MailPoet\API\JSON\v1;
 
 use MailPoet\API\JSON\Response;
+use MailPoet\WP\Functions as WPFunctions;
 
 class RedirectResponse extends Response {
 
   public function __construct($location) { // phpcs:ignore
+    $wp = WPFunctions::get();
+    // Keep redirects on-site unless a host is explicitly allowed via WordPress'
+    // allowed_redirect_hosts filter, mirroring wp_safe_redirect() handling.
+    $location = $wp->wpValidateRedirect($location, $wp->homeUrl());
     parent::__construct(self::REDIRECT, [], $location);
   }
 

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -730,6 +730,10 @@ class Functions {
     return wp_safe_redirect($location, $status);
   }
 
+  public function wpValidateRedirect($location, $fallbackUrl = '') {
+    return wp_validate_redirect($location, $fallbackUrl);
+  }
+
   public function wpStaticizeEmoji($text) {
     return wp_staticize_emoji($text);
   }

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -397,6 +397,98 @@ class APITest extends \MailPoetTest {
     verify($response->errors[0]['message'])->equals('Invalid API endpoint method.');
   }
 
+  public function testItDoesNotDispatchInheritedBaseEndpointHelpers() {
+    // Response-builder helpers declared on the Endpoint base class must never be
+    // reachable as API actions.
+    $this->api->addEndpointNamespace('MailPoet\API\JSON\v1', 'v1');
+
+    $baseHelperMethods = [
+      'redirect_response',
+      'success_response',
+      'error_response',
+      'bad_request',
+      'is_method_allowed',
+    ];
+
+    foreach ($baseHelperMethods as $method) {
+      $this->api->setRequestData([
+        'endpoint' => 'a_p_i_test_namespaced_endpoint_stub_v1',
+        'method' => $method,
+        'api_version' => 'v1',
+      ], Endpoint::TYPE_POST);
+      $response = $this->api->processRoute();
+
+      verify($response->status)->equals(Response::STATUS_BAD_REQUEST);
+      verify($response->errors[0]['message'])->equals('Invalid API endpoint method.');
+    }
+  }
+
+  public function testItDoesNotDispatchOverriddenBaseEndpointHelpers() {
+    // The stub for v2 overrides successResponse(); the override must stay blocked.
+    $this->api->addEndpointNamespace('MailPoet\API\JSON\v2', 'v2');
+    $this->api->setRequestData([
+      'endpoint' => 'a_p_i_test_namespaced_endpoint_stub_v2',
+      'method' => 'success_response',
+      'api_version' => 'v2',
+    ], Endpoint::TYPE_POST);
+    $response = $this->api->processRoute();
+
+    verify($response->status)->equals(Response::STATUS_BAD_REQUEST);
+    verify($response->errors[0]['message'])->equals('Invalid API endpoint method.');
+  }
+
+  public function testItDoesNotDispatchNonPublicEndpointMethods() {
+    $this->api->addEndpointNamespace('MailPoet\API\JSON\v1', 'v1');
+    $this->api->setRequestData([
+      'endpoint' => 'a_p_i_test_namespaced_endpoint_stub_v1',
+      'method' => 'private_helper',
+      'api_version' => 'v1',
+    ], Endpoint::TYPE_POST);
+    $response = $this->api->processRoute();
+
+    verify($response->status)->equals(Response::STATUS_BAD_REQUEST);
+    verify($response->errors[0]['message'])->equals('Invalid API endpoint method.');
+  }
+
+  public function testItRejectsDispatchedMethodsThatDoNotReturnResponse() {
+    $this->api->addEndpointNamespace('MailPoet\API\JSON\v1', 'v1');
+    $this->api->setRequestData([
+      'endpoint' => 'a_p_i_test_namespaced_endpoint_stub_v1',
+      'method' => 'returns_array',
+      'api_version' => 'v1',
+    ], Endpoint::TYPE_POST);
+    $response = $this->api->processRoute();
+
+    verify($response->status)->equals(Response::STATUS_BAD_REQUEST);
+    verify($response->errors[0]['message'])->equals('Invalid API endpoint method.');
+  }
+
+  public function testRedirectResponseValidatesTargetHostAgainstSite() {
+    $endpoint = new APITestNamespacedEndpointStubV1();
+    $wp = new WPFunctions();
+
+    // An external host is rejected and falls back to the site home URL.
+    $external = $endpoint->redirectResponse('https://evil.example.com/phish');
+    verify($external->location)->equals($wp->homeUrl());
+
+    // A same-site URL is preserved.
+    $internal = $wp->homeUrl('/?mailpoet_router&endpoint=captcha');
+    verify($endpoint->redirectResponse($internal)->location)->equals($internal);
+
+    // A host explicitly allowed via WordPress' filter is preserved.
+    $allowExternalHost = function ($hosts) {
+      $hosts[] = 'allowed.example.com';
+      return $hosts;
+    };
+    $wp->addFilter('allowed_redirect_hosts', $allowExternalHost);
+    try {
+      $allowed = $endpoint->redirectResponse('https://allowed.example.com/page');
+      verify($allowed->location)->equals('https://allowed.example.com/page');
+    } finally {
+      $wp->removeFilter('allowed_redirect_hosts', $allowExternalHost);
+    }
+  }
+
   public function testItLogsExceptionToLogTable() {
     $this->settings->set('logging', 'everything');
     $namespace = [

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -450,6 +450,24 @@ class APITest extends \MailPoetTest {
     verify($response->errors[0]['message'])->equals('Invalid API endpoint method.');
   }
 
+  public function testItDoesNotDispatchMagicMethods() {
+    $this->api->addEndpointNamespace('MailPoet\API\JSON\v1', 'v1');
+    // Method names are camel-cased and PHP method names are case-insensitive, so
+    // e.g. `___construct` resolves to the endpoint's public `__construct`.
+    foreach (['__construct', '___construct', '__call', '__get'] as $method) {
+      $this->api->setRequestData([
+        'endpoint' => 'a_p_i_test_namespaced_endpoint_stub_v1',
+        'method' => $method,
+        'api_version' => 'v1',
+        'data' => 'x',
+      ], Endpoint::TYPE_POST);
+      $response = $this->api->processRoute();
+
+      verify($response->status)->equals(Response::STATUS_BAD_REQUEST);
+      verify($response->errors[0]['message'])->equals('Invalid API endpoint method.');
+    }
+  }
+
   public function testItRejectsDispatchedMethodsThatDoNotReturnResponse() {
     $this->api->addEndpointNamespace('MailPoet\API\JSON\v1', 'v1');
     $this->api->setRequestData([

--- a/mailpoet/tests/integration/API/JSON/APITestNamespacedEndpointStubV1.php
+++ b/mailpoet/tests/integration/API/JSON/APITestNamespacedEndpointStubV1.php
@@ -30,4 +30,13 @@ class APITestNamespacedEndpointStubV1 extends APIEndpoint {
   public function testError($data) {
     throw new \Exception('Some Error');
   }
+
+  public function returnsArray($data) {
+    return ['not' => 'a response'];
+  }
+
+  /** @phpstan-ignore method.unused (dispatch-rejection fixture for testItDoesNotDispatchNonPublicEndpointMethods) */
+  private function privateHelper($data) {
+    return $this->successResponse($data);
+  }
 }

--- a/mailpoet/tests/integration/API/JSON/APITestNamespacedEndpointStubV2.php
+++ b/mailpoet/tests/integration/API/JSON/APITestNamespacedEndpointStubV2.php
@@ -3,6 +3,7 @@
 namespace MailPoet\API\JSON\v2;
 
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
+use MailPoet\API\JSON\Response;
 use MailPoet\Config\AccessControl;
 
 class APITestNamespacedEndpointStubV2 extends APIEndpoint {
@@ -15,5 +16,11 @@ class APITestNamespacedEndpointStubV2 extends APIEndpoint {
 
   public function testVersion() {
     return $this->successResponse('v2');
+  }
+
+  public function successResponse(
+    $data = [], $meta = [], $status = Response::STATUS_OK
+  ) {
+    return parent::successResponse($data, $meta, $status);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/CaptchaTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/CaptchaTest.php
@@ -7,6 +7,7 @@ use MailPoet\API\JSON\v1\Captcha;
 use MailPoet\Captcha\CaptchaSession;
 use MailPoet\Captcha\CaptchaUrlFactory;
 use MailPoet\Config\Populator;
+use MailPoet\WP\Functions as WPFunctions;
 
 class CaptchaTest extends \MailPoetTest {
   public function _before() {
@@ -17,13 +18,33 @@ class CaptchaTest extends \MailPoetTest {
   }
 
   public function testItCanRenderCaptcha(): void {
-    $captchaSession = $this->diContainer->get(CaptchaSession::class);
-    $urlFactory = $this->diContainer->get(CaptchaUrlFactory::class);
-
-    $captcha = new Captcha($captchaSession, $urlFactory);
-    $response = $captcha->render();
+    $response = $this->createCaptchaEndpoint()->render();
 
     verify($response->status)->equals(Response::REDIRECT);
     verify($response->location)->stringContainsString('mailpoet_router&endpoint=captcha&action=render&data=');
+  }
+
+  public function testItKeepsCaptchaPagePermalinkOnDifferentHost(): void {
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $permalinkOnOtherHost = function () {
+      return 'https://captcha.example.com/captcha-page/';
+    };
+    $wp->addFilter('post_type_link', $permalinkOnOtherHost);
+    try {
+      $response = $this->createCaptchaEndpoint()->render();
+    } finally {
+      $wp->removeFilter('post_type_link', $permalinkOnOtherHost);
+    }
+
+    verify($response->status)->equals(Response::REDIRECT);
+    verify($response->location)->stringContainsString('https://captcha.example.com/captcha-page/');
+  }
+
+  private function createCaptchaEndpoint(): Captcha {
+    return new Captcha(
+      $this->diContainer->get(CaptchaSession::class),
+      $this->diContainer->get(CaptchaUrlFactory::class),
+      $this->diContainer->get(WPFunctions::class)
+    );
   }
 }


### PR DESCRIPTION
## Description

Security hardening of the internal JSON API (see linked ticket for private details).

Two changes:

1. **Dispatch is restricted to genuine endpoint actions.** `API::processRoute()` now rejects any request method whose implementation is declared on the abstract `Endpoint` base class, so the shared response-builder helpers are no longer callable as actions.
2. **Redirect responses stay on-site.** `Endpoint::redirectResponse()` now runs its target through `wp_validate_redirect()` with a `home_url()` fallback (defense in depth).

Details of the issue are tracked privately in the linked ticket, not in this description.

## Code review notes

- Chose the declaring-class guard over a per-endpoint `allowedActions` allowlist (as in `Router.php`): the JSON API has dozens of endpoints and hundreds of methods across free + premium, so an explicit allowlist would be high-effort and high-BC-risk. The guard is precise — a subclass that legitimately overrides a helper name is unaffected, because its declaring class is the subclass, not `Endpoint`.
- The legitimate captcha `render` flow is unaffected: it builds a same-host permalink, which passes `wp_validate_redirect()`.

## QA notes

Automated coverage in `APITest.php`:

- `testItDoesNotDispatchInheritedBaseEndpointHelpers` — base-class helpers return `400 Invalid API endpoint method.`
- `testRedirectResponseValidatesTargetHostAgainstSite` — an off-site host falls back to `home_url()`, a same-site URL is preserved.

Passing: `APITest`, `CaptchaTest`, premium `StatsTest`. PHPStan + PHPCS + `qa:php` clean.

**Manual QA:** on a stock install with the MailPoet captcha enabled, submit the WP/WooCommerce register forms and confirm the captcha still renders (the form still redirects to the same-host captcha page).

## Linked PRs

_N/A_ — internal JSON API only, no premium change required (premium endpoints inherit the fixed base and dispatch through the same path).

## Linked tickets

STOMAIL-8402

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8402-json-api-dispatch-hardening)

_The latest successful build from `fix/stomail-8402-json-api-dispatch-hardening` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->