### PR TITLE
Fix Review & send panel position under the admin bar

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
@@ -159,47 +159,9 @@
   }
 }
 
+// Size, position and slide-in come from the core `editor-post-publish-panel`
+// class the panel also uses. See send-panel.tsx.
 .mailpoet-send-panel {
-  background: #fff;
-  box-sizing: border-box;
-  inset: 46px 0 0;
-  overflow: auto;
-  position: fixed;
-  z-index: 100001;
-
-  *,
-  *:before,
-  *:after {
-    box-sizing: inherit;
-  }
-
-  @media (min-width: 782px) {
-    border-left: 1px solid #ddd;
-    left: auto;
-    top: 32px;
-    width: 281px;
-    z-index: 99998;
-  }
-
-  @media (min-width: 782px) and (not (prefers-reduced-motion)) {
-    animation: mailpoet-send-panel__slide-in 0.1s forwards;
-    transform: translateX(100%);
-  }
-
-  // Editor runs fullscreen (no admin bar), so pin to the very top.
-  body.is-fullscreen-mode & {
-    @media (min-width: 782px) {
-      top: 0;
-    }
-  }
-
-  // Keep the panel in place once its region receives focus (slide-in fallback).
-  [role='region']:focus & {
-    @media (min-width: 782px) {
-      transform: translateX(0%);
-    }
-  }
-
   .mailpoet-inbox-preview-panel__card {
     margin-top: 12px;
   }
@@ -313,11 +275,5 @@
 
   .mailpoet-inline-notice {
     margin: 0;
-  }
-}
-
-@keyframes mailpoet-send-panel__slide-in {
-  100% {
-    transform: translateX(0%);
   }
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/send-panel/send-panel.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/send-panel/send-panel.tsx
@@ -90,7 +90,7 @@ export function SendPanel() {
 
   return (
     <Fill name="ComplementaryArea/core">
-      <div className="mailpoet-send-panel">
+      <div className="editor-post-publish-panel mailpoet-send-panel">
         <Stack
           className="mailpoet-send-panel__header"
           direction="row"

--- a/mailpoet/changelog/2026-08-26-09-02-48-fixed-review-send-panel-position-under-the-wordpress-adm.md
+++ b/mailpoet/changelog/2026-08-26-09-02-48-fixed-review-send-panel-position-under-the-wordpress-adm.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Review & send panel position under the WordPress admin bar in the email editor


### PR DESCRIPTION
## Description

WordPress 7.1 shows the admin bar on editor pages, so the "Review & send" panel was hidden behind it (it used `top: 0`).

Our styles were a copy of core's `.editor-post-publish-panel` rules, so the panel now uses that core class and the copy is removed. Core sets the offset per version - below the admin bar on 7.1, at the top on 7.0, where fullscreen mode still hides the bar.

## Code review notes

_N/A_

## QA notes

Open an email in the block editor and click "Review & send":

- With WP 7.1, the panel starts below the admin bar and Cancel and Send are fully visible.
- With, WP 7.0, the panel starts at the top of the screen, same as before.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After (WordPress 7.1)                          | After (WordPress 7.0)                          |
| ------------------------------- | ------------------------------ | ------------------------------ |
| <img width="2252" height="1635" alt="lAXibORhOLE09Qwx@2x" src="https://github.com/user-attachments/assets/32778e10-baac-4085-b110-11be8ba61fef" /> | <img width="2252" height="1635" alt="iumAaP5cCn4jqDBt@2x" src="https://github.com/user-attachments/assets/7bce5c3a-82a8-49aa-8de2-5e78d5e0600a" /> | <img width="2252" height="1637" alt="mxU9CqKH6j225n4X@2x" src="https://github.com/user-attachments/assets/7133e9a5-85cd-46cb-bb7e-369490723185" /> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/review-send-panel-positioning)

_The latest successful build from `fix/review-send-panel-positioning` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

- Bug: 0
- Security: 0
- Performance: 0
- Suggestion: 0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->