### PR TITLE
Bump nanoid to patched 3.3.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9082,8 +9082,8 @@ packages:
   nan@2.26.2:
     resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -24561,7 +24561,7 @@ snapshots:
 
   nan@2.26.2: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -25323,13 +25323,13 @@ snapshots:
 
   postcss@8.5.10:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Description

Bumps `nanoid` from 3.3.17 to 3.3.18 in `pnpm-lock.yaml`, clearing GHSA-2v37-7h3g-55p8 (high) and Dependabot alert [#417](https://github.com/mailpoet/mailpoet/security/dependabot/417).

`postcss` is the only parent of `nanoid` in the tree, and its two locked copies declare `^3.3.11` (8.5.10) and `^3.3.16` (8.5.23). Both ranges already admit the patched release, so this is a plain lockfile bump.

**The advisory is not reachable in this codebase, so this is audit hygiene rather than an urgent fix.**

## Code review notes

_N/A_

## QA notes

No user-facing behaviour changes. Verification is limited to confirming the dependency resolves and the build pipeline that consumes postcss still works.

1. Check out the branch and run `pnpm install`
2. Confirm the lockfile is not modified by the install, with `git status`
3. Run `pnpm audit` and confirm no nanoid advisory remains
4. Run `pnpm compile:css`, the build step that actually exercises postcss

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/bump-nanoid-to-3-3-18)

_The latest successful build from `update/bump-nanoid-to-3-3-18` will be used. If none is available, the link won't work._