### PR TITLE
Restore admin page hash routes stripped by other plugins

### DIFF
--- a/mailpoet/assets/js/src/common/functions/index.ts
+++ b/mailpoet/assets/js/src/common/functions/index.ts
@@ -6,3 +6,4 @@ export * from './parsley-helper-functions';
 export * from './extract-email-domain';
 export * from './extract-page-name-from-url';
 export * from './get-is-garden';
+export * from './restore-stripped-location-hash';

--- a/mailpoet/assets/js/src/common/functions/restore-stripped-location-hash.ts
+++ b/mailpoet/assets/js/src/common/functions/restore-stripped-location-hash.ts
@@ -1,0 +1,34 @@
+/**
+ * Some plugins rewrite the URL early on wp-admin pages and drop the hash
+ * fragment before our routers boot (e.g. Tourfic Pro removes any "#/..."
+ * hash on every admin page via history.replaceState). The navigation timing
+ * entry keeps the URL the document was requested with, so a lost route can
+ * be recovered from it. Call before mounting a HashRouter.
+ *
+ * One-shot by design: it undoes a strip that happened before our bundle
+ * runs, not one that happens later, and a back/forward navigation to an
+ * already rewritten history entry leaves nothing to restore.
+ */
+export function restoreStrippedLocationHash(): void {
+  if (window.location.hash) {
+    return;
+  }
+  try {
+    const [entry] = window.performance.getEntriesByType('navigation');
+    const url = entry?.name ?? '';
+    const hashIndex = url.indexOf('#');
+    if (hashIndex === -1) {
+      return;
+    }
+    const hash = url.slice(hashIndex);
+    if (hash.startsWith('#/')) {
+      window.history.replaceState(
+        window.history.state,
+        '',
+        window.location.pathname + window.location.search + hash,
+      );
+    }
+  } catch {
+    // performance API unavailable — nothing to restore from
+  }
+}

--- a/mailpoet/assets/js/src/forms/forms.jsx
+++ b/mailpoet/assets/js/src/forms/forms.jsx
@@ -4,7 +4,11 @@ import { GlobalContext, useGlobalContextValue } from 'context';
 import { GlobalNotices } from 'notices/global-notices';
 import { MssAccessNotices } from 'notices/mss-access-notices';
 import { Notices } from 'notices/notices.jsx';
-import { registerTranslations, ErrorBoundary } from 'common';
+import {
+  registerTranslations,
+  restoreStrippedLocationHash,
+  ErrorBoundary,
+} from 'common';
 import { FormList } from './list';
 
 function App() {
@@ -32,6 +36,7 @@ function App() {
 const container = document.getElementById('forms_container');
 
 if (container) {
+  restoreStrippedLocationHash();
   registerTranslations();
   const root = createRoot(container);
   root.render(<App />);

--- a/mailpoet/assets/js/src/help/help.tsx
+++ b/mailpoet/assets/js/src/help/help.tsx
@@ -10,7 +10,11 @@ import { GlobalNotices } from 'notices/global-notices';
 import { MssAccessNotices } from 'notices/mss-access-notices';
 import { Notices } from 'notices/notices';
 import { RoutedTabs } from '../common/tabs/routed-tabs';
-import { registerTranslations, Tab } from '../common';
+import {
+  registerTranslations,
+  restoreStrippedLocationHash,
+  Tab,
+} from '../common';
 import { PageHeader } from '../common/page-header/page-header';
 import { TopBar } from '../common/top-bar/top-bar';
 
@@ -46,6 +50,7 @@ function App(): JSX.Element {
 const container = document.getElementById('help_container');
 
 if (container) {
+  restoreStrippedLocationHash();
   registerTranslations();
   const root = createRoot(container);
   root.render(<App />);

--- a/mailpoet/assets/js/src/newsletters/newsletters.tsx
+++ b/mailpoet/assets/js/src/newsletters/newsletters.tsx
@@ -25,7 +25,13 @@ import { GlobalContext, useGlobalContextValue } from 'context';
 import { GlobalNotices } from 'notices/global-notices';
 import { Notices } from 'notices/notices.jsx';
 import { RoutedTabs } from 'common/tabs/routed-tabs';
-import { ErrorBoundary, registerTranslations, Tab, withBoundary } from 'common';
+import {
+  ErrorBoundary,
+  registerTranslations,
+  restoreStrippedLocationHash,
+  Tab,
+  withBoundary,
+} from 'common';
 import { withNpsPoll } from 'nps-poll.jsx';
 import { ListingHeading } from 'newsletters/listings/heading';
 import { ListingHeadingDisplay } from 'newsletters/listings/heading-display.jsx';
@@ -227,6 +233,7 @@ function App() {
 
 const container = document.getElementById('newsletters_container');
 if (container) {
+  restoreStrippedLocationHash();
   registerTranslations();
   const root = createRoot(container);
   root.render(<App />);

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic.tsx
@@ -4,7 +4,11 @@ import { HashRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { GlobalNotices } from 'notices/global-notices';
 import { Notices } from 'notices/notices.jsx';
-import { registerTranslations, withBoundary } from 'common';
+import {
+  registerTranslations,
+  restoreStrippedLocationHash,
+  withBoundary,
+} from 'common';
 import { Editor } from 'segments/dynamic/editor';
 import { DynamicSegmentList } from 'segments/dynamic/list';
 import { SegmentTemplates } from 'segments/dynamic/templates';
@@ -61,6 +65,7 @@ function App(): JSX.Element {
 }
 
 if (container) {
+  restoreStrippedLocationHash();
   registerTranslations();
   createStore();
   const root = createRoot(container);

--- a/mailpoet/assets/js/src/segments/static/static.tsx
+++ b/mailpoet/assets/js/src/segments/static/static.tsx
@@ -6,7 +6,11 @@ import { SegmentForm } from 'segments/static/form';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { GlobalNotices } from 'notices/global-notices';
 import { Notices } from 'notices/notices.jsx';
-import { registerTranslations, withBoundary } from 'common';
+import {
+  registerTranslations,
+  restoreStrippedLocationHash,
+  withBoundary,
+} from 'common';
 
 const container = document.getElementById('static_segments_container');
 const FormWithBoundary = withBoundary(SegmentForm);
@@ -29,6 +33,7 @@ function App(): JSX.Element {
 }
 
 if (container) {
+  restoreStrippedLocationHash();
   registerTranslations();
   const root = createRoot(container);
   root.render(<App />);

--- a/mailpoet/assets/js/src/settings/index.tsx
+++ b/mailpoet/assets/js/src/settings/index.tsx
@@ -4,7 +4,7 @@ import { createRoot } from 'react-dom/client';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { initStore } from './store';
 import { Settings } from './settings';
-import { registerTranslations } from '../common';
+import { registerTranslations, restoreStrippedLocationHash } from '../common';
 
 function Entry() {
   return (
@@ -16,6 +16,7 @@ function Entry() {
 
 const container = document.getElementById('settings_container');
 if (container) {
+  restoreStrippedLocationHash();
   registerTranslations();
   initStore();
   const root = createRoot(container);

--- a/mailpoet/assets/js/src/subscribers/import-export/import.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import.jsx
@@ -5,7 +5,11 @@ import { ScrollToTop } from 'common/scroll-to-top.jsx';
 
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
-import { registerTranslations, ErrorBoundary } from 'common';
+import {
+  registerTranslations,
+  restoreStrippedLocationHash,
+  ErrorBoundary,
+} from 'common';
 import { StepMethodSelection } from './import/step-method-selection.jsx';
 import { StepInputValidation } from './import/step-input-validation';
 import { StepDataManipulation } from './import/step-data-manipulation.jsx';
@@ -92,6 +96,7 @@ function ImportSubscribers() {
 }
 
 if (container) {
+  restoreStrippedLocationHash();
   registerTranslations();
   const root = createRoot(container);
   root.render(<ImportSubscribers />);

--- a/mailpoet/assets/js/src/subscribers/subscribers.jsx
+++ b/mailpoet/assets/js/src/subscribers/subscribers.jsx
@@ -7,7 +7,11 @@ import { SubscriberStats } from 'subscribers/stats';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { GlobalNotices } from 'notices/global-notices';
 import { Notices } from 'notices/notices.jsx';
-import { registerTranslations, ErrorBoundary } from 'common';
+import {
+  registerTranslations,
+  restoreStrippedLocationHash,
+  ErrorBoundary,
+} from 'common';
 
 function App() {
   return (
@@ -57,6 +61,7 @@ function App() {
 const container = document.getElementById('subscribers_container');
 
 if (container) {
+  restoreStrippedLocationHash();
   registerTranslations();
   const root = createRoot(container);
   root.render(<App />);

--- a/mailpoet/assets/js/src/wizard/wizard.tsx
+++ b/mailpoet/assets/js/src/wizard/wizard.tsx
@@ -4,7 +4,11 @@ import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
 import { initStore as initSettingsStore } from 'settings/store';
 import { WooCommerceController } from './woocommerce-controller';
-import { registerTranslations, withBoundary } from '../common';
+import {
+  registerTranslations,
+  restoreStrippedLocationHash,
+  withBoundary,
+} from '../common';
 import { WelcomeWizardStepsController } from './welcome-wizard-controller';
 
 const WizardWithBoundary = withBoundary(WelcomeWizardStepsController);
@@ -37,6 +41,7 @@ function App(): JSX.Element {
 const container = document.getElementById('mailpoet-wizard-container');
 
 if (container) {
+  restoreStrippedLocationHash();
   registerTranslations();
   initSettingsStore();
   const root = createRoot(container);

--- a/mailpoet/changelog/2026-08-28-09-00-41-fixed-other-plugins-may-break-navigation-on-mailpoet-adm.md
+++ b/mailpoet/changelog/2026-08-28-09-00-41-fixed-other-plugins-may-break-navigation-on-mailpoet-adm.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Other plugins may break navigation on MailPoet admin pages

--- a/mailpoet/tests/javascript/common/functions/restore-stripped-location-hash.spec.ts
+++ b/mailpoet/tests/javascript/common/functions/restore-stripped-location-hash.spec.ts
@@ -1,0 +1,109 @@
+import { restoreStrippedLocationHash } from '../../../../assets/js/src/common/functions/restore-stripped-location-hash';
+
+type ReplaceStateCall = {
+  state: unknown;
+  url: string;
+};
+
+type StubOptions = {
+  hash?: string;
+  navigationUrl?: string | null;
+  performance?: { getEntriesByType: (type: string) => unknown } | 'missing';
+};
+
+const globals = global as unknown as {
+  window?: unknown;
+};
+
+const pathname = '/wp-admin/admin.php';
+const search = '?page=mailpoet-newsletters';
+
+function setupWindow({
+  hash = '',
+  navigationUrl = null,
+  performance,
+}: StubOptions = {}): ReplaceStateCall[] {
+  const replaceStateCalls: ReplaceStateCall[] = [];
+  globals.window = {
+    location: { hash, pathname, search },
+    performance:
+      performance === 'missing'
+        ? undefined
+        : performance ?? {
+            getEntriesByType: () =>
+              navigationUrl === null ? [] : [{ name: navigationUrl }],
+          },
+    history: {
+      state: { idx: 0 },
+      replaceState: (state: unknown, _title: string, url: string) => {
+        replaceStateCalls.push({ state, url });
+      },
+    },
+  };
+  return replaceStateCalls;
+}
+
+describe('restoreStrippedLocationHash', () => {
+  afterEach(() => {
+    delete globals.window;
+  });
+
+  it('restores a stripped "#/" hash from the navigation entry', () => {
+    const calls = setupWindow({
+      navigationUrl: `https://example.com${pathname}${search}#/send/1`,
+    });
+    restoreStrippedLocationHash();
+    expect(calls).to.have.lengthOf(1);
+    expect(calls[0].url).to.equal(`${pathname}${search}#/send/1`);
+    expect(calls[0].state).to.deep.equal({ idx: 0 });
+  });
+
+  it('does nothing when a hash is already present', () => {
+    const calls = setupWindow({
+      hash: '#/standard',
+      navigationUrl: `https://example.com${pathname}${search}#/send/1`,
+    });
+    restoreStrippedLocationHash();
+    expect(calls).to.have.lengthOf(0);
+  });
+
+  it('ignores fragments that are not router paths', () => {
+    const calls = setupWindow({
+      navigationUrl: `https://example.com${pathname}${search}#state=abc`,
+    });
+    restoreStrippedLocationHash();
+    expect(calls).to.have.lengthOf(0);
+  });
+
+  it('does nothing when the navigation entry has no fragment', () => {
+    const calls = setupWindow({
+      navigationUrl: `https://example.com${pathname}${search}`,
+    });
+    restoreStrippedLocationHash();
+    expect(calls).to.have.lengthOf(0);
+  });
+
+  it('does nothing when there is no navigation entry', () => {
+    const calls = setupWindow();
+    restoreStrippedLocationHash();
+    expect(calls).to.have.lengthOf(0);
+  });
+
+  it('does not throw when the performance API is unavailable', () => {
+    const calls = setupWindow({ performance: 'missing' });
+    expect(() => restoreStrippedLocationHash()).to.not.throw();
+    expect(calls).to.have.lengthOf(0);
+  });
+
+  it('does not throw when reading navigation entries fails', () => {
+    const calls = setupWindow({
+      performance: {
+        getEntriesByType: () => {
+          throw new Error('not supported');
+        },
+      },
+    });
+    expect(() => restoreStrippedLocationHash()).to.not.throw();
+    expect(calls).to.have.lengthOf(0);
+  });
+});


### PR DESCRIPTION
## Description

A customer reported that the classic editor's "Next" button returned them to the email listing instead of the Send step. The cause is a third-party plugin (Tourfic Pro) that removes the `#/...` part of the URL on every wp-admin page, which silently breaks navigation on MailPoet pages — deep links and in-editor steps land on the default screen.

This change protects all hash-routed MailPoet admin pages: when the URL fragment was removed before our page loads, we restore it and navigation works as expected.

## Code review notes

The restore is one-shot: it recovers a fragment removed before our bundle boots (the reported case — the offending script runs in `admin_head`). A script that removes the fragment later, or a back/forward navigation to an already rewritten history entry, cannot be recovered.

## QA notes

Replicate the conflict with this snippet (mu-plugin or Code Snippets), which mimics what Tourfic Pro does:

```php
add_action('admin_head', function () {
  echo "<script>(function(){var h=window.location.hash;if(h&&h.indexOf('#/')===0){history.replaceState(null,'',window.location.pathname+window.location.search);}})();</script>";
}, 1);
```

With the snippet active:

1. Create a standard newsletter in the classic editor and click **Next** on the Design step — without this fix you land on the email listing; with it you reach the Send step.
2. Open a deep link directly, e.g. `admin.php?page=mailpoet-newsletters#/send/<id>` or `admin.php?page=mailpoet-settings#/advanced` — the URL keeps its `#/...` part and the right screen opens.
3. Remove the snippet and verify pages behave as before.

## Linked PRs

_N/A_

## Linked tickets

- [STOMAIL-8430](https://linear.app/a8c/issue/STOMAIL-8430/classic-editor-next-bounces-to-email-listing-when-tourfic-pro-is)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:next-button-redirect)

_The latest successful build from `next-button-redirect` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->