### PR TITLE
Fix form editor crash on Custom CSS panel close

### DIFF
--- a/mailpoet/assets/js/src/form-editor/components/form-settings/codemirror-wrap.jsx
+++ b/mailpoet/assets/js/src/form-editor/components/form-settings/codemirror-wrap.jsx
@@ -46,7 +46,13 @@ function CodemirrorWrap({ value, onChange, options = defaultOptions }) {
 
     return () => {
       codeMirror.off?.('change', handleChange);
-      codeMirror.toTextArea?.();
+      // toTextArea() throws when the textarea is detached — React removes
+      // the DOM before running this cleanup on unmount
+      if (textarea.isConnected) {
+        codeMirror.toTextArea?.();
+      } else {
+        codeMirror.getWrapperElement?.()?.remove();
+      }
       codeMirrorRef.current = null;
     };
   }, [options.lineNumbers, options.matchBrackets, options.tabMode]);

--- a/mailpoet/changelog/2026-08-28-09-27-19-fixed-form-editor-crashing-when-closing-the-custom-css-p.md
+++ b/mailpoet/changelog/2026-08-28-09-27-19-fixed-form-editor-crashing-when-closing-the-custom-css-p.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Form editor crashing when closing the Custom CSS panel

--- a/mailpoet/tests/javascript/form-editor/components/codemirror-wrap.spec.ts
+++ b/mailpoet/tests/javascript/form-editor/components/codemirror-wrap.spec.ts
@@ -115,6 +115,57 @@ describe('CodemirrorWrap', () => {
     await act(async () => root.unmount());
   });
 
+  it('cleans up without crashing when unmounted with the textarea detached', async () => {
+    let initializedTextarea: HTMLTextAreaElement | undefined;
+    let wrapper: HTMLDivElement | undefined;
+    const codeMirror = {
+      getValue: () => 'body { color: red; }',
+      getWrapperElement: () => wrapper,
+      off: () => undefined,
+      on: () => undefined,
+      setValue: () => undefined,
+      // mimics CodeMirror 5: throws when the textarea is no longer in the DOM
+      toTextArea: () => {
+        if (!initializedTextarea?.parentNode) {
+          throw new TypeError(
+            "Cannot read properties of null (reading 'removeChild')",
+          );
+        }
+        wrapper?.remove();
+      },
+    };
+
+    (
+      window as unknown as {
+        wp: {
+          codeEditor: {
+            defaultSettings: Record<string, unknown>;
+            initialize: (textarea: HTMLTextAreaElement) => {
+              codemirror: typeof codeMirror;
+            };
+          };
+        };
+      }
+    ).wp = {
+      codeEditor: {
+        defaultSettings: {},
+        initialize: (textarea) => {
+          initializedTextarea = textarea;
+          wrapper = document.createElement('div');
+          textarea.parentNode?.insertBefore(wrapper, textarea.nextSibling);
+          return { codemirror: codeMirror };
+        },
+      },
+    };
+
+    const root = await renderCodemirrorWrap(() => undefined);
+    expect(wrapper?.isConnected).to.equal(true);
+
+    // React detaches the DOM before running passive effect cleanups
+    await act(async () => root.unmount());
+    expect(wrapper?.isConnected).to.equal(false);
+  });
+
   it('falls back to a textarea when the WordPress code editor is unavailable', async () => {
     const changes: string[] = [];
 


### PR DESCRIPTION
## Description

Closing the Custom CSS panel in the form editor crashed the whole editor. This fixes the cleanup of the code editor so the panel can be opened and closed safely.

## Code review notes

_N/A_

## QA notes

1. Open a form in the form editor.
2. In the sidebar, open the **Custom CSS** panel.
3. Close the panel (or switch panels).
4. The editor should keep working — before the fix it crashed with an error boundary.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8432](https://linear.app/a8c/issue/STOMAIL-8432/form-editor-crashes-when-closing-the-custom-css-panel)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-codemirror-cleanup)

_The latest successful build from `fix-codemirror-cleanup` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->