### PR TITLE
Guard email editor against re-entrant replace_editor

### DIFF
--- a/mailpoet/changelog/2026-08-28-13-46-12-fixed-email-editor-loading-in-a-broken-unclickable-state.md
+++ b/mailpoet/changelog/2026-08-28-13-46-12-fixed-email-editor-loading-in-a-broken-unclickable-state.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Email editor loading in a broken, unclickable state when Yoast SEO Premium is active
+New block email editor loading in a broken, unclickable state when Yoast SEO Premium is active

--- a/mailpoet/changelog/2026-08-28-13-46-12-fixed-email-editor-loading-in-a-broken-unclickable-state.md
+++ b/mailpoet/changelog/2026-08-28-13-46-12-fixed-email-editor-loading-in-a-broken-unclickable-state.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Email editor loading in a broken, unclickable state when Yoast SEO Premium is active

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -33,6 +33,8 @@ class EmailEditor {
 
   private NewslettersRepository $newslettersRepository;
 
+  private bool $editorAlreadyRendered = false;
+
   public function __construct(
     WPFunctions $wp,
     EmailApiController $emailApiController,
@@ -120,8 +122,16 @@ class EmailEditor {
   }
 
   public function replaceEditor($replace, $post) {
-    $currentScreen = get_current_screen();
+    $currentScreen = $this->wp->getCurrentScreen();
     if ($post->post_type === self::MAILPOET_EMAIL_POST_TYPE && $currentScreen) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      // The no-arg WP_Screen::get() re-fires this filter, and some plugins (e.g. Yoast SEO
+      // Premium) call it during admin_enqueue_scripts — while render() is still printing
+      // the admin header. Rendering again would echo a second editor container into <head>
+      // and leave the editor unresponsive, so only report that the editor was replaced.
+      if ($this->editorAlreadyRendered) {
+        return true;
+      }
+      $this->editorAlreadyRendered = true;
       $this->editorPageRenderer->render();
       return true;
     }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailEditorTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailEditorTest.php
@@ -23,14 +23,20 @@ class EmailEditorTest extends \MailPoetTest {
 
   public function testItRendersEditorOnlyOnceWhenReplaceEditorFilterIsReentered() {
     $renderer = $this->createMock(EditorPageRenderer::class);
-    $renderer->expects($this->once())->method('render');
     $emailEditor = $this->getServiceWithOverrides(EmailEditor::class, ['editorPageRenderer' => $renderer]);
     $this->setCurrentScreen('post');
     $post = new \WP_Post((object)['post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE]);
 
-    $this->assertTrue($emailEditor->replaceEditor(false, $post));
     // Simulates WP_Screen::get() firing the filter again while render() is printing the admin header
+    $nestedResult = null;
+    $renderer->expects($this->once())->method('render')->willReturnCallback(
+      function () use (&$nestedResult, $emailEditor, $post) {
+        $nestedResult = $emailEditor->replaceEditor(false, $post);
+      }
+    );
+
     $this->assertTrue($emailEditor->replaceEditor(false, $post));
+    $this->assertTrue($nestedResult);
   }
 
   private function setCurrentScreen(string $hookName): void {

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailEditorTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailEditorTest.php
@@ -21,8 +21,31 @@ class EmailEditorTest extends \MailPoetTest {
     $this->assertArrayHasKey('mailpoet_email', $postTypes);
   }
 
+  public function testItRendersEditorOnlyOnceWhenReplaceEditorFilterIsReentered() {
+    $renderer = $this->createMock(EditorPageRenderer::class);
+    $renderer->expects($this->once())->method('render');
+    $emailEditor = $this->getServiceWithOverrides(EmailEditor::class, ['editorPageRenderer' => $renderer]);
+    $this->setCurrentScreen('post');
+    $post = new \WP_Post((object)['post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE]);
+
+    $this->assertTrue($emailEditor->replaceEditor(false, $post));
+    // Simulates WP_Screen::get() firing the filter again while render() is printing the admin header
+    $this->assertTrue($emailEditor->replaceEditor(false, $post));
+  }
+
+  private function setCurrentScreen(string $hookName): void {
+    if (!function_exists('set_current_screen')) {
+      require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
+      require_once ABSPATH . 'wp-admin/includes/screen.php';
+    }
+    set_current_screen($hookName);
+  }
+
   public function _after() {
     parent::_after();
+    if (function_exists('set_current_screen')) {
+      set_current_screen('front');
+    }
     remove_filter('woocommerce_email_editor_post_types', [$this->emailEditor, 'addEmailPostType']);
     $this->truncateEntity(NewsletterEntity::class);
   }


### PR DESCRIPTION
## Description

With Yoast SEO Premium active, the block email editor loads in a broken state: it renders but nothing responds to clicks — canvas, sidebar, and toolbar are all dead.

The problem is that Yoast Premium calls `WP_Screen::get()->is_block_editor()` during `admin_enqueue_scripts`, and the no-arg `WP_Screen::get()` re-applies the `replace_editor`, which causes that the block editor's render is called twice.

This PR adds a re-entrancy guard: the first `replace_editor` call renders, any nested call just reports the editor as replaced. This protects the editor against any plugin that calls `WP_Screen::get()` during rendering, not just Yoast.

## Code review notes

- Backward compatibility: no public surface changes. Our `replace_editor` callback still returns `true`/`$replace` exactly as before for the documented single firing in `wp-admin/post.php`; only re-entrant firings within the same request behave differently (return `true` without rendering, which is also what any caller sampling the filter observes today once the editor page is being rendered).
- The guard is per-request instance state, not a static — the class is a DI singleton, so one flag per request.

## QA notes

1. Install Yoast SEO + Yoast SEO Premium (reproduced with 28.3).
2. Open any email in the new block email editor (`post.php?post=<id>&action=edit` for a `mailpoet_email` post).
3. Without this fix the editor is frozen — nothing reacts to clicks. With the fix it works normally.

Verified locally against Yoast SEO Premium 28.3 on WP 7.1 / WooCommerce 11.0.1: before the fix the page contains two `#mailpoet-email-editor` containers (one inside `<head>` in the raw HTML) and `document.elementFromPoint` returns the empty overlay everywhere; after the fix there is one container and the editor is interactive.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8433](https://linear.app/a8c/issue/STOMAIL-8433/yoast-seo-premium-breaks-the-block-email-editor-re-entrant-replace)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_ (the breakage is dead pointer events — not visible in a static screenshot)

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:yoast-mailpoet-conflict)

_The latest successful build from `yoast-mailpoet-conflict` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->