### PR TITLE
Keep HTML entities escaped in blockquote headings

### DIFF
--- a/mailpoet/changelog/2026-08-31-08-23-58-fixed-keep-html-entities-escaped-in-headings-inside-quot.md
+++ b/mailpoet/changelog/2026-08-31-08-23-58-fixed-keep-html-entities-escaped-in-headings-inside-quot.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Keep HTML entities escaped in headings inside quotes when rendering post content in emails

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
@@ -36,7 +36,7 @@ class Text {
       $paragraphs = $blockquote->query('p, h1, h2, h3, h4', 0);
       foreach ($paragraphs as $index => $paragraph) {
         if (preg_match('/h\d/', $paragraph->getTag())) {
-          $contents[] = $paragraph->getOuterText();
+          $contents[] = $paragraph->toString();
         } else {
           $contents[] = $paragraph->toString(true, true, 1);
         }

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
@@ -226,7 +226,7 @@ class TextTest extends \MailPoetUnitTest {
     return [
       'paragraph' => ["<p>Text &lt;script&gt;alert('test');&lt;/script&gt;</p>"],
       'list' => ["<ul>Text &lt;script&gt;alert('test');&lt;/script&gt;</li></ul>"],
-      'blockquote' => ["<ul>Text &lt;script&gt;alert('test');&lt;/script&gt;</li></ul>"],
+      'blockquote' => ["<blockquote><p>Text &lt;script&gt;alert('test');&lt;/script&gt;</p></blockquote>"],
     ];
   }
 

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
@@ -240,6 +240,28 @@ class TextTest extends \MailPoetUnitTest {
     verify($output)->stringContainsString("&lt;script&gt;alert('test');&lt;/script&gt;");
   }
 
+  public function blockquoteHeadingEntitiesStrings(): array {
+    return [
+      'h1 script' => ["<blockquote><h1>Heading &lt;script&gt;alert('test');&lt;/script&gt;</h1></blockquote>", '<script', "&lt;script&gt;alert('test');&lt;/script&gt;"],
+      'h2 img onerror' => ['<blockquote><h2>&lt;img src=x onerror=alert(document.domain)&gt;</h2></blockquote>', '<img', '&lt;img src=x onerror=alert(document.domain)&gt;'],
+      'h3 svg onload' => ['<blockquote><h3>Quote &lt;svg onload=alert(1)&gt;</h3></blockquote>', '<svg', '&lt;svg onload=alert(1)&gt;'],
+    ];
+  }
+
+  /**
+   * Headings inside a blockquote must keep HTML entities escaped. The renderer used to
+   * serialise them with getOuterText(), which html_entity_decode()s the content and turns
+   * escaped markup back into live tags re-parsed as HTML (stored XSS).
+   *
+   * @dataProvider blockquoteHeadingEntitiesStrings
+   */
+  public function testItDoesNotDecodeHtmlEntitiesInBlockquoteHeadings(string $htmlString, string $injectedTag, string $expectedEscaped): void {
+    $this->block['text'] = $htmlString;
+    $output = (new Text())->render($this->block);
+    verify($output)->stringNotContainsString($injectedTag);
+    verify($output)->stringContainsString($expectedEscaped);
+  }
+
   public function childElementStrings(): array {
     return [
       'paragraph' => ['<p><a href="https://example.com">Link</a></p>'],


### PR DESCRIPTION
## Description

The Text renderer serialised `h1`–`h4` headings inside a `<blockquote>` with `getOuterText()`, which runs `html_entity_decode()` on the content. Escaped entities in the source markup (e.g. `&lt;img …&gt;`) were therefore turned back into live tags when the result was re-inserted via `$blockquote->html(...)` and re-parsed as HTML. The sibling branches — paragraphs and lists — already serialise with `toString()` and never decode.

This switches the heading branch to `toString()` so entities stay escaped, matching the paragraph/list branches. The heading's tag and children are preserved, so `styleHeadings()` still styles it downstream; the rendered newsletter markup is otherwise unchanged.

## Code review notes

`toString()` (default args) returns the full outer HTML of the heading — tag plus recursive children — without the `html_entity_decode()` that `getOuterText()` adds. This mirrors the `<p>` branch a few lines below, which uses `toString(true, true, 1)`.

## QA notes

- New data-provider cases in `TextTest::testItDoesNotDecodeHtmlEntitiesInBlockquoteHeadings` cover a heading inside a blockquote with escaped markup; they fail before this change and pass after.
- `pnpm test:unit --file=tests/unit/Newsletter/Renderer/Blocks/TextTest.php` — 24 tests / 61 assertions green.
- PHPStan (changed files) and `./do qa:php` are clean.

Manual check: an Automated Latest Content block set to "Full post" that pulls in a post whose blockquote heading contains escaped markup now renders that markup as inert text in the emailed newsletter and in the browser preview.

## Linked PRs

_N/A_

## Linked tickets

closes STOMAIL-8435

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/alc-blockquote-headings)

_The latest successful build from `fix/alc-blockquote-headings` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->