### PR TITLE
Pass the link resolver to Clicks in the opt-out link test

### DIFF
--- a/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
@@ -508,6 +508,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(TrackingConfig::class),
       $this->diContainer->get(Request::class),
       $this->diContainer->get(TrackingConsentController::class),
+      $this->diContainer->get(PersonalizationTagLinkResolver::class),
     ], [
       // The redirect still happens: this is about not recording, not about
       // breaking the link.


### PR DESCRIPTION
Trunk has been red on `integration_test_base` and `integration_tests_multisite` since #7062 merged this morning.

```
[ArgumentCountError] Too few arguments to function
MailPoet\Statistics\Track\Clicks::__construct(), 11 passed and exactly 12 expected
#4 tests/integration/Statistics/Track/ClicksTest.php:499
```

Two PRs collided. #7055 gave `Clicks` a twelfth constructor argument, `PersonalizationTagLinkResolver`, and updated every `Stub::construct` that existed at the time. #7062 added a new one, written against a base where the twelfth argument did not exist yet. Both were green on their own base, we merge by rebase, and CI never ran the combination until it was on trunk.

This adds the missing argument. It is the only short call site left in the file; the other eighteen already pass the resolver.

Ran `./do test:integration --file 'tests/integration/Statistics/Track/ClicksTest.php'` locally: `OK (29 tests, 89 assertions)`. Stashing the one line reproduces the CI error exactly, so the fix is doing the work.

---

Not included, on purpose: `SendingQueuesResponseBuilderTest::testBuildReturnsExpectedResult` also failed once on trunk (job 435824) with a one-second timestamp difference. Different problem, not caused by these PRs, and it did not recur on the two later trunk commits. Worth its own issue if it comes back.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/clickstest-linkresolver-ctor-arity)

_The latest successful build from `fix/clickstest-linkresolver-ctor-arity` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->