### PR TITLE
Reject mis-cased method names in JSON API dispatch

### DIFF
--- a/mailpoet/changelog/2026-08-31-12-48-57-fixed-hardened-internal-json-api-dispatch-to-require-the.md
+++ b/mailpoet/changelog/2026-08-31-12-48-57-fixed-hardened-internal-json-api-dispatch-to-require-the.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Hardened internal JSON API dispatch to require the exact declared method name

--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -264,7 +264,13 @@ class API {
     if (method_exists(Endpoint::class, $requestMethod)) {
       return false;
     }
-    return (new \ReflectionMethod($endpoint, $requestMethod))->isPublic();
+    $method = new \ReflectionMethod($endpoint, $requestMethod);
+    // PHP resolves method names case-insensitively; require the exact declared casing
+    // so that every name-keyed lookup downstream matches the method that runs.
+    if ($method->getName() !== $requestMethod) {
+      return false;
+    }
+    return $method->isPublic();
   }
 
   public function validatePermissions($requestMethod, $permissions) {

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -378,6 +378,27 @@ class APITest extends \MailPoetTest {
     verify($api->validatePermissions('test', $permissions))->true();
   }
 
+  public function testItDoesNotDispatchMethodNamesWithMismatchedCasing() {
+    // PHP resolves method names case-insensitively, so 'Restricted' would otherwise
+    // invoke the stub's restricted() action while missing its method-specific
+    // permission entry (keyed on the declared 'restricted') and falling back to the
+    // laxer global permission. The dispatch guard requires the exact declared casing.
+    $this->api->addEndpointNamespace('MailPoet\API\JSON\v1', 'v1');
+
+    foreach (['Restricted', 'RESTRICTED', 'rEsTrIcTeD'] as $methodName) {
+      $this->api->setRequestData([
+        'endpoint' => 'a_p_i_test_namespaced_endpoint_stub_v1',
+        'method' => $methodName,
+        'api_version' => 'v1',
+        'data' => ['test' => 'data'],
+      ], Endpoint::TYPE_POST);
+      $response = $this->api->processRoute();
+
+      verify($response->status)->equals(Response::STATUS_BAD_REQUEST);
+      verify($response->errors[0]['message'])->equals('Invalid API endpoint method.');
+    }
+  }
+
   public function testItThrowsExceptionWhenInvalidEndpointMethodIsCalled() {
     $namespace = [
       'name' => 'MailPoet\API\JSON\v2',


### PR DESCRIPTION
## Description

The internal JSON API dispatch guard (`isDispatchableEndpointMethod()`)
already rejects methods that are not genuine endpoint actions — base-class
response helpers, non-public methods, and magic methods. PHP resolves and
invokes method names case-insensitively, so an action could still be reached
through a spelling other than its declared name (`Send` → `send()`), while the
dispatcher's name-keyed lookups (`isMethodAllowed()`, the `permissions`
`methods` map) key on the exact requested string — leaving those lookups
inconsistent with the method that actually runs.

This extends the same guard to require the reflected method name to match the
request exactly, so a method resolves only under its declared name. Mismatched
spellings are rejected with the existing `Invalid API endpoint method.` response,
the same way magic methods and non-public methods already are.

## Code review notes

- Implemented in the existing `isDispatchableEndpointMethod()` guard, reusing the
  `ReflectionMethod` it already constructs — this keeps the "reject non-genuine
  actions" logic in one place and follows the precedent set by the base-helper,
  non-public, and magic-method rejections already there.
- Rejection (rather than silently normalising the casing) is the deliberate choice:
  it matches how this guard treats every other illegitimate method input, keeps a
  single canonical spelling per action, and fails closed. No legitimate caller sends
  a non-canonical spelling — the admin JS uses the declared names, and the only other
  `processRoute()` caller (`Subscription\Form::onSubmit`) matches the exact string
  `subscribe` before dispatch.
- Endpoint-name resolution is unaffected and already case-sensitive at the container
  layer; this change concerns the method half of the route only.

## QA notes

New integration test `testItDoesNotDispatchMethodNamesWithMismatchedCasing`
asserts that `Restricted`, `RESTRICTED`, and `rEsTrIcTeD` are rejected with
`STATUS_BAD_REQUEST` + `Invalid API endpoint method.` (the stub's `restricted`
action carries a method-specific permission over an unrestricted global, so
before this change a mismatched spelling reached the action under the laxer
global permission). Verified RED without the guard line (the mismatched request
returns 200) and GREEN with it. Full file: 24 tests green.

Backward compatibility: internal JSON API dispatch only; no third-party contract,
hook, or REST signature changes.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8434

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I added sufficient test coverage

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8434-json-api-method-name-case-consistency)

_The latest successful build from `fix/stomail-8434-json-api-method-name-case-consistency` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->