### PR TITLE
Prevent accidentally dismissed admin notices

### DIFF
--- a/mailpoet/assets/js/src/dismissible-notice.jsx
+++ b/mailpoet/assets/js/src/dismissible-notice.jsx
@@ -5,14 +5,13 @@ jQuery(($) => {
     'click',
     '.mailpoet-dismissible-notice .notice-dismiss',
     function dismiss() {
-      const type = $(this)
-        .closest('.mailpoet-dismissible-notice')
-        .data('notice');
+      const notice = $(this).closest('.mailpoet-dismissible-notice');
       $.ajax(window.ajaxurl, {
         type: 'POST',
         data: {
           action: 'dismissed_notice_handler',
-          type,
+          type: notice.data('notice'),
+          nonce: notice.data('nonce'),
         },
       });
     },

--- a/mailpoet/assets/js/src/dismissible-notice.jsx
+++ b/mailpoet/assets/js/src/dismissible-notice.jsx
@@ -6,11 +6,14 @@ jQuery(($) => {
     '.mailpoet-dismissible-notice .notice-dismiss',
     function dismiss() {
       const notice = $(this).closest('.mailpoet-dismissible-notice');
+      const type = notice.data('notice');
+      // notices without a name render no data attributes and cannot be persisted
+      if (!type) return;
       $.ajax(window.ajaxurl, {
         type: 'POST',
         data: {
           action: 'dismissed_notice_handler',
-          type: notice.data('notice'),
+          type,
           nonce: notice.data('nonce'),
         },
       });

--- a/mailpoet/changelog/2026-09-02-09-26-16-improved-validation-of-the-admin-notice-dismissal-request.md
+++ b/mailpoet/changelog/2026-09-02-09-26-16-improved-validation-of-the-admin-notice-dismissal-request.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Validation of the admin notice dismissal request

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Util\Notices;
 
+use MailPoet\Config\AccessControl;
 use MailPoet\Config\Menu;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Cron\CronHelper;
@@ -13,6 +14,7 @@ use MailPoet\Settings\TrackingConfig;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WP\Notice;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class PermanentNotices {
@@ -197,8 +199,27 @@ class PermanentNotices {
   }
 
   public function ajaxDismissNoticeHandler() {
-    if (!isset($_POST['type'])) return;
-    switch ($_POST['type']) {
+    if (!$this->wp->currentUserCan(AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN)) {
+      $this->wp->wpDie(
+        esc_html__('You do not have permission to perform this action.', 'mailpoet'),
+        esc_html__('Unauthorized', 'mailpoet'),
+        ['response' => 403]
+      );
+      return;
+    }
+
+    $nonce = isset($_POST['nonce']) && is_string($_POST['nonce']) ? sanitize_text_field(wp_unslash($_POST['nonce'])) : '';
+    if (!$this->wp->wpVerifyNonce($nonce, Notice::DISMISS_NONCE_ACTION)) {
+      $this->wp->wpDie(
+        esc_html__('Security check failed.', 'mailpoet'),
+        esc_html__('Error', 'mailpoet'),
+        ['response' => 403]
+      );
+      return;
+    }
+
+    if (!isset($_POST['type']) || !is_string($_POST['type'])) return;
+    switch (sanitize_text_field(wp_unslash($_POST['type']))) {
       case (PHPVersionWarnings::OPTION_NAME):
         $this->phpVersionWarnings->disable();
         break;

--- a/mailpoet/lib/WP/Notice.php
+++ b/mailpoet/lib/WP/Notice.php
@@ -6,6 +6,8 @@ use MailPoet\WP\Functions as WPFunctions;
 
 class Notice {
 
+  const DISMISS_NONCE_ACTION = 'mailpoet-dismiss-notice';
+
   const TYPE_ERROR = 'error';
   const TYPE_WARNING = 'warning';
   const TYPE_SUCCESS = 'success';
@@ -17,18 +19,23 @@ class Notice {
   private $dataNoticeName;
   private $renderInParagraph;
 
+  /** @var WPFunctions */
+  private $wp;
+
   public function __construct(
     $type,
     $message,
     $classes = '',
     $dataNoticeName = '',
-    $renderInParagraph = true
+    $renderInParagraph = true,
+    ?WPFunctions $wp = null
   ) {
     $this->type = $type;
     $this->message = $message;
     $this->classes = $classes;
     $this->dataNoticeName = $dataNoticeName;
     $this->renderInParagraph = $renderInParagraph;
+    $this->wp = $wp ?? WPFunctions::get();
   }
 
   public function getMessage() {
@@ -60,7 +67,7 @@ class Notice {
 
   protected static function createNotice($type, $message, $classes, $dataNoticeName, $renderInParagraph) {
     $notice = new Notice($type, $message, $classes, $dataNoticeName, $renderInParagraph);
-    WPFunctions::get()->addAction('admin_notices', [$notice, 'displayWPNotice']);
+    $notice->wp->addAction('admin_notices', [$notice, 'displayWPNotice']);
     return $notice;
   }
 
@@ -68,20 +75,11 @@ class Notice {
     $class = sprintf('notice notice-%s mailpoet_notice_server %s', $this->type, $this->classes);
     $message = nl2br($this->message);
 
-    if ($this->renderInParagraph) {
-      printf(
-        '<div class="%1$s" %3$s><p>%2$s</p></div>',
-        esc_attr($class),
-        wp_kses_post($message),
-        !empty($this->dataNoticeName) ? sprintf('data-notice="%s"', esc_attr($this->dataNoticeName)) : ''
-      );
-    } else {
-      printf(
-        '<div class="%1$s" %3$s>%2$s</div>',
-        esc_attr($class),
-        wp_kses_post($message),
-        !empty($this->dataNoticeName) ? sprintf('data-notice="%s"', esc_attr($this->dataNoticeName)) : ''
-      );
-    }
+    printf(
+      $this->renderInParagraph ? '<div class="%1$s" %3$s><p>%2$s</p></div>' : '<div class="%1$s" %3$s>%2$s</div>',
+      esc_attr($class),
+      wp_kses_post($message),
+      !empty($this->dataNoticeName) ? sprintf('data-notice="%s" data-nonce="%s"', esc_attr($this->dataNoticeName), esc_attr($this->wp->wpCreateNonce(self::DISMISS_NONCE_ACTION))) : ''
+    );
   }
 }

--- a/mailpoet/tests/integration/Util/Notices/PermanentNoticesTest.php
+++ b/mailpoet/tests/integration/Util/Notices/PermanentNoticesTest.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util\Notices;
+
+use Codeception\Stub\Expected;
+use Codeception\Util\Stub;
+use MailPoet\Config\ServicesChecker;
+use MailPoet\Cron\CronHelper;
+use MailPoet\Mailer\MailerFactory;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Services\AuthorizedSenderDomainController;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\TrackingConfig;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WP\Notice;
+
+class PermanentNoticesTest extends \MailPoetTest {
+  public function _before() {
+    parent::_before();
+    delete_transient(PHPVersionWarnings::OPTION_NAME);
+  }
+
+  public function _after() {
+    parent::_after();
+    unset($_POST['type'], $_POST['nonce']);
+    delete_transient(PHPVersionWarnings::OPTION_NAME);
+  }
+
+  public function testItRefusesDismissWithoutCapability() {
+    $wp = Stub::make(new WPFunctions, [
+      'currentUserCan' => false,
+      'wpVerifyNonce' => Expected::never(),
+      'wpDie' => Expected::once(),
+    ], $this);
+
+    $_POST['type'] = PHPVersionWarnings::OPTION_NAME;
+    $_POST['nonce'] = 'irrelevant';
+    $this->createPermanentNotices($wp)->ajaxDismissNoticeHandler();
+
+    verify(get_transient(PHPVersionWarnings::OPTION_NAME))->false();
+  }
+
+  public function testItRefusesDismissWithInvalidNonce() {
+    $wp = Stub::make(new WPFunctions, [
+      'currentUserCan' => true,
+      'wpVerifyNonce' => Expected::once(false),
+      'wpDie' => Expected::once(),
+    ], $this);
+
+    $_POST['type'] = PHPVersionWarnings::OPTION_NAME;
+    $_POST['nonce'] = 'invalid';
+    $this->createPermanentNotices($wp)->ajaxDismissNoticeHandler();
+
+    verify(get_transient(PHPVersionWarnings::OPTION_NAME))->false();
+  }
+
+  public function testItDismissesNoticeWithCapabilityAndValidNonce() {
+    $wp = Stub::make(new WPFunctions, [
+      'currentUserCan' => true,
+      'wpVerifyNonce' => Expected::once(function ($nonce, $action) {
+        verify($nonce)->equals('valid-nonce');
+        verify($action)->equals(Notice::DISMISS_NONCE_ACTION);
+        return true;
+      }),
+      'wpDie' => Expected::never(),
+    ], $this);
+
+    $_POST['type'] = PHPVersionWarnings::OPTION_NAME;
+    $_POST['nonce'] = 'valid-nonce';
+    $this->createPermanentNotices($wp)->ajaxDismissNoticeHandler();
+
+    verify(get_transient(PHPVersionWarnings::OPTION_NAME))->true();
+  }
+
+  public function testDismissibleNoticeMarkupContainsNonce() {
+    $wp = Stub::make(new WPFunctions, [
+      'wpCreateNonce' => Expected::once(function ($action) {
+        verify($action)->equals(Notice::DISMISS_NONCE_ACTION);
+        return 'test-nonce';
+      }),
+    ], $this);
+    $notice = new Notice(Notice::TYPE_WARNING, 'A message', '', 'some-notice-name', true, $wp);
+    ob_start();
+    $notice->displayWPNotice();
+    $output = ob_get_clean();
+
+    verify($output)->stringContainsString('data-notice="some-notice-name"');
+    verify($output)->stringContainsString('data-nonce="test-nonce"');
+  }
+
+  private function createPermanentNotices(WPFunctions $wp): PermanentNotices {
+    return new PermanentNotices(
+      $wp,
+      $this->diContainer->get(CronHelper::class),
+      $this->entityManager,
+      $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(SettingsController::class),
+      $this->diContainer->get(SubscribersFeature::class),
+      $this->diContainer->get(ServicesChecker::class),
+      $this->diContainer->get(MailerFactory::class),
+      $this->diContainer->get(SenderDomainAuthenticationNotices::class),
+      $this->diContainer->get(AuthorizedSenderDomainController::class),
+      $this->diContainer->get(NewslettersRepository::class)
+    );
+  }
+}

--- a/mailpoet/tests/integration/Util/Notices/PermanentNoticesTest.php
+++ b/mailpoet/tests/integration/Util/Notices/PermanentNoticesTest.php
@@ -90,6 +90,18 @@ class PermanentNoticesTest extends \MailPoetTest {
     verify($output)->stringContainsString('data-nonce="test-nonce"');
   }
 
+  public function testDismissibleNoticeMarkupContainsNonceWithoutParagraph() {
+    $wp = Stub::make(new WPFunctions, ['wpCreateNonce' => 'test-nonce']);
+    $notice = new Notice(Notice::TYPE_WARNING, 'A message', '', 'some-notice-name', false, $wp);
+    ob_start();
+    $notice->displayWPNotice();
+    $output = ob_get_clean();
+
+    verify($output)->stringContainsString('data-notice="some-notice-name"');
+    verify($output)->stringContainsString('data-nonce="test-nonce"');
+    verify($output)->stringNotContainsString('<p>');
+  }
+
   private function createPermanentNotices(WPFunctions $wp): PermanentNotices {
     return new PermanentNotices(
       $wp,


### PR DESCRIPTION
## Description

This PR fixes an issue where important notices might be dismissed by accident by any user and admin may miss important info.

## Code review notes

- The capability is `mailpoet_access_plugin_admin` rather than `manage_options`: editors can see these notices on MailPoet pages, so they must also be able to dismiss them.
- The approach mirrors the footer rating handler fix (STOMAIL-7609).

## QA notes

- On a MailPoet admin page with a dismissible MailPoet notice, dismissing it should still work and the notice should stay hidden after reload.
- A direct `POST` to `admin-ajax.php` with `action=dismissed_notice_handler` and no nonce should return HTTP 403 and leave the notice visible.

### How to test

1. Trigger a dismissible notice:
   ```bash
   pnpm wp eval 'MailPoet\DI\ContainerWrapper::getInstance()->get(MailPoet\Settings\SettingsController::class)->set("mailpoet_display_after_migration_notice", true);'
2. Open any MailPoet admin page (e.g. wp-admin/admin.php?page=mailpoet-homepage) — a green "Congrats! You're progressing well so far…" notice appears.
3. Dismiss it with the ✕ — the admin-ajax.php request returns 200 and the notice stays gone after reload.
4. Re-run step 1, then on any wp-admin page run in the browser console:
fetch(ajaxurl, {method: 'POST', body: new URLSearchParams({action: 'dismissed_notice_handler', type: 'mailpoet_display_after_migration_notice'})}).then((r) => console.log(r.status));
   Expect 403; the notice is still there after reload.


## Linked PRs

_N/A_

## Linked tickets

- [STOMAIL-8404](https://linear.app/a8c/issue/STOMAIL-8404/sec-2-missing-capability-nonce-on-notice-dismiss-ajax-15)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-notice-dismiss-nonce)

_The latest successful build from `fix-notice-dismiss-nonce` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->