### PR TITLE
Add the tracking opt-out footer as a whole row, so the sent email keeps it

### DIFF
--- a/mailpoet/assets/js/src/newsletter-editor/components/save.js
+++ b/mailpoet/assets/js/src/newsletter-editor/components/save.js
@@ -401,6 +401,7 @@ Module.SaveView = Marionette.View.extend({
     var footer;
     var FooterModel;
     var footerBlock;
+    var ContainerModel;
     linkHtml =
       '<a href="[link:subscription_tracking_opt_out_url]">' +
       __('Opt out of tracking', 'mailpoet') +
@@ -418,12 +419,30 @@ Module.SaveView = Marionette.View.extend({
       // the repaint explicitly.
       footer.trigger('redraw');
     } else {
-      // No footer block at all: add one at the end of the content container.
-      // Its defaults already carry the unsubscribe and manage links.
+      // No footer block at all: add one as a new row at the end of the content
+      // container. Its defaults already carry the unsubscribe and manage links.
+      //
+      // The row has to be built the way the layout widgets build one -- a
+      // horizontal container holding a vertical container per column -- because
+      // the root container only ever holds rows. A leaf block dropped straight
+      // into the root draws on the canvas and passes validation, but the
+      // renderer skips any top-level block with no `blocks` of its own, so the
+      // sent email would carry no footer at all.
       FooterModel = App.getBlockTypeModel('footer');
       footerBlock = new FooterModel({ type: 'footer' });
       footerBlock.set('text', footerBlock.get('text') + '<br />' + linkHtml);
-      App._contentContainer.get('blocks').add(footerBlock);
+      ContainerModel = App.getBlockTypeModel('container');
+      App._contentContainer.get('blocks').add(
+        new ContainerModel({
+          orientation: 'horizontal',
+          blocks: [
+            new ContainerModel({
+              orientation: 'vertical',
+              blocks: [footerBlock],
+            }),
+          ],
+        }),
+      );
     }
     this.validateNewsletter(App.toJSON());
   },

--- a/mailpoet/changelog/2026-09-01-11-15-36-fixed-on-an-email-with-no-footer-the-one-click-way-to-ad.md
+++ b/mailpoet/changelog/2026-09-01-11-15-36-fixed-on-an-email-with-no-footer-the-one-click-way-to-ad.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+On an email with no footer, the one-click way to add a tracking opt-out link now adds a footer the sent email actually keeps

--- a/mailpoet/tests/integration/Newsletter/Renderer/TrackingOptOutTextPartTest.php
+++ b/mailpoet/tests/integration/Newsletter/Renderer/TrackingOptOutTextPartTest.php
@@ -46,6 +46,56 @@ class TrackingOptOutTextPartTest extends \MailPoetTest {
     verify($rendered['text'])->stringNotContainsString('subscription_tracking_opt_out_url');
   }
 
+  /**
+   * STOMAIL-8446. On an email with no footer, the editor's one-click fix builds
+   * a footer of its own. It has to build a whole row -- horizontal container,
+   * vertical container, footer -- because the renderer skips any top-level
+   * block that has no `blocks` of its own, and skips it silently. The first
+   * version of that fix added the footer straight to the root, so the canvas
+   * showed a footer the subscriber never received.
+   */
+  public function testItRendersAFooterAddedAsItsOwnRow(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Footer added by the editor')
+      ->withBody($this->bodyWithFooterRow())
+      ->create();
+
+    $rendered = $this->renderer->render($newsletter);
+    $this->assertIsArray($rendered);
+
+    verify($rendered['html'])->stringNotContainsString('Skipped unsupported block');
+    verify($rendered['html'])->stringContainsString('subscription_tracking_opt_out_url');
+    verify($rendered['html'])->stringContainsString('subscription_unsubscribe_url');
+    verify($rendered['text'])->stringContainsString('subscription_tracking_opt_out_url');
+    verify($rendered['text'])->stringContainsString('Opt out of tracking');
+  }
+
+  /**
+   * The trap the test above guards against, stated outright: the root content
+   * container holds rows, so a footer put there directly is dropped, and
+   * dropped without a word in the log or the UI. This is what makes the shape
+   * the editor produces worth asserting rather than assuming.
+   */
+  public function testItSkipsAFooterPutStraightIntoTheRootContainer(): void {
+    $body = $this->body('Hello there.');
+    $body['content']['blocks'][] = [
+      'type' => 'footer',
+      'text' => '<a href="[link:subscription_tracking_opt_out_url]">Opt out of tracking</a>',
+      'styles' => ['block' => ['backgroundColor' => 'transparent']],
+    ];
+
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Footer in the wrong place')
+      ->withBody($body)
+      ->create();
+
+    $rendered = $this->renderer->render($newsletter);
+    $this->assertIsArray($rendered);
+
+    verify($rendered['html'])->stringContainsString('Skipped unsupported block type: footer');
+    verify($rendered['html'])->stringNotContainsString('subscription_tracking_opt_out_url');
+  }
+
   private function bodyWithOptOutLink(): array {
     return $this->body(
       'Hello there.<br /><a href="[link:subscription_tracking_opt_out_url]">Opt out of tracking</a>'
@@ -93,5 +143,39 @@ class TrackingOptOutTextPartTest extends \MailPoetTest {
         'body' => ['backgroundColor' => '#eeeeee'],
       ],
     ];
+  }
+
+  /**
+   * A text row followed by the footer row the editor adds when the email has no
+   * footer: the same row -> column -> block nesting every layout widget builds.
+   */
+  private function bodyWithFooterRow(): array {
+    $body = $this->body('Hello there.');
+    $body['content']['blocks'][] = [
+      'type' => 'container',
+      'orientation' => 'horizontal',
+      'styles' => ['block' => ['backgroundColor' => 'transparent']],
+      'blocks' => [
+        [
+          'type' => 'container',
+          'orientation' => 'vertical',
+          'styles' => ['block' => ['backgroundColor' => 'transparent']],
+          'blocks' => [
+            [
+              'type' => 'footer',
+              'text' => '<a href="[link:subscription_unsubscribe_url]">Unsubscribe</a> | '
+                . '<a href="[link:subscription_manage_url]">Manage subscription</a>'
+                . '<br /><a href="[link:subscription_tracking_opt_out_url]">Opt out of tracking</a>',
+              'styles' => [
+                'block' => ['backgroundColor' => 'transparent'],
+                'text' => ['fontColor' => '#000000', 'fontFamily' => 'Arial', 'fontSize' => '12px', 'textAlign' => 'center'],
+                'link' => ['fontColor' => '#0000ff', 'textDecoration' => 'none'],
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+    return $body;
   }
 }

--- a/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/components/save.spec.js
+++ b/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/components/save.spec.js
@@ -1,6 +1,8 @@
 import { App } from 'newsletter-editor/app';
 import { SaveComponent } from 'newsletter-editor/components/save';
 import { CommunicationComponent } from 'newsletter-editor/components/communication';
+import { ContainerBlock } from 'newsletter-editor/blocks/container';
+import { FooterBlock } from 'newsletter-editor/blocks/footer';
 import { MailPoet } from 'mailpoet';
 import jQuery from 'jquery';
 
@@ -140,6 +142,7 @@ describe('Save', function () {
       var errorCountFor;
       var optOutFooter =
         '<a href="[link:subscription_tracking_opt_out_url]">x</a>';
+      var stubEmptyContentContainer;
       beforeEach(function () {
         model = new Backbone.SuperModel({});
         model.isWoocommerceTransactional = function () {
@@ -185,6 +188,33 @@ describe('Save', function () {
         expect(showValidationErrorStub.callCount).to.be.equal(1);
       });
 
+      // The no-footer branch builds real block models, so the spec hands it the
+      // real constructors rather than stubs -- the shape they produce is the
+      // thing under test.
+      stubEmptyContentContainer = function (collector) {
+        // Building the models fires 'add'/'change', which both reach for the
+        // channel.
+        global.stubChannel(App);
+        App.getBlockTypeModel = sinon.stub();
+        App.getBlockTypeModel
+          .withArgs('footer')
+          .returns(FooterBlock.FooterBlockModel);
+        App.getBlockTypeModel
+          .withArgs('container')
+          .returns(ContainerBlock.ContainerBlockModel);
+        App._contentContainer = {
+          isValid: sinon.stub().returns(true),
+          get: sinon
+            .stub()
+            .withArgs('blocks')
+            .returns({
+              add: function (block) {
+                collector.push(block);
+              },
+            }),
+        };
+      };
+
       errorCountFor = function (settingOn, footerText) {
         var stub;
         global.stubConfig(App, {
@@ -229,6 +259,60 @@ describe('Save', function () {
         expect(footer.set.firstCall.args[1]).to.contain(
           '[link:subscription_tracking_opt_out_url]',
         );
+      });
+
+      it('adds the footer as a whole new row when the email has none', function () {
+        // The root content container only holds rows: a horizontal container
+        // per row, a vertical container per column inside it, leaf blocks
+        // inside those. A footer added straight to the root draws on the
+        // canvas and passes validation, but Columns\Renderer skips any
+        // top-level block with no `blocks` of its own, so the sent email would
+        // carry neither the opt-out link nor the unsubscribe link.
+        var added = [];
+        var row;
+        var column;
+        var footer;
+        stubEmptyContentContainer(added);
+        App.findModels = sinon.stub().returns([]);
+        sinon.stub(view, 'validateNewsletter');
+
+        view.addTrackingOptOutLink();
+
+        expect(added.length).to.be.equal(1);
+        row = added[0];
+        expect(row.get('type')).to.be.equal('container');
+        expect(row.get('orientation')).to.be.equal('horizontal');
+
+        column = row.get('blocks').at(0);
+        expect(column.get('type')).to.be.equal('container');
+        expect(column.get('orientation')).to.be.equal('vertical');
+
+        footer = column.get('blocks').at(0);
+        expect(footer.get('type')).to.be.equal('footer');
+        expect(footer.get('text')).to.contain(
+          '[link:subscription_tracking_opt_out_url]',
+        );
+      });
+
+      it('keeps the unsubscribe links the new footer comes with', function () {
+        // The footer defaults carry them, and on a footerless email this block
+        // is the only place a subscriber can unsubscribe from.
+        var added = [];
+        var footerText;
+        stubEmptyContentContainer(added);
+        App.findModels = sinon.stub().returns([]);
+        sinon.stub(view, 'validateNewsletter');
+
+        view.addTrackingOptOutLink();
+
+        footerText = added[0]
+          .get('blocks')
+          .at(0)
+          .get('blocks')
+          .at(0)
+          .get('text');
+        expect(footerText).to.contain('[link:subscription_unsubscribe_url]');
+        expect(footerText).to.contain('[link:subscription_manage_url]');
       });
 
       it('asks the footer to repaint, since change:text does not re-render it', function () {


### PR DESCRIPTION
## Description

Fixes [STOMAIL-8446](https://linear.app/a8c/issue/STOMAIL-8446), a regression from #7061 that the AI regression review caught on trunk.

#7061 added a one-click "Click here to add it" fix for the missing tracking opt-out link. When the email already has a footer, the link is appended to it and everything works. When the email has **no** footer, the handler built one and put it straight into the root content container.

The root container only ever holds rows. `Columns\Renderer` skips any top-level block that has no `blocks` of its own, so the footer was dropped at send time and the comment `<!-- Skipped unsupported block type: footer -->` went out in its place. The canvas still drew the footer and `validateNewsletter` still passed, because the shortcode is in the serialised JSON. So the person editing got a clear "fixed it" signal and their subscribers got an email with no opt-out link and no unsubscribe link. On the one feature whose whole job is keeping those links in the email.

This builds the footer the way every layout widget builds a row instead: horizontal container, vertical container, footer.

## Code review notes

- The `else` branch in `addTrackingOptOutLink` now mirrors `OneColumnContainerWidgetView.drop()` in `blocks/container.js`, which is the established shape for a new row. The `if` branch (email already has a footer) is untouched.
- The two new specs in `save.spec.js` fail on trunk. They hand the handler the real `FooterBlockModel` and `ContainerBlockModel` rather than stubs, because the shape those constructors produce is the thing under test.
- `TrackingOptOutTextPartTest` gains two cases. One renders the shape the editor now produces and asserts the links survive into HTML and text. Its neighbour asserts that a footer put straight into the root **is** skipped, so the next reader can see why the nesting matters rather than having to trust a comment.
- This was reachable because `editor.html:1891` deliberately does not gate the tracking check on the sending service, the way the unsubscribe check on line 1887 does. That asymmetry is correct and stays.

## QA notes

Local site, MailPoet Sending Service off, tracking consent set to **Ask everyone**, both values read back through the container rather than from what was written:

```
subscriber_choice=ask_all
mss_active=false
```

Steps, on an email with no footer block anywhere:

1. Open it in the legacy editor. The tracking error shows with "Click here to add it".
2. Click it. The error clears and a footer appears on the canvas.
3. Read the saved JSON back from the database:

```
root[1] type=container orientation=horizontal children=1
   [1][0] type=container orientation=vertical children=1
      [1][0][0] type=footer
```

4. Send it for real to a confirmed subscriber and read the delivered mail out of Mailpit:

```
HTML has 'Skipped unsupported block': False
HTML has 'Opt out of tracking':       True
HTML has 'Unsubscribe':               True
TEXT has 'Opt out of tracking':       True
```

5. The resolved per-subscriber `action=tracking_opt_out` URL in the delivered mail answers HTTP 200.
6. Repeated on an email that **already** has a footer: still 2 rows, still 1 footer, 1 opt-out link, appended in place. No extra row, no duplicate footer.

Automated: `test:newsletter-editor` 478 passing (three runs, all green; baseline on trunk is 476), `test:javascript` 408 passing, `test:integration --file tests/integration/Newsletter/Renderer` OK 9 tests / 35 assertions, plus `qa:lint-javascript`, `qa:php` and `qa:prettier` clean.

One thing to know: `Spacer -> model -> triggers autosave if any attribute changes` fails intermittently with `Anonymous mock already called twice`, from a debounced timer in `media-manager-behavior.js` fired by an earlier container spec. It is **not** from this PR: I stashed every change, recompiled and ran the suite three times on plain trunk, and the third run failed with the same stack. Worth its own ticket.

## Linked PRs

Fixes a regression introduced by #7061.

## Linked tickets

- [STOMAIL-8446](https://linear.app/a8c/issue/STOMAIL-8446)
- Caused by [STOMAIL-8313](https://linear.app/a8c/issue/STOMAIL-8313)

## After-merge notes

Nothing to do. The bug only ever existed on trunk, between #7061 landing and this PR, so no released version is affected.

## Screenshots or screencast

The email a subscriber actually receives, after clicking "Click here to add it" on a footerless newsletter.

| Before                                | After                                |
| ------------------------------------- | ------------------------------------ |
| ![before](https://d.pr/i/2Drssl+)     | ![after](https://d.pr/i/5vY3wl+)     |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

The legacy newsletter editor is Backbone and is not being extended, so this stays where it is rather than dragging `save.js` into TypeScript for a five-line fix.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8446-footer-block-dropped)

_The latest successful build from `fix/stomail-8446-footer-block-dropped` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->