### PR TITLE
Shorten the tracking consent changelog entries

### DIFF
--- a/mailpoet/changelog/2026-08-24-12-15-00-improved-subscriber-import-and-export-now-carry-tracking.md
+++ b/mailpoet/changelog/2026-08-24-12-15-00-improved-subscriber-import-and-export-now-carry-tracking.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Subscriber import and export now carry tracking consent: the state, when it changed, how it was collected, and the wording the subscriber saw. Exporting a list and importing it back keeps who opted in or out, and a CSV can set consent directly when you are migrating it from another system. A blank consent cell, or a CSV with no consent column, never changes what a subscriber already chose
+Subscriber import and export now carry tracking consent: the state, when it changed, how it was collected, and the wording the subscriber saw

--- a/mailpoet/changelog/2026-08-24-added-admins-can-now-see-and-set-a-subscribers-tracking.md
+++ b/mailpoet/changelog/2026-08-24-added-admins-can-now-see-and-set-a-subscribers-tracking.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Admins can now see a subscriber's email-tracking-consent state on the edit-subscriber page: what it is, when it changed, and how it was recorded. They can also set it themselves, which is what you need when someone asks to opt in or out by email or by phone. To find everyone in one state, filter the Subscribers list with the tracking-consent segment. None of this changes what tracking a subscriber actually receives.
+Admins can now see and set a subscriber's email-tracking-consent state on the edit-subscriber page: what it is, when it changed, and how it was recorded

--- a/mailpoet/changelog/2026-08-24-fixed-three-places-where-a-subscribers-tracking-choice.md
+++ b/mailpoet/changelog/2026-08-24-fixed-three-places-where-a-subscribers-tracking-choice.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Three places where a subscriber's tracking choice was lost or ignored. A first-time guest who leaves the tracking box unticked at checkout is now recorded as having declined, on both the classic and the block checkout. Registration and comment forms now record the tracking choice even when the "add me to your mailing list" box is left unticked, since those are two separate decisions. And clicking the tracking opt-out link in an email footer no longer records that click, which is the one link that should never track you
+Three places where a subscriber's tracking choice was lost or ignored: guest checkout, registration and comment forms, and the opt-out link in an email footer

--- a/mailpoet/changelog/2026-08-24-improved-the-editors-now-check-for-the-tracking-opt-out.md
+++ b/mailpoet/changelog/2026-08-24-improved-the-editors-now-check-for-the-tracking-opt-out.md
@@ -2,4 +2,4 @@
 
 # Description
 
-When you ask subscribers for tracking consent, the email editors now check that your email has a tracking opt-out link and the form editor checks that your form has the tracking consent checkbox, each with a one-click way to add what is missing. The checkbox is always added unticked and stays optional for the subscriber. Emails and forms you have already published are left alone until you next edit them
+When you ask subscribers for tracking consent, the email editors now check that your email has a tracking opt-out link and the form editor checks that your form has the consent checkbox, each with a one-click way to add what is missing

--- a/mailpoet/changelog/2026-08-24-improved-the-public-php-api-can-now-record-tracking-con.md
+++ b/mailpoet/changelog/2026-08-24-improved-the-public-php-api-can-now-record-tracking-con.md
@@ -2,4 +2,4 @@
 
 # Description
 
-The public PHP API can now record tracking consent. Integrations and headless stores that show their own consent checkbox can pass `tracking_consent` to `addSubscriber` or `updateSubscriber`, along with the exact wording they displayed; MailPoet stamps the method and the time itself. This covers the one place MailPoet's own consent checkboxes cannot reach, because a caller of the API is not a MailPoet-rendered form
+The public PHP API can now record tracking consent, so integrations and headless stores can pass their own consent checkbox result to `addSubscriber` or `updateSubscriber`

--- a/mailpoet/changelog/2026-08-25-fixed-one-invalid-tracking-consent-value-no-longer-brea.md
+++ b/mailpoet/changelog/2026-08-25-fixed-one-invalid-tracking-consent-value-no-longer-brea.md
@@ -2,4 +2,4 @@
 
 # Description
 
-One invalid tracking consent value in the database no longer breaks the plugin. A subscriber row holding an out-of-range value, from a hand-edited column, an incomplete migration or a restored backup, used to make MailPoet throw the moment anything saved that subscriber, which took down the whole MailPoet REST API and every signup form on the site. Bad stored values are now harmless to read and to save around, and page-view tracking can no longer stop the rest of the plugin from starting up
+One invalid tracking consent value in the database no longer breaks the plugin


### PR DESCRIPTION
## Description

The six changelog entries from the email tracking consent project each ran to
a full paragraph. In the release changelog that is a wall of text, and the
detail belongs in the docs and the Linear issues, not in a one-line release
note.

This cuts each one back to a single sentence. Only the changelog files change.
No code, and every entry still says what it was about.

| Entry | Before | After |
| --- | --- | --- |
| Added: subscriber consent state | 3 sentences | Admins can now see and set a subscriber's email-tracking-consent state on the edit-subscriber page: what it is, when it changed, and how it was recorded |
| Improved: import and export | 3 sentences | Subscriber import and export now carry tracking consent: the state, when it changed, how it was collected, and the wording the subscriber saw |
| Fixed: three lost choices | 4 sentences | Three places where a subscriber's tracking choice was lost or ignored: guest checkout, registration and comment forms, and the opt-out link in an email footer |
| Improved: editor checks | 3 sentences | When you ask subscribers for tracking consent, the email editors now check that your email has a tracking opt-out link and the form editor checks that your form has the consent checkbox, each with a one-click way to add what is missing |
| Improved: public PHP API | 3 sentences | The public PHP API can now record tracking consent, so integrations and headless stores can pass their own consent checkbox result to `addSubscriber` or `updateSubscriber` |
| Fixed: invalid consent value | 3 sentences | One invalid tracking consent value in the database no longer breaks the plugin |

Also dropped a trailing period on one entry, since the build system adds
punctuation.

## Code review notes

Read the six diffs and check the shortened line still describes the change you
remember shipping. If any entry lost something a user needs to know, say so and
I will put it back.

## QA notes

No testing needed. Changelog files only.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

This is for today's free plugin release.

## Tasks

- [x] I have added a changelog entry (this PR only edits existing ones)
- [x] I followed best practices for translations
- [x] I added sufficient test coverage (n/a, no code changes)
- [x] I embraced TypeScript (n/a, no code changes)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/shorten-tracking-consent-changelogs)

_The latest successful build from `update/shorten-tracking-consent-changelogs` will be used. If none is available, the link won't work._