### PR TITLE
Improve input validation and block sanitization for newsletter preview

### DIFF
--- a/mailpoet/changelog/2026-09-03-14-06-12-improved-input-validation-and-block-sanitization-for-the-ne.md
+++ b/mailpoet/changelog/2026-09-03-14-06-12-improved-input-validation-and-block-sanitization-for-the-ne.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Input validation and block sanitization for the newsletter browser preview request

--- a/mailpoet/lib/API/JSON/v1/NewsletterTemplates.php
+++ b/mailpoet/lib/API/JSON/v1/NewsletterTemplates.php
@@ -87,12 +87,13 @@ class NewsletterTemplates extends APIEndpoint {
       }
     }
     if (isset($data['body']) && is_string($data['body']) && $data['body'] !== '') {
-      $body = $this->apiDataSanitizer->decodeAndSanitizeBody($data['body']);
-      if ($body === null) {
+      $decodedBody = json_decode($data['body'], true);
+      if (!is_array($decodedBody)) {
         return $this->badRequest([
           APIError::BAD_REQUEST => __('Invalid template body payload.', 'mailpoet'),
         ]);
       }
+      $body = $this->apiDataSanitizer->sanitizeBody($decodedBody);
       $body = $this->newsletterCoupon->cleanupBodySensitiveData($body);
       $data['body'] = json_encode($body);
     }

--- a/mailpoet/lib/API/JSON/v1/NewsletterTemplates.php
+++ b/mailpoet/lib/API/JSON/v1/NewsletterTemplates.php
@@ -87,13 +87,12 @@ class NewsletterTemplates extends APIEndpoint {
       }
     }
     if (isset($data['body']) && is_string($data['body']) && $data['body'] !== '') {
-      $decodedBody = json_decode($data['body'], true);
-      if (!is_array($decodedBody)) {
+      $body = $this->apiDataSanitizer->decodeAndSanitizeBody($data['body']);
+      if ($body === null) {
         return $this->badRequest([
           APIError::BAD_REQUEST => __('Invalid template body payload.', 'mailpoet'),
         ]);
       }
-      $body = $this->apiDataSanitizer->sanitizeBody($decodedBody);
       $body = $this->newsletterCoupon->cleanupBodySensitiveData($body);
       $data['body'] = json_encode($body);
     }

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -194,7 +194,7 @@ class Newsletters extends APIEndpoint {
   }
 
   public function showPreview($data = []) {
-    if (empty($data['body'])) {
+    if (empty($data['body']) || !is_string($data['body'])) {
       return $this->badRequest([
         APIError::BAD_REQUEST => __('Newsletter data is missing.', 'mailpoet'),
       ]);

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -9,7 +9,6 @@ use MailPoet\API\JSON\ResponseBuilders\NewslettersResponseBuilder;
 use MailPoet\Config\AccessControl;
 use MailPoet\Doctrine\Validator\ValidationException;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Newsletter\ApiDataSanitizer;
 use MailPoet\Newsletter\NewsletterDeleteController;
 use MailPoet\Newsletter\NewsletterResendController;
 use MailPoet\Newsletter\NewsletterSaveController;
@@ -19,7 +18,6 @@ use MailPoet\Newsletter\Preview\SendPreviewException;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Subscribers\ConfirmationEmailCustomizer;
 use MailPoet\UnexpectedValueException;
-use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Newsletters extends APIEndpoint {
@@ -36,9 +34,6 @@ class Newsletters extends APIEndpoint {
 
   /** @var NewslettersResponseBuilder */
   private $newslettersResponseBuilder;
-
-  /** @var Emoji */
-  private $emoji;
 
   /** @var SendPreviewController */
   private $sendPreviewController;
@@ -57,33 +52,26 @@ class Newsletters extends APIEndpoint {
   /** @var ConfirmationEmailCustomizer */
   private $confirmationEmailCustomizer;
 
-  /** @var ApiDataSanitizer */
-  private $dataSanitizer;
-
   public function __construct(
     WPFunctions $wp,
     NewslettersRepository $newslettersRepository,
     NewslettersResponseBuilder $newslettersResponseBuilder,
-    Emoji $emoji,
     SendPreviewController $sendPreviewController,
     NewsletterSaveController $newsletterSaveController,
     NewsletterDeleteController $newsletterDeleteController,
     NewsletterResendController $newsletterResendController,
     NewsletterUrl $newsletterUrl,
-    ConfirmationEmailCustomizer $confirmationEmailCustomizer,
-    ApiDataSanitizer $dataSanitizer
+    ConfirmationEmailCustomizer $confirmationEmailCustomizer
   ) {
     $this->wp = $wp;
     $this->newslettersRepository = $newslettersRepository;
     $this->newslettersResponseBuilder = $newslettersResponseBuilder;
-    $this->emoji = $emoji;
     $this->sendPreviewController = $sendPreviewController;
     $this->newsletterSaveController = $newsletterSaveController;
     $this->newsletterDeleteController = $newsletterDeleteController;
     $this->newsletterResendController = $newsletterResendController;
     $this->newsletterUrl = $newsletterUrl;
     $this->confirmationEmailCustomizer = $confirmationEmailCustomizer;
-    $this->dataSanitizer = $dataSanitizer;
   }
 
   public function get($data = []) {
@@ -219,9 +207,7 @@ class Newsletters extends APIEndpoint {
       ]);
     }
 
-    $newslettersTableName = $this->newslettersRepository->getTableName();
-    $decodedBody = json_decode($this->emoji->encodeForUTF8Column($newslettersTableName, 'body', $data['body']), true);
-    $newsletter->setBody($this->dataSanitizer->sanitizeBody(is_array($decodedBody) ? $decodedBody : []));
+    $newsletter->setBody($this->newsletterSaveController->decodeAndSanitizeBody($data['body']));
     $this->newslettersRepository->flush();
 
     $response = $this->newslettersResponseBuilder->build($newsletter);

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -9,6 +9,7 @@ use MailPoet\API\JSON\ResponseBuilders\NewslettersResponseBuilder;
 use MailPoet\Config\AccessControl;
 use MailPoet\Doctrine\Validator\ValidationException;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\ApiDataSanitizer;
 use MailPoet\Newsletter\NewsletterDeleteController;
 use MailPoet\Newsletter\NewsletterResendController;
 use MailPoet\Newsletter\NewsletterSaveController;
@@ -56,6 +57,9 @@ class Newsletters extends APIEndpoint {
   /** @var ConfirmationEmailCustomizer */
   private $confirmationEmailCustomizer;
 
+  /** @var ApiDataSanitizer */
+  private $dataSanitizer;
+
   public function __construct(
     WPFunctions $wp,
     NewslettersRepository $newslettersRepository,
@@ -66,7 +70,8 @@ class Newsletters extends APIEndpoint {
     NewsletterDeleteController $newsletterDeleteController,
     NewsletterResendController $newsletterResendController,
     NewsletterUrl $newsletterUrl,
-    ConfirmationEmailCustomizer $confirmationEmailCustomizer
+    ConfirmationEmailCustomizer $confirmationEmailCustomizer,
+    ApiDataSanitizer $dataSanitizer
   ) {
     $this->wp = $wp;
     $this->newslettersRepository = $newslettersRepository;
@@ -78,6 +83,7 @@ class Newsletters extends APIEndpoint {
     $this->newsletterResendController = $newsletterResendController;
     $this->newsletterUrl = $newsletterUrl;
     $this->confirmationEmailCustomizer = $confirmationEmailCustomizer;
+    $this->dataSanitizer = $dataSanitizer;
   }
 
   public function get($data = []) {
@@ -214,9 +220,8 @@ class Newsletters extends APIEndpoint {
     }
 
     $newslettersTableName = $this->newslettersRepository->getTableName();
-    $newsletter->setBody(
-      json_decode($this->emoji->encodeForUTF8Column($newslettersTableName, 'body', $data['body']), true)
-    );
+    $decodedBody = json_decode($this->emoji->encodeForUTF8Column($newslettersTableName, 'body', $data['body']), true);
+    $newsletter->setBody($this->dataSanitizer->sanitizeBody(is_array($decodedBody) ? $decodedBody : []));
     $this->newslettersRepository->flush();
 
     $response = $this->newslettersResponseBuilder->build($newsletter);

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -207,7 +207,14 @@ class Newsletters extends APIEndpoint {
       ]);
     }
 
-    $newsletter->setBody($this->newsletterSaveController->decodeAndSanitizeBody($data['body']));
+    $body = $this->newsletterSaveController->decodeAndSanitizeBody($data['body']);
+    if ($body === null) {
+      return $this->badRequest([
+        APIError::BAD_REQUEST => __('Invalid newsletter body payload.', 'mailpoet'),
+      ]);
+    }
+
+    $newsletter->setBody($body);
     $this->newslettersRepository->flush();
 
     $response = $this->newslettersResponseBuilder->build($newsletter);

--- a/mailpoet/lib/Newsletter/ApiDataSanitizer.php
+++ b/mailpoet/lib/Newsletter/ApiDataSanitizer.php
@@ -21,6 +21,11 @@ class ApiDataSanitizer {
     $this->htmlSanitizer = $htmlSanitizer;
   }
 
+  public function decodeAndSanitizeBody(string $body): ?array {
+    $decodedBody = json_decode($body, true);
+    return is_array($decodedBody) ? $this->sanitizeBody($decodedBody) : null;
+  }
+
   public function sanitizeBody(array $body): array {
     if (isset($body['content']) && isset($body['content']['blocks']) && is_array($body['content']['blocks'])) {
       $body['content']['blocks'] = $this->sanitizeBlocks($body['content']['blocks']);

--- a/mailpoet/lib/Newsletter/ApiDataSanitizer.php
+++ b/mailpoet/lib/Newsletter/ApiDataSanitizer.php
@@ -47,7 +47,7 @@ class ApiDataSanitizer {
       return $block;
     }
     foreach (self::SANITIZATION_CONFIG[$block['type']] as $property) {
-      if (!isset($block[$property])) {
+      if (!isset($block[$property]) || !is_string($block[$property])) {
         continue;
       }
       $block[$property] = $this->htmlSanitizer->sanitize($block[$property]);

--- a/mailpoet/lib/Newsletter/ApiDataSanitizer.php
+++ b/mailpoet/lib/Newsletter/ApiDataSanitizer.php
@@ -21,11 +21,6 @@ class ApiDataSanitizer {
     $this->htmlSanitizer = $htmlSanitizer;
   }
 
-  public function decodeAndSanitizeBody(string $body): ?array {
-    $decodedBody = json_decode($body, true);
-    return is_array($decodedBody) ? $this->sanitizeBody($decodedBody) : null;
-  }
-
   public function sanitizeBody(array $body): array {
     if (isset($body['content']) && isset($body['content']['blocks']) && is_array($body['content']['blocks'])) {
       $body['content']['blocks'] = $this->sanitizeBlocks($body['content']['blocks']);

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -128,8 +128,8 @@ class NewsletterSaveController {
 
   public function decodeAndSanitizeBody(string $body): ?array {
     $newslettersTableName = $this->newslettersRepository->getTableName();
-    $encodedBody = $this->emoji->encodeForUTF8Column($newslettersTableName, 'body', $body);
-    return $this->dataSanitizer->decodeAndSanitizeBody($encodedBody);
+    $decodedBody = json_decode($this->emoji->encodeForUTF8Column($newslettersTableName, 'body', $body), true);
+    return is_array($decodedBody) ? $this->dataSanitizer->sanitizeBody($decodedBody) : null;
   }
 
   public function save(array $data = []): NewsletterEntity {

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -126,10 +126,10 @@ class NewsletterSaveController {
     $this->shareVisibility = $shareVisibility;
   }
 
-  public function decodeAndSanitizeBody(string $body): array {
+  public function decodeAndSanitizeBody(string $body): ?array {
     $newslettersTableName = $this->newslettersRepository->getTableName();
     $encodedBody = $this->emoji->encodeForUTF8Column($newslettersTableName, 'body', $body);
-    return $this->dataSanitizer->decodeAndSanitizeBody($encodedBody) ?? [];
+    return $this->dataSanitizer->decodeAndSanitizeBody($encodedBody);
   }
 
   public function save(array $data = []): NewsletterEntity {
@@ -141,7 +141,7 @@ class NewsletterSaveController {
     }
 
     if (!empty($data['body'])) {
-      $data['body'] = $this->decodeAndSanitizeBody($data['body']);
+      $data['body'] = $this->decodeAndSanitizeBody($data['body']) ?? [];
     }
 
     $newsletter = isset($data['id']) ? $this->getNewsletter($data) : $this->createNewsletter($data);

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -126,6 +126,12 @@ class NewsletterSaveController {
     $this->shareVisibility = $shareVisibility;
   }
 
+  public function decodeAndSanitizeBody(string $body): array {
+    $newslettersTableName = $this->newslettersRepository->getTableName();
+    $encodedBody = $this->emoji->encodeForUTF8Column($newslettersTableName, 'body', $body);
+    return $this->dataSanitizer->decodeAndSanitizeBody($encodedBody) ?? [];
+  }
+
   public function save(array $data = []): NewsletterEntity {
     if (!empty($data['template_id'])) {
       $template = $this->newsletterTemplatesRepository->findOneById($data['template_id']);
@@ -135,11 +141,7 @@ class NewsletterSaveController {
     }
 
     if (!empty($data['body'])) {
-      $newslettersTableName = $this->newslettersRepository->getTableName();
-      $body = $this->emoji->encodeForUTF8Column($newslettersTableName, 'body', $data['body']);
-      $decodedBody = json_decode($body, true);
-      $body = $this->dataSanitizer->sanitizeBody(is_array($decodedBody) ? $decodedBody : []);
-      $data['body'] = json_encode($body);
+      $data['body'] = $this->decodeAndSanitizeBody($data['body']);
     }
 
     $newsletter = isset($data['id']) ? $this->getNewsletter($data) : $this->createNewsletter($data);
@@ -351,8 +353,8 @@ class NewsletterSaveController {
     }
 
     if (array_key_exists('body', $data)) {
-      $decodedBody = json_decode($data['body'], true);
-      $newsletter->setBody(is_array($decodedBody) ? $decodedBody : null);
+      $body = is_string($data['body']) ? json_decode($data['body'], true) : $data['body'];
+      $newsletter->setBody(is_array($body) ? $body : null);
     }
 
     if (array_key_exists('ga_campaign', $data)) {

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -350,4 +350,29 @@ class NewslettersTest extends \MailPoetTest {
     verify($response->meta['preview_url'])->stringNotContainsString('http');
     verify($response->meta['preview_url'])->stringMatchesRegExp('!^\/\/!');
   }
+
+  public function testItSanitizesBodyBeforeStoringPreview() {
+    $body = [
+      'content' => [
+        'blocks' => [
+          ['type' => 'text', 'text' => '<p>Hello</p><script>alert(1)</script><img src="x" onerror="alert(2)">'],
+        ],
+      ],
+    ];
+
+    $response = $this->endpoint->showPreview([
+      'id' => $this->newsletter->getId(),
+      'body' => json_encode($body),
+    ]);
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+
+    $newsletter = $this->newsletterRepository->findOneById($this->newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $storedBody = $newsletter->getBody();
+    $this->assertIsArray($storedBody);
+    $storedText = $storedBody['content']['blocks'][0]['text'];
+    verify($storedText)->stringContainsString('<p>Hello</p>');
+    verify($storedText)->stringNotContainsString('<script');
+    verify($storedText)->stringNotContainsString('onerror');
+  }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -328,13 +328,13 @@ class NewslettersTest extends \MailPoetTest {
   public function testItReturnsBrowserPreviewUrlWithoutProtocol() {
     $data = [
       'id' => $this->newsletter->getId(),
-      'body' => 'fake body',
+      'body' => '{}',
     ];
 
     $emoji = $this->make(
       Emoji::class,
-      ['encodeForUTF8Column' => Expected::once(function ($params) {
-        return $params;
+      ['encodeForUTF8Column' => Expected::once(function ($table, $field, $value) {
+        return $value;
       })]
     );
 
@@ -351,7 +351,23 @@ class NewslettersTest extends \MailPoetTest {
 
     $response = $this->endpoint->showPreview($data);
     verify($response->meta['preview_url'])->stringNotContainsString('http');
-    verify($response->meta['preview_url'])->stringMatchesRegExp('!^\/\/!');
+    verify($response->meta['preview_url'])->stringStartsWith('//');
+  }
+
+  public function testItRejectsUndecodablePreviewBodyWithoutTouchingStoredBody() {
+    $storedBody = $this->newsletter->getBody();
+    $this->assertIsArray($storedBody);
+
+    $response = $this->endpoint->showPreview([
+      'id' => $this->newsletter->getId(),
+      'body' => 'not json',
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+    $this->entityManager->clear();
+    $newsletter = $this->newsletterRepository->findOneById($this->newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    verify($newsletter->getBody())->equals($storedBody);
   }
 
   public function testItSanitizesBodyBeforeStoringPreview() {

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -354,6 +354,15 @@ class NewslettersTest extends \MailPoetTest {
     verify($response->meta['preview_url'])->stringStartsWith('//');
   }
 
+  public function testItRejectsNonStringPreviewBody() {
+    $response = $this->endpoint->showPreview([
+      'id' => $this->newsletter->getId(),
+      'body' => ['not' => 'a string'],
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+  }
+
   public function testItRejectsUndecodablePreviewBodyWithoutTouchingStoredBody() {
     $storedBody = $this->newsletter->getBody();
     $this->assertIsArray($storedBody);

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -12,6 +12,7 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Logging\LogRepository;
+use MailPoet\Newsletter\NewsletterSaveController;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Preview\SendPreviewController;
 use MailPoet\Newsletter\Preview\SendPreviewException;
@@ -343,7 +344,9 @@ class NewslettersTest extends \MailPoetTest {
     ]);
     $this->endpoint = $this->getServiceWithOverrides(Newsletters::class, [
       'wp' => $wp,
-      'emoji' => $emoji,
+      'newsletterSaveController' => $this->getServiceWithOverrides(NewsletterSaveController::class, [
+        'emoji' => $emoji,
+      ]),
     ]);
 
     $response = $this->endpoint->showPreview($data);

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -373,10 +373,8 @@ class NewslettersTest extends \MailPoetTest {
     ]);
 
     verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
-    $this->entityManager->clear();
-    $newsletter = $this->newsletterRepository->findOneById($this->newsletter->getId());
-    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
-    verify($newsletter->getBody())->equals($storedBody);
+    $this->entityManager->refresh($this->newsletter);
+    verify($this->newsletter->getBody())->equals($storedBody);
   }
 
   public function testItSanitizesBodyBeforeStoringPreview() {
@@ -394,9 +392,8 @@ class NewslettersTest extends \MailPoetTest {
     ]);
     verify($response->status)->equals(APIResponse::STATUS_OK);
 
-    $newsletter = $this->newsletterRepository->findOneById($this->newsletter->getId());
-    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
-    $storedBody = $newsletter->getBody();
+    $this->entityManager->refresh($this->newsletter);
+    $storedBody = $this->newsletter->getBody();
     $this->assertIsArray($storedBody);
     $storedText = $storedBody['content']['blocks'][0]['text'];
     verify($storedText)->stringContainsString('<p>Hello</p>');

--- a/mailpoet/tests/integration/Newsletter/ApiDataSanitizerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ApiDataSanitizerTest.php
@@ -68,4 +68,18 @@ class ApiDataSanitizerTest extends \MailPoetTest {
 
     verify($result)->equals($body);
   }
+
+  public function testItDecodesJsonBodyAndStripsDisallowedMarkup() {
+    $body = '{"content":{"blocks":[{"type":"text","text":"<p>Hello</p><script>alert(1)</script>"}]}}';
+
+    $result = $this->sanitizer->decodeAndSanitizeBody($body);
+
+    $this->assertIsArray($result);
+    verify($result['content']['blocks'][0]['text'])->equals('<p>Hello</p>alert(1)');
+  }
+
+  public function testItReturnsNullForUndecodableBody() {
+    verify($this->sanitizer->decodeAndSanitizeBody('not json'))->null();
+    verify($this->sanitizer->decodeAndSanitizeBody('"just a string"'))->null();
+  }
 }

--- a/mailpoet/tests/integration/Newsletter/ApiDataSanitizerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ApiDataSanitizerTest.php
@@ -54,4 +54,18 @@ class ApiDataSanitizerTest extends \MailPoetTest {
     verify($image['link'])->equals('');
     verify($image['text'])->equals('http://some.url/wp-c\'"&gt;ontent/fake-logo.png');
   }
+
+  public function testItLeavesNonStringTextUntouched() {
+    $body = [
+      'content' => [
+        'blocks' => [
+          ['type' => 'text', 'text' => ['not', 'a', 'string']],
+        ],
+      ],
+    ];
+
+    $result = $this->sanitizer->sanitizeBody($body);
+
+    verify($result)->equals($body);
+  }
 }

--- a/mailpoet/tests/integration/Newsletter/ApiDataSanitizerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ApiDataSanitizerTest.php
@@ -68,18 +68,4 @@ class ApiDataSanitizerTest extends \MailPoetTest {
 
     verify($result)->equals($body);
   }
-
-  public function testItDecodesJsonBodyAndStripsDisallowedMarkup() {
-    $body = '{"content":{"blocks":[{"type":"text","text":"<p>Hello</p><script>alert(1)</script>"}]}}';
-
-    $result = $this->sanitizer->decodeAndSanitizeBody($body);
-
-    $this->assertIsArray($result);
-    verify($result['content']['blocks'][0]['text'])->equals('<p>Hello</p>alert(1)');
-  }
-
-  public function testItReturnsNullForUndecodableBody() {
-    verify($this->sanitizer->decodeAndSanitizeBody('not json'))->null();
-    verify($this->sanitizer->decodeAndSanitizeBody('"just a string"'))->null();
-  }
 }

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -81,12 +81,13 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
 
     $result = $this->saveController->decodeAndSanitizeBody($body);
 
+    $this->assertIsArray($result);
     verify($result['content']['blocks'][0]['text'])->stringContainsString('<p>Hello</p>');
     verify($result['content']['blocks'][0]['text'])->stringNotContainsString('<script');
   }
 
-  public function testItDecodesUndecodableBodyToEmptyArray() {
-    verify($this->saveController->decodeAndSanitizeBody('not json'))->equals([]);
+  public function testItReturnsNullForUndecodableBody() {
+    verify($this->saveController->decodeAndSanitizeBody('not json'))->null();
   }
 
   public function testItDoesNotRerenderPostNotificationsUponUpdate() {

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -76,6 +76,19 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     verify($newsletter->getBody())->equals(['value' => 'Updated 🙈body']);
   }
 
+  public function testItStripsDisallowedMarkupFromTextBlocks() {
+    $body = '{"content":{"blocks":[{"type":"text","text":"<p>Hello</p><script>alert(1)</script>"}]}}';
+
+    $result = $this->saveController->decodeAndSanitizeBody($body);
+
+    verify($result['content']['blocks'][0]['text'])->stringContainsString('<p>Hello</p>');
+    verify($result['content']['blocks'][0]['text'])->stringNotContainsString('<script');
+  }
+
+  public function testItDecodesUndecodableBodyToEmptyArray() {
+    verify($this->saveController->decodeAndSanitizeBody('not json'))->equals([]);
+  }
+
   public function testItDoesNotRerenderPostNotificationsUponUpdate() {
     $this->createPostNotificationOptions();
     $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION);


### PR DESCRIPTION
## Description

The newsletter browser preview endpoint stored the request body as-is, while saving a newsletter runs the body through `ApiDataSanitizer` first. This change applies the same processing on the preview path so both paths store the email content consistently, and consolidates that processing so it is defined once.

## Code review notes

- The decode-and-sanitize step now lives in `ApiDataSanitizer::decodeAndSanitizeBody()`, which returns `null` for undecodable input. `NewsletterSaveController::decodeAndSanitizeBody()` adds the emoji encoding for the newsletters table on top of it. The save path keeps its empty-array fallback for undecodable input; the preview endpoint now answers 400 and leaves the stored body untouched (previously it stored an empty body); `NewsletterTemplates::save()` uses the sanitizer method directly and keeps its existing 400 response.
- The preview endpoint drops its own `Emoji` dependency and reaches the helper through the `NewsletterSaveController` it already received. This is the internal JSON API (`lib/API/JSON/`), not a third-party contract, so the constructor change needs no BC statement. Premium has no callers of this endpoint, and every `NewsletterSaveController::save()` caller passes the body as a JSON string.
- `ApiDataSanitizer::sanitizeBlock()` now skips non-string `text` values instead of letting the HTML sanitizer throw a `TypeError`.
- The preview endpoint treats a non-string `body` like a missing one and answers with its regular 400 message; before, a nested-array body surfaced as a 400 carrying a raw PHP `TypeError` message from the API layer's catch-all.
- `NewsletterSaveController::save()` no longer re-encodes the sanitized body to JSON for `updateNewsletter()` to decode again; `updateNewsletter()` accepts either form.

## QA notes

The classic editor's text block goes through TinyMCE, so the UI does not exercise this path directly. To verify, call the `newsletters/showPreview` JSON API method with a classic-editor newsletter id and a body whose text block contains markup that the save path would strip, then check the stored body and the view-in-browser output. Details are in the linked ticket. Saving a classic newsletter and saving a newsletter template should behave as before.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8405

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8405-newsletter-preview-body-handling)

_The latest successful build from `fix/stomail-8405-newsletter-preview-body-handling` will be used. If none is available, the link won't work._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

