### PR TITLE
Update postcss-selector-parser

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9802,16 +9802,12 @@ packages:
     peerDependencies:
       postcss: ^8.4.29
 
-  postcss-selector-parser@6.1.0:
-    resolution: {integrity: sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==}
+  postcss-selector-parser@6.1.4:
+    resolution: {integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==, tarball: https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz}
     engines: {node: '>=4'}
 
-  postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
-    engines: {node: '>=4'}
-
-  postcss-selector-parser@7.1.1:
-    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+  postcss-selector-parser@7.1.5:
+    resolution: {integrity: sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==, tarball: https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz}
     engines: {node: '>=4'}
 
   postcss-sorting@8.0.2:
@@ -14645,13 +14641,13 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
 
-  '@csstools/selector-specificity@3.1.1(postcss-selector-parser@6.1.0)':
+  '@csstools/selector-specificity@3.1.1(postcss-selector-parser@6.1.4)':
     dependencies:
-      postcss-selector-parser: 6.1.0
+      postcss-selector-parser: 6.1.4
 
-  '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.1)':
+  '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.5)':
     dependencies:
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 7.1.5
 
   '@date-fns/tz@1.4.1': {}
 
@@ -16668,7 +16664,7 @@ snapshots:
       '@csstools/media-query-list-parser': 3.0.1(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       is-plain-object: 5.0.0
       postcss: 8.5.23
-      postcss-selector-parser: 6.1.2
+      postcss-selector-parser: 6.1.4
       postcss-value-parser: 4.2.0
       style-search: 0.1.0
       stylelint: 16.26.1(typescript@5.9.3)
@@ -25048,7 +25044,7 @@ snapshots:
   postcss-calc@9.0.1(postcss@8.5.10):
     dependencies:
       postcss: 8.5.10
-      postcss-selector-parser: 6.1.0
+      postcss-selector-parser: 6.1.4
       postcss-value-parser: 4.2.0
 
   postcss-cli@11.0.0(postcss@8.5.23):
@@ -25136,7 +25132,7 @@ snapshots:
       caniuse-api: 3.0.0
       cssnano-utils: 4.0.2(postcss@8.5.10)
       postcss: 8.5.10
-      postcss-selector-parser: 6.1.0
+      postcss-selector-parser: 6.1.4
 
   postcss-minify-font-values@6.1.0(postcss@8.5.10):
     dependencies:
@@ -25160,7 +25156,7 @@ snapshots:
   postcss-minify-selectors@6.0.4(postcss@8.5.10):
     dependencies:
       postcss: 8.5.10
-      postcss-selector-parser: 6.1.0
+      postcss-selector-parser: 6.1.4
 
   postcss-modules-extract-imports@3.1.0(postcss@8.5.23):
     dependencies:
@@ -25170,13 +25166,13 @@ snapshots:
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.23)
       postcss: 8.5.23
-      postcss-selector-parser: 6.1.0
+      postcss-selector-parser: 6.1.4
       postcss-value-parser: 4.2.0
 
   postcss-modules-scope@3.2.0(postcss@8.5.23):
     dependencies:
       postcss: 8.5.23
-      postcss-selector-parser: 6.1.0
+      postcss-selector-parser: 6.1.4
 
   postcss-modules-values@4.0.0(postcss@8.5.23):
     dependencies:
@@ -25279,17 +25275,12 @@ snapshots:
     dependencies:
       postcss: 8.5.23
 
-  postcss-selector-parser@6.1.0:
+  postcss-selector-parser@6.1.4:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-selector-parser@6.1.2:
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
-
-  postcss-selector-parser@7.1.1:
+  postcss-selector-parser@7.1.5:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
@@ -25307,7 +25298,7 @@ snapshots:
   postcss-unique-selectors@6.0.4(postcss@8.5.10):
     dependencies:
       postcss: 8.5.10
-      postcss-selector-parser: 6.1.0
+      postcss-selector-parser: 6.1.4
 
   postcss-urlrebase@1.3.0(postcss@8.5.23):
     dependencies:
@@ -26666,7 +26657,7 @@ snapshots:
     dependencies:
       browserslist: 4.28.2
       postcss: 8.5.10
-      postcss-selector-parser: 6.1.0
+      postcss-selector-parser: 6.1.4
 
   stylelint-config-recommended-scss@14.1.0(postcss@8.5.10)(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
@@ -26695,7 +26686,7 @@ snapshots:
       mdn-data: 2.28.0
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.6
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 7.1.5
       postcss-value-parser: 4.2.0
       stylelint: 16.26.1(typescript@5.9.3)
 
@@ -26704,7 +26695,7 @@ snapshots:
       known-css-properties: 0.31.0
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.1
-      postcss-selector-parser: 6.1.0
+      postcss-selector-parser: 6.1.4
       postcss-value-parser: 4.2.0
       stylelint: 16.6.1(typescript@5.9.3)
 
@@ -26714,7 +26705,7 @@ snapshots:
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.5)
       '@dual-bundle/import-meta-resolve': 4.2.1
       balanced-match: 2.0.0
       colord: 2.9.3
@@ -26741,7 +26732,7 @@ snapshots:
       postcss: 8.5.23
       postcss-resolve-nested-selector: 0.1.6
       postcss-safe-parser: 7.0.1(postcss@8.5.23)
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 7.1.5
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
       string-width: 4.2.3
@@ -26758,7 +26749,7 @@ snapshots:
       '@csstools/css-parser-algorithms': 2.6.3(@csstools/css-tokenizer@2.3.1)
       '@csstools/css-tokenizer': 2.3.1
       '@csstools/media-query-list-parser': 2.1.11(@csstools/css-parser-algorithms@2.6.3(@csstools/css-tokenizer@2.3.1))(@csstools/css-tokenizer@2.3.1)
-      '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.0)
+      '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.4)
       '@dual-bundle/import-meta-resolve': 4.1.0
       balanced-match: 2.0.0
       colord: 2.9.3
@@ -26785,7 +26776,7 @@ snapshots:
       postcss: 8.5.23
       postcss-resolve-nested-selector: 0.1.1
       postcss-safe-parser: 7.0.0(postcss@8.5.23)
-      postcss-selector-parser: 6.1.0
+      postcss-selector-parser: 6.1.4
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
       string-width: 4.2.3


### PR DESCRIPTION
Bumps `postcss-selector-parser` to clear two Dependabot alerts (#419, #420).

The package is build tooling for our CSS pipeline. It is not a direct dependency and it does not ship in the plugin zip.

- 6.1.0 and 6.1.2 both move to 6.1.4, collapsing into one copy
- 7.1.1 moves to 7.1.5

`pnpm-lock.yaml` is the only file changed, 57 lines. Nothing else in the tree moved.

Plain `pnpm update postcss-selector-parser` is a no-op here because the package is only ever transitive, so this was done with `--recursive`.

### QA
`./do compile:all` exits 0. Stylelint, sass, autoprefixer and webpack all run, and `assets/dist/css` and `assets/dist/js` are rebuilt. A passing build is the check that matters for these packages.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAibakHhBmsKuF9dBwUZRT

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/bump-postcss-selector-parser)

_The latest successful build from `fix/bump-postcss-selector-parser` will be used. If none is available, the link won't work._