### PR TITLE
Keep Hong Kong and Beijing listed so the cron daemon does not abort

### DIFF
--- a/mailpoet/changelog/2026-09-02-15-16-25-fixed-amazon-ses-sites-set-to-hong-kong-or-china-beijing.md
+++ b/mailpoet/changelog/2026-09-02-15-16-25-fixed-amazon-ses-sites-set-to-hong-kong-or-china-beijing.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Amazon SES sites set to Hong Kong or China (Beijing) no longer stop the background job runner, so bounce processing, WooCommerce sync and the other scheduled jobs keep working

--- a/mailpoet/lib/Settings/Hosts.php
+++ b/mailpoet/lib/Settings/Hosts.php
@@ -44,6 +44,10 @@ class Hosts {
         'South America (São Paulo)' => 'sa-east-1',
         'AWS GovCloud (US-East)' => 'us-gov-east-1',
         'AWS GovCloud (US-West)' => 'us-gov-west-1',
+        // Amazon SES never launched in these two. They stay listed because dropping
+        // them makes the mailer throw while the cron daemon is building its workers.
+        'Asia Pacific (Hong Kong) - not supported by Amazon SES' => 'ap-east-1',
+        'China (Beijing) - not supported by Amazon SES' => 'cn-north-1',
       ],
     ],
     'SendGrid' => [

--- a/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
@@ -99,24 +99,20 @@ class AmazonSESTest extends \MailPoetTest {
     verify($mailer->url)->equals('https://email.cn-northwest-1.amazonaws.com.cn');
   }
 
-  public function testItRejectsRegionsWhereSesIsNotAvailable() {
+  public function testItAcceptsTheDeprecatedRegionsSoWorkerConstructionDoesNotThrow() {
     foreach (['ap-east-1', 'cn-north-1'] as $region) {
-      try {
-        new AmazonSES(
-          $region,
-          $this->settings['access_key'],
-          $this->settings['secret_key'],
-          $this->sender,
-          $this->replyTo,
-          $this->returnPath,
-          new AmazonSESMapper(),
-          new WPFunctions(),
-          $this->diContainer->get(Url::class)
-        );
-        $this->fail(sprintf('Unsupported region exception was not thrown for %s', $region));
-      } catch (\Exception $e) {
-        verify($e->getMessage())->equals('Unsupported Amazon SES region');
-      }
+      $mailer = new AmazonSES(
+        $region,
+        $this->settings['access_key'],
+        $this->settings['secret_key'],
+        $this->sender,
+        $this->replyTo,
+        $this->returnPath,
+        new AmazonSESMapper(),
+        new WPFunctions(),
+        $this->diContainer->get(Url::class)
+      );
+      verify($mailer->awsRegion)->equals($region);
     }
   }
 


### PR DESCRIPTION
Fixes [STOMAIL-8448](https://linear.app/a8c/issue/STOMAIL-8448).

## What broke

#7088 removed `ap-east-1` (Hong Kong) and `cn-north-1` (Beijing) from the SES region list, because Amazon SES has never run in either. Both were selectable before, so real sites can still have one saved.

`AmazonSES::__construct()` now throws `Unsupported Amazon SES region` for those sites, and it throws in the worst possible place:

1. `Tasks\Mailer::__construct()` (line 23) calls `configureMailer()`, which calls `MailerFactory::buildMailer()`. The mailer is built **eagerly, in the constructor**.
2. `SendingQueue` takes `MailerTask` as a constructor dependency, so `WorkersFactory::createQueueWorker()` builds the whole graph.
3. `Daemon::run()` advances `getWorkers()` at the `foreach` header on line 49. The `try/catch` starts on line 55 — **the generator is advanced outside it.**
4. `createQueueWorker()` is the 3rd of ~33 yields.

So the exception escapes the loop. The ~30 workers after it never run, `saveDaemonRunCompleted()` is skipped, and `DaemonHttpRunner` never reaches `callSelf()` to reschedule.

For an affected site that means bounce processing, WooCommerce sync, subscriber cleanup, stats and automation scheduling all stop — not just sending. Every cycle, until the region is changed by hand.

## The fix

Put both regions back, with labels that say why they are there:

```php
// Amazon SES never launched in these two. They stay listed because dropping
// them makes the mailer throw while the cron daemon is building its workers.
'Asia Pacific (Hong Kong) - not supported by Amazon SES' => 'ap-east-1',
'China (Beijing) - not supported by Amazon SES' => 'cn-north-1',
```

This restores exactly what those sites had before #7088: construction succeeds, the endpoint does not resolve, `wp_remote_post` returns a `WP_Error`, and `send()` catches it. Sending stays broken, as it always was, and every other worker keeps running.

Both entries sit at the end of the list so they read as the exceptions they are.

## Why not the alternatives

- **Remap them in a migration.** There is no equivalent region for Hong Kong. Moving someone to Tokyo or Singapore silently relocates where their mail originates, and none of their SES identities are verified there, so the send fails anyway with a more confusing error.
- **Make `Tasks\Mailer` lazy.** Correct, but it changes when the mailer is built on the sending path. Too much risk for a fix that needs to ship.

## This is a stopgap

The real defect is that a worker which fails to *construct* takes down the whole daemon, because `Daemon.php:49` advances the generator outside the try/catch. That is latent for any future worker, not just this one. It deserves its own issue, and once it is fixed both entries can be removed for good.

`cn-north-1` is included even though `Migration_20260902_130046_App` remaps it, because migrations run on plugin update and the daemon can fire in the window before that.

## Testing

- `./do test:unit --file tests/unit/Settings/HostsTest.php` — 2 tests, 78 assertions, pass.
- `./do test:integration --file tests/integration/Mailer/Methods/AmazonSESTest.php` — 15 tests, 44 assertions, pass. One pre-existing skip that needs real AWS credentials.
- `./do test:integration --file tests/integration/Migrations/App/Migration_20260902_130046_App_Test.php` — 4 tests, pass.
- phpcs and phpstan clean.

`testItRejectsRegionsWhereSesIsNotAvailable` is replaced by `testItAcceptsTheDeprecatedRegionsSoWorkerConstructionDoesNotThrow`, which asserts the opposite and says in its name why.

## QA notes

On a site with `mta.method = AmazonSES` and `mta.region = ap-east-1`, trigger a cron run and confirm the daemon completes all workers instead of stopping at the sending queue. Sending itself should still fail, with a connection error.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8448-keep-deprecated-ses-regions)

_The latest successful build from `fix/stomail-8448-keep-deprecated-ses-regions` will be used. If none is available, the link won't work._