### PR TITLE
Align form preview permissions with the form editor

### DIFF
--- a/mailpoet/changelog/2026-09-02-10-04-09-improved-validation-of-form-preview-requests.md
+++ b/mailpoet/changelog/2026-09-02-10-04-09-improved-validation-of-form-preview-requests.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Validation of form preview requests

--- a/mailpoet/lib/Form/PreviewPage.php
+++ b/mailpoet/lib/Form/PreviewPage.php
@@ -8,7 +8,7 @@ use MailPoet\WP\Functions as WPFunctions;
 
 class PreviewPage {
   const PREVIEW_DATA_TRANSIENT_PREFIX = 'mailpoet_form_preview_';
-  const PREVIEW_DATA_EXPIRATION = 84600; // 1 DAY
+  const PREVIEW_DATA_EXPIRATION = DAY_IN_SECONDS;
 
   /** @var WPFunctions  */
   private $wp;

--- a/mailpoet/lib/Router/Endpoints/FormPreview.php
+++ b/mailpoet/lib/Router/Endpoints/FormPreview.php
@@ -21,7 +21,7 @@ class FormPreview {
 
   public $allowedActions = [self::ACTION_VIEW];
   public $permissions = [
-    'global' => AccessControl::NO_ACCESS_RESTRICTION,
+    'global' => AccessControl::PERMISSION_MANAGE_FORMS,
   ];
 
   public function __construct(

--- a/mailpoet/tests/integration/Router/Endpoints/FormPreviewTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/FormPreviewTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Router\Endpoints;
+
+use Codeception\Stub;
+use MailPoet\Config\AccessControl;
+use MailPoet\Entities\FormEntity;
+use MailPoet\Router\Endpoints\FormPreview;
+use MailPoet\Router\Router;
+use MailPoet\Test\DataFactories\Form;
+
+class FormPreviewTest extends \MailPoetTest {
+  private const SUCCESS_MESSAGE = 'Draft form preview rendered';
+
+  /** @var int */
+  private $editorUserId;
+
+  /** @var FormEntity */
+  private $disabledForm;
+
+  public function _before() {
+    parent::_before();
+    // Editors can open the MailPoet admin but cannot manage forms by default
+    $this->editorUserId = $this->tester->createWordPressUser('form_preview_editor@example.com', 'editor');
+    $this->disabledForm = (new Form())
+      ->withName('Draft form')
+      ->withStatus(FormEntity::STATUS_DISABLED)
+      ->withSuccessMessage(self::SUCCESS_MESSAGE)
+      ->create();
+  }
+
+  public function testItRejectsAnonymousRequests() {
+    wp_set_current_user(0);
+    verify($this->routePreviewRequest())->equals(Router::RESPONE_FORBIDDEN);
+  }
+
+  public function testItRejectsUsersWhoCannotManageForms() {
+    verify(user_can($this->editorUserId, AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN))->true();
+    wp_set_current_user($this->editorUserId);
+    verify($this->routePreviewRequest())->equals(Router::RESPONE_FORBIDDEN);
+  }
+
+  public function testItRendersDisabledFormForUsersWhoCanManageForms() {
+    wp_set_current_user(1); // administrator
+    $endpoint = $this->diContainer->get(FormPreview::class);
+
+    verify($this->routePreviewRequest())->null();
+    verify(has_filter('the_content', [$endpoint, 'renderContent']))->notFalse();
+    verify($endpoint->renderContent())->stringContainsString(self::SUCCESS_MESSAGE);
+  }
+
+  private function routePreviewRequest() {
+    $routerData = [
+      Router::NAME => '',
+      'endpoint' => FormPreview::ENDPOINT,
+      'action' => FormPreview::ACTION_VIEW,
+      'data' => Router::encodeRequestData([
+        'id' => $this->disabledForm->getId(),
+        'form_type' => FormEntity::DISPLAY_TYPE_OTHERS,
+        'editor_url' => 'http://example.com/editor',
+      ]),
+    ];
+    $router = Stub::construct(
+      Router::class,
+      [new AccessControl(), $this->diContainer, $routerData],
+      [
+        'terminateRequest' => function($code, $message) {
+          return $code;
+        },
+      ]
+    );
+    return $router->init();
+  }
+}


### PR DESCRIPTION
## Description

The form preview page is opened from the form editor. The editor page and the forms JSON API both check the `mailpoet_manage_forms` capability, but the router endpoint that renders the preview applied its own, looser rule, so the preview flow followed two different rules. This PR makes the preview endpoint check the same capability before rendering, so one rule covers the whole flow.

It also fixes the lifetime of the preview transient: the constant was documented as one day but held 84600 seconds (23.5 hours). It now uses `DAY_IN_SECONDS`.

Forms shown on the site (widget, shortcode, below posts, pop-ups, fixed bar, slide-in) use a separate rendering path and are not affected.

**Backward compatibility:** the preview URL is only reached from the form editor, which already requires the same capability, so no supported flow changes. 

## Code review notes

- The endpoint reuses the router's `permissions` mechanism, the same way `ExportDownload` does.

## QA notes

1. Go to MailPoet → Forms, open a form in the editor and click **Preview**. Switch between the form placements. The preview renders as before, including for a form whose status is disabled.
2. Copy the preview iframe URL (DevTools → Elements, the `mailpoet_form_preview_iframe` element) and open it in a private window. The response is 403 with an empty page.
3. Log in as a user with the Editor role and open the same URL. Same result.

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-8436

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8436-form-preview-permissions)

_The latest successful build from `fix/stomail-8436-form-preview-permissions` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->