### PR TITLE
Require the manage-emails capability for subject suggestions

### DIFF
--- a/mailpoet/changelog/2026-09-02-16-13-10-fixed-restricted-ai-subject-line-suggestions-to-users-wh.md
+++ b/mailpoet/changelog/2026-09-02-16-13-10-fixed-restricted-ai-subject-line-suggestions-to-users-wh.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Restricted AI subject line suggestions to users who can manage emails

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\EmailEditor\Engine\Settings_Controller;
 use Automattic\WooCommerce\EmailEditor\Engine\Theme_Controller;
 use Automattic\WooCommerce\EmailEditor\Engine\User_Theme;
 use MailPoet\Analytics\Analytics;
+use MailPoet\Config\AccessControl;
 use MailPoet\Config\Env;
 use MailPoet\Config\Installer;
 use MailPoet\Config\ServicesChecker;
@@ -245,7 +246,8 @@ class EditorPageRenderer {
       'mailpoet_automation_id' => $automationId,
       'mailpoet_feature_flags' => $this->featuresController->getAllFlags(),
       'mailpoet_capabilities' => $this->capabilitiesManager->getCapabilities(),
-      'mailpoet_ai_text_generation_available' => function_exists('wp_ai_client_prompt')
+      'mailpoet_ai_text_generation_available' => $this->wp->currentUserCan(AccessControl::PERMISSION_MANAGE_EMAILS)
+        && function_exists('wp_ai_client_prompt')
         && wp_ai_client_prompt('test')->is_supported_for_text_generation(),
     ];
     if ($this->bridge->isMailpoetSendingServiceEnabled()) {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
@@ -8,6 +8,7 @@ use MailPoet\API\REST\Endpoint;
 use MailPoet\API\REST\ErrorResponse;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
+use MailPoet\Config\AccessControl;
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Validator\Builder;
@@ -240,7 +241,7 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
   }
 
   public function checkPermissions(): bool {
-    return current_user_can('edit_posts');
+    return $this->wp->currentUserCan(AccessControl::PERMISSION_MANAGE_EMAILS);
   }
 
   /** @return array<string, Schema> */

--- a/mailpoet/tests/integration/REST/EmailEditor/GenerateSubjectSuggestionsEndpointTest.php
+++ b/mailpoet/tests/integration/REST/EmailEditor/GenerateSubjectSuggestionsEndpointTest.php
@@ -45,6 +45,35 @@ class GenerateSubjectSuggestionsEndpointTest extends Test {
     $this->assertSame('mailpoet_ai_unavailable', $data['code']);
   }
 
+  public function testItRejectsEmailsTheUserCannotEditEvenWithTheManageEmailsCapability(): void {
+    $authorId = $this->createUserWithRole('author');
+    $otherAuthorId = $this->createUserWithRole('author');
+    (new \WP_User($authorId))->add_cap(AccessControl::PERMISSION_MANAGE_EMAILS);
+    $emailId = $this->createEmailOwnedBy($otherAuthorId);
+    wp_set_current_user($authorId);
+
+    $data = $this->post(self::ENDPOINT, ['json' => ['post_id' => $emailId]]);
+
+    $this->assertSame('mailpoet_ai_forbidden', $data['code']);
+  }
+
+  public function testItRejectsPostsThatAreNotEmails(): void {
+    $editorId = $this->createUserWithRole('editor');
+    (new \WP_User($editorId))->add_cap(AccessControl::PERMISSION_MANAGE_EMAILS);
+    $postId = $this->tester->createPost([
+      'post_type' => 'post',
+      'post_status' => 'draft',
+      'post_author' => $editorId,
+      'post_title' => 'Not an email',
+      'post_content' => '<!-- wp:paragraph --><p>Regular blog post.</p><!-- /wp:paragraph -->',
+    ])->ID;
+    wp_set_current_user($editorId);
+
+    $data = $this->post(self::ENDPOINT, ['json' => ['post_id' => $postId]]);
+
+    $this->assertSame('mailpoet_ai_email_not_found', $data['code']);
+  }
+
   private function createUserWithRole(string $role): int {
     $suffix = uniqid();
     return (int)$this->tester->createWordPressUser("subject-suggestions-{$role}-{$suffix}@localhost.test", $role);

--- a/mailpoet/tests/integration/REST/EmailEditor/GenerateSubjectSuggestionsEndpointTest.php
+++ b/mailpoet/tests/integration/REST/EmailEditor/GenerateSubjectSuggestionsEndpointTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\REST\EmailEditor;
+
+use MailPoet\Config\AccessControl;
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\REST\Test;
+
+require_once __DIR__ . '/../Test.php';
+
+class GenerateSubjectSuggestionsEndpointTest extends Test {
+  private const ENDPOINT = '/mailpoet/v1/email/generate-subject-suggestions';
+
+  public function _after() {
+    parent::_after();
+    wp_set_current_user(0);
+  }
+
+  public function testItRejectsGuests(): void {
+    wp_set_current_user(0);
+
+    $data = $this->post(self::ENDPOINT, ['json' => ['post_id' => 1]]);
+
+    $this->assertSame('rest_forbidden', $data['code']);
+  }
+
+  public function testItRejectsAuthorsEvenForEmailsTheyOwn(): void {
+    $authorId = $this->createUserWithRole('author');
+    $emailId = $this->createEmailOwnedBy($authorId);
+    wp_set_current_user($authorId);
+
+    $data = $this->post(self::ENDPOINT, ['json' => ['post_id' => $emailId]]);
+
+    $this->assertSame('rest_forbidden', $data['code']);
+  }
+
+  public function testItLetsUsersWithTheManageEmailsCapabilityPastThePermissionCheck(): void {
+    $editorId = $this->createUserWithRole('editor');
+    (new \WP_User($editorId))->add_cap(AccessControl::PERMISSION_MANAGE_EMAILS);
+    $emailId = $this->createEmailOwnedBy($editorId);
+    wp_set_current_user($editorId);
+
+    $data = $this->post(self::ENDPOINT, ['json' => ['post_id' => $emailId]]);
+
+    $this->assertSame('mailpoet_ai_unavailable', $data['code']);
+  }
+
+  private function createUserWithRole(string $role): int {
+    $suffix = uniqid();
+    return (int)$this->tester->createWordPressUser("subject-suggestions-{$role}-{$suffix}@localhost.test", $role);
+  }
+
+  private function createEmailOwnedBy(int $userId): int {
+    return $this->tester->createPost([
+      'post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
+      'post_status' => 'draft',
+      'post_author' => $userId,
+      'post_title' => 'Subject suggestions email',
+      'post_content' => '<!-- wp:paragraph --><p>Big summer sale on garden tools this weekend only.</p><!-- /wp:paragraph -->',
+    ])->ID;
+  }
+}


### PR DESCRIPTION
## Description

Aligns the `email/generate-subject-suggestions` REST route with the other MailPoet email endpoints by requiring the `mailpoet_manage_emails` capability in its permission callback, and only offers the "Suggest with AI" button in the editor sidebar to users who hold that capability, so nobody sees a button their request would be refused for.

Follow-up to #6633, which introduced the route.

**Backward compatibility:** administrators and editors hold `mailpoet_manage_emails` by default, and the `mailpoet_permission_manage_emails` filter keeps working for sites that extend or narrow it. The `edit_post` object check inside the handler is unchanged.

## Code review notes

- The handler's per-post `edit_post` check still calls `current_user_can` directly, because `WPFunctions::currentUserCan()` accepts a single argument and cannot pass the post ID. Widening the wrapper felt out of scope for this change.
- The integration test grants `mailpoet_manage_emails` to its editor user explicitly. The integration environment never runs the activator that attaches MailPoet capabilities to WP roles, so a plain editor role does not carry the capability there.

## QA notes

1. As an administrator or editor, open an email in the block editor and confirm "Suggest with AI" still appears in the sidebar and works when an AI provider is configured.
2. Remove `editor` from the manage-emails permission via the MailPoet roles settings (or the `mailpoet_permission_manage_emails` filter) and open an email as an editor: the button is no longer offered, and a direct `POST /wp-json/mailpoet/v1/email/generate-subject-suggestions` returns `rest_forbidden`.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8438

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8438-subject-suggestions-capability)

_The latest successful build from `fix/stomail-8438-subject-suggestions-capability` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->