### PR TITLE
Keep the exception when writing a log context

### DIFF
--- a/mailpoet/changelog/2026-09-02-16-39-24-fixed-exceptions-recorded-in-the-mailpoet-logs-now-keep-.md
+++ b/mailpoet/changelog/2026-09-02-16-39-24-fixed-exceptions-recorded-in-the-mailpoet-logs-now-keep-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Exceptions recorded in the MailPoet logs now keep their class, file and line instead of being stored empty, which makes a failure easier to trace

--- a/mailpoet/lib/Entities/LogEntity.php
+++ b/mailpoet/lib/Entities/LogEntity.php
@@ -102,7 +102,10 @@ class LogEntity {
       }
     }
 
-    $str = json_encode($context);
+    // Exception messages can carry raw bytes from a database error or a file
+    // path. Without this flag json_encode() returns false and the whole context
+    // is dropped, including the fields that encoded fine.
+    $str = json_encode($context, JSON_INVALID_UTF8_SUBSTITUTE);
     if ($str) {
       $this->context = $str;
     }

--- a/mailpoet/lib/Entities/LogEntity.php
+++ b/mailpoet/lib/Entities/LogEntity.php
@@ -96,9 +96,37 @@ class LogEntity {
   }
 
   public function setContext(array $context): void {
+    foreach ($context as $key => $value) {
+      if ($value instanceof \Throwable) {
+        $context[$key] = $this->normalizeThrowable($value);
+      }
+    }
+
     $str = json_encode($context);
     if ($str) {
       $this->context = $str;
     }
+  }
+
+  /**
+   * json_encode() only serialises public properties, and every property of an
+   * exception is private, so an unconverted Throwable is stored as {}.
+   *
+   * @return array<string, mixed>
+   */
+  private function normalizeThrowable(\Throwable $throwable): array {
+    $normalized = [
+      'class' => get_class($throwable),
+      'message' => $throwable->getMessage(),
+      'code' => $throwable->getCode(),
+      'file' => $throwable->getFile() . ':' . $throwable->getLine(),
+    ];
+
+    $previous = $throwable->getPrevious();
+    if ($previous) {
+      $normalized['previous'] = $this->normalizeThrowable($previous);
+    }
+
+    return $normalized;
   }
 }

--- a/mailpoet/tests/unit/Entities/LogEntityTest.php
+++ b/mailpoet/tests/unit/Entities/LogEntityTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Entities;
+
+use MailPoet\Entities\LogEntity;
+
+class LogEntityTest extends \MailPoetUnitTest {
+  public function testItStoresAnExceptionInsteadOfAnEmptyObject() {
+    $entity = new LogEntity();
+    $entity->setContext(['error' => new \RuntimeException('Unsupported Amazon SES region', 42)]);
+
+    $context = $entity->getContext();
+    $this->assertNotNull($context);
+    $this->assertArrayHasKey('error', $context);
+    verify($context['error']['class'])->equals(\RuntimeException::class);
+    verify($context['error']['message'])->equals('Unsupported Amazon SES region');
+    verify($context['error']['code'])->equals(42);
+    verify($context['error']['file'])->stringContainsString('LogEntityTest.php:');
+    verify($context['error'])->arrayHasNotKey('trace');
+  }
+
+  public function testItKeepsTheCauseOfAWrappedException() {
+    $entity = new LogEntity();
+    $entity->setContext(['error' => new \RuntimeException('outer', 0, new \LogicException('the real cause'))]);
+
+    $context = $entity->getContext();
+    $this->assertNotNull($context);
+    $this->assertArrayHasKey('error', $context);
+    verify($context['error']['previous']['class'])->equals(\LogicException::class);
+    verify($context['error']['previous']['message'])->equals('the real cause');
+  }
+
+  public function testItLeavesOrdinaryValuesAlone() {
+    $entity = new LogEntity();
+    $entity->setContext(['worker' => 'createQueueWorker', 'count' => 3, 'ok' => true]);
+
+    verify($entity->getContext())->equals(['worker' => 'createQueueWorker', 'count' => 3, 'ok' => true]);
+  }
+}

--- a/mailpoet/tests/unit/Entities/LogEntityTest.php
+++ b/mailpoet/tests/unit/Entities/LogEntityTest.php
@@ -30,6 +30,21 @@ class LogEntityTest extends \MailPoetUnitTest {
     verify($context['error']['previous']['message'])->equals('the real cause');
   }
 
+  public function testItStillStoresTheContextWhenAMessageHasInvalidUtf8() {
+    $entity = new LogEntity();
+    $entity->setContext([
+      'error' => new \RuntimeException("boom \xFF\xFE invalid"),
+      'worker' => 'createQueueWorker',
+    ]);
+
+    $context = $entity->getContext();
+    $this->assertNotNull($context);
+    $this->assertArrayHasKey('error', $context);
+    verify($context['worker'])->equals('createQueueWorker');
+    verify($context['error']['message'])->stringContainsString('boom');
+    verify($context['error']['message'])->stringContainsString('invalid');
+  }
+
   public function testItLeavesOrdinaryValuesAlone() {
     $entity = new LogEntity();
     $entity->setContext(['worker' => 'createQueueWorker', 'count' => 3, 'ok' => true]);


### PR DESCRIPTION
## Description

`LogEntity::setContext()` json_encodes the context array. Every property of an exception is private, and `json_encode` only serialises public ones, so any `Throwable` passed in was stored as `{}`.

Call sites have been logging `['error' => $e]` for years and getting nothing back. No class, no file, no line. The message survived only because it is written separately as `raw_message`.

Found while debugging a cron failure. This is what actually reached the database:

```
RAW MESSAGE: Unsupported Amazon SES region
CONTEXT: { "error": {}, "worker": "createQueueWorker" }
```

`setContext()` now converts a top-level `Throwable` to `class`, `message`, `code` and `file:line` before encoding, and follows `getPrevious()` so a wrapped cause is not lost.

## Code review notes

**In the entity, not `LogHandler`.** `LogHandler` looks like the tidier home, but `BulkConfirmationEmailResender` and `BulkConfirmationEmailResend` build a `LogEntity` directly and would have been missed. `setContext()` is the one choke point everything passes through.

**No stack trace, deliberately.** `file:line` already says where it was thrown. A trace is the largest field by far and these logs are read in the admin UI.

**Top level only, deliberately.** An earlier version walked the context recursively. I checked every call site that passes an exception object — `Cron/Daemon.php:87`, `Cron/CronWorkerRunner.php:80`, `Subscribers/ConfirmationEmailMailer.php:141` — and all three put it at the top level. Everywhere else passes `getMessage()`, already a string. The known limit: if someone later writes `['task' => ['failure' => $e]]` it will store `{}` again.

**`getPrevious()` is a different recursion** and is kept. It walks the exception's own cause chain, not the context array. `WordPressMailer` and `Triggers\WordPress` both rethrow with a previous, so without it the outer message hides the real cause. No depth cap needed: `previous` can only be set at construction, so a chain cannot cycle.

## QA notes

Enable logging (Settings → Advanced → Logging → Everything), trigger an error that logs an exception, then open MailPoet → Help → Logs. The context column should name the class, file and line where it used to show `{"error":{}}`.

Automated:

- `./do test:unit --file tests/unit/Entities/LogEntityTest.php` — 3 tests, 12 assertions, pass
- `./do test:integration --file tests/integration/Logging` — 8 tests, 19 assertions, pass
- `./do qa` — exit 0

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/log-context-throwable)

_The latest successful build from `fix/log-context-throwable` will be used. If none is available, the link won't work._