### PR TITLE
Build cron workers inside the try, not at the foreach header

### DIFF
--- a/mailpoet/changelog/2026-09-02-15-38-00-fixed-one-background-job-that-fails-to-start-no-longer-s.md
+++ b/mailpoet/changelog/2026-09-02-15-38-00-fixed-one-background-job-that-fails-to-start-no-longer-s.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+One background job that fails to start no longer stops the rest of them, so bounce processing, WooCommerce sync and the other scheduled jobs keep running

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -46,13 +46,13 @@ class Daemon {
     $this->cronHelper->saveDaemon($settingsDaemonData);
 
     $errors = [];
-    foreach ($this->getWorkers() as $createWorker) {
+    foreach ($this->getWorkers() as $factoryMethod => $createWorker) {
       if (wp_is_maintenance_mode()) {
         // stop execution when in maintenance mode
         break;
       }
 
-      $workerName = 'unknown (worker could not be created)';
+      $workerName = $factoryMethod;
       try {
         // Clear the entity manager memory for every cron run.
         // This avoids using stale data and prevents memory leaks.
@@ -61,7 +61,7 @@ class Daemon {
         // Built inside the try on purpose. A worker that throws while being
         // constructed used to escape this loop and abort the whole daemon run.
         $worker = $createWorker();
-        $workerName = $this->getWorkerName($worker);
+        $workerName = $this->getWorkerName($worker) ?: $factoryMethod;
 
         if ($worker instanceof CronWorkerInterface) {
           $this->cronWorkerRunner->run($worker);
@@ -111,43 +111,45 @@ class Daemon {
 
   /**
    * Each worker is yielded as a factory rather than an instance, so that the
-   * cost and the risk of building it land inside run()'s try/catch.
+   * cost and the risk of building it land inside run()'s try/catch. The key is
+   * the factory method, which is the only name available when a worker throws
+   * before there is an instance to read a class off.
    *
-   * @return \Generator<int, callable, mixed, void>
+   * @return \Generator<string, callable, mixed, void>
    */
   private function getWorkers(): \Generator {
-    yield fn() => $this->workersFactory->createStatsNotificationsWorker(); // not CronWorkerInterface compatible
-    yield fn() => $this->workersFactory->createScheduleWorker(); // not CronWorkerInterface compatible
-    yield fn() => $this->workersFactory->createQueueWorker(); // not CronWorkerInterface compatible
-    yield fn() => $this->workersFactory->createSendingServiceKeyCheckWorker();
-    yield fn() => $this->workersFactory->createPremiumKeyCheckWorker();
-    yield fn() => $this->workersFactory->createSubscribersStatsReportWorker();
-    yield fn() => $this->workersFactory->createBounceWorker();
-    yield fn() => $this->workersFactory->createExportFilesCleanupWorker();
-    yield fn() => $this->workersFactory->createLogCleanupWorker();
-    yield fn() => $this->workersFactory->createSendingTaskSubscribersCleanupWorker();
-    yield fn() => $this->workersFactory->createBounceTaskSubscribersCleanupWorker();
-    yield fn() => $this->workersFactory->createSendingQueueBodyCleanupWorker();
-    yield fn() => $this->workersFactory->createInactiveSubscribersMaintenanceWorker();
-    yield fn() => $this->workersFactory->createUnconfirmedSubscribersCleanupWorker();
-    yield fn() => $this->workersFactory->createUnsubscribeTokensWorker();
-    yield fn() => $this->workersFactory->createWooCommerceSyncWorker();
-    yield fn() => $this->workersFactory->createAuthorizedSendingEmailsCheckWorker();
-    yield fn() => $this->workersFactory->createWooCommercePastOrdersWorker();
-    yield fn() => $this->workersFactory->createStatsNotificationsWorkerForAutomatedEmails();
-    yield fn() => $this->workersFactory->createSubscriberLinkTokensWorker();
-    yield fn() => $this->workersFactory->createSubscribersLastEngagementWorker();
-    yield fn() => $this->workersFactory->createSubscribersCountCacheRecalculationWorker();
-    yield fn() => $this->workersFactory->createReEngagementEmailsSchedulerWorker();
-    yield fn() => $this->workersFactory->createNewsletterTemplateThumbnailsWorker();
-    yield fn() => $this->workersFactory->createAbandonedCartWorker();
-    yield fn() => $this->workersFactory->createBackfillEngagementDataWorker();
-    yield fn() => $this->workersFactory->createSubscribersSegmentsCountSyncWorker();
-    yield fn() => $this->workersFactory->createMixpanelWorker();
-    yield fn() => $this->workersFactory->createTracksWorker();
-    yield fn() => $this->workersFactory->createStatisticsExportWorker();
-    yield fn() => $this->workersFactory->createBulkConfirmationEmailResendWorker();
-    yield fn() => $this->workersFactory->createSubscriberLimitNotificationWorker();
-    yield fn() => $this->workersFactory->createSubscribersEngagementScoreWorker();
+    yield 'createStatsNotificationsWorker' => fn() => $this->workersFactory->createStatsNotificationsWorker(); // not CronWorkerInterface compatible
+    yield 'createScheduleWorker' => fn() => $this->workersFactory->createScheduleWorker(); // not CronWorkerInterface compatible
+    yield 'createQueueWorker' => fn() => $this->workersFactory->createQueueWorker(); // not CronWorkerInterface compatible
+    yield 'createSendingServiceKeyCheckWorker' => fn() => $this->workersFactory->createSendingServiceKeyCheckWorker();
+    yield 'createPremiumKeyCheckWorker' => fn() => $this->workersFactory->createPremiumKeyCheckWorker();
+    yield 'createSubscribersStatsReportWorker' => fn() => $this->workersFactory->createSubscribersStatsReportWorker();
+    yield 'createBounceWorker' => fn() => $this->workersFactory->createBounceWorker();
+    yield 'createExportFilesCleanupWorker' => fn() => $this->workersFactory->createExportFilesCleanupWorker();
+    yield 'createLogCleanupWorker' => fn() => $this->workersFactory->createLogCleanupWorker();
+    yield 'createSendingTaskSubscribersCleanupWorker' => fn() => $this->workersFactory->createSendingTaskSubscribersCleanupWorker();
+    yield 'createBounceTaskSubscribersCleanupWorker' => fn() => $this->workersFactory->createBounceTaskSubscribersCleanupWorker();
+    yield 'createSendingQueueBodyCleanupWorker' => fn() => $this->workersFactory->createSendingQueueBodyCleanupWorker();
+    yield 'createInactiveSubscribersMaintenanceWorker' => fn() => $this->workersFactory->createInactiveSubscribersMaintenanceWorker();
+    yield 'createUnconfirmedSubscribersCleanupWorker' => fn() => $this->workersFactory->createUnconfirmedSubscribersCleanupWorker();
+    yield 'createUnsubscribeTokensWorker' => fn() => $this->workersFactory->createUnsubscribeTokensWorker();
+    yield 'createWooCommerceSyncWorker' => fn() => $this->workersFactory->createWooCommerceSyncWorker();
+    yield 'createAuthorizedSendingEmailsCheckWorker' => fn() => $this->workersFactory->createAuthorizedSendingEmailsCheckWorker();
+    yield 'createWooCommercePastOrdersWorker' => fn() => $this->workersFactory->createWooCommercePastOrdersWorker();
+    yield 'createStatsNotificationsWorkerForAutomatedEmails' => fn() => $this->workersFactory->createStatsNotificationsWorkerForAutomatedEmails();
+    yield 'createSubscriberLinkTokensWorker' => fn() => $this->workersFactory->createSubscriberLinkTokensWorker();
+    yield 'createSubscribersLastEngagementWorker' => fn() => $this->workersFactory->createSubscribersLastEngagementWorker();
+    yield 'createSubscribersCountCacheRecalculationWorker' => fn() => $this->workersFactory->createSubscribersCountCacheRecalculationWorker();
+    yield 'createReEngagementEmailsSchedulerWorker' => fn() => $this->workersFactory->createReEngagementEmailsSchedulerWorker();
+    yield 'createNewsletterTemplateThumbnailsWorker' => fn() => $this->workersFactory->createNewsletterTemplateThumbnailsWorker();
+    yield 'createAbandonedCartWorker' => fn() => $this->workersFactory->createAbandonedCartWorker();
+    yield 'createBackfillEngagementDataWorker' => fn() => $this->workersFactory->createBackfillEngagementDataWorker();
+    yield 'createSubscribersSegmentsCountSyncWorker' => fn() => $this->workersFactory->createSubscribersSegmentsCountSyncWorker();
+    yield 'createMixpanelWorker' => fn() => $this->workersFactory->createMixpanelWorker();
+    yield 'createTracksWorker' => fn() => $this->workersFactory->createTracksWorker();
+    yield 'createStatisticsExportWorker' => fn() => $this->workersFactory->createStatisticsExportWorker();
+    yield 'createBulkConfirmationEmailResendWorker' => fn() => $this->workersFactory->createBulkConfirmationEmailResendWorker();
+    yield 'createSubscriberLimitNotificationWorker' => fn() => $this->workersFactory->createSubscriberLimitNotificationWorker();
+    yield 'createSubscribersEngagementScoreWorker' => fn() => $this->workersFactory->createSubscribersEngagementScoreWorker();
   }
 }

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -46,16 +46,22 @@ class Daemon {
     $this->cronHelper->saveDaemon($settingsDaemonData);
 
     $errors = [];
-    foreach ($this->getWorkers() as $worker) {
+    foreach ($this->getWorkers() as $createWorker) {
       if (wp_is_maintenance_mode()) {
         // stop execution when in maintenance mode
         break;
       }
 
+      $workerName = 'unknown (worker could not be created)';
       try {
         // Clear the entity manager memory for every cron run.
         // This avoids using stale data and prevents memory leaks.
         $this->entityManager->clear();
+
+        // Built inside the try on purpose. A worker that throws while being
+        // constructed used to escape this loop and abort the whole daemon run.
+        $worker = $createWorker();
+        $workerName = $this->getWorkerName($worker);
 
         if ($worker instanceof CronWorkerInterface) {
           $this->cronWorkerRunner->run($worker);
@@ -64,10 +70,6 @@ class Daemon {
         }
       } catch (\Exception $e) {
         Helpers::mySqlGoneAwayExceptionHandler($e);
-
-        $workerClass = is_object($worker) ? get_class($worker) : '';
-        $workerClassNameParts = explode('\\', $workerClass);
-        $workerName = end($workerClassNameParts);
 
         // Expected sending state, not an error — sending resumes once the frequency interval passes.
         if ($e instanceof SendingLimitReachedException) {
@@ -96,39 +98,56 @@ class Daemon {
     $this->cronHelper->saveDaemonRunCompleted(time());
   }
 
-  private function getWorkers() {
-    yield $this->workersFactory->createStatsNotificationsWorker(); // not CronWorkerInterface compatible
-    yield $this->workersFactory->createScheduleWorker(); // not CronWorkerInterface compatible
-    yield $this->workersFactory->createQueueWorker(); // not CronWorkerInterface compatible
-    yield $this->workersFactory->createSendingServiceKeyCheckWorker();
-    yield $this->workersFactory->createPremiumKeyCheckWorker();
-    yield $this->workersFactory->createSubscribersStatsReportWorker();
-    yield $this->workersFactory->createBounceWorker();
-    yield $this->workersFactory->createExportFilesCleanupWorker();
-    yield $this->workersFactory->createLogCleanupWorker();
-    yield $this->workersFactory->createSendingTaskSubscribersCleanupWorker();
-    yield $this->workersFactory->createBounceTaskSubscribersCleanupWorker();
-    yield $this->workersFactory->createSendingQueueBodyCleanupWorker();
-    yield $this->workersFactory->createInactiveSubscribersMaintenanceWorker();
-    yield $this->workersFactory->createUnconfirmedSubscribersCleanupWorker();
-    yield $this->workersFactory->createUnsubscribeTokensWorker();
-    yield $this->workersFactory->createWooCommerceSyncWorker();
-    yield $this->workersFactory->createAuthorizedSendingEmailsCheckWorker();
-    yield $this->workersFactory->createWooCommercePastOrdersWorker();
-    yield $this->workersFactory->createStatsNotificationsWorkerForAutomatedEmails();
-    yield $this->workersFactory->createSubscriberLinkTokensWorker();
-    yield $this->workersFactory->createSubscribersLastEngagementWorker();
-    yield $this->workersFactory->createSubscribersCountCacheRecalculationWorker();
-    yield $this->workersFactory->createReEngagementEmailsSchedulerWorker();
-    yield $this->workersFactory->createNewsletterTemplateThumbnailsWorker();
-    yield $this->workersFactory->createAbandonedCartWorker();
-    yield $this->workersFactory->createBackfillEngagementDataWorker();
-    yield $this->workersFactory->createSubscribersSegmentsCountSyncWorker();
-    yield $this->workersFactory->createMixpanelWorker();
-    yield $this->workersFactory->createTracksWorker();
-    yield $this->workersFactory->createStatisticsExportWorker();
-    yield $this->workersFactory->createBulkConfirmationEmailResendWorker();
-    yield $this->workersFactory->createSubscriberLimitNotificationWorker();
-    yield $this->workersFactory->createSubscribersEngagementScoreWorker();
+  /**
+   * @param mixed $worker
+   */
+  private function getWorkerName($worker): string {
+    if (!is_object($worker)) {
+      return '';
+    }
+    $workerClassNameParts = explode('\\', get_class($worker));
+    return (string)end($workerClassNameParts);
+  }
+
+  /**
+   * Each worker is yielded as a factory rather than an instance, so that the
+   * cost and the risk of building it land inside run()'s try/catch.
+   *
+   * @return \Generator<int, callable, mixed, void>
+   */
+  private function getWorkers(): \Generator {
+    yield fn() => $this->workersFactory->createStatsNotificationsWorker(); // not CronWorkerInterface compatible
+    yield fn() => $this->workersFactory->createScheduleWorker(); // not CronWorkerInterface compatible
+    yield fn() => $this->workersFactory->createQueueWorker(); // not CronWorkerInterface compatible
+    yield fn() => $this->workersFactory->createSendingServiceKeyCheckWorker();
+    yield fn() => $this->workersFactory->createPremiumKeyCheckWorker();
+    yield fn() => $this->workersFactory->createSubscribersStatsReportWorker();
+    yield fn() => $this->workersFactory->createBounceWorker();
+    yield fn() => $this->workersFactory->createExportFilesCleanupWorker();
+    yield fn() => $this->workersFactory->createLogCleanupWorker();
+    yield fn() => $this->workersFactory->createSendingTaskSubscribersCleanupWorker();
+    yield fn() => $this->workersFactory->createBounceTaskSubscribersCleanupWorker();
+    yield fn() => $this->workersFactory->createSendingQueueBodyCleanupWorker();
+    yield fn() => $this->workersFactory->createInactiveSubscribersMaintenanceWorker();
+    yield fn() => $this->workersFactory->createUnconfirmedSubscribersCleanupWorker();
+    yield fn() => $this->workersFactory->createUnsubscribeTokensWorker();
+    yield fn() => $this->workersFactory->createWooCommerceSyncWorker();
+    yield fn() => $this->workersFactory->createAuthorizedSendingEmailsCheckWorker();
+    yield fn() => $this->workersFactory->createWooCommercePastOrdersWorker();
+    yield fn() => $this->workersFactory->createStatsNotificationsWorkerForAutomatedEmails();
+    yield fn() => $this->workersFactory->createSubscriberLinkTokensWorker();
+    yield fn() => $this->workersFactory->createSubscribersLastEngagementWorker();
+    yield fn() => $this->workersFactory->createSubscribersCountCacheRecalculationWorker();
+    yield fn() => $this->workersFactory->createReEngagementEmailsSchedulerWorker();
+    yield fn() => $this->workersFactory->createNewsletterTemplateThumbnailsWorker();
+    yield fn() => $this->workersFactory->createAbandonedCartWorker();
+    yield fn() => $this->workersFactory->createBackfillEngagementDataWorker();
+    yield fn() => $this->workersFactory->createSubscribersSegmentsCountSyncWorker();
+    yield fn() => $this->workersFactory->createMixpanelWorker();
+    yield fn() => $this->workersFactory->createTracksWorker();
+    yield fn() => $this->workersFactory->createStatisticsExportWorker();
+    yield fn() => $this->workersFactory->createBulkConfirmationEmailResendWorker();
+    yield fn() => $this->workersFactory->createSubscriberLimitNotificationWorker();
+    yield fn() => $this->workersFactory->createSubscribersEngagementScoreWorker();
   }
 }

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -167,7 +167,7 @@ class DaemonTest extends \MailPoetTest {
 
     $daemonData = $this->settings->get(CronHelper::DAEMON_SETTING);
     verify($daemonData['run_completed_at'])->notEmpty();
-    verify($daemonData['last_error'][0]['worker'])->equals('unknown (worker could not be created)');
+    verify($daemonData['last_error'][0]['worker'])->equals('createQueueWorker');
   }
 
   private function createWorkersFactoryMock(array $workers = []) {

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -128,6 +128,48 @@ class DaemonTest extends \MailPoetTest {
     $this->wp->removeFilter('mailpoet_cron_get_execution_limit', $limitCallback);
   }
 
+  public function testItKeepsRunningWhenAWorkerCannotBeCreated() {
+    $cronWorkerRunner = $this->make(CronWorkerRunner::class, ['run' => null]);
+    $data = ['token' => 123];
+    $this->settings->set(CronHelper::DAEMON_SETTING, $data);
+
+    // The queue worker is 3rd of 33. Every later worker must still run.
+    $daemon = $this->getServiceWithOverrides(Daemon::class, [
+      'cronWorkerRunner' => $cronWorkerRunner,
+      'workersFactory' => $this->createWorkersFactoryMock([
+        'createQueueWorker' => function () {
+          throw new \Exception('Unsupported Amazon SES region');
+        },
+      ]),
+    ]);
+
+    $daemon->run($data);
+
+    $log = $this->logRepository->findOneBy(['name' => 'cron', 'level' => 400]);
+    $this->assertInstanceOf(LogEntity::class, $log);
+    verify($log->getMessage())->stringContainsString('Unsupported Amazon SES region');
+  }
+
+  public function testItRecordsTheRunAsCompletedWhenAWorkerCannotBeCreated() {
+    $cronWorkerRunner = $this->make(CronWorkerRunner::class, ['run' => null]);
+    $data = ['token' => 123];
+    $this->settings->set(CronHelper::DAEMON_SETTING, $data);
+    $daemon = $this->getServiceWithOverrides(Daemon::class, [
+      'cronWorkerRunner' => $cronWorkerRunner,
+      'workersFactory' => $this->createWorkersFactoryMock([
+        'createQueueWorker' => function () {
+          throw new \Exception('Unsupported Amazon SES region');
+        },
+      ]),
+    ]);
+
+    $daemon->run($data);
+
+    $daemonData = $this->settings->get(CronHelper::DAEMON_SETTING);
+    verify($daemonData['run_completed_at'])->notEmpty();
+    verify($daemonData['last_error'][0]['worker'])->equals('unknown (worker could not be created)');
+  }
+
   private function createWorkersFactoryMock(array $workers = []) {
     return $this->make(WorkersFactory::class, $workers + [
       'createScheduleWorker' => $this->createSimpleWorkerMock(),


### PR DESCRIPTION
## Description

Fixes [STOMAIL-8448](https://linear.app/a8c/issue/STOMAIL-8448).

`Daemon::run()` looped over `getWorkers()`, a generator that yielded already constructed workers. A generator is advanced at the `foreach` header, which sits **outside** the try/catch in the loop body — so a worker that threw while being *built* escaped the loop entirely.

The damage was not limited to that worker:

- every later worker was skipped
- `saveDaemonRunCompleted()` never ran
- `DaemonHttpRunner` never reached `callSelf()` to reschedule

STOMAIL-8448 hit it. Removing a dead Amazon SES region made `AmazonSES` throw during construction, and because `Tasks\Mailer` builds its mailer in its own constructor, the throw happened while the queue worker was being created. The queue worker is 3rd of 33, so a site with a stale region lost bounce processing, WooCommerce sync, subscriber cleanup, stats and automation scheduling. Not just sending.

Retrying did not help: the setting is the same every run, so every cycle failed at the same worker.

`getWorkers()` now yields factories instead of instances, and `run()` calls each inside the try. A worker that cannot be built is logged and skipped like any other failing worker, and the run completes.

## Code review notes

**Same shape as the STOMAIL-8365 fix**, where one throw inside `Initializer::initialize()` took down every registration after it.

**Worker naming.** The name used to be read off the instance in the catch, which is impossible when construction is what failed. Each yield now carries its factory method as the generator key, so a construction failure logs `createQueueWorker` rather than nothing. Successful construction still reads the class off the instance, so existing log output and anything parsing it are unchanged.

**Worth knowing while reviewing the logging:** `['error' => $e]` is currently stored as `{}`, because `LogEntity::setContext()` json_encodes it and every exception property is private. That is why the generator key matters so much here — it is the only diagnostic that survives. Fixed separately in #7094; this PR does not depend on it.

**Construction now happens after `$this->entityManager->clear()`** rather than before. Workers only wire services in their constructors, so this is safe, and clearing first is what the existing comment says the loop intends.

## QA notes

On a site with `mta.method = AmazonSES` and `mta.region = ap-east-1`, trigger a cron run and confirm the daemon completes every worker instead of stopping at the sending queue. Sending itself should still fail, with a connection error.

Automated:

- `./do test:integration --file tests/integration/Cron/DaemonTest.php` — 6 tests, 11 assertions, pass
- `./do test:integration --file tests/integration/Cron/DaemonHttpRunnerTest.php` — 13 tests, 28 assertions, pass
- `./do qa` — exit 0

The two new tests were checked against a reverted `Daemon.php`: without the fix they error, with it they pass. They assert that later workers still run when the 3rd of 33 cannot be built, and that the run is still recorded as completed with the failing worker named.

## Linked PRs

#7094 — unrelated fix, but it restores the exception detail that makes a failure here diagnosable.

## Linked tickets

STOMAIL-8448

## After-merge notes

The real defect is fixed here, so `ap-east-1` and `cn-north-1` can stay removed from the SES region list. #7091, which proposed putting them back as a workaround, is closed.

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-daemon-worker-construction)

_The latest successful build from `stomail-daemon-worker-construction` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->