### PR TITLE
Fix flaky itCanCreateMailPoetCampaigns test

### DIFF
--- a/mailpoet/tests/acceptance/WooCommerce/MPMarketingChannelCest.php
+++ b/mailpoet/tests/acceptance/WooCommerce/MPMarketingChannelCest.php
@@ -83,7 +83,7 @@ class MPMarketingChannelCest {
       $i->login();
 
       $i->amOnPage('/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing');
-      $i->see('Create a campaign', '.woocommerce-marketing-introduction-banner-buttons');
+      $i->waitForText('Create a campaign', 10, '.woocommerce-marketing-introduction-banner-buttons');
       $i->click('Create a campaign', '.woocommerce-marketing-introduction-banner-buttons');
       $i->waitForText('Create a new campaign');
       $i->see('Where would you like to promote your products?');


### PR DESCRIPTION
## Description

`MPMarketingChannelCest::itCanCreateMailPoetCampaigns` failed on [an unrelated branch](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/24768/workflows/98d00fc7-35e0-4f88-8094-aec20353d6d1/jobs/437097/tests) with:

```
Element located either by name, CSS or XPath element with '.woocommerce-marketing-introduction-banner-buttons' was not found.
```

CircleCI's trunk test metrics show the same test failing once more in the last 100 runs. The CI screenshot and page dump show why: the WooCommerce marketing overview was still on its loading spinner. 

This PR swaps the `see()` for `waitForText()` with a 10-second timeout, the same wait the other tests in this file use for the channels card.

To prove the change addresses the race rather than passing by luck, I ran the test locally with a temporary mu-plugin that delays the marketing REST responses by 4 seconds:

| Code | REST delay | Result |
| --- | --- | --- |
| before | no | pass |
| before | 4s | fails with the exact CI message at line 86 |
| after | 4s | pass |

## Code review notes

`waitForText()` with a context selector keeps retrying while the context element itself is missing: php-webdriver's `WebDriverWait::until()` swallows `NoSuchElementException` between polls. So no separate `waitForElement()` is needed before it.

## QA notes

_N/A_ (test-only change; the acceptance job on this PR is the check)

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGr4A77oRnm88mz4CSGGjv

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-flaky-test)

_The latest successful build from `fix-flaky-test` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->