### PR TITLE
Rerun only failed acceptance tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,45 +506,30 @@ jobs:
             cd ../tests_env/docker
             docker compose run wordpress php --version
       - run:
-          name: Group acceptance tests
-          command: |
-            # Convert test result filename values to be relative paths because the circleci CLI's split command requires exact matches
-            if [ -e $CIRCLE_INTERNAL_TASK_DATA/circle-test-results/results.json ]; then
-              sed -i.bak 's#/wp-core/wp-content/plugins/mailpoet/##g' $CIRCLE_INTERNAL_TASK_DATA/circle-test-results/results.json
-            fi
-            # `circleci tests split` returns different values based on the container it's run on
-            # in case group is defined find only tests containing the group
-            if [[ -n '<< parameters.group >>' ]]; then
-              grep -rw 'tests/acceptance' -e '@group << parameters.group >>' | sed -e "s/:.*//" | circleci tests split --split-by=timings > tests/acceptance/_groups/circleci_split_group
-            else
-              circleci tests glob "tests/acceptance/**/*Cest.php" | circleci tests split --split-by=timings > tests/acceptance/_groups/circleci_split_group
-            fi
-            cat tests/acceptance/_groups/circleci_split_group
-      - run:
           name: Run acceptance tests
           command: |
             mkdir -m 777 -p tests/_output/exceptions
-            cd ../tests_env/docker
-            args=(
-              --steps
-              --debug
-              -vvv
-              --html
-              --xml
-              -g circleci_split_group
-            )
-            docker compose run -e SKIP_DEPS=1 \
-            -e CIRCLE_BRANCH=${CIRCLE_BRANCH} \
-            -e CIRCLE_JOB=${CIRCLE_JOB} \
-            -e GH_TOKEN=${WP_GITHUB_WOOCOMMERCE_TOKEN} \
-            -e MULTISITE=<< parameters.multisite >> \
-            -e BLOCKBASED_THEME=<< parameters.blockbased_theme >> \
-            -e ENABLE_HPOS=<< parameters.enable_hpos >> \
-            -e ENABLE_HPOS_SYNC=<< parameters.enable_hpos_sync >> \
-            -e DISABLE_HPOS=<< parameters.disable_hpos >> \
-            -e WORDPRESS_VERSION=${WORDPRESS_VERSION} \
-            -e GUTENBERG_VERSION=${GUTENBERG_VERSION} \
-            codeception_acceptance "${args[@]}"
+            # Convert test result filename values to be relative paths because the circleci CLI requires exact matches
+            if [ -e $CIRCLE_INTERNAL_TASK_DATA/circle-test-results/results.json ]; then
+              sed -i.bak 's#/wp-core/wp-content/plugins/mailpoet/##g' $CIRCLE_INTERNAL_TASK_DATA/circle-test-results/results.json
+            fi
+            export MULTISITE=<< parameters.multisite >>
+            export BLOCKBASED_THEME=<< parameters.blockbased_theme >>
+            export ENABLE_HPOS=<< parameters.enable_hpos >>
+            export ENABLE_HPOS_SYNC=<< parameters.enable_hpos_sync >>
+            export DISABLE_HPOS=<< parameters.disable_hpos >>
+            # `circleci tests run` splits the list and launches the tests itself, which is what
+            # lets CircleCI offer "Rerun failed tests" on this job. `circleci tests split` cannot.
+            # in case group is defined find only tests containing the group
+            if [[ -n '<< parameters.group >>' ]]; then
+              grep -rw 'tests/acceptance' -e '@group << parameters.group >>' | sed -e "s/:.*//"
+            else
+              circleci tests glob "tests/acceptance/**/*Cest.php"
+            fi | circleci tests run \
+              --command='../.circleci/run_acceptance_tests.sh' \
+              --split-by=timings \
+              --timings-type=filename \
+              --verbose
       - run:
           name: Check exceptions
           command: |

--- a/.circleci/run_acceptance_tests.sh
+++ b/.circleci/run_acceptance_tests.sh
@@ -29,7 +29,9 @@ args=(
   -g circleci_split_group
 )
 
-docker compose run -e SKIP_DEPS=1 \
+# -T and </dev/null because our stdin is the pipe `circleci tests run` sent the test
+# list on, and compose refuses to allocate a TTY on it.
+docker compose run -T -e SKIP_DEPS=1 \
   -e CIRCLE_BRANCH="${CIRCLE_BRANCH}" \
   -e CIRCLE_JOB="${CIRCLE_JOB}" \
   -e GH_TOKEN="${WP_GITHUB_WOOCOMMERCE_TOKEN}" \
@@ -40,4 +42,4 @@ docker compose run -e SKIP_DEPS=1 \
   -e DISABLE_HPOS="${DISABLE_HPOS}" \
   -e WORDPRESS_VERSION="${WORDPRESS_VERSION}" \
   -e GUTENBERG_VERSION="${GUTENBERG_VERSION}" \
-  codeception_acceptance "${args[@]}"
+  codeception_acceptance "${args[@]}" < /dev/null

--- a/.circleci/run_acceptance_tests.sh
+++ b/.circleci/run_acceptance_tests.sh
@@ -8,8 +8,10 @@ set -eo pipefail
 
 GROUP_FILE=tests/acceptance/_groups/circleci_split_group
 
-# A blank line would make Codeception run with an empty group, so drop them.
-sed '/^[[:space:]]*$/d' > "$GROUP_FILE"
+# `circleci tests run` sends the names space separated on one line, and Codeception
+# reads one path per line, so put each on its own. Blank lines would make it run with
+# an empty group.
+tr '[:space:]' '\n' | sed '/^[[:space:]]*$/d' > "$GROUP_FILE"
 
 if [ ! -s "$GROUP_FILE" ]; then
   echo "No acceptance tests were assigned to this container."

--- a/.circleci/run_acceptance_tests.sh
+++ b/.circleci/run_acceptance_tests.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Runs the acceptance suite for the test files `circleci tests run` sends on stdin.
+# It lives in a script rather than inline in config.yml because CircleCI has to
+# launch the tests itself for "Rerun failed tests" to work.
+
+set -eo pipefail
+
+GROUP_FILE=tests/acceptance/_groups/circleci_split_group
+
+# A blank line would make Codeception run with an empty group, so drop them.
+sed '/^[[:space:]]*$/d' > "$GROUP_FILE"
+
+if [ ! -s "$GROUP_FILE" ]; then
+  echo "No acceptance tests were assigned to this container."
+  exit 0
+fi
+
+cat "$GROUP_FILE"
+
+cd ../tests_env/docker
+
+args=(
+  --steps
+  --debug
+  -vvv
+  --html
+  --xml
+  -g circleci_split_group
+)
+
+docker compose run -e SKIP_DEPS=1 \
+  -e CIRCLE_BRANCH="${CIRCLE_BRANCH}" \
+  -e CIRCLE_JOB="${CIRCLE_JOB}" \
+  -e GH_TOKEN="${WP_GITHUB_WOOCOMMERCE_TOKEN}" \
+  -e MULTISITE="${MULTISITE}" \
+  -e BLOCKBASED_THEME="${BLOCKBASED_THEME}" \
+  -e ENABLE_HPOS="${ENABLE_HPOS}" \
+  -e ENABLE_HPOS_SYNC="${ENABLE_HPOS_SYNC}" \
+  -e DISABLE_HPOS="${DISABLE_HPOS}" \
+  -e WORDPRESS_VERSION="${WORDPRESS_VERSION}" \
+  -e GUTENBERG_VERSION="${GUTENBERG_VERSION}" \
+  codeception_acceptance "${args[@]}"


### PR DESCRIPTION
## Description

CircleCI can rerun only the tests that failed, instead of the whole job. Today we cannot use it: the button only appears when a job launches its tests with `circleci tests run`, and `acceptance_tests` uses `circleci tests split`. With `split`, CircleCI hands us a list and we run it ourselves, so it never learns which tests a container actually ran. After one flaky test the only option is rerunning all 20 containers.

This converts the free plugin's `acceptance_tests` job. Nothing else is touched yet.

- `Group acceptance tests` and `Run acceptance tests` merge into one step. The file list (or the `@group` grep) now pipes into `circleci tests run`, which splits it and calls the command with each container's share on stdin.
- New `.circleci/run_acceptance_tests.sh` reads that list, writes it to the existing `tests/acceptance/_groups/circleci_split_group`, and runs the same `docker compose run ... codeception_acceptance` as before.
- The job parameters that used to be interpolated into the `docker compose` line are exported as env vars so the script can read them.

Splitting behaviour is unchanged: `circleci tests run` reads the same `CIRCLE_NODE_INDEX` / `CIRCLE_NODE_TOTAL`, so `parallelism` works as before.

## Code review notes

**Why a script instead of an inline `--command`.** CircleCI has to launch the tests itself. That invocation carries eleven `-e` flags and an args array, which inline would be a quoting maze. `.circleci/` already holds `check_wordpress_beta.sh` and `check_woocommerce_beta.sh`, so this follows the existing pattern.

**Why the group file stays.** Codeception's CLI takes one path argument, so `xargs codecept run <many files>` is not possible. Writing stdin into the group file keeps `-g` working and keeps the change to one thing.

**Why the list pipes straight from `if`/`fi` rather than through a variable.** An earlier version used `TEST_FILES=$(...)` and `echo "$TEST_FILES"`. On an empty list `echo ""` emits a newline, so the group file was one byte instead of zero, the emptiness guard passed, and Codeception ran with an empty group. The script also strips blank lines now, as a second guard.

**The `sed` on `results.json` is deliberately kept.** Codeception writes the JUnit `file=` attribute as the in-container absolute path, and that `sed` is what makes it match the relative paths we put on stdin. If it turns out not to cover the rerun list as well as the timings data, the fallback is `--timings-type=classname`.

**Two things only a real run can answer**, both visible in this PR's first `acceptance_tests` log:

1. Whether `circleci tests run` propagates a non-zero exit from the command. If it swallows one, failing tests would report green — `Check exceptions` only catches exceptions, not failures.
2. Whether it calls the command once per container or once per test. Once per container is the documented shape; once per test would mean a `docker compose run` each.

## QA notes

Verified locally by running the script with a fake `docker` on `PATH`:

| Case | Result |
| --- | --- |
| Two test paths on stdin | Group file holds both, docker called with the identical flag list to before |
| Single blank line | Skipped, exit 0, docker never called |
| Empty stdin | Same |
| Trailing blank line after a real test | Blank dropped, test still runs |
| Docker exits 7 | Script exits 7 |

Also checked: the config still parses as YAML with all 20 jobs; `bash -n` clean; `prettier --check .` clean; git records the script as mode `100755`; no duplicate entries from the `@group` grep for any group in use (`frontend` 49/49, `woo` 23/23, `gutenberg-latest` 6/6); `skip_group` belongs to `integration_tests` only; there are no approval jobs, so the docs' "cancel the approval job first" caveat does not apply.

Did not run `./do qa` — this diff has no PHP, JS or CSS, and CI's own `qa_php` / `qa_js` jobs cover it.

The real check is this PR's `acceptance_tests` jobs going green with the same test counts as trunk. After that, failing one test on purpose and using the Rerun failed tests button.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

If this works, the same pattern applies to shop's `acceptance_tests`, then free and premium `integration_tests`. `unit_tests` and `js_tests` need more: they run inside the `mailpoet/wordpress:*` images, which probably lack the `circleci` binary, and `js_tests` runs two test types in one job, which the feature does not support.

Reruns upload a JUnit containing only the tests that were rerun, so the timings store may drift and unbalance later splits. Worth watching.

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/circleci-rerun-failed-acceptance-tests)

_The latest successful build from `update/circleci-rerun-failed-acceptance-tests` will be used. If none is available, the link won't work._