### PR TITLE
Catch Throwable in the daemon loop, not just Exception

### DIFF
--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -68,7 +68,10 @@ class Daemon {
         } else {
           $worker->process($this->timer); // BC for workers not implementing CronWorkerInterface
         }
-      } catch (\Exception $e) {
+      } catch (\Throwable $e) {
+        // Throwable, not Exception: a worker that fails to build usually fails with
+        // an Error (a type mismatch or a missing class), which is the whole reason
+        // construction moved inside this try.
         Helpers::mySqlGoneAwayExceptionHandler($e);
 
         // Expected sending state, not an error — sending resumes once the frequency interval passes.

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -170,6 +170,31 @@ class DaemonTest extends \MailPoetTest {
     verify($daemonData['last_error'][0]['worker'])->equals('createQueueWorker');
   }
 
+  public function testItKeepsRunningWhenAWorkerConstructionThrowsAnError() {
+    $cronWorkerRunner = $this->make(CronWorkerRunner::class, ['run' => null]);
+    $data = ['token' => 123];
+    $this->settings->set(CronHelper::DAEMON_SETTING, $data);
+
+    // A missing class or a type mismatch raises an Error, not an Exception.
+    $daemon = $this->getServiceWithOverrides(Daemon::class, [
+      'cronWorkerRunner' => $cronWorkerRunner,
+      'workersFactory' => $this->createWorkersFactoryMock([
+        'createQueueWorker' => function () {
+          throw new \TypeError('Argument #1 must be of type SubscribersRepository, null given');
+        },
+      ]),
+    ]);
+
+    $daemon->run($data);
+
+    $daemonData = $this->settings->get(CronHelper::DAEMON_SETTING);
+    verify($daemonData['run_completed_at'])->notEmpty();
+    verify($daemonData['last_error'][0]['worker'])->equals('createQueueWorker');
+    $log = $this->logRepository->findOneBy(['name' => 'cron', 'level' => 400]);
+    $this->assertInstanceOf(LogEntity::class, $log);
+    verify($log->getMessage())->stringContainsString('must be of type');
+  }
+
   private function createWorkersFactoryMock(array $workers = []) {
     return $this->make(WorkersFactory::class, $workers + [
       'createScheduleWorker' => $this->createSimpleWorkerMock(),


### PR DESCRIPTION
## Description

Fixes [STOMAIL-8450](https://linear.app/a8c/issue/STOMAIL-8450).

#7095 moved cron worker construction inside `run()`'s try, so a worker that fails to build no longer aborts the whole daemon run. The catch was left at `\Exception`.

That misses the error class most likely to come out of a constructor. A `\TypeError` or `\Error` — a type mismatch, a missing class after a partial upgrade, DI wiring drift — is not an `\Exception`, so it still escaped the loop, skipped every later worker, skipped `saveDaemonRunCompleted()`, and stopped `DaemonHttpRunner` reaching `callSelf()` to reschedule.

That is the exact failure #7095 set out to remove, for a different error class.

**Not a regression from #7095.** Before that PR, every construction failure aborted the run. This closes the half it left open.

## Code review notes

**Drop-in.** `Helpers::mySqlGoneAwayExceptionHandler()` already type-hints `\Throwable` (`Helpers.php:123`), and the rest of the block only reads `getMessage()`, `getCode()` and one `instanceof` — all unchanged on a Throwable.

**Catching `\Error` is deliberate.** The usual objection is that it can hide a genuine code bug, which should surface loudly. That does not apply in this loop: the alternative is not a loud failure, it is killing about thirty unrelated background jobs and writing nothing to the log at all, because the throw escapes before the logging line. A logged, named, skipped worker is the better outcome, and it matches what the loop already does for Exceptions — one worker's failure must not stop the others.

**The same narrowness exists one level up** and is not addressed here: `DaemonHttpRunner` has no try/catch around `run()` at all, so anything that does escape still skips `callSelf()`. Separate question.

## QA notes

No changelog entry.

- `./do test:integration --file tests/integration/Cron/DaemonTest.php` — 7 tests, 15 assertions, pass
- `./do test:integration --file tests/integration/Cron/DaemonHttpRunnerTest.php` — 13 tests, 28 assertions, pass
- `./do qa` — exit 0

The new test throws a `\TypeError` from a worker factory and asserts the run still completes, the failing worker is named in `last_error`, and the message reaches the cron log. Checked against a reverted catch clause: with `catch (\Exception)` it errors, with `catch (\Throwable)` it passes.

## Linked PRs

#7095 — the PR this completes.

## Linked tickets

STOMAIL-8450

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->