### PR TITLE
Require the manage-emails capability for preview sending

### DIFF
--- a/mailpoet/changelog/2026-09-03-12-06-55-fixed-restricted-sending-email-previews-from-the-email-e.md
+++ b/mailpoet/changelog/2026-09-03-12-06-55-fixed-restricted-sending-email-previews-from-the-email-e.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Restricted sending email previews from the email editor to users who can manage emails

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorPreviewEmail.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorPreviewEmail.php
@@ -2,21 +2,27 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
+use MailPoet\Config\AccessControl;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Preview\SendPreviewController;
+use MailPoet\WP\Functions as WPFunctions;
 
 class EmailEditorPreviewEmail {
   private NewslettersRepository $newslettersRepository;
 
   private SendPreviewController $sendPreviewController;
 
+  private WPFunctions $wp;
+
   public function __construct(
     NewslettersRepository $newslettersRepository,
-    SendPreviewController $sendPreviewController
+    SendPreviewController $sendPreviewController,
+    WPFunctions $wp
   ) {
     $this->newslettersRepository = $newslettersRepository;
     $this->sendPreviewController = $sendPreviewController;
+    $this->wp = $wp;
   }
 
   /**
@@ -28,6 +34,10 @@ class EmailEditorPreviewEmail {
   public function sendPreviewEmail($postData) {
     if (is_bool($postData) || !isset($postData['postId']) || get_post_type((int)$postData['postId']) !== EmailEditor::MAILPOET_EMAIL_POST_TYPE) {
       return $postData;
+    }
+
+    if (!$this->wp->currentUserCan(AccessControl::PERMISSION_MANAGE_EMAILS)) {
+      throw new \Exception(esc_html__('You do not have permission to perform this action.', 'mailpoet'));
     }
 
     $this->validateData($postData);

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailEditorPreviewEmailTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailEditorPreviewEmailTest.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet;
+
+use MailPoet\Config\AccessControl;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\Preview\SendPreviewController;
+use MailPoet\Test\DataFactories\Newsletter;
+
+class EmailEditorPreviewEmailTest extends \MailPoetTest {
+  /** @var SendPreviewController&\PHPUnit\Framework\MockObject\MockObject */
+  private $sendPreviewController;
+
+  /** @var EmailEditorPreviewEmail */
+  private $previewEmail;
+
+  public function _before() {
+    parent::_before();
+    $this->sendPreviewController = $this->createMock(SendPreviewController::class);
+    $this->previewEmail = $this->getServiceWithOverrides(EmailEditorPreviewEmail::class, [
+      'sendPreviewController' => $this->sendPreviewController,
+    ]);
+  }
+
+  public function testItLeavesPostsThatAreNotEmailsToOtherHandlers(): void {
+    $authorId = $this->createUserWithRole('author');
+    $postId = $this->tester->createPost([
+      'post_type' => 'post',
+      'post_author' => $authorId,
+      'post_title' => 'Not an email',
+    ])->ID;
+    wp_set_current_user($authorId);
+    $this->sendPreviewController->expects($this->never())->method('sendPreview');
+
+    $data = ['email' => 'test@example.com', 'postId' => $postId];
+
+    $this->assertSame($data, $this->previewEmail->sendPreviewEmail($data));
+  }
+
+  public function testItRejectsUsersWithoutTheManageEmailsCapability(): void {
+    $authorId = $this->createUserWithRole('author');
+    $postId = $this->createEmailOwnedBy($authorId);
+    (new Newsletter())->withWpPostId($postId)->create();
+    wp_set_current_user($authorId);
+    $this->sendPreviewController->expects($this->never())->method('sendPreview');
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('You do not have permission to perform this action.');
+    $this->previewEmail->sendPreviewEmail(['email' => 'test@example.com', 'postId' => $postId]);
+  }
+
+  public function testItSendsThePreviewForUsersWithTheManageEmailsCapability(): void {
+    $editorId = $this->createUserWithRole('editor');
+    (new \WP_User($editorId))->add_cap(AccessControl::PERMISSION_MANAGE_EMAILS);
+    $postId = $this->createEmailOwnedBy($editorId);
+    $newsletter = (new Newsletter())->withWpPostId($postId)->create();
+    wp_set_current_user($editorId);
+    $this->sendPreviewController->expects($this->once())
+      ->method('sendPreview')
+      ->with($this->callback(function (NewsletterEntity $sent) use ($newsletter) {
+        return $sent->getId() === $newsletter->getId();
+      }), 'test@example.com');
+
+    $this->assertTrue($this->previewEmail->sendPreviewEmail(['email' => 'test@example.com', 'postId' => $postId]));
+  }
+
+  public function _after() {
+    parent::_after();
+    wp_set_current_user(0);
+    $this->truncateEntity(NewsletterEntity::class);
+  }
+
+  private function createUserWithRole(string $role): int {
+    $suffix = uniqid();
+    return (int)$this->tester->createWordPressUser("preview-email-{$role}-{$suffix}@localhost.test", $role);
+  }
+
+  private function createEmailOwnedBy(int $userId): int {
+    return $this->tester->createPost([
+      'post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
+      'post_status' => 'draft',
+      'post_author' => $userId,
+      'post_title' => 'Preview email',
+    ])->ID;
+  }
+}


### PR DESCRIPTION
## Description

`EmailEditorPreviewEmail::sendPreviewEmail()` now requires `mailpoet_manage_emails` before sending a preview of a `mailpoet_email` post, like the other MailPoet email endpoints. Other post types still pass through unchanged, so the WooCommerce preview flow is not affected.

Companion to https://github.com/woocommerce/woocommerce/pull/68335, which restricts the package route to registered email post types. This PR does not depend on it.

## Code review notes

_N/A_

## QA notes

1. As admin, "Send a test email" from the block editor still works.
2. Remove `editor` from the manage-emails permission in MailPoet roles settings, then as an editor try the same. Expect "You do not have permission to perform this action." and no mail.

## Linked PRs

- https://github.com/woocommerce/woocommerce/pull/68335

## Linked tickets

- [STOMAIL-8437: Security: Email-editor preview route sends arbitrary mail as a default Author (HackerOne #3961747)](https://linear.app/a8c/issue/STOMAIL-8437/security-email-editor-preview-route-sends-arbitrary-mail-as-a-default)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8437-security-email-editor-preview-route-sends-arbitrary-mail-as)

_The latest successful build from `stomail-8437-security-email-editor-preview-route-sends-arbitrary-mail-as` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->