### PR TITLE
Let plugins override the author and categories shown with posts in emails

### DIFF
--- a/mailpoet/changelog/2026-09-03-14-01-07-added-filters-to-override-the-author-and-categories-show.md
+++ b/mailpoet/changelog/2026-09-03-14-01-07-added-filters-to-override-the-author-and-categories-show.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Filters to override the author and categories shown in newsletters that include posts

--- a/mailpoet/lib/Newsletter/Editor/MetaInformationManager.php
+++ b/mailpoet/lib/Newsletter/Editor/MetaInformationManager.php
@@ -22,6 +22,14 @@ class MetaInformationManager {
       $text = [];
 
       if (isset($args['showAuthor']) && $args['showAuthor'] === $positionField) {
+        /**
+         * Filters the author line shown with a post in an email.
+         *
+         * @param string      $author     The author line, including the label set in the block.
+         * @param int         $postId     ID of the post being rendered.
+         * @param string|null $postAuthor ID of the post author. Null for WooCommerce products, which show no author.
+         * @return string The author line to render. A return that is not a string or a number is ignored.
+         */
         $text[] = self::applyMetaFilter(
           'mailpoet_newsletter_post_author',
           self::getPostAuthor($postAuthor, $args['authorPrecededBy']),
@@ -30,6 +38,14 @@ class MetaInformationManager {
       }
 
       if (isset($args['showCategories']) && $args['showCategories'] === $positionField) {
+        /**
+         * Filters the categories line shown with a post in an email.
+         *
+         * @param string $categories The categories line, including the label set in the block. Empty when the post has no categories.
+         * @param int    $postId     ID of the post being rendered.
+         * @param string $postType   Post type being rendered, 'product' for WooCommerce products.
+         * @return string The categories line to render. A return that is not a string or a number is ignored.
+         */
         $text[] = self::applyMetaFilter(
           'mailpoet_newsletter_post_categories',
           self::getPostCategories($postId, $postType, $args['categoriesPrecededBy']),

--- a/mailpoet/lib/Newsletter/Editor/MetaInformationManager.php
+++ b/mailpoet/lib/Newsletter/Editor/MetaInformationManager.php
@@ -22,17 +22,18 @@ class MetaInformationManager {
       $text = [];
 
       if (isset($args['showAuthor']) && $args['showAuthor'] === $positionField) {
-        $text[] = self::getPostAuthor(
-          $postAuthor,
-          $args['authorPrecededBy']
+        $text[] = self::applyMetaFilter(
+          'mailpoet_newsletter_post_author',
+          self::getPostAuthor($postAuthor, $args['authorPrecededBy']),
+          [$postId, $postAuthor]
         );
       }
 
       if (isset($args['showCategories']) && $args['showCategories'] === $positionField) {
-        $text[] = self::getPostCategories(
-          $postId,
-          $postType,
-          $args['categoriesPrecededBy']
+        $text[] = self::applyMetaFilter(
+          'mailpoet_newsletter_post_categories',
+          self::getPostCategories($postId, $postType, $args['categoriesPrecededBy']),
+          [$postId, $postType]
         );
       }
 
@@ -44,6 +45,30 @@ class MetaInformationManager {
     }
 
     return $content;
+  }
+
+  /**
+   * Applies a meta information filter and keeps the unfiltered value when a
+   * callback returns something that cannot be rendered as text.
+   *
+   * @param string $filterName
+   * @param string $value
+   * @param array $args
+   * @return string
+   */
+  private static function applyMetaFilter($filterName, $value, array $args) {
+    $filtered = WPFunctions::get()->applyFilters($filterName, $value, ...$args);
+
+    if (is_string($filtered)) {
+      return $filtered;
+    }
+
+    if (is_int($filtered) || is_float($filtered)) {
+      return (string)$filtered;
+    }
+
+    // An array or object here would fatal in the implode() that joins these lines.
+    return $value;
   }
 
   private static function getPostCategories($postId, $postType, $precededBy) {

--- a/mailpoet/tests/integration/Newsletter/Editor/MetaInformationManagerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Editor/MetaInformationManagerTest.php
@@ -1,0 +1,217 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Newsletter\Editor;
+
+use MailPoet\Newsletter\Editor\MetaInformationManager;
+use MailPoet\WP\Functions as WPFunctions;
+
+class MetaInformationManagerTest extends \MailPoetTest {
+  private const AUTHOR_FILTER = 'mailpoet_newsletter_post_author';
+  private const CATEGORIES_FILTER = 'mailpoet_newsletter_post_categories';
+
+  /** @var MetaInformationManager */
+  private $metaManager;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var int */
+  private $authorId;
+
+  /** @var int */
+  private $postId;
+
+  /** @var array */
+  private $args;
+
+  /** @var array<array{string, callable}> */
+  private $registeredFilters = [];
+
+  public function _before() {
+    parent::_before();
+    $this->metaManager = new MetaInformationManager();
+    $this->wp = new WPFunctions();
+
+    $authorId = wp_insert_user([
+      'user_login' => 'stomail8385',
+      'user_email' => 'stomail8385@example.com',
+      'user_pass' => 'password',
+      'display_name' => 'Original Author',
+    ]);
+    $this->assertIsInt($authorId);
+    $this->authorId = $authorId;
+
+    $this->postId = (int)$this->wp->wpInsertPost([
+      'post_title' => 'Post with meta information',
+      'post_content' => 'Body',
+      'post_status' => 'publish',
+      'post_type' => 'post',
+      'post_author' => $this->authorId,
+    ]);
+    wp_set_post_terms($this->postId, ['Announcements'], 'category');
+
+    $this->args = [
+      'showAuthor' => 'belowText',
+      'authorPrecededBy' => 'Author:',
+      'showCategories' => 'belowText',
+      'categoriesPrecededBy' => 'Categories:',
+    ];
+  }
+
+  public function testItRendersTheAuthorAndCategoriesWhenNoFilterIsRegistered() {
+    $content = $this->appendMetaInformation();
+
+    verify($content)->stringContainsString('Author: Original Author');
+    verify($content)->stringContainsString('Categories: Announcements');
+  }
+
+  public function testItLetsAFilterReplaceTheAuthor() {
+    $this->addFilter(self::AUTHOR_FILTER, function () {
+      return 'Guest Author';
+    });
+
+    $content = $this->appendMetaInformation();
+
+    verify($content)->stringContainsString('Guest Author');
+    verify($content)->stringNotContainsString('Original Author');
+    verify($content)->stringContainsString('Categories: Announcements');
+  }
+
+  public function testItLetsAFilterReplaceTheCategories() {
+    $this->addFilter(self::CATEGORIES_FILTER, function () {
+      return 'Filed under: Politics';
+    });
+
+    $content = $this->appendMetaInformation();
+
+    verify($content)->stringContainsString('Filed under: Politics');
+    verify($content)->stringNotContainsString('Announcements');
+    verify($content)->stringContainsString('Author: Original Author');
+  }
+
+  public function testItPassesThePostIdAndAuthorIdToTheAuthorFilter() {
+    $received = [];
+    $this->addFilter(self::AUTHOR_FILTER, function ($author, $postId, $postAuthor) use (&$received) {
+      $received = [$author, $postId, $postAuthor];
+      return $author;
+    }, 3);
+
+    $this->appendMetaInformation();
+
+    verify($received[0])->equals('Author: Original Author');
+    verify((int)$received[1])->equals($this->postId);
+    verify((int)$received[2])->equals($this->authorId);
+  }
+
+  public function testItPassesThePostIdAndPostTypeToTheCategoriesFilter() {
+    $received = [];
+    $this->addFilter(self::CATEGORIES_FILTER, function ($categories, $postId, $postType) use (&$received) {
+      $received = [$categories, $postId, $postType];
+      return $categories;
+    }, 3);
+
+    $this->appendMetaInformation();
+
+    verify($received[0])->equals('Categories: Announcements');
+    verify((int)$received[1])->equals($this->postId);
+    verify($received[2])->equals('post');
+  }
+
+  public function testItKeepsTheOriginalAuthorWhenAFilterReturnsAnArray() {
+    $this->addFilter(self::AUTHOR_FILTER, function () {
+      return ['Guest Author'];
+    });
+
+    $content = $this->appendMetaInformation();
+
+    verify($content)->stringContainsString('Author: Original Author');
+    verify($content)->stringNotContainsString('Array');
+  }
+
+  public function testItKeepsTheOriginalAuthorWhenAFilterReturnsAnObject() {
+    $this->addFilter(self::AUTHOR_FILTER, function () {
+      return new \stdClass();
+    });
+
+    $content = $this->appendMetaInformation();
+
+    verify($content)->stringContainsString('Author: Original Author');
+  }
+
+  public function testItKeepsTheOriginalAuthorWhenAFilterReturnsNull() {
+    $this->addFilter(self::AUTHOR_FILTER, function () {
+      return null;
+    });
+
+    $content = $this->appendMetaInformation();
+
+    verify($content)->stringContainsString('Author: Original Author');
+  }
+
+  public function testItRendersANumericAuthorReturnedByAFilter() {
+    $this->addFilter(self::AUTHOR_FILTER, function () {
+      return 42;
+    });
+
+    $content = $this->appendMetaInformation();
+
+    verify($content)->stringContainsString('42');
+    verify($content)->stringNotContainsString('Original Author');
+  }
+
+  public function testItAppliesTheAuthorFilterWhenThePostHasNoAuthor() {
+    $received = [];
+    $this->addFilter(self::AUTHOR_FILTER, function ($author, $postId, $postAuthor) use (&$received) {
+      $received = [$postId, $postAuthor];
+      return 'Guest Author';
+    }, 3);
+
+    $post = (object)[
+      'ID' => $this->postId,
+      'post_author' => null,
+      'post_type' => 'post',
+    ];
+    $content = $this->metaManager->appendMetaInformation('<p>Body</p>', $post, $this->args);
+
+    verify($content)->stringContainsString('Guest Author');
+    verify($received[1])->null();
+  }
+
+  public function testItJoinsTheAuthorAndCategoriesFilterResults() {
+    $this->addFilter(self::AUTHOR_FILTER, function () {
+      return 'Guest Author';
+    });
+    $this->addFilter(self::CATEGORIES_FILTER, function () {
+      return 'Politics';
+    });
+
+    $content = $this->appendMetaInformation();
+
+    verify($content)->stringContainsString('Guest Author<br />Politics');
+  }
+
+  public function _after() {
+    foreach ($this->registeredFilters as [$name, $callback]) {
+      $this->wp->removeFilter($name, $callback, 10);
+    }
+    $this->registeredFilters = [];
+    $this->wp->wpDeletePost($this->postId, true);
+    wp_delete_user($this->authorId);
+    parent::_after();
+  }
+
+  private function addFilter(string $name, callable $callback, int $acceptedArgs = 1): void {
+    $this->wp->addFilter($name, $callback, 10, $acceptedArgs);
+    $this->registeredFilters[] = [$name, $callback];
+  }
+
+  private function appendMetaInformation(): string {
+    return $this->metaManager->appendMetaInformation('<p>Body</p>', $this->getPost(), $this->args);
+  }
+
+  private function getPost(): \WP_Post {
+    $post = $this->wp->getPost($this->postId);
+    $this->assertInstanceOf(\WP_Post::class, $post);
+    return $post;
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Editor/MetaInformationManagerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Editor/MetaInformationManagerTest.php
@@ -163,6 +163,17 @@ class MetaInformationManagerTest extends \MailPoetTest {
     verify($content)->stringNotContainsString('Original Author');
   }
 
+  public function testItRendersAFloatAuthorReturnedByAFilter() {
+    $this->addFilter(self::AUTHOR_FILTER, function () {
+      return 4.5;
+    });
+
+    $content = $this->appendMetaInformation();
+
+    verify($content)->stringContainsString('4.5');
+    verify($content)->stringNotContainsString('Original Author');
+  }
+
   public function testItAppliesTheAuthorFilterWhenThePostHasNoAuthor() {
     $received = [];
     $this->addFilter(self::AUTHOR_FILTER, function ($author, $postId, $postAuthor) use (&$received) {

--- a/mailpoet/tests/integration/Newsletter/Editor/MetaInformationManagerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Editor/MetaInformationManagerTest.php
@@ -24,6 +24,9 @@ class MetaInformationManagerTest extends \MailPoetTest {
   /** @var int */
   private $categoryId;
 
+  /** @var string */
+  private $categoryName;
+
   /** @var array */
   private $args;
 
@@ -35,9 +38,10 @@ class MetaInformationManagerTest extends \MailPoetTest {
     $this->metaManager = new MetaInformationManager();
     $this->wp = new WPFunctions();
 
+    $unique = uniqid();
     $authorId = wp_insert_user([
-      'user_login' => 'stomail8385',
-      'user_email' => 'stomail8385@example.com',
+      'user_login' => "author_$unique",
+      'user_email' => "author_$unique@example.com",
       'user_pass' => 'password',
       'display_name' => 'Original Author',
     ]);
@@ -51,7 +55,8 @@ class MetaInformationManagerTest extends \MailPoetTest {
       'post_type' => 'post',
       'post_author' => $this->authorId,
     ]);
-    $this->categoryId = $this->createCategory('Announcements');
+    $this->categoryName = "Announcements $unique";
+    $this->categoryId = $this->createCategory($this->categoryName);
     wp_set_post_terms($this->postId, [$this->categoryId], 'category');
 
     $this->args = [
@@ -66,7 +71,7 @@ class MetaInformationManagerTest extends \MailPoetTest {
     $content = $this->appendMetaInformation();
 
     verify($content)->stringContainsString('Author: Original Author');
-    verify($content)->stringContainsString('Categories: Announcements');
+    verify($content)->stringContainsString('Categories: ' . $this->categoryName);
   }
 
   public function testItLetsAFilterReplaceTheAuthor() {
@@ -78,7 +83,7 @@ class MetaInformationManagerTest extends \MailPoetTest {
 
     verify($content)->stringContainsString('Guest Author');
     verify($content)->stringNotContainsString('Original Author');
-    verify($content)->stringContainsString('Categories: Announcements');
+    verify($content)->stringContainsString('Categories: ' . $this->categoryName);
   }
 
   public function testItLetsAFilterReplaceTheCategories() {
@@ -89,7 +94,7 @@ class MetaInformationManagerTest extends \MailPoetTest {
     $content = $this->appendMetaInformation();
 
     verify($content)->stringContainsString('Filed under: Politics');
-    verify($content)->stringNotContainsString('Announcements');
+    verify($content)->stringNotContainsString($this->categoryName);
     verify($content)->stringContainsString('Author: Original Author');
   }
 
@@ -116,7 +121,7 @@ class MetaInformationManagerTest extends \MailPoetTest {
 
     $this->appendMetaInformation();
 
-    verify($received[0])->equals('Categories: Announcements');
+    verify($received[0])->equals('Categories: ' . $this->categoryName);
     verify((int)$received[1])->equals($this->postId);
     verify($received[2])->equals('post');
   }
@@ -218,11 +223,7 @@ class MetaInformationManagerTest extends \MailPoetTest {
 
   private function createCategory(string $name): int {
     $term = wp_insert_term($name, 'category');
-    if ($term instanceof \WP_Error) {
-      $existing = $term->get_error_data('term_exists');
-      $this->assertIsInt($existing);
-      return $existing;
-    }
+    $this->assertIsArray($term);
     return (int)$term['term_id'];
   }
 

--- a/mailpoet/tests/integration/Newsletter/Editor/MetaInformationManagerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Editor/MetaInformationManagerTest.php
@@ -21,6 +21,9 @@ class MetaInformationManagerTest extends \MailPoetTest {
   /** @var int */
   private $postId;
 
+  /** @var int */
+  private $categoryId;
+
   /** @var array */
   private $args;
 
@@ -48,7 +51,8 @@ class MetaInformationManagerTest extends \MailPoetTest {
       'post_type' => 'post',
       'post_author' => $this->authorId,
     ]);
-    wp_set_post_terms($this->postId, ['Announcements'], 'category');
+    $this->categoryId = $this->createCategory('Announcements');
+    wp_set_post_terms($this->postId, [$this->categoryId], 'category');
 
     $this->args = [
       'showAuthor' => 'belowText',
@@ -196,8 +200,19 @@ class MetaInformationManagerTest extends \MailPoetTest {
     }
     $this->registeredFilters = [];
     $this->wp->wpDeletePost($this->postId, true);
+    wp_delete_term($this->categoryId, 'category');
     wp_delete_user($this->authorId);
     parent::_after();
+  }
+
+  private function createCategory(string $name): int {
+    $term = wp_insert_term($name, 'category');
+    if ($term instanceof \WP_Error) {
+      $existing = $term->get_error_data('term_exists');
+      $this->assertIsInt($existing);
+      return $existing;
+    }
+    return (int)$term['term_id'];
   }
 
   private function addFilter(string $name, callable $callback, int $acceptedArgs = 1): void {


### PR DESCRIPTION
## Description

MailPoet reads a post's single `post_author` when it renders the author line with a post in an email. Sites that use Co-Authors Plus to assign guest authors get the wrong name, and there is no way to change it.

This adds two filters to `MetaInformationManager`:

- `mailpoet_newsletter_post_author` — `($author, $postId, $postAuthor)`
- `mailpoet_newsletter_post_categories` — `($categories, $postId, $postType)`

A callback that returns something other than text is ignored and the original value is kept, so a badly behaved filter cannot break email rendering.

Additive only. With no callback registered the output is unchanged.

## Code review notes

_N/A_

## QA notes

1. Create a Post Notification email, or any newsletter with a Latest Posts block, and turn on "Display author".
2. Add a filter:
   ```php
   add_filter('mailpoet_newsletter_post_author', function ($author, $postId) {
     return 'By a guest author';
   }, 10, 2);
   ```
3. Preview the email. The author line shows the filtered text; the categories line is untouched.
4. Change the callback to return `['not', 'a', 'string']`. The original author renders, with no warning and no literal `Array`.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8385](https://linear.app/a8c/issue/STOMAIL-8385/add-mailpoet-post-author-filter-for-co-authors-plus-compatibility)

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8385-newsletter-post-author-filter)

_The latest successful build from `add/stomail-8385-newsletter-post-author-filter` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->