### PR TITLE
Sanitize newsletter blocks that contain nested blocks

### DIFF
--- a/mailpoet/changelog/2026-09-04-10-27-30-improved-sanitization-of-nested-content-blocks-in-emails.md
+++ b/mailpoet/changelog/2026-09-04-10-27-30-improved-sanitization-of-nested-content-blocks-in-emails.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Sanitization of nested content blocks in emails

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -9,6 +9,7 @@ use MailPoet\API\JSON\ResponseBuilders\NewslettersResponseBuilder;
 use MailPoet\Config\AccessControl;
 use MailPoet\Doctrine\Validator\ValidationException;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\ApiDataSanitizer;
 use MailPoet\Newsletter\NewsletterDeleteController;
 use MailPoet\Newsletter\NewsletterResendController;
 use MailPoet\Newsletter\NewsletterSaveController;
@@ -52,6 +53,9 @@ class Newsletters extends APIEndpoint {
   /** @var ConfirmationEmailCustomizer */
   private $confirmationEmailCustomizer;
 
+  /** @var ApiDataSanitizer */
+  private $apiDataSanitizer;
+
   public function __construct(
     WPFunctions $wp,
     NewslettersRepository $newslettersRepository,
@@ -61,7 +65,8 @@ class Newsletters extends APIEndpoint {
     NewsletterDeleteController $newsletterDeleteController,
     NewsletterResendController $newsletterResendController,
     NewsletterUrl $newsletterUrl,
-    ConfirmationEmailCustomizer $confirmationEmailCustomizer
+    ConfirmationEmailCustomizer $confirmationEmailCustomizer,
+    ApiDataSanitizer $apiDataSanitizer
   ) {
     $this->wp = $wp;
     $this->newslettersRepository = $newslettersRepository;
@@ -72,6 +77,7 @@ class Newsletters extends APIEndpoint {
     $this->newsletterResendController = $newsletterResendController;
     $this->newsletterUrl = $newsletterUrl;
     $this->confirmationEmailCustomizer = $confirmationEmailCustomizer;
+    $this->apiDataSanitizer = $apiDataSanitizer;
   }
 
   public function get($data = []) {
@@ -87,6 +93,9 @@ class Newsletters extends APIEndpoint {
       NewslettersResponseBuilder::RELATION_OPTIONS,
       NewslettersResponseBuilder::RELATION_QUEUE,
     ]);
+    if (is_array($response['body'])) {
+      $response['body'] = $this->apiDataSanitizer->sanitizeBody($response['body']);
+    }
     $response = $this->wp->applyFilters('mailpoet_api_newsletters_get_after', $response);
     return $this->successResponse($response, ['preview_url' => $this->getViewInBrowserUrl($newsletter)]);
   }

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -93,10 +93,10 @@ class Newsletters extends APIEndpoint {
       NewslettersResponseBuilder::RELATION_OPTIONS,
       NewslettersResponseBuilder::RELATION_QUEUE,
     ]);
-    if (is_array($response['body'])) {
-      $response['body'] = $this->apiDataSanitizer->sanitizeBody($response['body']);
-    }
     $response = $this->wp->applyFilters('mailpoet_api_newsletters_get_after', $response);
+    if (is_array($response)) {
+      $response = $this->sanitizeResponseBody($response);
+    }
     return $this->successResponse($response, ['preview_url' => $this->getViewInBrowserUrl($newsletter)]);
   }
 
@@ -119,8 +119,16 @@ class Newsletters extends APIEndpoint {
     if (!is_array($response)) {
       $response = [];
     }
+    $response = $this->sanitizeResponseBody($response);
     $response['preview_url'] = $this->getViewInBrowserUrl($newsletter);
     return $this->successResponse($response);
+  }
+
+  private function sanitizeResponseBody(array $response): array {
+    if (is_array($response['body'] ?? null)) {
+      $response['body'] = $this->apiDataSanitizer->sanitizeBody($response['body']);
+    }
+    return $response;
   }
 
   public function save($data = []) {

--- a/mailpoet/lib/Newsletter/ApiDataSanitizer.php
+++ b/mailpoet/lib/Newsletter/ApiDataSanitizer.php
@@ -25,7 +25,20 @@ class ApiDataSanitizer {
     if (isset($body['content']) && isset($body['content']['blocks']) && is_array($body['content']['blocks'])) {
       $body['content']['blocks'] = $this->sanitizeBlocks($body['content']['blocks']);
     }
+    if (isset($body['blockDefaults']) && is_array($body['blockDefaults'])) {
+      $body['blockDefaults'] = $this->sanitizeBlockDefaults($body['blockDefaults']);
+    }
     return $body;
+  }
+
+  private function sanitizeBlockDefaults(array $blockDefaults): array {
+    foreach ($blockDefaults as $type => $defaults) {
+      if (!is_array($defaults)) {
+        continue;
+      }
+      $blockDefaults[$type] = $this->sanitizeBlockProperties($defaults, $type);
+    }
+    return $blockDefaults;
   }
 
   private function sanitizeBlocks(array $blocks): array {
@@ -43,7 +56,13 @@ class ApiDataSanitizer {
   }
 
   private function sanitizeBlock(array $block): array {
-    $type = $block['type'] ?? null;
+    return $this->sanitizeBlockProperties($block, $block['type'] ?? null);
+  }
+
+  /**
+   * @param mixed $type
+   */
+  private function sanitizeBlockProperties(array $block, $type): array {
     if (!is_string($type) || !isset(self::SANITIZATION_CONFIG[$type])) {
       return $block;
     }

--- a/mailpoet/lib/Newsletter/ApiDataSanitizer.php
+++ b/mailpoet/lib/Newsletter/ApiDataSanitizer.php
@@ -30,23 +30,24 @@ class ApiDataSanitizer {
 
   private function sanitizeBlocks(array $blocks): array {
     foreach ($blocks as $key => $block) {
-      if (!is_array($block) || !isset($block['type'])) {
+      if (!is_array($block)) {
         continue;
       }
+      $block = $this->sanitizeBlock($block);
       if (isset($block['blocks']) && is_array($block['blocks'])) {
-        $blocks[$key]['blocks'] = $this->sanitizeBlocks($block['blocks']);
-      } else {
-        $blocks[$key] = $this->sanitizeBlock($block);
+        $block['blocks'] = $this->sanitizeBlocks($block['blocks']);
       }
-    };
+      $blocks[$key] = $block;
+    }
     return $blocks;
   }
 
   private function sanitizeBlock(array $block): array {
-    if (!isset(self::SANITIZATION_CONFIG[$block['type']])) {
+    $type = $block['type'] ?? null;
+    if (!is_string($type) || !isset(self::SANITIZATION_CONFIG[$type])) {
       return $block;
     }
-    foreach (self::SANITIZATION_CONFIG[$block['type']] as $property) {
+    foreach (self::SANITIZATION_CONFIG[$type] as $property) {
       if (!isset($block[$property]) || !is_string($block[$property])) {
         continue;
       }

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -12,6 +12,7 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Logging\LogRepository;
+use MailPoet\Newsletter\ApiDataSanitizer;
 use MailPoet\Newsletter\NewsletterSaveController;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Preview\SendPreviewController;
@@ -76,6 +77,34 @@ class NewslettersTest extends \MailPoetTest {
     $this->postNotification = (new Newsletter())->withPostNotificationsType()->withSubject('My Post Notification')->loadBodyFrom('newsletterWithALC.json')->create();
   }
 
+  public function testItSanitizesBodyBlocksWhenGettingANewsletter() {
+    $newsletter = (new Newsletter())
+      ->withSubject('Newsletter with stored markup')
+      ->withBody([
+        'content' => [
+          'blocks' => [
+            [
+              'type' => 'container',
+              'orientation' => 'vertical',
+              'blocks' => [
+                [
+                  'type' => 'text',
+                  'text' => '<p>Thanks for reading.<img src=x onerror=alert(1)> See you soon!</p>',
+                ],
+              ],
+            ],
+          ],
+        ],
+      ])
+      ->create();
+
+    $response = $this->endpoint->get(['id' => $newsletter->getId()]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['body']['content']['blocks'][0]['blocks'][0]['text'])
+      ->equals('<p>Thanks for reading. See you soon!</p>');
+  }
+
   public function testItCanGetANewsletter() {
     $response = $this->endpoint->get(); // missing id
     verify($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
@@ -98,11 +127,13 @@ class NewslettersTest extends \MailPoetTest {
     verify($response->status)->equals(APIResponse::STATUS_OK);
     $newsletter = $this->newsletterRepository->findOneById($this->newsletter->getId());
     $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
-    verify($response->data)->equals($this->newslettersResponseBuilder->build($newsletter, [
+    $expected = $this->newslettersResponseBuilder->build($newsletter, [
       NewslettersResponseBuilder::RELATION_SEGMENTS,
       NewslettersResponseBuilder::RELATION_OPTIONS,
       NewslettersResponseBuilder::RELATION_QUEUE,
-    ]));
+    ]);
+    $expected['body'] = $this->diContainer->get(ApiDataSanitizer::class)->sanitizeBody($expected['body']);
+    verify($response->data)->equals($expected);
     $hookName = 'mailpoet_api_newsletters_get_after';
     verify(WPHooksHelper::isFilterApplied($hookName))->true();
     verify(WPHooksHelper::getFilterApplied($hookName)[0])->isArray();

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -105,6 +105,54 @@ class NewslettersTest extends \MailPoetTest {
       ->equals('<p>Thanks for reading. See you soon!</p>');
   }
 
+  public function testItSanitizesBodyBlocksWhenGettingANewsletterWithStats() {
+    $newsletter = (new Newsletter())
+      ->withSubject('Sent newsletter with stored markup')
+      ->withSentStatus()
+      ->withBody([
+        'content' => [
+          'blocks' => [
+            [
+              'type' => 'text',
+              'text' => '<p>Thanks for reading.<img src=x onerror=alert(1)> See you soon!</p>',
+            ],
+          ],
+        ],
+      ])
+      ->create();
+
+    $response = $this->endpoint->getWithStats(['id' => $newsletter->getId()]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['body']['content']['blocks'][0]['text'])
+      ->equals('<p>Thanks for reading. See you soon!</p>');
+  }
+
+  public function testItSanitizesBodyBlocksModifiedByTheGetAfterFilter() {
+    $newsletter = (new Newsletter())->withSubject('Filtered newsletter')->withSentStatus()->create();
+    $wp = new WPFunctions();
+    $filter = function ($response) {
+      $response['body'] = [
+        'content' => [
+          'blocks' => [
+            ['type' => 'text', 'text' => '<p>Filtered<img src=x onerror=alert(1)> text</p>'],
+          ],
+        ],
+      ];
+      return $response;
+    };
+    $wp->addFilter('mailpoet_api_newsletters_get_after', $filter);
+    try {
+      $response = $this->endpoint->get(['id' => $newsletter->getId()]);
+      verify($response->data['body']['content']['blocks'][0]['text'])->equals('<p>Filtered text</p>');
+
+      $response = $this->endpoint->getWithStats(['id' => $newsletter->getId()]);
+      verify($response->data['body']['content']['blocks'][0]['text'])->equals('<p>Filtered text</p>');
+    } finally {
+      $wp->removeFilter('mailpoet_api_newsletters_get_after', $filter);
+    }
+  }
+
   public function testItCanGetANewsletter() {
     $response = $this->endpoint->get(); // missing id
     verify($response->status)->equals(APIResponse::STATUS_NOT_FOUND);

--- a/mailpoet/tests/integration/Newsletter/ApiDataSanitizerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ApiDataSanitizerTest.php
@@ -128,6 +128,21 @@ class ApiDataSanitizerTest extends \MailPoetTest {
     verify($block['text'])->equals('<p>Some text</p>');
   }
 
+  public function testItSanitizesBlockDefaults() {
+    $body = [
+      'content' => ['blocks' => []],
+      'blockDefaults' => [
+        'text' => ['text' => '<p>Default<img src=x onerror=alert(1)> text</p>', 'styles' => []],
+        'footer' => ['text' => '<p>Footer<img src=x onerror=alert(2)> text</p>'],
+        'button' => ['text' => 'Read <b>more</b>'],
+      ],
+    ];
+    $result = $this->sanitizer->sanitizeBody($body);
+    verify($result['blockDefaults']['text'])->equals(['text' => '<p>Default text</p>', 'styles' => []]);
+    verify($result['blockDefaults']['footer']['text'])->equals('<p>Footer text</p>');
+    verify($result['blockDefaults']['button']['text'])->equals('Read <b>more</b>');
+  }
+
   private function bodyWithBlocks(array $blocks): array {
     return ['content' => ['blocks' => $blocks]];
   }

--- a/mailpoet/tests/integration/Newsletter/ApiDataSanitizerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ApiDataSanitizerTest.php
@@ -68,4 +68,67 @@ class ApiDataSanitizerTest extends \MailPoetTest {
 
     verify($result)->equals($body);
   }
+
+  public function testItSanitizesBlockTextWhenBlockHasNestedBlocks() {
+    $body = $this->bodyWithBlocks([
+      [
+        'type' => 'text',
+        'text' => '<p>Hello<img src=x onerror=alert(1)> there</p>',
+        'blocks' => [
+          [
+            'type' => 'text',
+            'text' => '<p>Nested<img src=x onerror=alert(2)> text</p>',
+          ],
+        ],
+      ],
+    ]);
+    $block = $this->sanitizer->sanitizeBody($body)['content']['blocks'][0];
+    verify($block['text'])->equals('<p>Hello there</p>');
+    verify($block['blocks'][0]['text'])->equals('<p>Nested text</p>');
+  }
+
+  public function testItSanitizesBlockTextWhenNestedBlocksAreEmpty() {
+    $body = $this->bodyWithBlocks([
+      [
+        'type' => 'text',
+        'text' => '<p>Empty<img src=x onerror=alert(3)> children</p>',
+        'blocks' => [],
+      ],
+    ]);
+    $block = $this->sanitizer->sanitizeBody($body)['content']['blocks'][0];
+    verify($block['text'])->equals('<p>Empty children</p>');
+    verify($block['blocks'])->equals([]);
+  }
+
+  public function testItSanitizesNestedBlocksOfBlockWithoutType() {
+    $body = $this->bodyWithBlocks([
+      [
+        'blocks' => [
+          [
+            'type' => 'text',
+            'text' => '<p>Nested<img src=x onerror=alert(4)> text</p>',
+          ],
+        ],
+      ],
+    ]);
+    $block = $this->sanitizer->sanitizeBody($body)['content']['blocks'][0];
+    verify($block)->arrayHasNotKey('type');
+    verify($block['blocks'][0]['text'])->equals('<p>Nested text</p>');
+  }
+
+  public function testItLeavesBlockWithNonStringTypeUntouched() {
+    $body = $this->bodyWithBlocks([
+      [
+        'type' => ['text'],
+        'text' => '<p>Some text</p>',
+      ],
+    ]);
+    $block = $this->sanitizer->sanitizeBody($body)['content']['blocks'][0];
+    verify($block['type'])->equals(['text']);
+    verify($block['text'])->equals('<p>Some text</p>');
+  }
+
+  private function bodyWithBlocks(array $blocks): array {
+    return ['content' => ['blocks' => $blocks]];
+  }
 }


### PR DESCRIPTION
## Description

The newsletter block sanitizer walked nested blocks and sanitized a block's own properties as two mutually exclusive branches. Blocks that carried a nested `blocks` array were not sanitized themselves, and blocks without a `type` were not walked at all. The walker now sanitizes every block and then descends into its children regardless of the block's type.

The sanitizer also covers the body's `blockDefaults`, which the editor merges into its configuration and uses to seed newly added text, header and footer blocks.

The `get` and `getWithStats` endpoints run the same block sanitization on the body they return, after the `mailpoet_api_newsletters_get_after` filter, so the classic editor and other consumers always receive the normalized body that saving produces.

## Code review notes

- The block email renderer already descends into `blocks` independently of `type`, so the walker now mirrors that traversal.
- For the block structures the legacy editor produces the walker change is a no-op: only `container` blocks carry `blocks`, and they have no sanitized properties.
- Sanitizing on load is idempotent with sanitizing on save: `wp_kses` only strips markup outside the allowlist and normalizes entities, so a body that already went through save comes back unchanged. The existing `get` test fixture is persisted directly and carries a `data-post-id` attribute the allowlist does not include, hence the adjusted expectation.
- Sanitization runs after the filter so that whatever the filter returns is normalized too. This matches the save path, where `mailpoet_api_newsletters_save_before` runs before the save controller sanitizes.

## QA notes

Save a newsletter in the legacy editor containing text, header, and footer blocks inside columns, reload the editor, then add a new text block and a new footer block. Existing content is preserved and the new blocks get the expected defaults. Open the campaign stats page of a sent newsletter and confirm it loads. The integration tests cover the nested cases, block defaults, both load endpoints, and the filter.

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-8451

## After-merge notes

_N/A_

## Backward compatibility

The `mailpoet_api_newsletters_get_after` filter still receives the response first. Its returned `body` is now normalized by the same block sanitization the save path applies, so a filter callback cannot put markup outside the allowlist into the final `get` and `getWithStats` responses. Non-array filter results keep their previous handling in both endpoints. The `Newsletters` endpoint gains a constructor dependency, appended last, and is only ever built by the DI container.

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
