### PR TITLE
Declare compatibility with WooCommerce 11.1.0

### DIFF
--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,8 +11,8 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 10.9
- * WC tested up to: 11.0
+ * WC requires at least: 11.0
+ * WC tested up to: 11.1
  *
  * @package WordPress
  * @author MailPoet
@@ -28,7 +28,7 @@ $mailpoetPlugin = [
 ];
 
 const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '7.0'; // L-1 version, not the latest
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.9'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '11.0'; // L-1 version, not the latest
 
 
 // Display WP version error notice


### PR DESCRIPTION
### What this does

Declares MailPoet compatible with WooCommerce 11.1.0.

Sets `WC tested up to` to 11.1 and `WC requires at least` to 11.0. Also bumps `MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION` from 10.9 to 11.0 so the constant matches the header. The minimum stays one minor version behind the tested version, as the comment on that line says it should.

Only `mailpoet/mailpoet.php` changed. The WordPress headers are not touched, that is a separate change.

### How to test

1. Activate MailPoet on a store running WooCommerce 11.1.
2. Check no compatibility notice shows on the plugins screen or in the MailPoet admin.
3. Drop WooCommerce to 10.9 and confirm the minimum version notice now appears.

### Changelog entry

Updated: Bump the minimum required WooCommerce version to 11.0 and tested up to version to 11.1;
