### PR TITLE
Fix Emails listing timing out on sites with a large log table

### DIFF
--- a/mailpoet/changelog/2026-09-07-09-42-27-fixed-emails-page-failing-to-load-on-sites-with-a-large-.md
+++ b/mailpoet/changelog/2026-09-07-09-42-27-fixed-emails-page-failing-to-load-on-sites-with-a-large-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Emails page failing to load on sites with a large log table

--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
@@ -164,6 +164,7 @@ class NewslettersResponseBuilder {
     $latestQueues = $this->getBatchLatestQueuesWithTasks($newsletters);
     $this->newslettersRepository->prefetchOptions($newsletters);
     $this->newslettersRepository->prefetchSegments($newsletters);
+    $couponBlockLogs = $this->logRepository->getRawMessagesForNewsletters($newsletters, LoggerFactory::TOPIC_COUPONS);
 
     $data = [];
     foreach ($newsletters as $newsletter) {
@@ -171,7 +172,8 @@ class NewslettersResponseBuilder {
       $data[] = $this->buildListingItem(
         $newsletter,
         $statistics[$id] ?? null,
-        $latestQueues[$id] ?? null
+        $latestQueues[$id] ?? null,
+        $couponBlockLogs[$id] ?? []
       );
     }
     return $data;
@@ -181,16 +183,18 @@ class NewslettersResponseBuilder {
    * @param NewsletterEntity $newsletter
    * @param NewsletterStatistics|null $statistics
    * @param SendingQueueEntity|null $latestQueue
+   * @param string[] $couponBlockLogs
    * @return array<string, mixed>
    */
   private function buildListingItem(
     NewsletterEntity $newsletter,
     ?NewsletterStatistics $statistics = null,
-    ?SendingQueueEntity $latestQueue = null
+    ?SendingQueueEntity $latestQueue = null,
+    array $couponBlockLogs = []
   ): array {
     $couponBlockLogs = array_map(function ($item) {
       return "Coupon block: $item";
-    }, $this->logRepository->getRawMessagesForNewsletter($newsletter, LoggerFactory::TOPIC_COUPONS));
+    }, $couponBlockLogs);
     $data = [
       'id' => (string)$newsletter->getId(), // (string) for BC
       'hash' => $newsletter->getHash(),

--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -243,17 +243,52 @@ class LogRepository extends Repository {
     return is_scalar($value) ? (string)$value : null;
   }
 
-  public function getRawMessagesForNewsletter(NewsletterEntity $newsletter, string $topic): array {
-    return $this->entityManager->createQueryBuilder()
-      ->select('DISTINCT logs.rawMessage message')
+  /**
+   * Returns raw messages logged under $topic for the given newsletters, keyed by newsletter ID
+   * with the oldest message first. Newsletters without messages are not present in the result.
+   * A single query serves the whole listing page instead of one query per row.
+   *
+   * @param NewsletterEntity[] $newsletters
+   * @return array<int, string[]>
+   */
+  public function getRawMessagesForNewsletters(array $newsletters, string $topic): array {
+    $newsletterIdsByContext = [];
+    foreach ($newsletters as $newsletter) {
+      $newsletterIdsByContext[json_encode(['newsletter_id' => $newsletter->getId()])] = (int)$newsletter->getId();
+    }
+    if (!$newsletterIdsByContext) {
+      return [];
+    }
+
+    $rows = $this->entityManager->createQueryBuilder()
+      ->select('logs.context context, logs.rawMessage message')
       ->from(LogEntity::class, 'logs')
       ->where('logs.name = :topic')
-      ->andWhere('logs.context LIKE :context')
+      ->andWhere('logs.context IN (:contexts)')
       ->orderBy('logs.createdAt')
-      ->setParameter('context', json_encode(['newsletter_id' => $newsletter->getId()]))
+      ->addOrderBy('logs.id')
       ->setParameter('topic', $topic)
+      ->setParameter('contexts', array_keys($newsletterIdsByContext))
       ->getQuery()
-      ->getSingleColumnResult();
+      ->getArrayResult();
+
+    $messages = [];
+    foreach ($rows as $row) {
+      $context = is_array($row) ? ($row['context'] ?? null) : null;
+      $message = is_array($row) ? ($row['message'] ?? null) : null;
+      if (!is_string($context) || !is_string($message)) {
+        continue;
+      }
+      $newsletterId = $newsletterIdsByContext[$context] ?? null;
+      if ($newsletterId === null) {
+        continue;
+      }
+      if (in_array($message, $messages[$newsletterId] ?? [], true)) {
+        continue;
+      }
+      $messages[$newsletterId][] = $message;
+    }
+    return $messages;
   }
 
   public function persist($entity): void {

--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -244,9 +244,9 @@ class LogRepository extends Repository {
   }
 
   /**
-   * Returns raw messages logged under $topic for the given newsletters, keyed by newsletter ID
-   * with the oldest message first. Newsletters without messages are not present in the result.
-   * A single query serves the whole listing page instead of one query per row.
+   * Returns distinct raw messages logged under $topic for the given newsletters, keyed by
+   * newsletter ID and ordered by first occurrence. Newsletters without messages are not present
+   * in the result. A single query serves the whole listing page instead of one query per row.
    *
    * @param NewsletterEntity[] $newsletters
    * @return array<int, string[]>
@@ -262,11 +262,14 @@ class LogRepository extends Repository {
 
     $rows = $this->entityManager->createQueryBuilder()
       ->select('logs.context context, logs.rawMessage message')
+      ->addSelect('MIN(logs.createdAt) AS HIDDEN firstCreatedAt, MIN(logs.id) AS HIDDEN firstId')
       ->from(LogEntity::class, 'logs')
       ->where('logs.name = :topic')
       ->andWhere('logs.context IN (:contexts)')
-      ->orderBy('logs.createdAt')
-      ->addOrderBy('logs.id')
+      ->groupBy('logs.context')
+      ->addGroupBy('logs.rawMessage')
+      ->orderBy('firstCreatedAt')
+      ->addOrderBy('firstId')
       ->setParameter('topic', $topic)
       ->setParameter('contexts', array_keys($newsletterIdsByContext))
       ->getQuery()
@@ -281,9 +284,6 @@ class LogRepository extends Repository {
       }
       $newsletterId = $newsletterIdsByContext[$context] ?? null;
       if ($newsletterId === null) {
-        continue;
-      }
-      if (in_array($message, $messages[$newsletterId] ?? [], true)) {
         continue;
       }
       $messages[$newsletterId][] = $message;

--- a/mailpoet/lib/Migrations/Db/Migration_20260907_120000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260907_120000_Db.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\LogEntity;
+use MailPoet\Migrator\DbMigration;
+
+/**
+ * The newsletters listing and the log listing filter the log table by `name`, which had no index,
+ * so every lookup scanned the whole table. Sites that ran with verbose logging accumulated
+ * millions of rows and the newsletters listing timed out.
+ *
+ * Some affected sites already added an index on `name` by hand under their own name. Any index
+ * that starts with `name` serves the lookups, so the migration checks the leading column instead
+ * of the index name to avoid building a redundant index on a multi-GB table.
+ */
+class Migration_20260907_120000_Db extends DbMigration {
+  private const INDEX_NAME = 'idx_log_name_created_at';
+
+  public function run(): void {
+    $logTable = $this->getTableName(LogEntity::class);
+
+    if ($this->indexStartingWithColumnExists($logTable, 'name')) {
+      return;
+    }
+
+    $this->connection->executeStatement(
+      "CREATE INDEX `" . self::INDEX_NAME . "` ON `{$logTable}` (`name`, `created_at`)"
+    );
+  }
+
+  private function indexStartingWithColumnExists(string $tableName, string $columnName): bool {
+    global $wpdb;
+    $count = $this->connection->fetchOne(
+      "SELECT COUNT(*)
+       FROM information_schema.statistics
+       WHERE table_schema = COALESCE(DATABASE(), :database)
+         AND table_name = :table
+         AND column_name = :column
+         AND seq_in_index = 1
+         AND index_type = 'BTREE'",
+      [
+        'database' => $wpdb->dbname,
+        'table' => $tableName,
+        'column' => $columnName,
+      ]
+    );
+    return is_numeric($count) && (int)$count > 0;
+  }
+}

--- a/mailpoet/tests/DataFactories/Log.php
+++ b/mailpoet/tests/DataFactories/Log.php
@@ -21,6 +21,8 @@ class Log {
       'level' => 5,
       'message' => 'Message' . bin2hex(random_bytes(7)),
       'created_at' => Carbon::now(),
+      'raw_message' => null,
+      'context' => [],
     ];
   }
 
@@ -52,12 +54,30 @@ class Log {
     return $this->update('level', $level);
   }
 
+  /**
+   * @return static
+   */
+  public function withRawMessage(?string $rawMessage): Log {
+    return $this->update('raw_message', $rawMessage);
+  }
+
+  /**
+   * @return static
+   */
+  public function withContext(array $context): Log {
+    return $this->update('context', $context);
+  }
+
   public function create(): LogEntity {
     $entity = new LogEntity();
     $entity->setName($this->data['name']);
     $entity->setLevel($this->data['level']);
     $entity->setMessage($this->data['message']);
     $entity->setCreatedAt($this->data['created_at']);
+    if ($this->data['raw_message'] !== null) {
+      $entity->setRawMessage($this->data['raw_message']);
+    }
+    $entity->setContext($this->data['context']);
     $this->repository->saveLog($entity);
     return $entity;
   }

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
@@ -8,6 +8,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Logging\LogRepository;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\NewsletterReplayMetadata;
@@ -18,6 +19,7 @@ use MailPoet\Newsletter\Statistics\NewsletterStatistics;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Url;
 use MailPoet\Statistics\StatisticsUnsubscribesRepository;
+use MailPoet\Test\DataFactories\Log;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -240,5 +242,21 @@ class NewslettersResponseBuilderTest extends \MailPoetTest {
     verify($response[0]['can_share'])->false();
     verify($response[0]['is_share_supported'])->false();
     verify($response[0]['share_unavailable_reason'])->equals('Only sent emails can be shared.');
+  }
+
+  public function testItAddsCouponBlockLogsToListingItems(): void {
+    $responseBuilder = $this->diContainer->get(NewslettersResponseBuilder::class);
+    $withLogs = (new Newsletter())->withSubject('With coupon logs')->create();
+    $withoutLogs = (new Newsletter())->withSubject('Without coupon logs')->create();
+    (new Log())
+      ->withName(LoggerFactory::TOPIC_COUPONS)
+      ->withRawMessage('Coupon "SUMMER" was not found')
+      ->withContext(['newsletter_id' => $withLogs->getId()])
+      ->create();
+
+    $response = $responseBuilder->buildForListing([$withLogs, $withoutLogs]);
+
+    verify($response[0]['logs'])->equals(['Coupon block: Coupon "SUMMER" was not found']);
+    verify($response[1]['logs'])->equals([]);
   }
 }

--- a/mailpoet/tests/integration/Logging/LogRepositoryTest.php
+++ b/mailpoet/tests/integration/Logging/LogRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Logging;
 
 use MailPoet\Test\DataFactories\Log;
+use MailPoet\Test\DataFactories\Newsletter;
 use MailPoetVendor\Carbon\Carbon;
 
 class LogRepositoryTest extends \MailPoetTest {
@@ -139,5 +140,30 @@ class LogRepositoryTest extends \MailPoetTest {
     }
 
     verify(count($rows))->equals(3);
+  }
+
+  public function testGetRawMessagesForNewslettersGroupsDistinctMessagesByNewsletter(): void {
+    $first = (new Newsletter())->withSubject('First')->create();
+    $second = (new Newsletter())->withSubject('Second')->create();
+    $third = (new Newsletter())->withSubject('Third')->create();
+    $couponLog = (new Log())->withName(LoggerFactory::TOPIC_COUPONS);
+
+    $couponLog->withRawMessage('later')->withContext(['newsletter_id' => $first->getId()])->withCreatedAt(Carbon::now())->create();
+    $couponLog->withRawMessage('earlier')->withContext(['newsletter_id' => $first->getId()])->withCreatedAt(Carbon::now()->subMinute())->create();
+    $couponLog->withRawMessage('earlier')->withContext(['newsletter_id' => $first->getId()])->withCreatedAt(Carbon::now()->subMinutes(2))->create();
+    $couponLog->withRawMessage('second only')->withContext(['newsletter_id' => $second->getId()])->create();
+    $couponLog->withRawMessage('unrelated topic')->withName('cron')->withContext(['newsletter_id' => $first->getId()])->create();
+    $couponLog->withRawMessage('unrelated context')->withContext(['newsletter_id' => $first->getId(), 'task_id' => 1])->create();
+
+    $messages = $this->repository->getRawMessagesForNewsletters([$first, $second, $third], LoggerFactory::TOPIC_COUPONS);
+
+    verify($messages)->equals([
+      $first->getId() => ['earlier', 'later'],
+      $second->getId() => ['second only'],
+    ]);
+  }
+
+  public function testGetRawMessagesForNewslettersReturnsEmptyArrayForNoNewsletters(): void {
+    verify($this->repository->getRawMessagesForNewsletters([], LoggerFactory::TOPIC_COUPONS))->equals([]);
   }
 }

--- a/mailpoet/tests/integration/Migrations/Db/Migration_20260907_120000_Db_Test.php
+++ b/mailpoet/tests/integration/Migrations/Db/Migration_20260907_120000_Db_Test.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Migrations\Db;
+
+use MailPoet\Entities\LogEntity;
+use MailPoet\Migrations\Db\Migration_20260907_120000_Db;
+
+//phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class Migration_20260907_120000_Db_Test extends \MailPoetTest {
+  private const INDEX_NAME = 'idx_log_name_created_at';
+  private const PREEXISTING_INDEX_NAME = 'test_preexisting_name_index';
+
+  /** @var Migration_20260907_120000_Db */
+  private $migration;
+
+  /** @var string */
+  private $tableName;
+
+  public function _before() {
+    parent::_before();
+    $this->migration = new Migration_20260907_120000_Db($this->diContainer);
+    $this->tableName = $this->entityManager->getClassMetadata(LogEntity::class)->getTableName();
+    $this->dropIndex(self::INDEX_NAME);
+    $this->dropIndex(self::PREEXISTING_INDEX_NAME);
+  }
+
+  public function _after() {
+    // The suite's shared schema has the migration's index in place; put it back
+    // so the tests that drop or skip it leave the database as they found it.
+    $this->dropIndex(self::PREEXISTING_INDEX_NAME);
+    $this->migration->run();
+    parent::_after();
+  }
+
+  public function testItCreatesIndexOnNameAndCreatedAt(): void {
+    $this->migration->run();
+
+    verify($this->getIndexColumns(self::INDEX_NAME))->equals(['name', 'created_at']);
+  }
+
+  public function testItCanBeRerunSafely(): void {
+    $this->migration->run();
+    $this->migration->run();
+
+    verify($this->getIndexColumns(self::INDEX_NAME))->equals(['name', 'created_at']);
+  }
+
+  public function testItSkipsWhenAnotherIndexAlreadyStartsWithName(): void {
+    $this->entityManager->getConnection()->executeStatement(
+      "CREATE INDEX `" . self::PREEXISTING_INDEX_NAME . "` ON `{$this->tableName}` (`name`)"
+    );
+
+    $this->migration->run();
+
+    verify($this->getIndexColumns(self::INDEX_NAME))->equals([]);
+    verify($this->getIndexColumns(self::PREEXISTING_INDEX_NAME))->equals(['name']);
+  }
+
+  /**
+   * @return string[]
+   */
+  private function getIndexColumns(string $index): array {
+    $columns = $this->entityManager->getConnection()->fetchFirstColumn(
+      "SELECT column_name
+       FROM information_schema.statistics
+       WHERE table_schema = DATABASE() AND table_name = :table AND index_name = :index
+       ORDER BY seq_in_index",
+      ['table' => $this->tableName, 'index' => $index]
+    );
+    return array_values(array_filter($columns, 'is_string'));
+  }
+
+  private function dropIndex(string $index): void {
+    if ($this->getIndexColumns($index) === []) {
+      return;
+    }
+    $this->entityManager->getConnection()->executeStatement("ALTER TABLE `{$this->tableName}` DROP INDEX `{$index}`");
+  }
+}


### PR DESCRIPTION
## Description

The Emails listing (`GET /wp-json/mailpoet/v1/newsletters`) ran one query against `mailpoet_log` for every listed newsletter to collect coupon block warnings (`LogRepository::getRawMessagesForNewsletter()`, added in MAILPOET-4983). The table has no index on `name`, so each query scanned it whole. Sites that ran with Logging set to "Everything" accumulated millions of rows, the 20 scans per page outlived the host's proxy timeout, and the DataViews listing showed "The response is not a valid JSON response". Two customers root-caused it independently (STOMAIL-8367).

Reproduced locally on 5.37.0 with 8.4M synthetic log rows (2.6 GB, 128 MB buffer pool):

| Scenario | Listing request (20 rows) |
| --- | --- |
| trunk: 20 per-row scans | 35.5 s |
| this PR, batched query, no index | 2.7 s (1 query) |
| this PR, with the new index | 0.01 s |

Two changes, one per commit:

1. **Batch the lookup.** `LogRepository::getRawMessagesForNewsletters()` loads the messages for the whole page in one query keyed by newsletter ID; `NewslettersResponseBuilder::buildForListing()` prefetches them like it already does for statistics and queues. This alone makes the page load regardless of table size.
2. **Index `mailpoet_log (name, created_at)`** via `Migration_20260907_120000_Db`. The newsletters listing and the Logs page both filter on `name`; with the index the lookup reads one row instead of the table.

**Backward compatibility:** no change to any public API, hook, or REST response shape (`logs` on each listing item is unchanged). `getRawMessagesForNewsletter()` was removed; it is an internal repository method with no usage in Premium.

## Code review notes

- The migration checks `information_schema.statistics` for **any BTREE index whose leading column is `name`**, not for the index name like `indexExists()` does. Both reporting customers already created such an index by hand under their own names (`name_created`, `idx_name`); a name-based check would build a second, redundant index on a multi-GB table. Kept the check local to the migration rather than adding a helper to `DbMigration`.
- The index build runs inline during activation, same as every earlier index migration (2026-04-27, 06-09, 06-10, 06-22, 07-09 on `subscribers`, `subscriber_segment`, `statistics_newsletters`, and 2025-09-03 on this same table). Locally it takes 7.7 s on 8.4M rows; InnoDB builds it online. If a host kills the PHP process mid-build, the migration retries on the next request, but because of commit 1 the index is an optimization, not a prerequisite for the page to work. No incidents were found for the earlier migrations; deferring index builds to a cron worker would be a new pattern worth a separate issue if we want it generally.
- The batched query matches `context` exactly (`{"newsletter_id":N}`), which preserves the semantics of the previous `LIKE` without wildcards.

## QA notes

1. On a site with some newsletters, set Logging to "Everything" and either seed `wp_mailpoet_log` with a few million rows, or just verify the Emails page still lists coupon block warnings: render a newsletter with a coupon block whose coupon does not exist, the listing row should show "Coupon block: …".
2. `SHOW INDEX FROM wp_mailpoet_log` after the update should include `idx_log_name_created_at (name, created_at)`.
3. Re-running the migration, or running it on a table that already has a manual index on `name`, must not create a second index.

## Linked PRs

_N/A_

## Linked tickets

- STOMAIL-8367
- Zendesk 11569523, 11573204

## After-merge notes

Reply to both Zendesk tickets once the fix is released. Both sites already have a manual index, so the migration will skip it there.

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8367-newsletters-listing-log-table-scan)

_The latest successful build from `fix/stomail-8367-newsletters-listing-log-table-scan` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->