### PR TITLE
Update email editor packages

### DIFF
--- a/mailpoet/changelog/2026-09-03-14-27-35-improved-social-icon-rendering-in-the-block-email-editor.md
+++ b/mailpoet/changelog/2026-09-03-14-27-35-improved-social-icon-rendering-in-the-block-email-editor.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Social icon rendering in the block email editor

--- a/mailpoet/changelog/2026-09-03-14-27-36-fixed-back-button-sizing-in-the-block-email-editor-on-wo.md
+++ b/mailpoet/changelog/2026-09-03-14-27-36-fixed-back-button-sizing-in-the-block-email-editor-on-wo.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Back button sizing in the block email editor on WordPress 7.1

--- a/mailpoet/changelog/2026-09-03-14-27-36-fixed-missing-personalization-tags-toolbar-button-on-but.md
+++ b/mailpoet/changelog/2026-09-03-14-27-36-fixed-missing-personalization-tags-toolbar-button-on-but.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Missing Personalization Tags toolbar button on Button blocks in the block email editor

--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -6,7 +6,7 @@
     "dragonmantank/cron-expression": "^3.3",
     "mixpanel/mixpanel-php": "2.*",
     "woocommerce/action-scheduler": "3.9.2",
-    "woocommerce/email-editor": "2.16.0"
+    "woocommerce/email-editor": "2.17.1"
   },
   "require-dev": {
     "ext-gd": "*",

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "872900f5b87449668837c6f68e6176ac",
+    "content-hash": "3c06f4f40e4e55fb593a5ff4f106bc45",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -285,16 +285,16 @@
         },
         {
             "name": "woocommerce/email-editor",
-            "version": "2.16.0",
+            "version": "2.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/email-editor.git",
-                "reference": "39c5f20776b98fb669459a55b452a30d82c0e2bd"
+                "reference": "a55136a6c07f57391a1932d53abb199e5757c078"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/39c5f20776b98fb669459a55b452a30d82c0e2bd",
-                "reference": "39c5f20776b98fb669459a55b452a30d82c0e2bd",
+                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/a55136a6c07f57391a1932d53abb199e5757c078",
+                "reference": "a55136a6c07f57391a1932d53abb199e5757c078",
                 "shasum": ""
             },
             "require": {
@@ -336,9 +336,9 @@
             ],
             "description": "Email editor based on WordPress Gutenberg package.",
             "support": {
-                "source": "https://github.com/woocommerce/email-editor/tree/2.16.0"
+                "source": "https://github.com/woocommerce/email-editor/tree/2.17.1"
             },
-            "time": "2026-08-12T10:25:20+00:00"
+            "time": "2026-09-07T09:23:35+00:00"
         }
     ],
     "packages-dev": [

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -53,7 +53,7 @@
     "@woocommerce/components": "^13.1.0",
     "@woocommerce/currency": "^4.3.0",
     "@woocommerce/date": "^4.3.0",
-    "@woocommerce/email-editor": "2.4.0",
+    "@woocommerce/email-editor": "2.4.1",
     "@wordpress/a11y": "^4.43.0",
     "@wordpress/api-fetch": "^7.43.0",
     "@wordpress/block-editor": "^15.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0(lodash@4.18.1)
       '@woocommerce/email-editor':
-        specifier: 2.4.0
-        version: 2.4.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))
+        specifier: 2.4.1
+        version: 2.4.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))
       '@wordpress/a11y':
         specifier: ^4.43.0
         version: 4.44.0
@@ -4367,8 +4367,8 @@ packages:
     peerDependencies:
       lodash: ^4.17.0
 
-  '@woocommerce/email-editor@2.4.0':
-    resolution: {integrity: sha512-1EF0SoSc3rzJIBmjCZp19j3wbkiTVrrn2Dhuo6j6zagPYShl3XI5LWWSMIbx0m/Fnu1Mus4kcAzvKoZFtSg6bQ==}
+  '@woocommerce/email-editor@2.4.1':
+    resolution: {integrity: sha512-VHcA04WtIKebeLmUe4gZxPiNSoXolexSXB+2gGPCI4sce86litIzT51QAFnrAB5/C+PORW8reXx3nmuYM6xffw==}
 
   '@woocommerce/navigation@8.2.0':
     resolution: {integrity: sha512-joAbrzdhrnWf91kEwuNO3hzT0IiUuh8SNOs0Qbth/heZaN+SixA5yJ98UqEHNa2Mitjm5BTC4M0Qk7X+I8uUvQ==}
@@ -17640,7 +17640,7 @@ snapshots:
       moment-timezone: 0.5.45
       qs: 6.15.2
 
-  '@woocommerce/email-editor@2.4.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))':
+  '@woocommerce/email-editor@2.4.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/api-fetch': 7.44.0
       '@wordpress/base-styles': 6.20.0


### PR DESCRIPTION
## Description

MailPoet consumes the PHP and JavaScript email editor packages independently. Updating both packages brings recent block editor rendering and interface fixes into the plugin.

This updates:

- `woocommerce/email-editor` from 2.16.0 to 2.17.1
- `@woocommerce/email-editor` from 2.4.0 to 2.4.1

## Code review notes

I handpicked some changes included in the package updates and added changelogs. I focused on what users may notice in the UI. Would you suggest adding more changes? Please let me know.

I did basic smoke tests of the editor:
 - created an email from a template containing paragraphs, headings, and an image
 - added button block with link
 - added Latest posts
 - sent an email

## QA notes

- `cd mailpoet && ./do qa:prettier-check`
- `cd mailpoet && ./do qa`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm compile:js`
- Composer validation and dry-run installation

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-email-editors)

_The latest successful build from `update-email-editors` will be used. If none is available, the link won't work._