### PR TITLE
Prefix the log table name index to fit the 767-byte key limit

### DIFF
--- a/mailpoet/lib/Migrations/Db/Migration_20260907_120000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260907_120000_Db.php
@@ -13,9 +13,16 @@ use MailPoet\Migrator\DbMigration;
  * Some affected sites already added an index on `name` by hand under their own name. Any index
  * that starts with `name` serves the lookups, so the migration checks the leading column instead
  * of the index name to avoid building a redundant index on a multi-GB table.
+ *
+ * `name` is varchar(255) in utf8mb4, i.e. 1020 bytes, which exceeds the 767-byte index limit of
+ * tables still on the COMPACT or REDUNDANT row format (the default before MySQL 5.7.9 and
+ * MariaDB 10.2.2). MariaDB rejects such an index outright, which would fail the migration on
+ * every retry. A 191-character prefix (764 bytes) fits everywhere and fully covers the short
+ * topic names the lookups filter by.
  */
 class Migration_20260907_120000_Db extends DbMigration {
   private const INDEX_NAME = 'idx_log_name_created_at';
+  private const NAME_PREFIX_LENGTH = 191;
 
   public function run(): void {
     $logTable = $this->getTableName(LogEntity::class);
@@ -25,7 +32,7 @@ class Migration_20260907_120000_Db extends DbMigration {
     }
 
     $this->connection->executeStatement(
-      "CREATE INDEX `" . self::INDEX_NAME . "` ON `{$logTable}` (`name`, `created_at`)"
+      "CREATE INDEX `" . self::INDEX_NAME . "` ON `{$logTable}` (`name`(" . self::NAME_PREFIX_LENGTH . "), `created_at`)"
     );
   }
 

--- a/mailpoet/tests/integration/Migrations/Db/Migration_20260907_120000_Db_Test.php
+++ b/mailpoet/tests/integration/Migrations/Db/Migration_20260907_120000_Db_Test.php
@@ -32,17 +32,17 @@ class Migration_20260907_120000_Db_Test extends \MailPoetTest {
     parent::_after();
   }
 
-  public function testItCreatesIndexOnNameAndCreatedAt(): void {
+  public function testItCreatesPrefixedIndexOnNameAndCreatedAt(): void {
     $this->migration->run();
 
-    verify($this->getIndexColumns(self::INDEX_NAME))->equals(['name', 'created_at']);
+    verify($this->getIndexColumns(self::INDEX_NAME))->equals(['name(191)', 'created_at']);
   }
 
   public function testItCanBeRerunSafely(): void {
     $this->migration->run();
     $this->migration->run();
 
-    verify($this->getIndexColumns(self::INDEX_NAME))->equals(['name', 'created_at']);
+    verify($this->getIndexColumns(self::INDEX_NAME))->equals(['name(191)', 'created_at']);
   }
 
   public function testItSkipsWhenAnotherIndexAlreadyStartsWithName(): void {
@@ -57,11 +57,13 @@ class Migration_20260907_120000_Db_Test extends \MailPoetTest {
   }
 
   /**
+   * Index columns in order, with the prefix length appended for prefixed columns, e.g. "name(191)".
+   *
    * @return string[]
    */
   private function getIndexColumns(string $index): array {
     $columns = $this->entityManager->getConnection()->fetchFirstColumn(
-      "SELECT column_name
+      "SELECT IF(sub_part IS NULL, column_name, CONCAT(column_name, '(', sub_part, ')'))
        FROM information_schema.statistics
        WHERE table_schema = DATABASE() AND table_name = :table AND index_name = :index
        ORDER BY seq_in_index",

--- a/mailpoet/tests/integration/Migrations/DbIndexesTest.php
+++ b/mailpoet/tests/integration/Migrations/DbIndexesTest.php
@@ -7,12 +7,13 @@ use MailPoetVendor\Doctrine\DBAL\Connection;
 
 class DbIndexesTest extends \MailPoetTest {
   /**
-   * This test checks that we don't have an unique varchar index on a varchar column with a length bigger than 191.
-   * The length of 191 is the safe limit that works for all common MySQL configurations.
-   * We don't want to allow creating unique indexes on varchar columns with a length bigger than 191.
+   * This test checks that we don't index more than 191 characters of any varchar column.
+   * The length of 191 is the safe limit that works for all common MySQL configurations:
+   * in utf8mb4 it is 764 bytes, just under the 767-byte index limit of InnoDB tables on the
+   * COMPACT/REDUNDANT row format. Longer columns must be indexed with a prefix, e.g. `name(191)`.
    * @see https://stackoverflow.com/questions/15157227/mysql-varchar-index-length/16474039#16474039
    */
-  public function testDbHasCorrectUniqueVarcharIndexes() {
+  public function testDbHasNoVarcharIndexesLongerThan191Characters() {
     $connection = $this->diContainer->get(Connection::class);
     $incorrectIndexes = $connection->executeQuery(
       "SELECT DISTINCT
@@ -20,18 +21,19 @@ class DbIndexesTest extends \MailPoetTest {
       ISS.INDEX_NAME,
       ISS.COLUMN_NAME,
       ISS.NON_UNIQUE,
+      ISS.SUB_PART,
       ISC.CHARACTER_MAXIMUM_LENGTH,
       ISC.DATA_TYPE
     FROM INFORMATION_SCHEMA.STATISTICS ISS
-    JOIN INFORMATION_SCHEMA.COLUMNS ISC ON ISC.COLUMN_NAME = ISS.COLUMN_NAME AND ISC.TABLE_NAME = ISS.TABLE_NAME
-    WHERE ISS.TABLE_NAME LIKE :prefix
-      AND ISS.NON_UNIQUE = 0
+    JOIN INFORMATION_SCHEMA.COLUMNS ISC ON ISC.COLUMN_NAME = ISS.COLUMN_NAME AND ISC.TABLE_NAME = ISS.TABLE_NAME AND ISC.TABLE_SCHEMA = ISS.TABLE_SCHEMA
+    WHERE ISS.TABLE_SCHEMA = DATABASE()
+      AND ISS.TABLE_NAME LIKE :prefix
       AND ISC.DATA_TYPE = 'varchar'
-      AND ISC.CHARACTER_MAXIMUM_LENGTH > 191;",
+      AND COALESCE(ISS.SUB_PART, ISC.CHARACTER_MAXIMUM_LENGTH) > 191;",
       ['prefix' => Env::$dbPrefix . '%']
     )->fetchAllAssociative();
     if (!empty($incorrectIndexes)) {
-      $this->fail("The following unique indexes use varchar column, but have incorrect length over 191 chars:\n " . json_encode($incorrectIndexes, JSON_PRETTY_PRINT));
+      $this->fail("The following indexes cover more than 191 characters of a varchar column:\n " . json_encode($incorrectIndexes, JSON_PRETTY_PRINT));
     }
   }
 }


### PR DESCRIPTION
## Description

Follow-up to #7106 (merged, not yet released). `Migration_20260907_120000_Db` creates `idx_log_name_created_at (name, created_at)` on `mailpoet_log`. `name` is `varchar(255)` in utf8mb4, so the key part is 1020 bytes, above the 767-byte index limit of InnoDB tables that still use the COMPACT or REDUNDANT row format (the server default before MySQL 5.7.9 and MariaDB 10.2.2; an in-place server upgrade does not change existing tables). Long-lived installs, which are the ones with huge log tables, are the most likely to carry that format.

Verified on a `ROW_FORMAT=COMPACT` utf8mb4 table, non-strict `sql_mode` as set by wpdb:

| Server | `(name, created_at)` | `(name(191), created_at)` |
| --- | --- | --- |
| MariaDB 12.3 | **ERROR 1709** "Index column size too large. The maximum column size is 767 bytes" | created, `ref` lookup, `key_len 767` |
| MySQL 8.0.46 | Warning 1071, key silently prefixed to `name(191)` | created, same plan |

On MariaDB the migration would throw, the activation would abort, and it would retry on every request, blocking that and every later migration. The fix indexes `name(191)` (764 bytes), which fits everywhere and fully covers the short topic names the lookups filter by. On 8.4M rows the listing query still resolves as a `ref` lookup on the index and the Emails page loads in 0.02 s.

The migration is edited in place because it has not shipped. Sites that already ran the trunk version have a full-width index on a DYNAMIC table; the migration's leading-column check skips them.

The second commit extends `DbIndexesTest` from unique indexes to all indexes, honouring prefixes, so an unprefixed index over a long varchar fails the suite instead of reaching review.

**Backward compatibility:** no public surface changes.

## Code review notes

- The existing `indexExists()`-by-name pattern is not used here on purpose; see the class docblock. This PR only changes the column list and the guard test.
- `DbIndexesTest` now joins `INFORMATION_SCHEMA` on `TABLE_SCHEMA` as well; without it the join could match same-named tables in other databases on shared servers.

## QA notes

1. On a fresh site, update to this branch; `SHOW INDEX FROM wp_mailpoet_log` should list `idx_log_name_created_at` with `Sub_part 191` on `name`.
2. To exercise the failure this fixes: `ALTER TABLE wp_mailpoet_log ROW_FORMAT=COMPACT`, drop the index, rerun the migration on MariaDB. Trunk fails with error 1709, this branch succeeds.

## Linked PRs

- #7106

## Linked tickets

- STOMAIL-8457
- STOMAIL-8367

## After-merge notes

Should ship in the same release as #7106; the two must not be split across releases.

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8457-prefix-log-name-index)

_The latest successful build from `fix/stomail-8457-prefix-log-name-index` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

1 issue found.

- Bug: The full-width `name` index can exceed InnoDB’s 767-byte key limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->