### PR TITLE
Update Transifex CLI to 1.6.17

### DIFF
--- a/mailpoet/tools/transifex.php
+++ b/mailpoet/tools/transifex.php
@@ -21,7 +21,7 @@ if (!file_exists($vendorDir)) {
 
 // paths
 $name = "tx-$os-$arch";
-$url = "https://github.com/transifex/cli/releases/download/v1.0.3/$name.tar.gz";
+$url = "https://github.com/transifex/cli/releases/download/v1.6.17/$name.tar.gz";
 $filePath = __DIR__ . "/vendor/$name";
 $fileInfoPath = "$filePath.info";
 


### PR DESCRIPTION
## Description

Updates the Transifex CLI downloaded by `mailpoet/tools/transifex.php` from v1.0.3 to v1.6.17 (the latest release).

Only the version in the download URL changes. The wrapper re-downloads the binary automatically because the stored URL in the `.info` file no longer matches.

## Code review notes

There are no changes in the API between 1.0.3 and 1.6.17, so nothing else needs to change on our end.

Useful changes we get - parallel push/pull, retry on API throttling, and the push now exits with an error on a bad API response instead of possibly passing silently. Both `translations:push` tasks (free and premium) use this wrapper.

## QA notes

- `php mailpoet/tools/transifex.php --version` downloads the new binary and prints `TX Client, version=1.6.17`
- `php mailpoet/tools/transifex.php push --help` still lists `--source, -s`
- A real `./do translations:push` was not run locally. It will run as part of the next release.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/transifex-cli)

_The latest successful build from `update/transifex-cli` will be used. If none is available, the link won't work._