### PR TITLE
Keep imported tracking consent from rewriting what a subscriber chose

### DIFF
--- a/mailpoet/changelog/2026-09-09-08-34-38-fixed-keep-the-original-tracking-consent-record-when-a-l.md
+++ b/mailpoet/changelog/2026-09-09-08-34-38-fixed-keep-the-original-tracking-consent-record-when-a-l.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Keep the original tracking consent record when a list is imported again

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -179,6 +179,9 @@ class Import {
             $newSubscribers,
             $this->subscribersCustomFields
           );
+        if ($createdSubscribers) {
+          $this->notifyTrackingConsentForNewSubscribers($createdSubscribers, $newSubscribers);
+        }
       }
 
       $updateExistingSubscribersStatus = false;
@@ -282,12 +285,13 @@ class Import {
         ];
         $data = array_map(function($value) use ($validStates) {
           $value = trim((string)$value);
-          // A blank cell is left blank on purpose: blank means "leave the stored value alone",
-          // which is a different thing from an invalid value, and only the caller can act on it.
           if ($value === '') {
             return '';
           }
-          return in_array($value, $validStates, true) ? $value : SubscriberEntity::TRACKING_CONSENT_UNKNOWN;
+          // An unreadable value is not an answer, so it is blanked and treated like an
+          // empty cell: leave whatever the subscriber actually chose alone. Writing
+          // 'unknown' here would let one mistyped cell erase a real consent record.
+          return in_array($value, $validStates, true) ? $value : '';
         }, $data);
       }
       // if this is a custom column
@@ -590,6 +594,11 @@ class Import {
   /**
    * Writes consent for existing subscribers, skipping every row whose CSV cell
    * was blank so their stored value is left alone.
+   *
+   * A cell repeating the state the subscriber already holds is skipped too. The
+   * timestamp records when they chose, not when a list was last re-uploaded, so
+   * re-importing an unchanged answer must not restamp its evidence. This matches
+   * SubscriberEntity::setTrackingConsent(), which every other write path uses.
    */
   private function updateTrackingConsent(array $subscribersData): void {
     if (!in_array('tracking_consent', $subscribersData['fields'], true)) {
@@ -600,10 +609,18 @@ class Import {
     $methods = $subscribersData['data']['tracking_consent_method'] ?? [];
     $copies = $subscribersData['data']['tracking_consent_copy'] ?? [];
 
+    $stored = $this->getStoredTrackingConsent($emails);
+
     $rows = [];
+    $changes = [];
     foreach ($states as $index => $state) {
       $state = trim((string)$state);
       if ($state === '') {
+        continue;
+      }
+      $email = mb_strtolower((string)$emails[$index]);
+      $current = $stored[$email] ?? null;
+      if ($current !== null && $current['tracking_consent'] === $state) {
         continue;
       }
       $method = trim((string)($methods[$index] ?? ''));
@@ -615,6 +632,9 @@ class Import {
         $method !== '' ? mb_substr($method, 0, self::TRACKING_CONSENT_METHOD_MAX_LENGTH) : SubscriberEntity::TRACKING_CONSENT_METHOD_IMPORT,
         $copy !== '' ? $copy : null,
       ];
+      if ($current !== null) {
+        $changes[$current['id']] = [$current['tracking_consent'], $state];
+      }
     }
     if (!$rows) {
       return;
@@ -626,6 +646,54 @@ class Import {
         $chunk
       );
     }
+    $this->importExportRepository->notifyTrackingConsentChanges($changes);
+  }
+
+  /**
+   * @param string[] $emails
+   * @return array<string, array{id: int, tracking_consent: string}>
+   */
+  private function getStoredTrackingConsent(array $emails): array {
+    $stored = [];
+    foreach (array_chunk($emails, self::DB_QUERY_CHUNK_SIZE) as $chunk) {
+      foreach ($this->subscriberRepository->findIdEmailAndTrackingConsentByEmails($chunk) as $row) {
+        $stored[mb_strtolower((string)$row['email'])] = [
+          'id' => (int)$row['id'],
+          'tracking_consent' => (string)$row['trackingConsent'],
+        ];
+      }
+    }
+    return $stored;
+  }
+
+  /**
+   * Consent that arrived with a newly created subscriber is a change from the
+   * 'unknown' every new row starts at, and the bulk insert bypasses Doctrine, so
+   * it is announced here rather than by the entity listener.
+   *
+   * @param array<int, array{id: int, email: string}> $createdSubscribers
+   */
+  private function notifyTrackingConsentForNewSubscribers(array $createdSubscribers, array $newSubscribers): void {
+    if (!in_array('tracking_consent', $newSubscribers['fields'], true)) {
+      return;
+    }
+    $states = [];
+    foreach ($newSubscribers['data']['email'] as $index => $email) {
+      $state = (string)($newSubscribers['data']['tracking_consent'][$index] ?? '');
+      if ($state === '' || $state === SubscriberEntity::TRACKING_CONSENT_UNKNOWN) {
+        continue;
+      }
+      $states[mb_strtolower((string)$email)] = $state;
+    }
+    $changes = [];
+    foreach ($createdSubscribers as $created) {
+      $email = mb_strtolower((string)$created['email']);
+      if (!isset($states[$email])) {
+        continue;
+      }
+      $changes[(int)$created['id']] = [SubscriberEntity::TRACKING_CONSENT_UNKNOWN, $states[$email]];
+    }
+    $this->importExportRepository->notifyTrackingConsentChanges($changes);
   }
 
   public function getSubscribersFields(array $subscribersFields): array {

--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
@@ -312,6 +312,19 @@ class ImportExportRepository {
     return $qb;
   }
 
+  /**
+   * Bulk consent writes go straight to SQL, so Doctrine's lifecycle listener never
+   * sees them and the consent-changed hook would not fire. Import reports the
+   * transitions it made here instead.
+   *
+   * @param array<int, array{0: string, 1: string}> $changes old and new consent, keyed by subscriber id
+   */
+  public function notifyTrackingConsentChanges(array $changes): void {
+    foreach ($changes as $subscriberId => list($oldConsent, $newConsent)) {
+      $this->subscriberChangesNotifier->subscriberTrackingConsentChanged((int)$subscriberId, $oldConsent, $newConsent);
+    }
+  }
+
   private function notifyCreations(string $className, array $columns, array $data): void {
     if ($className === SubscriberEntity::class) {
       $ids = $this->getIdsByEmail($className, $columns, $data);

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -915,6 +915,19 @@ class SubscribersRepository extends Repository {
   }
 
   /**
+   * @param string[] $emails
+   * @return array<int, array{id: int, email: string, trackingConsent: string}>
+   */
+  public function findIdEmailAndTrackingConsentByEmails(array $emails): array {
+    return $this->entityManager->createQueryBuilder()
+      ->select('s.id, LOWER(s.email) AS email, s.trackingConsent')
+      ->from(SubscriberEntity::class, 's')
+      ->where('s.email IN (:emails)')
+      ->setParameter('emails', $emails)
+      ->getQuery()->getResult();
+  }
+
+  /**
    * @return int[]
    */
   public function findIdsOfDeletedByEmails(array $emails): array {

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/CliTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/CliTest.php
@@ -147,11 +147,14 @@ class CliTest extends \MailPoetTest {
     $this->assertSame('Allow open and click tracking', $granted->getTrackingConsentCopy());
     $this->assertInstanceOf(\DateTimeInterface::class, $granted->getTrackingConsentUpdatedAt());
 
-    // an unrecognised state still means "they answered", we just cannot honour the answer
+    // An unreadable state is not an answer, so it is treated like an empty cell and
+    // no evidence is stamped. Recording "answered by import" for a value we could not
+    // read would be a consent record of something nobody said.
     $bogus = $this->subscribersRepository->findOneBy(['email' => 'bogus@example.com']);
     $this->assertInstanceOf(SubscriberEntity::class, $bogus);
     $this->assertSame(SubscriberEntity::TRACKING_CONSENT_UNKNOWN, $bogus->getTrackingConsent());
-    $this->assertSame(SubscriberEntity::TRACKING_CONSENT_METHOD_IMPORT, $bogus->getTrackingConsentMethod());
+    $this->assertNull($bogus->getTrackingConsentMethod());
+    $this->assertNull($bogus->getTrackingConsentUpdatedAt());
 
     $silent = $this->subscribersRepository->findOneBy(['email' => 'silent@example.com']);
     $this->assertInstanceOf(SubscriberEntity::class, $silent);

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Subscribers\ImportExport\Import;
 
 use Codeception\Stub;
+use MailPoet\Config\SubscriberChangesNotifier;
 use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\SegmentEntity;
@@ -11,6 +12,7 @@ use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Entities\SubscriberTagEntity;
 use MailPoet\Entities\TagEntity;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
+use MailPoet\Segments\DynamicSegments\FilterHandler;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\WP;
 use MailPoet\Services\Validator;
@@ -293,8 +295,8 @@ class ImportTest extends \MailPoetTest {
     $result = $this->import->validateSubscribersData($data);
     $this->assertIsArray($result);
     verify($result['tracking_consent'][0])->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
-    // invalid but non-blank: we know something was meant, we just cannot honour it
-    verify($result['tracking_consent'][1])->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    // an unreadable value is blanked, so it leaves the stored answer alone
+    verify($result['tracking_consent'][1])->equals('');
     // blank stays blank so the import paths can leave the stored value alone
     verify($result['tracking_consent'][2])->equals('');
     verify($result['tracking_consent'][3])->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
@@ -865,6 +867,147 @@ class ImportTest extends \MailPoetTest {
     // the previous wording belongs to the previous answer, so it is cleared with it
     verify($updated->getTrackingConsentCopy())->null();
     $this->assertInstanceOf(\DateTimeInterface::class, $updated->getTrackingConsentUpdatedAt());
+  }
+
+  public function testAMistypedConsentCellLeavesTheStoredAnswerAlone(): void {
+    $data = $this->testData;
+    $data['columns']['tracking_consent'] = ['index' => 8];
+    $data['subscribers'][0][] = 'grnated'; // a plausible typo in one cell of a long list
+    $data['subscribers'][1][] = '';
+
+    $existing = $this->createSubscriber('Adam', 'Smith', 'Adam@Smith.com');
+    $existing->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FORM,
+      'Original wording'
+    );
+    $this->subscriberRepository->flush();
+
+    $this->createImportInstance($data)->process();
+    $this->entityManager->clear();
+
+    $updated = $this->subscriberRepository->findOneBy(['email' => 'adam@smith.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $updated);
+    verify($updated->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    verify($updated->getTrackingConsentMethod())->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_FORM);
+    verify($updated->getTrackingConsentCopy())->equals('Original wording');
+  }
+
+  public function testReimportingAnUnchangedStateKeepsTheOriginalEvidence(): void {
+    $data = $this->testData;
+    $data['columns']['tracking_consent'] = ['index' => 8];
+    $data['subscribers'][0][] = 'granted'; // same state the subscriber already holds
+    $data['subscribers'][1][] = '';
+
+    $existing = $this->createSubscriber('Adam', 'Smith', 'Adam@Smith.com');
+    $existing->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FORM,
+      'Original wording'
+    );
+    $this->subscriberRepository->flush();
+    $storedUpdatedAt = $existing->getTrackingConsentUpdatedAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $storedUpdatedAt);
+
+    $this->createImportInstance($data)->process();
+    $this->entityManager->clear();
+
+    $updated = $this->subscriberRepository->findOneBy(['email' => 'adam@smith.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $updated);
+    verify($updated->getTrackingConsentMethod())->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_FORM);
+    verify($updated->getTrackingConsentCopy())->equals('Original wording');
+    $currentUpdatedAt = $updated->getTrackingConsentUpdatedAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $currentUpdatedAt);
+    verify($currentUpdatedAt->getTimestamp())->equals($storedUpdatedAt->getTimestamp());
+  }
+
+  public function testUpdatingConsentByImportAnnouncesTheChange(): void {
+    $data = $this->testData;
+    $data['columns']['tracking_consent'] = ['index' => 8];
+    $data['subscribers'][0][] = 'denied';
+    $data['subscribers'][1][] = '';
+
+    $this->createSubscriber('Adam', 'Smith', 'Adam@Smith.com');
+    $this->subscriberRepository->flush();
+
+    $fired = $this->captureTrackingConsentChanges(function () use ($data): void {
+      $this->createImportInstance($data)->process();
+    });
+
+    verify(count($fired))->equals(1);
+    verify($fired[0][1])->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    verify($fired[0][2])->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+  }
+
+  public function testImportingAConsentDecisionForANewSubscriberAnnouncesTheChange(): void {
+    $data = $this->testData;
+    $data['columns']['tracking_consent'] = ['index' => 8];
+    $data['subscribers'][0][] = 'denied';
+    $data['subscribers'][1][] = '';
+
+    $fired = $this->captureTrackingConsentChanges(function () use ($data): void {
+      $this->createImportInstance($data)->process();
+    });
+
+    verify(count($fired))->equals(1);
+    verify($fired[0][1])->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    verify($fired[0][2])->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+  }
+
+  public function testAnUnchangedConsentCellAnnouncesNothing(): void {
+    $data = $this->testData;
+    $data['columns']['tracking_consent'] = ['index' => 8];
+    $data['subscribers'][0][] = 'granted';
+    $data['subscribers'][1][] = '';
+
+    $existing = $this->createSubscriber('Adam', 'Smith', 'Adam@Smith.com');
+    $existing->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_GRANTED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_FORM,
+      'Original wording'
+    );
+    $this->subscriberRepository->flush();
+
+    $fired = $this->captureTrackingConsentChanges(function () use ($data): void {
+      $this->createImportInstance($data)->process();
+    });
+
+    verify($fired)->empty();
+  }
+
+  /**
+   * The notifier collects changes during the request and fires them together on
+   * shutdown, so the hook is only observable once notify() has run. The
+   * container inlines the notifier, hence the hand-built repository here: it is
+   * the only way to hold the same instance the import reports to.
+   *
+   * @return array<int, array{0: int, 1: string, 2: string}>
+   */
+  private function captureTrackingConsentChanges(callable $work): array {
+    $notifier = new SubscriberChangesNotifier(WPFunctions::get());
+    $previousRepository = $this->importExportRepository;
+    $this->importExportRepository = new ImportExportRepository(
+      $this->entityManager,
+      $notifier,
+      $this->diContainer->get(FilterHandler::class),
+      $this->subscriberRepository,
+      $this->subscriberCustomFieldRepository
+    );
+
+    $fired = [];
+    $listener = function ($subscriberId, $oldConsent, $newConsent) use (&$fired): void {
+      $fired[] = [$subscriberId, $oldConsent, $newConsent];
+    };
+    $hook = SubscriberEntity::HOOK_SUBSCRIBER_TRACKING_CONSENT_CHANGED;
+    add_action($hook, $listener, 10, 3);
+    try {
+      $work();
+      $notifier->notify();
+    } finally {
+      remove_action($hook, $listener, 10);
+      $this->importExportRepository = $previousRepository;
+    }
+    return $fired;
   }
 
   public function testItSynchronizesWpUsers(): void {


### PR DESCRIPTION
## Description

Bulk subscriber import could rewrite a subscriber's tracking-consent record in three ways. All three are in `Import::updateTrackingConsent()`, and one lookup of the stored state before the write fixes all of them.

**Re-importing an unchanged answer restamped its evidence.** A cell repeating the state a subscriber already holds was written anyway, resetting `tracking_consent_updated_at` and, when the CSV mapped only the state column, replacing the method with `import` and clearing the stored wording. The timestamp records when someone chose, not when a list was last uploaded, so an unchanged answer is now skipped. `SubscriberEntity::setTrackingConsent()` has always done this; the import path was the odd one out.

**One typo could erase a real answer.** An unreadable value was clamped to `unknown` and then written, so `grnated` in one cell of a long CSV silently turned a stored `granted` into `unknown`. Invalid values are now blanked and treated like an empty cell, which leaves the stored choice alone. New subscribers still land on the `unknown` default, so both cases end up correct. This also stops evidence being stamped for a value nobody could read.

**AutomateWoo never heard about imported consent.** Bulk writes go straight to SQL, so Doctrine's listener never saw them and `mailpoet_subscriber_tracking_consent_changed` never fired. An imported `denied` was recorded in MailPoet but never mirrored, so the two systems disagreed, which is the thing the hook exists to prevent. The lookup added above gives the before-and-after pair each firing needs, for updated and newly created subscribers alike.

## Code review notes

**Two shipped behaviours change on purpose, and both had tests asserting the old way.**

1. An invalid consent cell no longer records `unknown` with method `import`. `CliTest::testItImportsTrackingConsentColumns` asserted that, on the reasoning that an unreadable value still means "they answered". I think that is backwards for a proof-of-consent field: we do not know what they answered, so stamping "answered via import on this date" records something nobody said. Worth a second opinion if you disagree.
2. `ImportTest::testItClampsTrackingConsent` now expects a blank rather than `unknown`, for the same reason.

**The extra query.** `getStoredTrackingConsent()` runs one chunked `SELECT` per import, only when the CSV actually has a consent column. It is the same chunk size the write path already uses.

**Firing volume.** A large import that genuinely changes consent for every row will queue one hook firing per subscriber, and `SubscriberChangesNotifier` holds them until shutdown. That matches the hook's per-subscriber contract and mirrors what the Doctrine path already does for single writes, but if we would rather have a bulk variant for import-sized batches, this is the moment to say so.

**Test helper.** The container inlines `SubscriberChangesNotifier`, so `captureTrackingConsentChanges()` builds its own `ImportExportRepository` to hold the same instance the import reports to. Without that there is no way to call `notify()` on the right object, and the hook is only observable after `notify()` runs.

## QA notes

Consent capture has to be on: **MailPoet → Settings → Advanced → Subscriber choice**, set to "ask new subscribers" or "ask everyone".

1. **Unchanged re-import.** Give a subscriber `granted` through a form. Export the list, re-import it with "update existing" on. Their consent method and wording should stay as they were, and the timestamp should not move.
2. **Typo.** Import a CSV with `grnated` in the `tracking_consent` cell for a subscriber who is already `granted`. They should stay `granted`. Before this change they became `unknown`.
3. **AutomateWoo mirroring.** With AutomateWoo active, import a subscriber with `tracking_consent` set to `denied`. The matching AutomateWoo customer should end up opted out of tracking.

## Linked PRs

_N/A_

## Linked tickets

- STOMAIL-8444
- STOMAIL-8460

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8444-import-consent-evidence-and-hook)

_The latest successful build from `fix/stomail-8444-import-consent-evidence-and-hook` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->