### PR TITLE
Only let a collection point record consent it actually collected

### DIFF
--- a/mailpoet/changelog/2026-09-09-08-44-06-fixed-stop-a-subscribers-tracking-choice-being-changed-b.md
+++ b/mailpoet/changelog/2026-09-09-08-44-06-fixed-stop-a-subscribers-tracking-choice-being-changed-b.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Stop a subscriber's tracking choice being changed by someone else

--- a/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
@@ -251,11 +251,14 @@ class SubscriberSubscribeController {
     $email = $data['email'] ?? null;
     $method = SubscriberEntity::TRACKING_CONSENT_METHOD_FORM;
 
+    $email = is_string($email) ? $email : null;
+
     return $this->trackingConsentCapture->getConsentData(
       (bool)$data[TrackingConsentCapture::FIELD_ID],
       $method,
       $this->trackingConsentCapture->getCopy($method, $this->getFormConsentCopy($form)),
-      $this->trackingConsentCapture->isNewSubscriber(is_string($email) ? $email : null)
+      $this->trackingConsentCapture->isNewSubscriber($email),
+      $this->trackingConsentCapture->getStoredConsent($email)
     );
   }
 

--- a/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
@@ -251,14 +251,11 @@ class SubscriberSubscribeController {
     $email = $data['email'] ?? null;
     $method = SubscriberEntity::TRACKING_CONSENT_METHOD_FORM;
 
-    $email = is_string($email) ? $email : null;
-
-    return $this->trackingConsentCapture->getConsentData(
+    return $this->trackingConsentCapture->getConsentDataForEmail(
       (bool)$data[TrackingConsentCapture::FIELD_ID],
       $method,
       $this->trackingConsentCapture->getCopy($method, $this->getFormConsentCopy($form)),
-      $this->trackingConsentCapture->isNewSubscriber($email),
-      $this->trackingConsentCapture->getStoredConsent($email)
+      is_string($email) ? $email : null
     );
   }
 

--- a/mailpoet/lib/Subscribers/TrackingConsentCapture.php
+++ b/mailpoet/lib/Subscribers/TrackingConsentCapture.php
@@ -142,16 +142,24 @@ class TrackingConsentCapture {
   }
 
   /**
-   * The consent already on record for this email, or null when nobody with it is
-   * on the list yet. Callers that only have an address use this to tell an
-   * unanswered subscriber from one whose answer must not be overwritten.
+   * Consent fields for a collection point that knows the subscriber only by an
+   * email address someone typed. One lookup answers both questions the decision
+   * needs: whether a row exists, and what it already says.
+   *
+   * @return array<string, string>
    */
-  public function getStoredConsent(?string $email): ?string {
-    if ($email === null || $email === '') {
-      return null;
-    }
-    $subscriber = $this->subscribersRepository->findOneBy(['email' => $email]);
-    return $subscriber instanceof SubscriberEntity ? $subscriber->getTrackingConsent() : null;
+  public function getConsentDataForEmail(bool $granted, string $method, string $copy, ?string $email): array {
+    $subscriber = ($email === null || $email === '')
+      ? null
+      : $this->subscribersRepository->findOneBy(['email' => $email]);
+
+    return $this->getConsentData(
+      $granted,
+      $method,
+      $copy,
+      !$subscriber instanceof SubscriberEntity,
+      $subscriber instanceof SubscriberEntity ? $subscriber->getTrackingConsent() : null
+    );
   }
 
   /**

--- a/mailpoet/lib/Subscribers/TrackingConsentCapture.php
+++ b/mailpoet/lib/Subscribers/TrackingConsentCapture.php
@@ -80,18 +80,15 @@ class TrackingConsentCapture {
    * Consent fields to merge into subscriber data on a signup path, or an empty
    * array when nothing should be written.
    *
-   * Granting is always recorded. Declining is recorded only for a subscriber
-   * being created now: someone already on the list who submits a form again
-   * keeps whatever they chose before, because an unticked box on a signup form
-   * is not a withdrawal of consent given somewhere else.
-   *
+   * @param string|null $storedConsent What the subscriber already has on record,
+   *                                   or null when there is no row yet.
    * @return array<string, string>
    */
-  public function getConsentData(bool $granted, string $method, string $copy, bool $isNewSubscriber): array {
+  public function getConsentData(bool $granted, string $method, string $copy, bool $isNewSubscriber, ?string $storedConsent = null): array {
     if (!$this->isCaptureEnabled()) {
       return [];
     }
-    if (!$granted && !$isNewSubscriber) {
+    if (!$this->mayRecord($granted, $isNewSubscriber, $storedConsent)) {
       return [];
     }
     return [
@@ -104,16 +101,57 @@ class TrackingConsentCapture {
   }
 
   /**
+   * Whether a collection point may write this answer.
+   *
+   * These points are all reachable without proving who you are: a comment, a
+   * subscription form, a registration and a checkout all identify the subscriber
+   * by an email address the visitor typed, and nothing verifies that the address
+   * is theirs. So an answer that would replace a choice already on record is
+   * dropped. Changing an answer already given is done from the manage
+   * subscription page, which checks a link token first.
+   *
+   * Someone who has never been asked can still answer here, and a subscriber
+   * being created now records either answer, since neither overwrites anything.
+   * An unticked box on a signup form is still not a withdrawal of consent given
+   * somewhere else.
+   */
+  private function mayRecord(bool $granted, bool $isNewSubscriber, ?string $storedConsent): bool {
+    if ($isNewSubscriber) {
+      return true;
+    }
+    if (
+      $storedConsent === SubscriberEntity::TRACKING_CONSENT_GRANTED
+      || $storedConsent === SubscriberEntity::TRACKING_CONSENT_DENIED
+    ) {
+      return false;
+    }
+    return $granted;
+  }
+
+  /**
    * Applies consent straight to an entity, for paths that persist the
    * subscriber themselves instead of going through SubscriberSaveController
    * (WooCommerce checkout).
    */
   public function applyToSubscriber(SubscriberEntity $subscriber, bool $granted, string $method, string $copy, bool $isNewSubscriber): void {
-    $data = $this->getConsentData($granted, $method, $copy, $isNewSubscriber);
+    $data = $this->getConsentData($granted, $method, $copy, $isNewSubscriber, $subscriber->getTrackingConsent());
     if (!$data) {
       return;
     }
     $subscriber->setTrackingConsent($data[self::FIELD_ID], $method, $copy);
+  }
+
+  /**
+   * The consent already on record for this email, or null when nobody with it is
+   * on the list yet. Callers that only have an address use this to tell an
+   * unanswered subscriber from one whose answer must not be overwritten.
+   */
+  public function getStoredConsent(?string $email): ?string {
+    if ($email === null || $email === '') {
+      return null;
+    }
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => $email]);
+    return $subscriber instanceof SubscriberEntity ? $subscriber->getTrackingConsent() : null;
   }
 
   /**

--- a/mailpoet/lib/Subscription/Comment.php
+++ b/mailpoet/lib/Subscription/Comment.php
@@ -218,7 +218,8 @@ class Comment {
         $trackingConsent,
         $method,
         $this->trackingConsentCapture->getCopy($method),
-        $this->trackingConsentCapture->isNewSubscriber($email)
+        $this->trackingConsentCapture->isNewSubscriber($email),
+        $this->trackingConsentCapture->getStoredConsent($email)
       );
 
       $this->subscriberActions->subscribe(

--- a/mailpoet/lib/Subscription/Comment.php
+++ b/mailpoet/lib/Subscription/Comment.php
@@ -214,12 +214,11 @@ class Comment {
       $comment = WPFunctions::get()->getComment($commentId);
       $email = $comment->comment_author_email; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       $method = SubscriberEntity::TRACKING_CONSENT_METHOD_COMMENT;
-      $consentData = $this->trackingConsentCapture->getConsentData(
+      $consentData = $this->trackingConsentCapture->getConsentDataForEmail(
         $trackingConsent,
         $method,
         $this->trackingConsentCapture->getCopy($method),
-        $this->trackingConsentCapture->isNewSubscriber($email),
-        $this->trackingConsentCapture->getStoredConsent($email)
+        $email
       );
 
       $this->subscriberActions->subscribe(

--- a/mailpoet/lib/Subscription/Registration.php
+++ b/mailpoet/lib/Subscription/Registration.php
@@ -193,12 +193,11 @@ class Registration {
       []
     );
     $method = SubscriberEntity::TRACKING_CONSENT_METHOD_REGISTRATION;
-    $consentData = $this->trackingConsentCapture->getConsentData(
+    $consentData = $this->trackingConsentCapture->getConsentDataForEmail(
       $trackingConsent,
       $method,
       $this->trackingConsentCapture->getCopy($method),
-      $this->trackingConsentCapture->isNewSubscriber($email),
-      $this->trackingConsentCapture->getStoredConsent($email)
+      $email
     );
 
     $this->subscriberActions->subscribe(

--- a/mailpoet/lib/Subscription/Registration.php
+++ b/mailpoet/lib/Subscription/Registration.php
@@ -197,7 +197,8 @@ class Registration {
       $trackingConsent,
       $method,
       $this->trackingConsentCapture->getCopy($method),
-      $this->trackingConsentCapture->isNewSubscriber($email)
+      $this->trackingConsentCapture->isNewSubscriber($email),
+      $this->trackingConsentCapture->getStoredConsent($email)
     );
 
     $this->subscriberActions->subscribe(

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -129,6 +129,20 @@ class Subscription {
   }
 
   /**
+   * Whether checkout actually put the consent question to the customer.
+   *
+   * The checkbox is rendered by extendWooCommerceCheckoutForm, which is only
+   * hooked when the checkout opt-in is switched on, while the code that reads
+   * the answer runs on every order. On a store that asks for consent but leaves
+   * the opt-in off, no box is drawn, so there is no answer to record and an
+   * empty POST field means "not asked" rather than "declined".
+   */
+  private function wasTrackingConsentOffered(): bool {
+    return $this->trackingConsentCapture->isCaptureEnabled()
+      && (bool)$this->settings->get(self::OPTIN_ENABLED_SETTING_NAME, false);
+  }
+
+  /**
    * The tracking-consent checkbox, shown only on sites that chose to ask. It is
    * never pre-ticked: a pre-ticked consent box is not valid consent (CJEU
    * Planet49).
@@ -267,6 +281,9 @@ class Subscription {
    * writes the entity itself instead of going through SubscriberSaveController.
    */
   private function applyTrackingConsent(SubscriberEntity $subscriber, bool $granted, bool $isNewSubscriber = false): void {
+    if (!$this->wasTrackingConsentOffered()) {
+      return;
+    }
     $method = SubscriberEntity::TRACKING_CONSENT_METHOD_WOOCOMMERCE_CHECKOUT;
     $before = $subscriber->getTrackingConsent();
 

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -136,10 +136,22 @@ class Subscription {
    * the answer runs on every order. On a store that asks for consent but leaves
    * the opt-in off, no box is drawn, so there is no answer to record and an
    * empty POST field means "not asked" rather than "declined".
+   *
+   * Settings are necessary but not sufficient: the opt-in block can also be
+   * emptied through the mailpoet_woocommerce_checkout_optin_template filter,
+   * which takes the consent box with it. Callers that can see whether the block
+   * reached the customer pass that in.
    */
-  private function wasTrackingConsentOffered(): bool {
-    return $this->trackingConsentCapture->isCaptureEnabled()
-      && (bool)$this->settings->get(self::OPTIN_ENABLED_SETTING_NAME, false);
+  private function wasTrackingConsentOffered(?bool $consentFieldRendered = null): bool {
+    if (!$this->trackingConsentCapture->isCaptureEnabled()) {
+      return false;
+    }
+    if (!(bool)$this->settings->get(self::OPTIN_ENABLED_SETTING_NAME, false)) {
+      return false;
+    }
+    // Callers that can tell whether the field really reached the customer say so.
+    // Null means they cannot, so the settings are the best answer available.
+    return $consentFieldRendered ?? true;
   }
 
   /**
@@ -228,8 +240,14 @@ class Subscription {
     // this same hook three priorities earlier, so by now a brand new guest's row
     // is already there. Ask the sync what it actually inserted.
     $isNewSubscriber = $this->woocommerceSegment->wasNewlyCreatedByGuestSync($data['billing_email']);
+    // The consent box is printed inside the opt-in block, next to this hidden
+    // field, so its absence means the block did not render and no question was
+    // put to the customer. A site can empty the block through the
+    // mailpoet_woocommerce_checkout_optin_template filter with both settings
+    // still on, which the settings alone cannot tell us.
+    $consentFieldRendered = !empty($_POST[self::CHECKOUT_OPTIN_PRESENCE_CHECK_INPUT_NAME]);
 
-    return $this->handleSubscriberOptin($subscriber, $checkoutOptin, $trackingConsent, $isNewSubscriber);
+    return $this->handleSubscriberOptin($subscriber, $checkoutOptin, $trackingConsent, $isNewSubscriber, $consentFieldRendered);
   }
 
   /**
@@ -239,11 +257,11 @@ class Subscription {
    * @param bool $shouldSubscribe Whether the subscriber should be subscribed
    * @param bool $trackingConsent Whether the separate tracking-consent box was ticked
    */
-  public function handleSubscriberOptin(SubscriberEntity $subscriber, bool $shouldSubscribe, bool $trackingConsent = false, bool $isNewSubscriber = false): bool {
+  public function handleSubscriberOptin(SubscriberEntity $subscriber, bool $shouldSubscribe, bool $trackingConsent = false, bool $isNewSubscriber = false, ?bool $consentFieldRendered = null): bool {
     // Recorded before the opt-in branch, and independently of it: consenting to
     // tracking and subscribing are two separate decisions, so a customer who
     // declines the newsletter can still allow tracking and vice versa.
-    $this->applyTrackingConsent($subscriber, $trackingConsent, $isNewSubscriber);
+    $this->applyTrackingConsent($subscriber, $trackingConsent, $isNewSubscriber, $consentFieldRendered);
 
     $wcSegment = $this->segmentsRepository->getWooCommerceSegment();
 
@@ -280,8 +298,8 @@ class Subscription {
    * choice alone rather than revoking it. Persisted here because this path
    * writes the entity itself instead of going through SubscriberSaveController.
    */
-  private function applyTrackingConsent(SubscriberEntity $subscriber, bool $granted, bool $isNewSubscriber = false): void {
-    if (!$this->wasTrackingConsentOffered()) {
+  private function applyTrackingConsent(SubscriberEntity $subscriber, bool $granted, bool $isNewSubscriber = false, ?bool $consentFieldRendered = null): void {
+    if (!$this->wasTrackingConsentOffered($consentFieldRendered)) {
       return;
     }
     $method = SubscriberEntity::TRACKING_CONSENT_METHOD_WOOCOMMERCE_CHECKOUT;

--- a/mailpoet/tests/integration/Subscribers/SubscriberSubscribeControllerTrackingConsentTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSubscribeControllerTrackingConsentTest.php
@@ -231,6 +231,41 @@ class SubscriberSubscribeControllerTrackingConsentTest extends \MailPoetTest {
     verify(isset($decoded['tracking_consent']))->false();
   }
 
+  public function testAFormPostCannotOverwriteAStoredChoice(): void {
+    // The form identifies the subscriber by the posted email and nothing proves
+    // it belongs to whoever submitted it. Sites with double opt-in off would
+    // otherwise let any visitor flip a stranger's answer.
+    $this->askEveryone();
+    $email = 'consent-victim' . rand(0, 100000) . '@example.com';
+    $victim = (new SubscriberFactory())->withEmail($email)->create();
+    $victim->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE,
+      'declined on the manage page'
+    );
+    $this->subscribersRepository->flush();
+
+    $this->submit($email, '1');
+
+    $this->entityManager->clear();
+    $subscriber = $this->getSubscriber($email);
+    verify($subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+    verify($subscriber->getTrackingConsentMethod())
+      ->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE);
+  }
+
+  public function testSomeoneWhoWasNeverAskedCanStillAnswerOnAForm(): void {
+    $this->askEveryone();
+    $email = 'consent-unasked' . rand(0, 100000) . '@example.com';
+    (new SubscriberFactory())->withEmail($email)->create();
+
+    $this->submit($email, '1');
+
+    $this->entityManager->clear();
+    verify($this->getSubscriber($email)->getTrackingConsent())
+      ->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+  }
+
   private function submit(string $email, string $consent, array $extra = []): void {
     $segment = $this->segmentsRepository->createOrUpdate('Consent segment ' . rand(0, 100000));
     $form = $this->createForm($segment, true);

--- a/mailpoet/tests/integration/Subscription/CommentTrackingConsentTest.php
+++ b/mailpoet/tests/integration/Subscription/CommentTrackingConsentTest.php
@@ -184,6 +184,30 @@ class CommentTrackingConsentTest extends \MailPoetTest {
     verify($whenAsking)->stringNotContainsString('checked');
   }
 
+  public function testAStrangerCannotOverwriteAStoredChoiceByCommenting(): void {
+    // comment_author_email is whatever the visitor typed and WordPress never
+    // verifies it, so a comment must not be able to change an answer somebody
+    // else already gave.
+    $this->askEveryone();
+    $victim = (new SubscriberFactory())->withEmail('commenter-consent@example.com')->create();
+    $victim->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE,
+      'declined on the manage page'
+    );
+    $this->subscribersRepository->flush();
+
+    $_POST['mailpoet'] = ['tracking_consent' => '1'];
+    // Not approved: comment_post runs before moderation.
+    $this->comment->onSubmit($this->commentId, Comment::PENDING_APPROVAL);
+
+    $this->entityManager->clear();
+    $subscriber = $this->getSubscriber();
+    verify($subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+    verify($subscriber->getTrackingConsentMethod())
+      ->equals(SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE);
+  }
+
   private function getSubscriber(): SubscriberEntity {
     $subscriber = $this->subscribersRepository->findOneBy(['email' => 'commenter-consent@example.com']);
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);

--- a/mailpoet/tests/integration/WooCommerce/SubscriptionTrackingConsentTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriptionTrackingConsentTest.php
@@ -190,6 +190,40 @@ class SubscriptionTrackingConsentTest extends \MailPoetTest {
     verify($this->subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
   }
 
+  public function testNothingIsRecordedWhenTheOptInBlockDidNotRender() {
+    // Both settings can be on while the mailpoet_woocommerce_checkout_optin_template
+    // filter empties the block, which takes the consent box with it. The settings
+    // cannot see that, so the caller reports whether the field reached the customer.
+    $this->askEveryone();
+    $newGuest = new SubscriberEntity();
+    $newGuest->setEmail('filtered-away-guest@example.com');
+    $newGuest->setIsWoocommerceUser(true);
+    $newGuest->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->subscribersRepository->persist($newGuest);
+    $this->subscribersRepository->flush();
+
+    $this->subscription->handleSubscriberOptin($newGuest, false, false, true, false);
+
+    verify($newGuest->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    verify($newGuest->getTrackingConsentMethod())->null();
+  }
+
+  public function testACraftedConsentPostIsIgnoredWhenTheOptInBlockDidNotRender() {
+    $this->askEveryone();
+
+    $this->subscription->handleSubscriberOptin($this->subscriber, true, true, true, false);
+
+    verify($this->subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+  }
+
+  public function testConsentIsStillRecordedWhenTheBlockDidRender() {
+    $this->askEveryone();
+
+    $this->subscription->handleSubscriberOptin($this->subscriber, false, true, false, true);
+
+    verify($this->subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+  }
+
   public function testTheCheckoutFieldIsHiddenUntilTheSiteAsks() {
     $this->settings->set(Subscription::OPTIN_ENABLED_SETTING_NAME, true);
 

--- a/mailpoet/tests/integration/WooCommerce/SubscriptionTrackingConsentTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriptionTrackingConsentTest.php
@@ -42,11 +42,26 @@ class SubscriptionTrackingConsentTest extends \MailPoetTest {
     $this->settings->set('signup_confirmation.enabled', false);
   }
 
+  /**
+   * A store that actually puts the question to customers at checkout. Both
+   * switches matter: the consent box is rendered by the checkout opt-in hook, so
+   * with the opt-in off no box is drawn and there is nothing to record.
+   */
   private function askEveryone(): void {
     $this->settings->set(
       TrackingConsentController::SETTING_SUBSCRIBER_CHOICE,
       TrackingConsentController::CHOICE_ASK_ALL
     );
+    $this->settings->set(Subscription::OPTIN_ENABLED_SETTING_NAME, true);
+  }
+
+  /** Consent asked for elsewhere, but the checkout opt-in left at its default off. */
+  private function askEveryoneButNotAtCheckout(): void {
+    $this->settings->set(
+      TrackingConsentController::SETTING_SUBSCRIBER_CHOICE,
+      TrackingConsentController::CHOICE_ASK_ALL
+    );
+    $this->settings->set(Subscription::OPTIN_ENABLED_SETTING_NAME, false);
   }
 
   public function testItRecordsConsentTickedAtCheckout() {
@@ -144,6 +159,35 @@ class SubscriptionTrackingConsentTest extends \MailPoetTest {
     $reloaded = $this->subscribersRepository->findOneBy(['email' => 'checkout-consent@example.com']);
     $this->assertInstanceOf(SubscriberEntity::class, $reloaded);
     verify($reloaded->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+  }
+
+  public function testAGuestWhoWasNeverShownTheBoxIsNotRecordedAsDeclining() {
+    // Stores that ask for consent but leave the checkout opt-in off render no
+    // box, yet the code reading the answer still runs. An empty POST field there
+    // means "never asked", so recording a decline would invent a choice the
+    // customer never made.
+    $this->askEveryoneButNotAtCheckout();
+    $newGuest = new SubscriberEntity();
+    $newGuest->setEmail('unasked-guest@example.com');
+    $newGuest->setIsWoocommerceUser(true);
+    $newGuest->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->subscribersRepository->persist($newGuest);
+    $this->subscribersRepository->flush();
+
+    $this->subscription->handleSubscriberOptin($newGuest, false, false, true);
+
+    verify($newGuest->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    verify($newGuest->getTrackingConsentMethod())->null();
+  }
+
+  public function testAConsentValueIsIgnoredWhenNoBoxWasRendered() {
+    // Same configuration, crafted post: no box was shown, so a ticked value did
+    // not come from the customer and must not be stored as their consent.
+    $this->askEveryoneButNotAtCheckout();
+
+    $this->subscription->handleSubscriberOptin($this->subscriber, true, true, true);
+
+    verify($this->subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
   }
 
   public function testTheCheckoutFieldIsHiddenUntilTheSiteAsks() {


### PR DESCRIPTION
## Description

Two ways a tracking-consent record could end up saying something the subscriber never said.

**Somebody else could change your answer.** A comment, a subscription form, a registration and a checkout all find the subscriber by an email address the visitor typed, and nothing checks that the address belongs to them. A grant was written whatever was already on record. So posting a blog comment with someone else's address and the consent box ticked replaced their stored decline with a grant, with no login and before any moderator saw the comment. The same shape works through a public subscription form on sites with double opt-in switched off, where posted data is applied immediately rather than held for confirmation.

An answer that would replace a choice already on record is now dropped. Someone who has never been asked can still answer at a collection point, and a subscriber being created now still records either answer, since neither overwrites anything. Changing an answer already given is done from the manage subscription page, which checks a link token first.

**Checkout recorded a decline for customers who were never asked.** The consent box is rendered by the checkout opt-in hook, but the code that reads the answer runs on every order. On a store that asks for consent with the checkout opt-in left off, no box is drawn and every new guest was stamped as having declined. An empty field there means "not asked", not "declined", so nothing is recorded unless the box was actually offered.

Both need the store to have moved **Subscriber choice** off its default, so this affects the stores that turned the feature on. The checkout half mostly hits existing installs, since `woocommerce.optin_on_checkout.enabled` defaults on for new installs and off for upgrades.

## Code review notes

**The guard sits in `TrackingConsentCapture` on purpose.** `getConsentData()` and `applyToSubscriber()` are used only by the four collection points that identify a subscriber by an unverified email. The MP v1 API only calls `getCopy()`, and the admin and manage-subscription paths go through `SubscriberSaveController` / `setTrackingConsent()` directly, so none of them change behaviour. One guard, four surfaces, no risk to the authenticated paths.

**A residual case is knowingly left open.** Someone can still move a subscriber from `unknown` to `granted` at a collection point. Closing that too would mean "collection points may only write consent for a row they are creating now", which would revert the STOMAIL-8363 behaviour that an existing subscriber can answer the tracking question on a form or comment. We chose to keep that and close the sharper case, overwriting a choice already made. Happy to go stricter if reviewers prefer.

**`askEveryone()` in the checkout test now sets the opt-in too.** That is not test-fixing to suit the change: with the opt-in off no consent box is rendered at checkout, so the old fixture described a store that never asked. `askEveryoneButNotAtCheckout()` covers the real configuration behind the bug.

**Left alone deliberately.** An unticked box on a signup form is still not a withdrawal of consent given elsewhere, and a decline from a genuinely new subscriber is still recorded.

## QA notes

Set **MailPoet → Settings → Advanced → Subscriber choice** to "ask everyone".

1. **Comment forgery.** Turn on subscribe-in-comments. Give a subscriber `denied` from the manage subscription page. From a logged-out browser, post a comment on any post using that subscriber's email address with the tracking-consent box ticked. Their consent must stay `denied`. Before this change it flipped to `granted`, even while the comment sat in moderation.
2. **Form forgery.** Turn off signup confirmation (Settings → Signup Confirmation). Submit a subscription form carrying a consent checkbox, using the same subscriber's email, box ticked. Consent must stay `denied`.
3. **Still able to answer.** A subscriber who has never been asked (consent shows as unknown) ticks the box on a form. It must record `granted`.
4. **Checkout never asked.** Leave **WooCommerce → Sign-up at checkout** off. Place a first-time guest order. The new subscriber's consent must stay unknown, not `denied`.
5. **Checkout asked.** Turn the checkout opt-in on. Place a first-time guest order leaving the consent box unticked. That customer must end `denied`, as before.

## Linked PRs

_N/A_

## Linked tickets

- STOMAIL-8442

## After-merge notes

Existing `denied` records written at checkout on stores with the opt-in off are still in the database. They were never asked, so those rows say something the customer did not say. Worth deciding separately whether to clear them.

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8442-consent-overwrite-and-unasked-decline)

_The latest successful build from `fix/stomail-8442-consent-overwrite-and-unasked-decline` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->