### PR TITLE
Fix email template selector layout on Gutenberg 23.9

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
@@ -1,6 +1,8 @@
 /* stylelint-disable selector-nested-pattern */
 @import '~@wordpress/base-styles/colors';
 @import '~@wordpress/base-styles/variables';
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
 
 .mailpoet-editor-feedback-button {
   bottom: 5px;
@@ -275,5 +277,22 @@
 
   .mailpoet-inline-notice {
     margin: 0;
+  }
+}
+
+// The template selector reuses Gutenberg's pattern explorer classes.
+// Gutenberg 23.9 dropped these rules, so we keep them here.
+.block-editor-block-patterns-explorer {
+  &__sidebar__categories-list__item {
+    display: block;
+    height: 48px;
+    text-align: left;
+    width: 100%;
+  }
+
+  &:not(.no-sidebar) &__list {
+    @include break-medium() {
+      margin-left: $sidebar-width;
+    }
   }
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
@@ -286,13 +286,13 @@
   &__sidebar__categories-list__item {
     display: block;
     height: 48px;
-    text-align: left;
+    text-align: start;
     width: 100%;
   }
 
-  &:not(.no-sidebar) &__list {
+  &:not(.no-sidebar) > &__list {
     @include break-medium() {
-      margin-left: $sidebar-width;
+      margin-inline-start: $sidebar-width;
     }
   }
 }

--- a/mailpoet/changelog/2026-09-09-09-31-21-fixed-email-template-selector-layout-with-gutenberg-239-.md
+++ b/mailpoet/changelog/2026-09-09-09-31-21-fixed-email-template-selector-layout-with-gutenberg-239-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Email template selector layout with Gutenberg 23.9 or newer

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -134,7 +134,7 @@ class EditorPageRenderer {
     $this->wp->wpEnqueueStyle(
       'email_editor_integration',
       Env::$assetsUrl . '/dist/js/email_editor_integration/email_editor_integration.css',
-      [],
+      ['wp-components'],
       $editorIntegrationAssetsParams['version']
     );
 


### PR DESCRIPTION
## Description

Gutenberg 23.9 moved the pattern explorer sidebar to Tabs and removed the CSS the email editor template selector still relies on, so the template list covered the category buttons. This restores the two missing rules in our integration styles.

The long-term fix belongs in `@woocommerce/email-editor`. This override is safe to keep either way.

Fixes the [failing](https://app.circleci.com/pipelines/gh/mailpoet/mailpoet/24844/details?useNewPipelines=true&workflowId=b97cca2b-3e52-4e0a-96b7-e57319c7a4da) `acceptance_gutenberg_latest` nightly job. The fix was verified on CI via a temporary branch that runs the nightly jobs on push - https://app.circleci.com/pipelines/gh/mailpoet/mailpoet/24852/details?useNewPipelines=true&workflowId=31312a9b-37c0-4e6e-a7c8-4c7d33c30be0.

## Code review notes

_N/A_

## QA notes

Open the email editor with Gutenberg 23.9+ active. The template selector shows the category list on the left and the templates next to it.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          | After (WP 7.1 with Gutenberg 23.6)
| ------------------------------- | ------------------------------ | ------------------------------ |
| <img width="2360" height="1602" alt="wWW3Xw8v75DOrMIj@2x" src="https://github.com/user-attachments/assets/b88a0956-6f10-430f-ac91-11a8a683db39" /> | <img width="2360" height="1599" alt="9jHRToo7ehnr92me@2x" src="https://github.com/user-attachments/assets/b36d9742-62f0-4846-9049-6319a2c14b6f" /> | <img width="2360" height="1602" alt="vEg9IMSoe6Tn15Z8@2x" src="https://github.com/user-attachments/assets/0a51fbeb-4442-4462-9e31-3ee24dbd6e57" /> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/email-template-selector-gutenberg-23-9)

_The latest successful build from `fix/email-template-selector-gutenberg-23-9` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->