### PR TITLE
Fix log index migration test on MySQL 5.6

### DIFF
--- a/mailpoet/tests/integration/Migrations/Db/Migration_20260907_120000_Db_Test.php
+++ b/mailpoet/tests/integration/Migrations/Db/Migration_20260907_120000_Db_Test.php
@@ -47,13 +47,13 @@ class Migration_20260907_120000_Db_Test extends \MailPoetTest {
 
   public function testItSkipsWhenAnotherIndexAlreadyStartsWithName(): void {
     $this->entityManager->getConnection()->executeStatement(
-      "CREATE INDEX `" . self::PREEXISTING_INDEX_NAME . "` ON `{$this->tableName}` (`name`)"
+      "CREATE INDEX `" . self::PREEXISTING_INDEX_NAME . "` ON `{$this->tableName}` (`name`(191))"
     );
 
     $this->migration->run();
 
     verify($this->getIndexColumns(self::INDEX_NAME))->equals([]);
-    verify($this->getIndexColumns(self::PREEXISTING_INDEX_NAME))->equals(['name']);
+    verify($this->getIndexColumns(self::PREEXISTING_INDEX_NAME))->equals(['name(191)']);
   }
 
   /**


### PR DESCRIPTION
## Description

`Migration_20260907_120000_Db_Test` asserted a full `name` index, but MySQL 5.6 silently shortens it to `name(191)`, so the `integration_oldest` nightly job failed. The fixture now creates the prefixed index explicitly.

Fixes the [failing](https://app.circleci.com/pipelines/gh/mailpoet/mailpoet/24844/details?useNewPipelines=true&workflowId=b97cca2b-3e52-4e0a-96b7-e57319c7a4da) `integration_oldest` and `integration_with_premium_oldest` nightly jobs. The fix was verified on CI via a temporary branch that runs the nightly jobs on push - https://app.circleci.com/pipelines/gh/mailpoet/mailpoet/24852/details?useNewPipelines=true&workflowId=31312a9b-37c0-4e6e-a7c8-4c7d33c30be0.

## Code review notes

Test-only change.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/log-index-migration-test-mysql-56)

_The latest successful build from `fix/log-index-migration-test-mysql-56` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->