### PR TITLE
Shorten customer emails in WooCommerce email logs

### DIFF
--- a/mailpoet/changelog/2026-09-09-15-55-20-changed-shorten-customer-email-addresses-in-woocommerce-au.md
+++ b/mailpoet/changelog/2026-09-09-15-55-20-changed-shorten-customer-email-addresses-in-woocommerce-au.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+Shorten customer email addresses in WooCommerce automatic email logs

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
@@ -11,6 +11,7 @@ use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\AutomaticEmailsRepository;
 use MailPoet\Newsletter\Scheduler\AutomaticEmailScheduler;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Util\Helpers;
 use MailPoet\WooCommerce\Helper as WCHelper;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -188,7 +189,7 @@ class FirstPurchase {
         'Email not scheduled because this is not the first order of the customer',
         [
           'order_id' => $orderId,
-          'customer_email' => $customerEmail,
+          'customer_email' => Helpers::maskEmail($customerEmail),
           'order_count' => $customerOrderCount,
         ]
       );
@@ -206,7 +207,7 @@ class FirstPurchase {
     if (!$subscriber instanceof SubscriberEntity) {
       $this->loggerFactory->getLogger(self::SLUG)->info(
         'Email not scheduled because the customer was not found as WooCommerce list subscriber',
-        ['order_id' => $orderId, 'customer_email' => $customerEmail]
+        ['order_id' => $orderId, 'customer_email' => Helpers::maskEmail($customerEmail)]
       );
       return;
     }
@@ -219,7 +220,7 @@ class FirstPurchase {
       'Email scheduled',
       [
         'order_id' => $orderId,
-        'customer_email' => $customerEmail,
+        'customer_email' => Helpers::maskEmail($customerEmail),
         'subscriber_id' => $subscriber->getId(),
       ]
     );

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
@@ -145,7 +145,7 @@ class PurchasedInCategory {
     if (!$subscriber instanceof SubscriberEntity) {
       $this->loggerFactory->getLogger(self::SLUG)->info(
         'Email not scheduled because the customer was not found as WooCommerce list subscriber',
-        ['order_id' => $orderId, 'customer_email' => $customerEmail]
+        ['order_id' => $orderId, 'customer_email' => Helpers::maskEmail($customerEmail)]
       );
       return;
     }
@@ -182,7 +182,7 @@ class PurchasedInCategory {
       'Email scheduled',
       [
         'order_id' => $orderId,
-        'customer_email' => $customerEmail,
+        'customer_email' => Helpers::maskEmail($customerEmail),
         'subscriber_id' => $subscriber->getId(),
       ]
     );

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
@@ -157,7 +157,7 @@ class PurchasedProduct {
     if (!$subscriber instanceof SubscriberEntity) {
       $this->loggerFactory->getLogger(self::SLUG)->info(
         'Email not scheduled because the customer was not found as WooCommerce list subscriber',
-        ['order_id' => $orderId, 'customer_email' => $customerEmail]
+        ['order_id' => $orderId, 'customer_email' => Helpers::maskEmail($customerEmail)]
       );
       return;
     }
@@ -185,7 +185,7 @@ class PurchasedProduct {
       'Email scheduled',
       [
         'order_id' => $orderId,
-        'customer_email' => $customerEmail,
+        'customer_email' => Helpers::maskEmail($customerEmail),
         'subscriber_id' => $subscriber->getId(),
       ]
     );

--- a/mailpoet/lib/Util/Helpers.php
+++ b/mailpoet/lib/Util/Helpers.php
@@ -5,6 +5,8 @@ namespace MailPoet\Util;
 class Helpers {
   const DIVIDER = '***MailPoet***';
   const LINK_TAG = 'link';
+  // Fixed width on purpose: a mask that follows the input's length leaks it.
+  const EMAIL_MASK = '***';
 
   public static function isJson($string) {
     if (!is_string($string)) return false;
@@ -118,6 +120,38 @@ class Helpers {
   public static function extractEmailDomain(string $email = ''): string {
     $arrayOfItems = explode('@', trim($email));
     return strtolower(array_pop($arrayOfItems));
+  }
+
+  /**
+   * Shortens an email address to its first letter, domain initial and top level domain,
+   * e.g. john.doe@example.com becomes j***@e***.com.
+   */
+  public static function maskEmail(string $email = ''): string {
+    $email = trim($email);
+    if ($email === '') {
+      return '';
+    }
+
+    $atPosition = strrpos($email, '@');
+    if ($atPosition === false || $atPosition === 0) {
+      return self::EMAIL_MASK;
+    }
+
+    $domain = substr($email, $atPosition + 1);
+    if ($domain === '') {
+      return self::EMAIL_MASK;
+    }
+
+    return substr($email, 0, 1) . self::EMAIL_MASK . '@' . self::maskEmailDomain($domain);
+  }
+
+  private static function maskEmailDomain(string $domain): string {
+    $masked = substr($domain, 0, 1) . self::EMAIL_MASK;
+    $dotPosition = strrpos($domain, '.');
+    if ($dotPosition === false || $dotPosition === 0) {
+      return $masked;
+    }
+    return $masked . substr($domain, $dotPosition);
   }
 
   public static function mySqlGoneAwayExceptionHandler(\Throwable $err): string {

--- a/mailpoet/tests/unit/Util/HelpersTest.php
+++ b/mailpoet/tests/unit/Util/HelpersTest.php
@@ -69,4 +69,27 @@ class HelpersTest extends \MailPoetUnitTest {
     verify(Helpers::escapeSearch('He_llo'))->equals('He\_llo');
     verify(Helpers::escapeSearch('He\\llo'))->equals('He\\\llo');
   }
+
+  public function testMaskEmail() {
+    verify(Helpers::maskEmail('john.doe@example.com'))->equals('j***@e***.com');
+    verify(Helpers::maskEmail('a@b.com'))->equals('a***@b***.com');
+    verify(Helpers::maskEmail('a@mail.example.com'))->equals('a***@m***.com');
+    verify(Helpers::maskEmail('  john.doe@example.com  '))->equals('j***@e***.com');
+    verify(Helpers::maskEmail('john+tag@example.co.uk'))->equals('j***@e***.uk');
+    verify(Helpers::maskEmail('john@doe@example.com'))->equals('j***@e***.com');
+  }
+
+  public function testMaskEmailHandlesValuesThatAreNotEmails() {
+    verify(Helpers::maskEmail('a@localhost'))->equals('a***@l***');
+    verify(Helpers::maskEmail('notanemail'))->equals('***');
+    verify(Helpers::maskEmail('@example.com'))->equals('***');
+    verify(Helpers::maskEmail('john.doe@'))->equals('***');
+    verify(Helpers::maskEmail(''))->equals('');
+    verify(Helpers::maskEmail('   '))->equals('');
+  }
+
+  public function testMaskEmailLengthDoesNotFollowTheInput() {
+    verify(Helpers::maskEmail('j@example.com'))
+      ->equals(Helpers::maskEmail('jonathan.livingston.seagull@example.com'));
+  }
 }


### PR DESCRIPTION
## Description

The three WooCommerce automatic email listeners (first purchase, purchased product, purchased in category) wrote the buyer's full billing email into the MailPoet log whenever logging is set to "Everything". They now write a shortened form instead: `john.doe@example.com` becomes `j***@e***.com`.

The order ID is already logged next to it and answers the same question, so support loses nothing here that the order itself cannot give them.

New `Helpers::maskEmail()` does the shortening.

## Code review notes

Two things worth knowing that the diff does not show:

- The mask is a **fixed width** rather than one that follows the input. A mask that mirrors the original length gives the length away, which is itself a clue about the value. There is a test pinning this, so a later "improvement" to a proportional mask fails the suite.
- The value was being stored **twice**: the log's `message` column holds Monolog's formatted record, which appends the context array, and the `context` column holds the same array as JSON. Masking at the call site covers both. Masking the formatted string alone would not have.

The key name stays `customer_email`. Log search runs on `message` only, so nothing reads the key and renaming it would only be churn.

## QA notes

1. **Settings → Advanced → Logging → Everything**, and save.
2. Set up a WooCommerce automatic email (First Purchase is the quickest).
3. Place a guest order and let it reach processing.
4. **Settings → Logs** and find the `woocommerce-first-purchase` rows.
5. The `customer_email` value should read `j***@e***.com` rather than the full address. The order ID next to it is unchanged.
6. Check the log download too (the button on that screen) — same value.

Existing rows keep the old format until the 30-day log cleanup clears them.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8439

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/stomail-8439-mask-customer-email-in-logs)

_The latest successful build from `update/stomail-8439-mask-customer-email-in-logs` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->