### PR TITLE
Render pop-up, fixed bar and slide-in forms on single posts rendered outside the main loop

### DIFF
--- a/mailpoet/changelog/2026-09-11-06-26-28-fixed-pop-up-fixed-bar-and-slide-in-forms-not-appearing-.md
+++ b/mailpoet/changelog/2026-09-11-06-26-28-fixed-pop-up-fixed-bar-and-slide-in-forms-not-appearing-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Pop-up, fixed bar, and slide-in forms not appearing on single posts and pages when the theme or page builder renders the content outside the main loop

--- a/mailpoet/lib/Form/DisplayFormInWPContent.php
+++ b/mailpoet/lib/Form/DisplayFormInWPContent.php
@@ -63,6 +63,10 @@ class DisplayFormInWPContent {
 
   private $renderedDisplayTypes = [];
 
+  private $formsEvaluatedInContent = false;
+
+  private $placementPostId = null;
+
   public function __construct(
     WPFunctions $wp,
     FormsRepository $formsRepository,
@@ -83,9 +87,9 @@ class DisplayFormInWPContent {
     $this->woocommerceHelper = $woocommerceHelper;
   }
 
-  private function getFormMarkup(): string {
+  private function getFormMarkup(array $displayTypes): string {
     $formMarkup = '';
-    $forms = $this->getForms();
+    $forms = $this->getForms($displayTypes);
     if (count($forms) === 0) {
       return $formMarkup;
     }
@@ -113,10 +117,12 @@ class DisplayFormInWPContent {
   }
 
   private function getContentWithFormMarkup($content = null) {
+    $this->placementPostId = null;
     if (!is_string($content) || !$this->shouldDisplay()) {
       return $content;
     }
-    $formsMarkup = $this->getFormMarkup();
+    $this->formsEvaluatedInContent = true;
+    $formsMarkup = $this->getFormMarkup(self::TYPES);
     if ($formsMarkup === '') {
       return $content;
     }
@@ -130,15 +136,42 @@ class DisplayFormInWPContent {
    * @return void
    */
   public function maybeRenderFormsInFooter(): void {
+    // A page builder may leave a secondary loop's post in the global scope, so placement is matched against the queried post
+    $this->placementPostId = $this->wp->isSingular() ? $this->wp->getQueriedObjectId() : null;
     if ($this->wp->isArchive() || $this->wp->isFrontPage() || $this->wp->isHome() || $this->isWooProductPageWithoutContent()) {
-      $formMarkup = $this->getFormMarkup();
-      if (!empty($formMarkup)) {
-        $this->assetsController->setupFrontEndDependencies();
-        // We are in control of the template and the data can be considered safe at this point
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        echo $formMarkup;
-      }
+      $this->renderFormsInFooter(self::TYPES);
+      return;
     }
+    if ($this->shouldRenderOverlayFormsInFooter()) {
+      $this->renderFormsInFooter(self::WITH_COOKIE_TYPES);
+    }
+  }
+
+  /**
+   * Page builders (e.g. Divi Theme Builder) apply the_content outside the main loop, so overlay forms get a second chance here.
+   */
+  private function shouldRenderOverlayFormsInFooter(): bool {
+    if ($this->formsEvaluatedInContent) {
+      return false;
+    }
+    if (!$this->wp->isSingular($this->getSupportedPostTypes()) && !$this->wp->isPage()) {
+      return false;
+    }
+    if (!$this->wp->hasFilter('the_content', [$this, 'contentDisplay'])) {
+      return false;
+    }
+    return !$this->noFormsCached();
+  }
+
+  private function renderFormsInFooter(array $displayTypes): void {
+    $formMarkup = $this->getFormMarkup($displayTypes);
+    if (empty($formMarkup)) {
+      return;
+    }
+    $this->assetsController->setupFrontEndDependencies();
+    // We are in control of the template and the data can be considered safe at this point
+    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    echo $formMarkup;
   }
 
   /**
@@ -170,9 +203,12 @@ class DisplayFormInWPContent {
     // Ensure form does not show up multiple times when called from the woocommerce_product_loop_end filter
     if ($this->inWooProductLoop) $result = $this->displayFormInProductListPage();
 
-    $noFormsCache = $this->wp->getTransient(DisplayFormInWPContent::NO_FORM_TRANSIENT_KEY);
-    if ($noFormsCache === '1') $result = false;
+    if ($this->noFormsCached()) $result = false;
     return (bool)$result;
+  }
+
+  private function noFormsCached(): bool {
+    return $this->wp->getTransient(DisplayFormInWPContent::NO_FORM_TRANSIENT_KEY) === '1';
   }
 
   private function displayFormInProductListPage(): bool {
@@ -193,9 +229,10 @@ class DisplayFormInWPContent {
   }
 
   /**
+   * @param string[] $displayTypes
    * @return array<string, FormEntity>
    */
-  private function getForms(): array {
+  private function getForms(array $displayTypes): array {
     $forms = $this->formsRepository->findBy([
       'deletedAt' => null,
       'status' => FormEntity::STATUS_ENABLED,
@@ -203,18 +240,19 @@ class DisplayFormInWPContent {
     if (count($forms) === 0) {
       $this->saveNoForms();
     }
-    $forms = $this->filterOneFormInEachDisplayType($forms);
+    $forms = $this->filterOneFormInEachDisplayType($forms, $displayTypes);
     return $forms;
   }
 
   /**
    * @param FormEntity[] $forms
+   * @param string[] $displayTypes
    * @return array<string, FormEntity>
    */
-  private function filterOneFormInEachDisplayType($forms): array {
+  private function filterOneFormInEachDisplayType($forms, array $displayTypes): array {
     $formsFiltered = [];
     foreach ($forms as $form) {
-      foreach (self::TYPES as $displayType) {
+      foreach ($displayTypes as $displayType) {
         if ($this->shouldDisplayFormType($form, $displayType)) {
           $formsFiltered[$displayType] = $form;
         }
@@ -327,8 +365,7 @@ class DisplayFormInWPContent {
       return true;
     }
 
-    $supportedPostTypes = $this->wp->applyFilters('mailpoet_display_form_supported_post_types', self::SUPPORTED_POST_TYPES);
-    if ($this->wp->isSingular(is_array($supportedPostTypes) || is_string($supportedPostTypes) ? $supportedPostTypes : self::SUPPORTED_POST_TYPES)) {
+    if ($this->wp->isSingular($this->getSupportedPostTypes())) {
       if ($this->shouldDisplayFormOnPost($setup, 'posts')) return true;
       if ($this->shouldDisplayFormOnCategory($setup)) return true;
       if ($this->shouldDisplayFormOnTag($setup)) return true;
@@ -355,6 +392,14 @@ class DisplayFormInWPContent {
     return false;
   }
 
+  /**
+   * @return string|mixed[]
+   */
+  private function getSupportedPostTypes() {
+    $supportedPostTypes = $this->wp->applyFilters('mailpoet_display_form_supported_post_types', self::SUPPORTED_POST_TYPES);
+    return is_array($supportedPostTypes) || is_string($supportedPostTypes) ? $supportedPostTypes : self::SUPPORTED_POST_TYPES;
+  }
+
   private function shouldDisplayFormOnPost(array $setup, string $postsKey, $postId = null): bool {
     if (!isset($setup[$postsKey])) {
       return false;
@@ -362,7 +407,7 @@ class DisplayFormInWPContent {
     if (isset($setup[$postsKey]['all']) && $setup[$postsKey]['all'] === '1') {
       return true;
     }
-    $post = $this->wp->getPost($postId, ARRAY_A);
+    $post = $this->wp->getPost($postId ?? $this->placementPostId, ARRAY_A);
     if (isset($setup[$postsKey]['selected']) && in_array($post['ID'], $setup[$postsKey]['selected'])) {
       return true;
     }
@@ -371,15 +416,15 @@ class DisplayFormInWPContent {
 
   private function shouldDisplayFormOnCategory(array $setup): bool {
     if (!isset($setup['categories'])) return false;
-    if ($this->wp->hasCategory($setup['categories'])) return true;
-    if ($this->wp->hasTerm($setup['categories'], 'product_cat')) return true;
+    if ($this->wp->hasCategory($setup['categories'], $this->placementPostId)) return true;
+    if ($this->wp->hasTerm($setup['categories'], 'product_cat', $this->placementPostId)) return true;
     return false;
   }
 
   private function shouldDisplayFormOnTag(array $setup): bool {
     if (!isset($setup['tags'])) return false;
-    if ($this->wp->hasTag($setup['tags'])) return true;
-    if ($this->wp->hasTerm($setup['tags'], 'product_tag')) return true;
+    if ($this->wp->hasTag($setup['tags'], $this->placementPostId)) return true;
+    if ($this->wp->hasTerm($setup['tags'], 'product_tag', $this->placementPostId)) return true;
     return false;
   }
 

--- a/mailpoet/tests/unit/Form/DisplayFormInWPContentTest.php
+++ b/mailpoet/tests/unit/Form/DisplayFormInWPContentTest.php
@@ -43,12 +43,17 @@ class DisplayFormInWPContentTest extends \MailPoetUnitTest {
   // fix for method return override
   private $applyFiltersValue = false;
 
+  private $inTheLoopValue = true;
+
+  private $hasContentFilterValue = true;
+
   public function _before() {
     parent::_before();
     if (!defined('ARRAY_A')) define('ARRAY_A', 'ARRAY_A');
     $this->repository = $this->createMock(FormsRepository::class);
     $this->wp = $this->createMock(WPFunctions::class);
-    $this->wp->expects($this->any())->method('inTheLoop')->willReturn(true);
+    $this->wp->expects($this->any())->method('inTheLoop')->willReturnCallback(fn() => $this->inTheLoopValue);
+    $this->wp->expects($this->any())->method('hasFilter')->willReturnCallback(fn() => $this->hasContentFilterValue);
     $this->wp->expects($this->any())->method('isMainQuery')->willReturn(true);
     $this->wp->expects($this->any())->method('wpCreateNonce')->willReturn('asdfgh');
     $this->wp->expects($this->any())->method('applyFilters')->will($this->returnCallback(function () { return $this->applyFiltersValue;
@@ -961,6 +966,188 @@ class DisplayFormInWPContentTest extends \MailPoetUnitTest {
     $renderedFormHtml = ob_get_clean();
     verify($renderedFormHtml)->notEquals('content');
     verify($renderedFormHtml)->stringEndsWith($formHtml);
+  }
+
+  public function testRendersOverlayFormsInFooterOnSinglePostWhenContentIsRenderedOutsideTheLoop(): void {
+    $formHtml = '<form id="test-form"></form>';
+    $this->inTheLoopValue = false;
+    $this->wp->expects($this->any())->method('isSingular')->willReturnCallback(
+      fn(...$args) => ($args[0] ?? '') === '' || $args[0] === DisplayFormInWPContent::SUPPORTED_POST_TYPES
+    );
+    $this->wp->expects($this->any())->method('isSingle')->willReturn(true);
+    $this->assetsController->expects($this->once())->method('setupFrontEndDependencies');
+    $this->templateRenderer->expects($this->once())->method('render')->willReturn($formHtml);
+    $form = $this->createFormWithPlacement([
+      'popup' => ['enabled' => '1', 'pages' => ['all' => ''], 'posts' => ['all' => '1']],
+    ]);
+    $this->repository->expects($this->once())->method('findBy')->willReturn([$form]);
+
+    verify($this->hook->contentDisplay('content'))->equals('content');
+    verify($this->renderFooter())->equals($formHtml);
+  }
+
+  public function testRendersOverlayFormsInFooterOnPageRenderedOutsideTheLoop(): void {
+    $formHtml = '<form id="test-form"></form>';
+    $this->inTheLoopValue = false;
+    $this->wp->expects($this->any())->method('isSingular')->willReturn(false);
+    $this->wp->expects($this->any())->method('isSingle')->willReturn(false);
+    $this->wp->expects($this->any())->method('isPage')->willReturn(true);
+    $this->templateRenderer->expects($this->once())->method('render')->willReturn($formHtml);
+    $form = $this->createFormWithPlacement([
+      'fixed_bar' => ['enabled' => '1', 'pages' => ['all' => '1'], 'posts' => ['all' => '']],
+    ]);
+    $this->repository->expects($this->once())->method('findBy')->willReturn([$form]);
+
+    verify($this->hook->contentDisplay('content'))->equals('content');
+    verify($this->renderFooter())->equals($formHtml);
+  }
+
+  public function testDoesNotRenderOverlayFormsInFooterOnUnsupportedPostType(): void {
+    $this->inTheLoopValue = false;
+    $this->wp->expects($this->any())->method('isSingular')->willReturnCallback(fn(...$args) => ($args[0] ?? '') === '');
+    $this->wp->expects($this->any())->method('isSingle')->willReturn(true);
+    $this->wp->expects($this->any())->method('isPage')->willReturn(false);
+    $this->repository->expects($this->never())->method('findBy');
+
+    verify($this->hook->contentDisplay('content'))->equals('content');
+    verify($this->renderFooter())->equals('');
+  }
+
+  public function testDoesNotRenderBelowPostFormInFooterOnSinglePost(): void {
+    $this->inTheLoopValue = false;
+    $this->wp->expects($this->any())->method('isSingular')->willReturn(true);
+    $this->wp->expects($this->any())->method('isSingle')->willReturn(true);
+    $this->assetsController->expects($this->never())->method('setupFrontEndDependencies');
+    $this->templateRenderer->expects($this->never())->method('render');
+    $form = $this->createFormWithPlacement([
+      'below_posts' => ['enabled' => '1', 'pages' => ['all' => ''], 'posts' => ['all' => '1']],
+    ]);
+    $this->repository->expects($this->any())->method('findBy')->willReturn([$form]);
+
+    verify($this->hook->contentDisplay('content'))->equals('content');
+    verify($this->renderFooter())->equals('');
+  }
+
+  public function testDoesNotRenderFormsInFooterAgainWhenContentFilterAlreadyRenderedThem(): void {
+    $formHtml = '<form id="test-form"></form>';
+    $this->wp->expects($this->any())->method('isSingular')->willReturn(true);
+    $this->wp->expects($this->any())->method('isSingle')->willReturn(true);
+    $this->assetsController->expects($this->once())->method('setupFrontEndDependencies');
+    $this->templateRenderer->expects($this->once())->method('render')->willReturn($formHtml);
+    $form = $this->createFormWithPlacement([
+      'popup' => ['enabled' => '1', 'pages' => ['all' => ''], 'posts' => ['all' => '1']],
+    ]);
+    $this->repository->expects($this->once())->method('findBy')->willReturn([$form]);
+
+    verify($this->hook->contentDisplay('content'))->stringEndsWith($formHtml);
+    verify($this->renderFooter())->equals('');
+  }
+
+  public function testDoesNotRenderOverlayFormsInFooterWhenContentFilterWasRemoved(): void {
+    $this->inTheLoopValue = false;
+    $this->hasContentFilterValue = false;
+    $this->wp->expects($this->any())->method('isSingular')->willReturn(true);
+    $this->wp->expects($this->any())->method('isSingle')->willReturn(true);
+    $this->repository->expects($this->never())->method('findBy');
+
+    verify($this->renderFooter())->equals('');
+  }
+
+  public function testDoesNotQueryDatabaseInFooterOnSinglePostIfTransientIsSet(): void {
+    $this->inTheLoopValue = false;
+    $this->wp->expects($this->any())->method('isSingular')->willReturn(true);
+    $this->wp->expects($this->any())->method('isSingle')->willReturn(true);
+    $this->wp->expects($this->any())->method('getTransient')->willReturn('1');
+    $this->repository->expects($this->never())->method('findBy');
+
+    verify($this->renderFooter())->equals('');
+  }
+
+  public function testFooterFallbackMatchesSelectedPostsAgainstTheQueriedPost(): void {
+    $formHtml = '<form id="test-form"></form>';
+    $this->inTheLoopValue = false;
+    $this->wp->expects($this->any())->method('isSingular')->willReturn(true);
+    $this->wp->expects($this->any())->method('isSingle')->willReturn(true);
+    $this->wp->expects($this->any())->method('getQueriedObjectId')->willReturn(1);
+    $this->wp->expects($this->any())->method('getPost')->willReturnCallback(fn($postId) => ['ID' => $postId ?? 106]);
+    $this->templateRenderer->expects($this->once())->method('render')->willReturn($formHtml);
+    $form = $this->createFormWithPlacement([
+      'popup' => ['enabled' => '1', 'pages' => ['all' => ''], 'posts' => ['all' => '', 'selected' => ['1']]],
+    ]);
+    $this->repository->expects($this->once())->method('findBy')->willReturn([$form]);
+
+    verify($this->renderFooter())->equals($formHtml);
+  }
+
+  public function testFooterFallbackMatchesCategoriesAndTagsAgainstTheQueriedPost(): void {
+    $formHtml = '<form id="test-form"></form>';
+    $this->inTheLoopValue = false;
+    $this->wp->expects($this->any())->method('isSingular')->willReturn(true);
+    $this->wp->expects($this->any())->method('isSingle')->willReturn(true);
+    $this->wp->expects($this->any())->method('getQueriedObjectId')->willReturn(1);
+    $this->wp->expects($this->any())->method('hasCategory')->willReturnCallback(
+      fn($categories, $post) => $post === 1 && in_array('5', $categories, true)
+    );
+    $this->wp->expects($this->any())->method('hasTag')->willReturnCallback(
+      fn($tags, $post) => $post === 1 && in_array('7', $tags, true)
+    );
+    $this->templateRenderer->expects($this->exactly(2))->method('render')->willReturn($formHtml);
+    $form = $this->createFormWithPlacement([
+      'popup' => ['enabled' => '1', 'pages' => ['all' => ''], 'posts' => ['all' => ''], 'categories' => ['5']],
+      'slide_in' => ['enabled' => '1', 'pages' => ['all' => ''], 'posts' => ['all' => ''], 'tags' => ['7']],
+    ]);
+    $this->repository->expects($this->once())->method('findBy')->willReturn([$form]);
+
+    verify($this->renderFooter())->equals($formHtml . $formHtml);
+  }
+
+  public function testProductWithoutContentFallbackMatchesSelectedPostsAgainstTheQueriedProduct(): void {
+    $formHtml = '<form id="test-form"></form>';
+    $this->wp->expects($this->any())->method('isSingular')->willReturn(true);
+    $this->wp->expects($this->any())->method('didAction')->with($this->equalTo('wp_footer'))->willReturn(true);
+    $this->wp->expects($this->any())->method('getTheContent')->willReturn('');
+    $this->wp->expects($this->any())->method('getQueriedObjectId')->willReturn(26);
+    $this->wp->expects($this->any())->method('getPost')->willReturnCallback(fn($postId) => ['ID' => $postId ?? 106]);
+    $this->templateRenderer->expects($this->once())->method('render')->willReturn($formHtml);
+    $form = $this->createFormWithPlacement([
+      'popup' => ['enabled' => '1', 'pages' => ['all' => ''], 'posts' => ['all' => '', 'selected' => ['26']]],
+    ]);
+    $this->repository->expects($this->once())->method('findBy')->willReturn([$form]);
+
+    verify($this->renderFooter())->equals($formHtml);
+  }
+
+  public function testStaticFrontPageFallbackMatchesSelectedPagesAgainstTheQueriedPage(): void {
+    $formHtml = '<form id="test-form"></form>';
+    $this->wp->expects($this->any())->method('isFrontPage')->willReturn(true);
+    $this->wp->expects($this->any())->method('isSingular')->willReturnCallback(fn(...$args) => ($args[0] ?? '') === '');
+    $this->wp->expects($this->any())->method('isPage')->willReturn(true);
+    $this->wp->expects($this->any())->method('getQueriedObjectId')->willReturn(5);
+    $this->wp->expects($this->any())->method('getPost')->willReturnCallback(fn($postId) => ['ID' => $postId ?? 106]);
+    $this->templateRenderer->expects($this->once())->method('render')->willReturn($formHtml);
+    $form = $this->createFormWithPlacement([
+      'popup' => ['enabled' => '1', 'homepage' => '', 'pages' => ['all' => '', 'selected' => ['5']], 'posts' => ['all' => '']],
+    ]);
+    $this->repository->expects($this->once())->method('findBy')->willReturn([$form]);
+
+    verify($this->renderFooter())->equals($formHtml);
+  }
+
+  private function createFormWithPlacement(array $formPlacement): FormEntity {
+    $form = new FormEntity('My Form');
+    $form->setSettings([
+      'segments' => ['3'],
+      'form_placement' => $formPlacement,
+      'success_message' => 'Hello',
+    ]);
+    $form->setBody([['type' => 'submit', 'params' => ['label' => 'Subscribe!'], 'id' => 'submit', 'name' => 'Submit']]);
+    return $form;
+  }
+
+  private function renderFooter(): string {
+    ob_start();
+    $this->hook->maybeRenderFormsInFooter();
+    return (string)ob_get_clean();
   }
 
   public function _after() {


### PR DESCRIPTION
## Description

Pop-up, fixed bar and slide-in forms were only appended through the `the_content` filter, and only when it ran inside the main loop. The `wp_footer` fallback deliberately skipped singular views. Page builders such as Divi Theme Builder apply `the_content` outside the loop as soon as a template has a Custom Body, so on single posts none of these forms rendered, while pages using the default template kept working.

The footer fallback now also covers single posts of the supported post types (post, product, job_listing, filterable) and pages: when the content filter never got to evaluate forms, the footer renders the three overlay types. Below-post forms stay in the content, the main-loop guard in the content path is unchanged (it still protects against Yoast/Shapely double rendering), and the existing once-per-request tracking prevents duplicates.

Rendering in the footer also keeps the form outside the page builder's column structure. With the `mailpoet_display_form_is_main_loop` filter workaround, the form landed inside the Divi Post Content column, whose stacking context let later columns paint over the pop-up regardless of the pop-up's own z-index.

## Code review notes

- The footer gate is a flag set when the content path evaluated forms, not the list of rendered display types. On a normal theme, a post where no overlay form matches would otherwise trigger a second forms query in the footer.
- The new branch skips `shouldDisplay()`, like the existing archive branch. The two filters in there only apply outside the loop or off singular views and default to `false`, so they cannot be used to suppress forms on a single post; nothing previously reachable is lost.
- On singular views the footer matches the selected-posts, category and tag placements against the queried object, not the global post (this covers the new overlay fallback, the existing empty-product fallback and a static front page). A builder that leaves a secondary loop without `wp_reset_postdata()` would otherwise evaluate the wrong post; this was reproduced with a simulated unreset loop before the change. The content path is unchanged and keeps using the global post, which is the loop post there.
- The fallback is skipped when MailPoet's own `the_content` callback has been removed, so a site that disabled forms on posts that way keeps that behaviour.
- No public symbol changed. The change is additive: forms render in more cases, never fewer.

## QA notes

The Divi behaviour can be reproduced without Divi with a temporary mu-plugin that renders a single post outside the loop:

```php
<?php
add_action('template_redirect', function () {
  if (!is_singular('post') || !isset($_GET['divisim'])) return;
  $post = get_post();
  ?><!doctype html><html><head><?php wp_head(); ?></head><body>
  <main><?php echo apply_filters('the_content', $post->post_content); ?></main>
  <?php
  // Optional: leave another post in the global scope, like a builder module without wp_reset_postdata()
  if (isset($_GET['staleloop'])) {
    $q = new WP_Query(['p' => (int)$_GET['staleloop']]);
    while ($q->have_posts()) { $q->the_post(); }
  }
  wp_footer(); ?></body></html><?php
  exit;
});
```

1. Enable the pop-up and fixed bar placement for all posts on a form.
2. Open a single post normally: both forms are present once (`mp_form_popup<ID>`, `mp_form_fixed_bar<ID>` in the HTML).
3. Open the same post with `?divisim=1`. Before: no form markup. After: both forms present exactly once, after `</main>`.
4. Regressions: a normal post still renders each form once, the homepage and archives are unchanged, and a form with only the below-post placement renders nothing in the footer on `?divisim=1`.
5. A site that added the `mailpoet_display_form_is_main_loop` workaround keeps rendering through the content path until the filter is removed.
6. Place a form on one selected post only (or on a category/tag) and open that post with `?divisim=1&staleloop=<other post ID>`: the form is still present, because placement is matched against the queried post.
7. Tested on Twenty Twenty-Four, Twenty Twenty-Five, Twenty Twenty-One and Storefront with one form per display type in different placements (all posts/pages, selected post/page, category, tag, homepage, category/tag archives, shop) across single posts, pages, homepage (latest posts and static page), category and tag archives, products with and without description, shop, search and 404: the output is identical to trunk everywhere except the outside-the-loop single post, where the overlay forms now render once.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8463
https://wordpress.org/support/topic/pop-up-form-works-on-pages-but-is-not-loaded-on-standard-wordpress-posts/

## After-merge notes

Reply in the forum thread once released and ask the reporter to remove the filter workaround, otherwise the stacking issue they hit stays.

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-popup-forms-single-posts)

_The latest successful build from `fix-popup-forms-single-posts` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->