### PR TITLE
Keep tracking consent true for repeated import rows and block checkout

### DIFF
--- a/mailpoet/changelog/2026-09-11-07-51-02-fixed-stop-block-checkout-recording-a-tracking-decline-f.md
+++ b/mailpoet/changelog/2026-09-11-07-51-02-fixed-stop-block-checkout-recording-a-tracking-decline-f.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Stop block checkout recording a tracking decline for customers who were never asked

--- a/mailpoet/changelog/2026-09-11-07-51-02-fixed-use-the-first-row-for-an-email-listed-twice-in-a-w.md
+++ b/mailpoet/changelog/2026-09-11-07-51-02-fixed-use-the-first-row-for-an-email-listed-twice-in-a-w.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Use the first row for an email listed twice in a WP-CLI subscriber import, as the import screen does
+Use the first row for an email listed twice within one batch of a WP-CLI subscriber import, as the import screen does

--- a/mailpoet/changelog/2026-09-11-07-51-02-fixed-use-the-first-row-for-an-email-listed-twice-in-a-w.md
+++ b/mailpoet/changelog/2026-09-11-07-51-02-fixed-use-the-first-row-for-an-email-listed-twice-in-a-w.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Use the first row for an email listed twice in a WP-CLI subscriber import, as the import screen does

--- a/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
+++ b/mailpoet/lib/PostEditorBlocks/WooCommerceBlocksIntegration.php
@@ -175,9 +175,10 @@ class WooCommerceBlocksIntegration {
 
   public function processCheckoutBlockOptin(\WC_Order $order, $request) {
     $checkoutOptin = isset($request['extensions']['mailpoet']['optin']) ? (bool)$request['extensions']['mailpoet']['optin'] : false;
-    $trackingConsent = isset($request['extensions']['mailpoet']['tracking_consent'])
-      ? (bool)$request['extensions']['mailpoet']['tracking_consent']
-      : false;
+    // The block sends this key as soon as it shows the consent box, ticked or not,
+    // so a request without it comes from a checkout that never asked.
+    $consentFieldRendered = isset($request['extensions']['mailpoet']['tracking_consent']);
+    $trackingConsent = $consentFieldRendered && (bool)$request['extensions']['mailpoet']['tracking_consent'];
 
     // Emulate checkout opt-in triggering for AutomateWoo
     if ($checkoutOptin) {
@@ -210,6 +211,6 @@ class WooCommerceBlocksIntegration {
       return null;
     }
 
-    $this->woocommerceSubscription->handleSubscriberOptin($subscriber, $checkoutOptin, $trackingConsent, $isNewSubscriber);
+    $this->woocommerceSubscription->handleSubscriberOptin($subscriber, $checkoutOptin, $trackingConsent, $isNewSubscriber, $consentFieldRendered);
   }
 }

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -151,6 +151,7 @@ class Import {
     if (!$subscribersData) {
       throw new \Exception(__('No valid subscribers were found.', 'mailpoet'));
     }
+    $subscribersData = $this->removeRepeatedEmails($subscribersData);
     // permanently trash deleted subscribers
     $this->deleteExistingTrashedSubscribers($subscribersData);
 
@@ -374,6 +375,28 @@ class Import {
 
     $invalidRecords = $dateTimeInvalidRecords;
     return $dateTimeDates;
+  }
+
+  /**
+   * Keeps the first row for each email, as the import wizard does. A repeated email
+   * is otherwise split across the create and update writes, and the consent change
+   * announced for it can differ from the value stored.
+   */
+  private function removeRepeatedEmails(array $subscribersData): array {
+    $firstRowByEmail = [];
+    foreach ($subscribersData['email'] as $index => $email) {
+      if (!isset($firstRowByEmail[$email])) {
+        $firstRowByEmail[$email] = $index;
+      }
+    }
+    if (count($firstRowByEmail) === count($subscribersData['email'])) {
+      return $subscribersData;
+    }
+    $rowsToKeep = array_flip($firstRowByEmail);
+    foreach ($subscribersData as $column => $data) {
+      $subscribersData[$column] = array_values(array_intersect_key($data, $rowsToKeep));
+    }
+    return $subscribersData;
   }
 
   public function transformSubscribersData(array $subscribers, array $columns): array {

--- a/mailpoet/tests/integration/PostEditorBlocks/WooCommerceBlocksIntegrationTest.php
+++ b/mailpoet/tests/integration/PostEditorBlocks/WooCommerceBlocksIntegrationTest.php
@@ -7,6 +7,7 @@ use MailPoet\Segments\WooCommerce as WooSegment;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscribers\TrackingConsentCapture;
+use MailPoet\Subscribers\TrackingConsentController;
 use MailPoet\Test\DataFactories\Subscriber;
 use MailPoet\WooCommerce\Helper as WooHelper;
 use MailPoet\WooCommerce\Subscription;
@@ -120,6 +121,46 @@ class WooCommerceBlocksIntegrationTest extends \MailPoetTest {
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     $this->entityManager->refresh($subscriber);
     verify($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+  }
+
+  public function testANewGuestWhoLeavesTheConsentBoxUntickedEndsDenied() {
+    $this->askForTrackingConsentAtCheckout();
+    $email = 'unticked-guest@customer.com';
+    $this->wcOrderMock->method('get_billing_email')
+      ->willReturn($email);
+    $this->setupSyncGuestUserMock($email);
+    $request['extensions']['mailpoet']['optin'] = false;
+    $request['extensions']['mailpoet']['tracking_consent'] = false;
+    $this->integration->processCheckoutBlockOptin($this->wcOrderMock, $request);
+
+    $subscriber = $this->entityManager->getRepository(SubscriberEntity::class)->findOneBy(['email' => $email]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->entityManager->refresh($subscriber);
+    verify($subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+  }
+
+  public function testANewGuestWhoseCheckoutSentNoConsentFieldIsNotRecordedAsDeclining() {
+    $this->askForTrackingConsentAtCheckout();
+    $email = 'headless-guest@customer.com';
+    $this->wcOrderMock->method('get_billing_email')
+      ->willReturn($email);
+    $this->setupSyncGuestUserMock($email);
+    $request['extensions']['mailpoet']['optin'] = false;
+    $this->integration->processCheckoutBlockOptin($this->wcOrderMock, $request);
+
+    $subscriber = $this->entityManager->getRepository(SubscriberEntity::class)->findOneBy(['email' => $email]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->entityManager->refresh($subscriber);
+    verify($subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_UNKNOWN);
+    verify($subscriber->getTrackingConsentMethod())->null();
+  }
+
+  private function askForTrackingConsentAtCheckout(): void {
+    $this->settings->set('woocommerce.optin_on_checkout.enabled', true);
+    $this->settings->set(
+      TrackingConsentController::SETTING_SUBSCRIBER_CHOICE,
+      TrackingConsentController::CHOICE_ASK_ALL
+    );
   }
 
   private function setupSyncGuestUserMock(string $email) {

--- a/mailpoet/tests/integration/PostEditorBlocks/WooCommerceBlocksIntegrationTest.php
+++ b/mailpoet/tests/integration/PostEditorBlocks/WooCommerceBlocksIntegrationTest.php
@@ -139,6 +139,22 @@ class WooCommerceBlocksIntegrationTest extends \MailPoetTest {
     verify($subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
   }
 
+  public function testANewGuestWhoTicksTheConsentBoxEndsGranted() {
+    $this->askForTrackingConsentAtCheckout();
+    $email = 'ticked-guest@customer.com';
+    $this->wcOrderMock->method('get_billing_email')
+      ->willReturn($email);
+    $this->setupSyncGuestUserMock($email);
+    $request['extensions']['mailpoet']['optin'] = false;
+    $request['extensions']['mailpoet']['tracking_consent'] = true;
+    $this->integration->processCheckoutBlockOptin($this->wcOrderMock, $request);
+
+    $subscriber = $this->entityManager->getRepository(SubscriberEntity::class)->findOneBy(['email' => $email]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $this->entityManager->refresh($subscriber);
+    verify($subscriber->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+  }
+
   public function testANewGuestWhoseCheckoutSentNoConsentFieldIsNotRecordedAsDeclining() {
     $this->askForTrackingConsentAtCheckout();
     $email = 'headless-guest@customer.com';

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Import/ImportTest.php
@@ -975,6 +975,58 @@ class ImportTest extends \MailPoetTest {
     verify($fired)->empty();
   }
 
+  public function testARepeatedEmailAnnouncesTheConsentStoredForAnExistingSubscriber(): void {
+    $data = $this->testData;
+    $data['columns']['tracking_consent'] = ['index' => 8];
+    $data['subscribers'][0][] = 'granted';
+    $data['subscribers'][1][] = '';
+    $repeatedRow = $data['subscribers'][0];
+    $repeatedRow[8] = 'denied';
+    $data['subscribers'][] = $repeatedRow;
+
+    $existing = $this->createSubscriber('Adam', 'Smith', 'Adam@Smith.com');
+    $existing->setTrackingConsent(
+      SubscriberEntity::TRACKING_CONSENT_DENIED,
+      SubscriberEntity::TRACKING_CONSENT_METHOD_MANAGE_PAGE,
+      'Original wording'
+    );
+    $this->subscriberRepository->flush();
+
+    $fired = $this->captureTrackingConsentChanges(function () use ($data): void {
+      $this->createImportInstance($data)->process();
+    });
+    $this->entityManager->clear();
+
+    $stored = $this->subscriberRepository->findOneBy(['email' => 'adam@smith.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $stored);
+    verify($stored->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_GRANTED);
+    verify($fired)->equals([
+      [$stored->getId(), SubscriberEntity::TRACKING_CONSENT_DENIED, SubscriberEntity::TRACKING_CONSENT_GRANTED],
+    ]);
+  }
+
+  public function testARepeatedEmailAnnouncesTheConsentStoredForANewSubscriber(): void {
+    $data = $this->testData;
+    $data['columns']['tracking_consent'] = ['index' => 8];
+    $data['subscribers'][0][] = 'denied';
+    $data['subscribers'][1][] = '';
+    $repeatedRow = $data['subscribers'][0];
+    $repeatedRow[8] = 'granted';
+    $data['subscribers'][] = $repeatedRow;
+
+    $fired = $this->captureTrackingConsentChanges(function () use ($data): void {
+      $this->createImportInstance($data)->process();
+    });
+    $this->entityManager->clear();
+
+    $stored = $this->subscriberRepository->findOneBy(['email' => 'adam@smith.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $stored);
+    verify($stored->getTrackingConsent())->equals(SubscriberEntity::TRACKING_CONSENT_DENIED);
+    verify($fired)->equals([
+      [$stored->getId(), SubscriberEntity::TRACKING_CONSENT_UNKNOWN, SubscriberEntity::TRACKING_CONSENT_DENIED],
+    ]);
+  }
+
   /**
    * The notifier collects changes during the request and fires them together on
    * shutdown, so the hook is only observable once notify() has run. The


### PR DESCRIPTION
## Description

Two follow-ups to #7114 and #7115, both filed by the AI regression review. Neither has shipped: both PRs merged after 5.38.0.

**An email listed twice in one import could tell AutomateWoo the wrong answer.** Import sorts rows into "new" and "existing" by email. With a repeated email, the last row went to the update, and the earlier row went to the insert. The insert then skipped that row because the email already exists, but its consent was still announced on `mailpoet_subscriber_tracking_consent_changed`. For example, a subscriber stored as `denied`, imported with `granted` then `denied`, stayed `denied` in MailPoet while AutomateWoo was told `granted` and opted them into tracking. Import now keeps the first row for each email, which is what the import screen already does before it sends anything. `wp mailpoet import` runs each batch as its own import, so this holds within one batch. A repeat in a later batch updates the subscriber the way a second import would, and the consent announced still matches what is stored.

**Block checkout could record a decline for a customer who was never asked.** A checkout that reaches the Store API without the MailPoet block, such as a headless client, sends no `tracking_consent` key. A new guest was then stamped `denied`. The block sends that key as soon as it shows the consent box, ticked or not, so a missing key now means "not asked" and nothing is recorded. This is the same rule classic checkout follows with its hidden field since #7115.

## Code review notes

- **The bot's explanation on STOMAIL-8466 was wrong, but the bug was real.** It blamed SQL `CASE` order against the change map. Repeated rows never reach the same update. The split in `splitSubscribersData()` is the real cause, and `testARepeatedEmailAnnouncesTheConsentStoredForANewSubscriber` fails on trunk with the database at `denied` and the hook at `granted`.
- **The admin import screen was never affected.** `sanitize-csv-data.jsx` already drops repeated emails, keeping the first. Only `wp mailpoet import` and direct calls to the import endpoint could send them.
- **`removeRepeatedEmails()` runs in `process()`, not in `validateSubscribersData()`.** The validator is public and the CLI dry run counts from it.
- **Backward compatibility.** No signature, hook or REST shape changes. Two behaviours change:
  - `wp mailpoet import` with an email repeated inside one batch now uses the first row for an existing subscriber, not the last, and no longer counts that subscriber as "created" as well as "updated". Repeats across batches are unchanged: no set of emails is carried between batches, so memory stays flat on large files.
  - A custom Store API client that wants to record a decline must now send `extensions.mailpoet.tracking_consent: false`. Sending nothing records nothing, which matches what we decided for headless callers in STOMAIL-8363.

## QA notes

Set **MailPoet → Settings → Advanced → Subscriber choice** to "ask everyone". Turn on **WooCommerce → Sign-up at checkout**.

1. **Repeated email in a WP-CLI import.** Give a subscriber `denied` from the manage subscription page. Import this CSV with `wp mailpoet import file.csv --update-existing`:
   ```
   email,first_name,tracking_consent
   that-subscriber@example.com,Row1,granted
   that-subscriber@example.com,Row2,denied
   ```
   The subscriber must end `granted`, first name `Row1`, and the output must say `0 created, 1 updated`. Before this change it said `1 created, 1 updated`, kept `denied`, and announced `granted`.
2. **Block checkout, box left unticked.** As a guest with a new email, check out without ticking the tracking box. The new subscriber must be `denied`, as before.
3. **Block checkout, box ticked.** Same, with the box ticked. Must be `granted`.
4. **Checkout without the block.** Place a guest order through the Store API without `extensions.mailpoet` (for example with curl: `GET /wp-json/wc/store/v1/cart` for the `Nonce` and `Cart-Token` headers, `POST cart/add-item`, then `POST checkout`). The new subscriber must stay unknown, not `denied`.

## Linked PRs

- #7114
- #7115

## Linked tickets

- STOMAIL-8465
- STOMAIL-8466

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8466-import-duplicates-and-block-checkout-consent)

_The latest successful build from `fix/stomail-8466-import-duplicates-and-block-checkout-consent` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
