### PR TITLE
Fix bulk unsubscribe timing out on large selections

### DIFF
--- a/mailpoet/changelog/2026-09-11-09-28-28-fixed-bulk-unsubscribe-of-large-subscriber-selections-ti.md
+++ b/mailpoet/changelog/2026-09-11-09-28-28-fixed-bulk-unsubscribe-of-large-subscriber-selections-ti.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Bulk unsubscribe of large subscriber selections timing out instead of completing

--- a/mailpoet/lib/Statistics/StatisticsUnsubscribesRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsUnsubscribesRepository.php
@@ -8,6 +8,7 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 
 /**
  * @extends Repository<StatisticsUnsubscribeEntity>
@@ -15,6 +16,36 @@ use MailPoetVendor\Carbon\Carbon;
 class StatisticsUnsubscribesRepository extends Repository {
   protected function getEntityClassName() {
     return StatisticsUnsubscribeEntity::class;
+  }
+
+  /**
+   * Inserts one unsubscribe record per subscriber that is not yet unsubscribed.
+   * Runs as a single INSERT ... SELECT so large selections do not go through
+   * the ORM one entity at a time.
+   *
+   * @param int[] $subscriberIds
+   * @return int Number of inserted rows
+   */
+  public function trackBulk(array $subscriberIds, string $source, string $method = StatisticsUnsubscribeEntity::METHOD_UNKNOWN): int {
+    if ($subscriberIds === []) {
+      return 0;
+    }
+    $statisticsTable = $this->getTableName();
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    return (int)$this->entityManager->getConnection()->executeStatement(
+      "INSERT INTO $statisticsTable (subscriber_id, source, method, created_at)
+       SELECT id, :source, :method, :created_at
+       FROM $subscribersTable
+       WHERE id IN (:ids) AND status != :unsubscribed",
+      [
+        'ids' => array_map('intval', $subscriberIds),
+        'source' => $source,
+        'method' => $method,
+        'created_at' => Carbon::now()->millisecond(0)->format('Y-m-d H:i:s'),
+        'unsubscribed' => SubscriberEntity::STATUS_UNSUBSCRIBED,
+      ],
+      ['ids' => ArrayParameterType::INTEGER]
+    );
   }
 
   public function getTotalForMonths(int $forMonths): int {

--- a/mailpoet/lib/Statistics/Track/Unsubscribes.php
+++ b/mailpoet/lib/Statistics/Track/Unsubscribes.php
@@ -70,4 +70,12 @@ class Unsubscribes {
     $this->statisticsUnsubscribesRepository->flush();
     return $statistics;
   }
+
+  /**
+   * @param int[] $subscriberIds
+   * @return int Number of tracked subscribers
+   */
+  public function trackBulk(array $subscriberIds, string $source): int {
+    return $this->statisticsUnsubscribesRepository->trackBulk($subscriberIds, $source);
+  }
 }

--- a/mailpoet/lib/Subscribers/BulkActionController.php
+++ b/mailpoet/lib/Subscribers/BulkActionController.php
@@ -4,7 +4,6 @@ namespace MailPoet\Subscribers;
 
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
-use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\TagEntity;
 use MailPoet\Listing\ListingDefinition;
 use MailPoet\Segments\SegmentsRepository;
@@ -246,18 +245,6 @@ class BulkActionController {
    * @param int[] $ids
    */
   private function trackBulkUnsubscribe(array $ids): void {
-    if ($ids === []) return;
-    $subscribers = $this->subscribersRepository->findBy(['id' => $ids]);
-    foreach ($subscribers as $subscriber) {
-      if (
-        $subscriber instanceof SubscriberEntity
-        && $subscriber->getStatus() !== SubscriberEntity::STATUS_UNSUBSCRIBED
-      ) {
-        $this->unsubscribesTracker->track(
-          (int)$subscriber->getId(),
-          StatisticsUnsubscribeEntity::SOURCE_ADMINISTRATOR
-        );
-      }
-    }
+    $this->unsubscribesTracker->trackBulk($ids, StatisticsUnsubscribeEntity::SOURCE_ADMINISTRATOR);
   }
 }

--- a/mailpoet/tests/integration/Statistics/Track/UnsubscribesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/UnsubscribesTest.php
@@ -82,4 +82,34 @@ class UnsubscribesTest extends \MailPoetTest {
     }
     verify(count($this->statisticsUnsubscribesRepository->findAll()))->equals(1);
   }
+
+  public function testItTracksBulkUnsubscribesWithoutLoadingEntities(): void {
+    $active = (new SubscriberFactory())->withEmail('active@example.com')->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
+    $inactive = (new SubscriberFactory())->withEmail('inactive@example.com')->withStatus(SubscriberEntity::STATUS_INACTIVE)->create();
+    $unsubscribed = (new SubscriberFactory())->withEmail('done@example.com')->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)->create();
+    $missingId = (int)$unsubscribed->getId() + 1000;
+
+    $count = $this->unsubscribes->trackBulk(
+      [(int)$active->getId(), (int)$inactive->getId(), (int)$unsubscribed->getId(), $missingId],
+      StatisticsUnsubscribeEntity::SOURCE_ADMINISTRATOR
+    );
+
+    verify($count)->equals(2);
+    $this->entityManager->clear();
+    verify($this->statisticsUnsubscribesRepository->findAll())->arrayCount(2);
+    verify($this->statisticsUnsubscribesRepository->findBy(['subscriber' => $unsubscribed]))->arrayCount(0);
+    $activeStats = $this->statisticsUnsubscribesRepository->findBy(['subscriber' => $active]);
+    verify($activeStats)->arrayCount(1);
+    verify($this->statisticsUnsubscribesRepository->findBy(['subscriber' => $inactive]))->arrayCount(1);
+    verify($activeStats[0]->getSource())->equals(StatisticsUnsubscribeEntity::SOURCE_ADMINISTRATOR);
+    verify($activeStats[0]->getMethod())->equals(StatisticsUnsubscribeEntity::METHOD_UNKNOWN);
+    verify($activeStats[0]->getCreatedAt())->notNull();
+    verify($activeStats[0]->getNewsletter())->null();
+    verify($activeStats[0]->getQueue())->null();
+  }
+
+  public function testBulkTrackingOfEmptySelectionInsertsNothing(): void {
+    verify($this->unsubscribes->trackBulk([], StatisticsUnsubscribeEntity::SOURCE_ADMINISTRATOR))->equals(0);
+    verify($this->statisticsUnsubscribesRepository->findAll())->arrayCount(0);
+  }
 }


### PR DESCRIPTION
## Description

Bulk unsubscribe from the Subscribers list failed for large selections. The action tracked each subscriber one by one and ran a full Doctrine flush after every insert. With a large selection of subscribers the request can hit the PHP execution limit, returning a 500, and no subscriber get unsubscribed. When that happens, the modal stays open with no feedback.

## Code review notes

_N/A_

## QA notes

1. Create a large number of subscribed subscribers (a few thousand is enough, ~10,000 reproduces the timeout reliably).
2. Go to MailPoet → Subscribers → Subscribed tab.
3. Tick the header checkbox, click "Select all N subscribers matching this view".
4. Choose Unsubscribe → Apply.
5. Expect a success notice within a few seconds, all subscribers moved to the Unsubscribed tab, and one `admin` row per subscriber in `mailpoet_statistics_unsubscribes` table.
6. Repeat the action on the same subscribers and confirm no new statistics rows are added.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8464: Investigate bulk subscriber actions freezing on large selections (8000+)](https://linear.app/a8c/issue/STOMAIL-8464/investigate-bulk-subscriber-actions-freezing-on-large-selections-8000)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8464-investigate-bulk-subscriber-actions-freezing-on-large)

_The latest successful build from `stomail-8464-investigate-bulk-subscriber-actions-freezing-on-large` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->